### PR TITLE
feat(claude): improve git workflow automation and add mandatory instructions

### DIFF
--- a/.claude/agents/git-workflow.md
+++ b/.claude/agents/git-workflow.md
@@ -1,6 +1,6 @@
 ---
 name: git-workflow
-description: Git workflow automation. Creates GitHub issues, branches from main, manages commits, squashes, and creates pull requests. Use proactively when making codebase changes, implementing features, or fixing bugs.
+description: Git workflow automation. MUST be used FIRST before any code changes. Creates GitHub issues, feature branches, manages commits, and creates pull requests. Invoke IMMEDIATELY when user asks to implement, add, fix, refactor, or modify any code.
 tools: Bash, Read, Write, Edit, Glob, Grep
 model: sonnet
 ---
@@ -200,13 +200,35 @@ Example setup for parallel work:
 ## When Invoked
 
 **For new feature/fix:**
-1. Ask: "Use worktree (recommended) or standard branch?"
+1. Check if already in a worktree (skip setup if so)
 2. Create issue via `gh issue create`
-3. Set up worktree or branch
+3. If not in worktree, set up branch
 4. Report the setup and hand back for code changes
 
 **For finishing work:**
 1. Check changes with `git status && git diff`
 2. Commit with proper message format
-3. Create PR via `gh pr create`
+3. Push and create PR via `gh pr create`
 4. Report PR URL
+5. **Provide cleanup instructions** (see below)
+
+## Post-PR Cleanup
+
+After creating a PR, ALWAYS output cleanup instructions:
+
+```
+PR created: <URL>
+
+After PR is merged, clean up this worktree:
+  cd /home/tetsuo/git/tetsuo-socket
+  git worktree remove <current-worktree-path>
+  git worktree prune
+  git branch -d <branch-name>  # if branch was merged
+```
+
+Detect the current worktree path with:
+```bash
+git rev-parse --show-toplevel
+```
+
+If in main repo (not a worktree), skip the worktree cleanup instructions.

--- a/.claude/hooks/git-workflow-reminder.sh
+++ b/.claude/hooks/git-workflow-reminder.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
-# UserPromptSubmit hook - triggers git-workflow agent for code changes
+# UserPromptSubmit hook - injects git workflow reminders as context
+# For UserPromptSubmit, stdout plain text is automatically added to context
 
 set -e
 
 input=$(cat)
 prompt=$(echo "$input" | jq -r '.prompt // ""' | tr '[:upper:]' '[:lower:]')
 
-# Keywords that suggest starting new work (need full git workflow)
+# Keywords that suggest starting new work
 new_work_patterns=(
     "add a"
     "add the"
@@ -29,7 +30,7 @@ finish_patterns=(
     "done with"
 )
 
-# Keywords that suggest fixing/updating (may need branch)
+# Keywords that suggest fixing/updating
 fix_patterns=(
     "fix the"
     "fix a"
@@ -45,41 +46,35 @@ fix_patterns=(
     "patch"
 )
 
-# Check for new work patterns - need worktree/branch setup
+# Check for new work patterns
 for pattern in "${new_work_patterns[@]}"; do
     if echo "$prompt" | grep -qi "$pattern"; then
         cat << 'EOF'
-{
-  "addToPrompt": "\n\n<system-reminder>\n**IMPORTANT: Use the git-workflow agent for this task.**\n\nThis appears to be new work. You MUST:\n1. Use Task tool with subagent_type='git-workflow' to set up proper workflow\n2. The agent will create a GitHub issue and worktree (or branch)\n3. Only start coding after the agent confirms setup\n\nPrefer worktrees for isolation: `git worktree add ../tetsuo-socket-red -b issue-N-desc origin/main`\n\nDo NOT commit directly to main. The git-safety-check hook will block you.\n</system-reminder>"
-}
+GIT WORKFLOW REQUIRED: This is new work. Use the /git-workflow skill to set up proper git workflow before making changes. The skill will create a GitHub issue and ensure you're on a feature branch. Do NOT work directly on main.
 EOF
         exit 0
     fi
 done
 
-# Check for finish patterns - need commit/PR help
+# Check for finish patterns
 for pattern in "${finish_patterns[@]}"; do
     if echo "$prompt" | grep -qi "$pattern"; then
         cat << 'EOF'
-{
-  "addToPrompt": "\n\n<system-reminder>\n**Use /git-workflow to finalize changes.**\n\nFor commits, use this format:\n```\ngit commit -m \"$(cat <<'COMMIT'\n<type>: <description>\n\n<body>\n\nFixes #<issue>\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: Claude <noreply@anthropic.com>\nCOMMIT\n)\"\n```\n\nFor PRs: `gh pr create --title \"<type>: desc\" --body \"...\"`\n</system-reminder>"
-}
+GIT WORKFLOW: Use /git-workflow skill for proper commit/PR formatting. Commit messages must include type prefix (feat/fix/refactor), reference the issue with "Fixes #N", and include the Claude Code footer.
 EOF
         exit 0
     fi
 done
 
-# Check for fix patterns - may need branch if on main
+# Check for fix patterns
 for pattern in "${fix_patterns[@]}"; do
     if echo "$prompt" | grep -qi "$pattern"; then
         cat << 'EOF'
-{
-  "addToPrompt": "\n\n<system-reminder>\nThis appears to involve code changes. Check your current branch:\n- If on main: Use git-workflow agent to create issue + worktree/branch first\n- If on feature branch: Proceed with changes\n\nPrefer worktrees for parallel work: `git worktree add ../tetsuo-socket-red -b issue-N-desc origin/main`\n\nRun `git branch` to verify you're not on main before making changes.\n</system-reminder>"
-}
+GIT WORKFLOW: This involves code changes. Verify you're on a feature branch (not main). If on main, use /git-workflow to create an issue and branch first.
 EOF
         exit 0
     fi
 done
 
-# No code change detected, no reminder needed
+# No reminder needed
 exit 0

--- a/.claude/skills/git-workflow/SKILL.md
+++ b/.claude/skills/git-workflow/SKILL.md
@@ -140,3 +140,19 @@ Each directory gets its own Claude session with full isolation.
 - [ ] Links to issue with "Fixes #N"
 - [ ] Describes WHY, not just WHAT
 - [ ] Includes test plan
+
+## Post-PR Cleanup
+
+After creating a PR, ALWAYS show cleanup instructions:
+
+```
+PR created: <URL>
+
+After PR is merged, clean up this worktree:
+  cd /home/tetsuo/git/tetsuo-socket
+  git worktree remove $(pwd)
+  git worktree prune
+  git branch -d <branch-name>
+```
+
+Skip worktree cleanup if working in main repo (not a worktree).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,45 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+## MANDATORY: Git Workflow for Code Changes
+
+**BEFORE making ANY code changes** (implement, add, fix, refactor, modify), you MUST:
+
+1. **Invoke `/git-workflow`** to set up proper git workflow
+2. The skill will ensure you're on a feature branch (not main)
+3. Only proceed with code changes AFTER git workflow confirms setup
+
+**This is NOT optional.** The git-safety-check hook will block commits to main.
+
+### Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Start new work | `/git-workflow` → creates issue + branch |
+| Commit changes | `/git-workflow` → proper commit format |
+| Create PR | `/git-workflow` → PR with correct template |
+
+### Branch Naming
+
+- Features: `issue-<num>-<description>`
+- Fixes: `issue-<num>-fix-<description>`
+
+### Commit Format
+
+```
+<type>: <description>
+
+<body>
+
+Fixes #<issue>
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`
+
 ## Build Commands
 
 ```bash


### PR DESCRIPTION
## Summary
- Fix UserPromptSubmit hook to output plain text instead of invalid JSON (`addToPrompt` doesn't exist in Claude Code hooks API)
- Add stronger trigger words to git-workflow agent description for proactive invocation
- Add post-PR cleanup instructions to both agent and skill
- Add mandatory git workflow section to CLAUDE.md requiring `/git-workflow` before code changes

Also includes a wrapper script (`~/.local/bin/claude-worktree`) that auto-creates worktrees when starting Claude in this repo on main branch (not committed to repo as it's user-specific).

## Test plan
- [ ] Hook outputs plain text context on matching prompts
- [ ] `/git-workflow` skill invokes correctly
- [ ] Post-PR cleanup instructions appear after PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)