### PR TITLE
chore: cleanup comments in include/dns/

### DIFF
--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -9,47 +9,9 @@
 
 /**
  * @file SocketDNS-private.h
- * @brief Internal structures, enums, and prototypes for asynchronous DNS
- * resolver implementation.
+ * @brief Internal structures and prototypes for DNS resolver implementation.
  * @ingroup dns
- *
- * Defines private data structures, state enumerations, and internal function
- * prototypes for the thread-pool based DNS resolution module. Intended solely
- * for library maintainers. Applications must use public API in SocketDNS.h
- * exclusively.
- *
- * Core internal architecture:
- * - #SocketDNS_T: Resolver with arena, worker threads, request queue/hash,
- * sync primitives, completion pipe
- * - #SocketDNS_Request_T: Per-request state including hostname, callback,
- * result, timeout tracking
- * - RequestState enum: Lifecycle tracking (PENDING -> PROCESSING ->
- * COMPLETE/CANCELLED)
- * - Hash table (SOCKET_DNS_REQUEST_HASH_SIZE buckets) for O(1) request
- * lookup/removal
- * - Mutex-protected FIFO queue for pending requests
- * - Pipe FD for non-blocking completion notification to SocketPoll
- *
- * Dependencies:
- * - @ref foundation (Arena_T for memory, Except_T for errors)
- * - @ref core_io (SocketCommon.h for util, SocketUtil.h for hashing/timing)
- * - POSIX threads (pthread) and <netdb.h> for getaddrinfo()
- *
- * Security considerations:
- * - Deterministic pointer hashing mitigates collision attacks but monitor
- * max_pending
- * - Worker threads isolated; callbacks execute in worker context (no main
- * thread reentrancy)
- * - Timeouts prevent DoS from slow/broken DNS servers
- *
- * @see SocketDNS.h for public asynchronous API (resolve, pollfd, getresult).
- * @see src/dns/SocketDNS.c for public wrapper functions and exception setup.
- * @see src/dns/SocketDNS-internal.c for full implementation details.
- * @see @ref dns "DNS module overview" and @ref core_io "Core I/O group".
- * @see docs/ASYNC_IO.md for integration with event loops.
  * @warning INTERNAL USE ONLY - unstable ABI, may change without notice.
- * @warning Callback functions must be reentrant and fast; see
- * SocketDNS_Callback documentation.
  */
 
 /* System headers */
@@ -114,45 +76,11 @@ typedef struct Arena_T *Arena_T;
 typedef void (*SocketDNS_Callback) (SocketDNS_Request_T *, struct addrinfo *,
                                     int, void *);
 
-/*
- * =============================================================================
- * Internal Enumerations and Constants
- * =============================================================================
- */
-
 /**
- * @brief Enumeration of DNS request lifecycle states.
+ * @brief DNS request lifecycle states.
  * @ingroup dns
  *
- * Defines the processing states for individual DNS resolution requests.
- * Requests transition linearly: REQ_PENDING → REQ_PROCESSING → (REQ_COMPLETE |
- * REQ_CANCELLED)
- *
- * State transitions are atomic under mutex protection to ensure consistency
- * across threads (submitters, workers, pollers). Used for:
- * - Queue management and worker assignment
- * - Timeout detection and forced completion
- * - Result availability checks
- * - Cancellation safety
- *
- *  State Transition Table
- *
- * | State       | Description                          | Transitions From |
- * Actions Available          |
- * |-------------|--------------------------------------|---------------------------|----------------------------|
- * | REQ_PENDING | Queued, waiting for worker           | SocketDNS_resolve()
- * | cancel, timeout check      | | REQ_PROCESSING | Worker executing
- * getaddrinfo()     | Worker dequeues           | no cancel (unsafe), timeout|
- * | REQ_COMPLETE | Result ready, callback pending      | getaddrinfo()
- * success/error| getresult, invoke callback | | REQ_CANCELLED | User
- * cancelled, no further action   | SocketDNS_cancel()        | geterror
- * (EAI_NONAME)      |
- *
- * @see SocketDNS_Request_T::state field for storage.
- * @see submit_dns_request() for PENDING insertion.
- * @see process_single_request() for PROCESSING → COMPLETE.
- * @see cancel_pending_request() for CANCELLED transition.
- * @see request_timed_out() for timeout handling.
+ * Transitions: REQ_PENDING → REQ_PROCESSING → REQ_COMPLETE | REQ_CANCELLED
  */
 typedef enum
 {
@@ -165,31 +93,8 @@ typedef enum
 } RequestState;
 
 /**
- * @brief Levels for partial cleanup during initialization failures.
+ * @brief Cleanup levels for partial initialization failure recovery.
  * @ingroup dns
- *
- * Defines cleanup scope for cleanup_on_init_failure() based on init progress.
- * Values correspond to initialization order to enable reverse-order resource
- * release. Used in TRY/EXCEPT blocks during SocketDNS_new() to ensure no leaks
- * on failure.
- *
- * @see initialize_dns_components()
- * @see cleanup_on_init_failure()
- * @see SocketDNS_new() constructor exception handling.
- */
-/**
- * @brief Enum for DNS cleanup levels during partial failure recovery.
- * @ingroup dns
- * @details
- * Defines levels corresponding to initialization stages, enabling precise
- * resource cleanup on partial failure in SocketDNS_new().
- * Values match order: mutex -> conds -> pipe -> arena.
- * Used in TRY/EXCEPT for exception-safe initialization.
- *
- * @note Higher levels include cleanup for lower levels (reverse order).
- * @see SocketDNS_new() for usage in constructor.
- * @see cleanup_on_init_failure() for cleanup logic.
- * @see initialize_dns_components() for init sequence.
  */
 enum DnsCleanupLevel
 {
@@ -200,19 +105,9 @@ enum DnsCleanupLevel
   DNS_CLEAN_ARENA     /**< Cleanup arena and all above */
 };
 
-/*
- * =============================================================================
- * Internal Structures
- * =============================================================================
- */
-
 /**
  * @brief DNS resolution request structure.
  * @ingroup dns
- *
- * Represents a single DNS resolution request with all associated state.
- * Allocated from the resolver's arena and lives until result is retrieved
- * or request is cancelled.
  */
 struct SocketDNS_Request_T
 {
@@ -234,8 +129,6 @@ struct SocketDNS_Request_T
 /**
  * @brief DNS cache entry structure.
  * @ingroup dns
- *
- * Stores a cached DNS resolution result with TTL and LRU tracking.
  */
 struct SocketDNS_CacheEntry
 {
@@ -251,17 +144,6 @@ struct SocketDNS_CacheEntry
 /**
  * @brief Async DNS resolver structure.
  * @ingroup dns
- *
- * Thread pool-based DNS resolver with queue management, hash table lookup,
- * and pipe-based completion signaling for integration with SocketPoll.
- *
- * SECURITY NOTE: The request hash table uses deterministic pointer-based
- * hashing via socket_util_hash_ptr(). While attackers cannot typically control
- * memory allocation addresses, a large number of concurrent requests could
- * theoretically cause hash collisions. This is mitigated by:
- * - max_pending limit (default SOCKET_DNS_MAX_PENDING = 1000)
- * - Hash table size is prime (SOCKET_DNS_REQUEST_HASH_SIZE = 1021)
- * - Worst case is O(n) lookup per bucket, not a security vulnerability
  */
 struct SocketDNS_T
 {
@@ -400,882 +282,104 @@ extern const Except_T SocketDNS_Failed;
  * SOCKET_DECLARE_MODULE_EXCEPTION. See SocketDNS.c and SocketDNS-internal.c
  * for the pattern. */
 
-/*
- * =============================================================================
- * Forward Declarations - SocketDNS-internal.c
- *
- * Internal implementation functions for initialization, synchronization,
- * cleanup, request management, timeout handling, and worker threads.
- * =============================================================================
- */
+/* Forward Declarations - SocketDNS-internal.c */
 
-/* Initialization and allocation */
-
-/**
- * @brief Allocate and zero-initialize DNS resolver structure from heap memory.
- * @ingroup dns
- *
- * Performs calloc(1, sizeof(struct SocketDNS_T)) for zero-initialization of
-all fields.
- * Used during SocketDNS_new() bootstrap before arena allocation.
- * Caller must subsequently call initialize_dns_fields() and other init
-functions.
- *
- * @return Pointer to allocated and zeroed SocketDNS_T instance.
- *
- * @throws SocketDNS_Failed on memory allocation failure (calloc failure).
- *
- * @threadsafe No - intended for single-threaded initialization in
-SocketDNS_new().
- *
- *  Usage Example
- *
- * @code{.c}
- * struct SocketDNS_T *dns = allocate_dns_resolver();
- * if (dns == NULL) {
-
-extern struct SocketDNS_T * allocate_dns_resolver (void);
- *     // Handle allocation failure (ENOMEM)
- *     RAISE(SocketDNS_Failed);
- * }
- * TRY {
- *     initialize_dns_fields(dns);
- *     initialize_dns_components(dns);
-
-extern void initialize_dns_components (struct SocketDNS_T *dns);
- *     // Success: dns ready for use
- * } EXCEPT(SocketDNS_Failed) {
- *     cleanup_on_init_failure(dns, DNS_CLEAN_NONE);  // Or appropriate level
- *     free(dns);
- *     RAISE;
- * } END_TRY;
- * @endcode
- *
- * @note Heap allocation (not arena); arena is initialized later for requests.
- * Caller owns the pointer until cleanup_on_init_failure() or SocketDNS_free().
- *
- * @complexity O(1) - single calloc() call.
- *
- * @warning Do not use directly; part of internal SocketDNS_new()
-implementation.
- * Applications must use public SocketDNS_new() API.
- *
- * @see initialize_dns_fields() for field initialization.
- * @see initialize_dns_components() for component setup (threads, sync
-primitives).
-
-extern void initialize_dns_components (struct SocketDNS_T *dns);
- * @see cleanup_on_init_failure() for error cleanup.
- * @see SocketDNS_new() public constructor that orchestrates this allocation.
- */
-
-/**
- * @brief Initialize basic DNS resolver fields to safe default values.
- * @ingroup dns
- *
- * Sets all fields in the DNS resolver structure to safe defaults:
- * - NULL for pointers (arena, workers, queue pointers, hash table entries)
- * - 0/1 for counters and flags (num_workers, queue_size, shutdown, etc.)
- * - Default values for configurable limits (max_pending, timeout)
- *
- * This ensures the structure is in a consistent state before component
- * initialization (mutex, pipe, threads). Zero-initialization from calloc
- * is supplemented with explicit defaults for clarity and future-proofing.
- *
- * @param[in,out] dns Pre-allocated DNS resolver structure (from
-allocate_dns_resolver()).
- *
- * @threadsafe No - called during single-threaded initialization.
- *
- *  Usage Example
- *
- * @code{.c}
- * struct SocketDNS_T *dns = allocate_dns_resolver();
- * TRY {
- *     initialize_dns_fields(dns);  // Set defaults
-
-extern void initialize_dns_fields (struct SocketDNS_T *dns);
- *     // Now safe to call initialize_dns_components(dns)
- * } EXCEPT(SocketDNS_Failed) {
- *     // Minimal cleanup needed (already zeroed)
- * } END_TRY;
- * @endcode
- *
- * @note Explicitly sets defaults even after calloc() for code clarity
- * and to handle future field additions without relying on zero-init.
- *
- * @complexity O(1) - direct field assignments, no loops or allocations.
- *
- * @see allocate_dns_resolver() for structure allocation.
- * @see initialize_dns_components() next step after fields init.
- * @see reset_dns_state() for symmetric reset during cleanup.
- * @see SocketDNS_new() orchestrating function.
- */
-
-/**
- * @brief Initialize core DNS resolver components including arena, sync
- * primitives, pipe, and threads.
- * @ingroup dns
- *
- * Orchestrates the complete setup of resolver internals:
- * 1. Arena allocation for request structures and hostnames
- * 2. Synchronization primitives (recursive mutex + 2 condition vars)
- * 3. Non-blocking completion pipe for event loop integration
- * 4. Worker thread pool creation (SOCKET_DNS_THREAD_COUNT threads)
- *
- * Uses TRY/EXCEPT blocks internally for exception-safe partial failure
- * recovery. Cleanup levels track init progress for precise resource release on
- * errors.
- *
- * @param[in,out] dns Pre-allocated and field-initialized DNS resolver (from
- * allocate_dns_resolver() + initialize_dns_fields()).
- *
- * @throws SocketDNS_Failed on:
- * - Arena_new() failure (ENOMEM)
- * - pthread_mutex_init() / pthread_cond_init() failure (EAGAIN, ENOMEM)
- * - pipe() or socketpair() failure for completion signaling (EMFILE,
- * EAFNOSUPPORT)
- * - pthread_create() failure for workers (EAGAIN, EINVAL, EMFILE, EPERM)
- *
- * @threadsafe No - single-threaded initialization phase only.
- *
- *  Usage Example
- *
- * @code{.c}
- * struct SocketDNS_T *dns = allocate_dns_resolver();
- * enum DnsCleanupLevel cleanup_level = DNS_CLEAN_NONE;
- * TRY {
- *     initialize_dns_fields(dns);
- *     cleanup_level = DNS_CLEAN_MUTEX;
- *     initialize_synchronization(dns);  // Or direct calls
- *     cleanup_level = DNS_CLEAN_PIPE;
- *     initialize_pipe(dns);
- *     cleanup_level = DNS_CLEAN_ARENA;
- *     create_worker_threads(dns);
- *     start_dns_workers(dns);
- *     // Full init complete - return dns to SocketDNS_new()
- * } EXCEPT(SocketDNS_Failed) {
- *     cleanup_on_init_failure(dns, cleanup_level);
- *     free(dns);
- *     RAISE;
- * } END_TRY;
- * @endcode
- *
- * @note Recursive mutex allows nested locking during init/cleanup.
- * @note Pipe FD [0] is pollfd for reading completions; [1] for writing
- * signals.
- * @note Worker threads start in suspended state until start_dns_workers().
- *
- * @complexity O(n) where n = number of worker threads (typically small, ~4-8).
- *
- * @warning Partial failures cleaned up automatically; do not reuse partially
- * init dns.
- * @warning Thread creation may fail under resource exhaustion (ulimit -u).
- *
- * @pre dns->arena == NULL, dns->workers == NULL, dns->mutex uninitialized,
- * etc.
- * @see cleanup_on_init_failure() for symmetric error handling.
- * @see create_worker_threads() for thread spawning details.
- * @see initialize_synchronization() / initialize_pipe() sub-components.
- * @see SocketDNS_new() public API entry point.
- * @see docs/ASYNC_IO.md for async integration patterns.
- */
-
-/**
- * @brief Configure pthread attributes for DNS worker threads.
- * @ingroup dns
- *
- * Sets up thread attributes for detached operation with default stack size
- * and scheduling policy. Ensures workers run independently without join
- * requirements during shutdown.
- *
- * Specific settings:
- * - Detached state: PTHREAD_CREATE_DETACHED (no pthread_join needed)
- * - Inherit scheduler: PTHREAD_EXPLICIT_SCHED not set (inherits parent)
- * - Default stack size and guards (platform defaults)
- *
- * @param[in,out] attr Pointer to pthread_attr_t structure to configure.
- *     Must be initialized (via pthread_attr_init) before call.
- *     Modified in place with worker-specific attributes.
- *
- * @return Void - raises SocketDNS_Failed on pthread_attr_* failure (rare).
- *     Implementation uses TRY/EXCEPT internally.
- *
- * @throws SocketDNS_Failed if pthread_attr_setdetachstate() or other attr
- * calls fail.
- *
- * @threadsafe Yes - reentrant, modifies local attr structure only.
- *
- *  Usage Example
- *
- * @code{.c}
- * pthread_attr_t attr;
- * TRY {
- *     pthread_attr_init(&attr);
- *     setup_thread_attributes(&attr);
- *     // Now attr is ready for pthread_create()
- *     int ret = pthread_create(&thread_id, &attr, worker_thread, dns);
- *     if (ret != 0) RAISE_FMT(SocketDNS_Failed, "pthread_create failed: %s",
- * strerror(ret)); } EXCEPT(SocketDNS_Failed) {
- *     // Handle error
- * } FINALLY {
- *     pthread_attr_destroy(&attr);
- * } END_TRY;
- * @endcode
- *
- * @complexity O(1) - fixed number of pthread_attr_* calls.
- *
- * @note Detached threads simplify shutdown; no explicit joins required.
- * @note Defaults to platform scheduler policy (SCHED_OTHER typically).
- *
- * @warning Caller must pthread_attr_destroy(&attr) after use, even on failure.
- * Caller must pthread_attr_init(&attr) before calling this function.
- *
- * @see create_single_worker_thread() for using configured attributes.
- * @see create_worker_threads() for multi-thread creation.
- * @see worker_thread() thread entry point.
- * @see SocketDNS_new() high-level initialization.
- */
-
-/**
- * @brief Create a single worker thread.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param thread_index Index of thread to create (0-based).
- * @return 0 on success, errno on failure.
- *
- * Creates one worker thread with proper attributes and error handling.
- */
 extern int create_single_worker_thread (struct SocketDNS_T *dns,
                                         int thread_index);
-
-/**
- * @brief Spawn the configured number of DNS worker threads.
- * @ingroup dns
- * @param dns DNS resolver instance (with num_workers set).
- * @throws SocketDNS_Failed if pthread_create() fails for any thread (ENOMEM,
- * etc.).
- *
- * Creates dns->num_workers (default SOCKET_DNS_THREAD_COUNT) detached worker
- * threads. Each thread runs worker_thread() loop until shutdown. Threads are
- * stored in dns->workers array (arena-allocated).
- *
- * @note Threads are created detached with default scheduling attributes.
- * @note Partial success: some threads may start before failure; cleanup
- * handles join.
- * @threadsafe Conditional - must be called under single thread during init.
- * @see setup_thread_attributes() for thread config.
- * @see create_single_worker_thread() low-level single thread creation.
- * @see worker_thread() entry point for each thread.
- * @see shutdown_workers() to stop all threads.
- */
 extern void create_worker_threads (struct SocketDNS_T *dns);
-
-/**
- * @brief Start DNS worker threads (transition from initialization to running).
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Signals workers to begin processing requests from the queue.
- */
 extern void start_dns_workers (struct SocketDNS_T *dns);
 
 /* Synchronization primitives */
-
-/**
- * @brief Initialize the main mutex protecting DNS resolver state.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Creates a recursive mutex for protecting all mutable resolver state.
- */
 extern void initialize_mutex (struct SocketDNS_T *dns);
-
-/**
- * @brief Initialize condition variable for queue empty/full signaling.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Creates condition variable used to wake worker threads when requests arrive.
- */
 extern void initialize_queue_condition (struct SocketDNS_T *dns);
-
-/**
- * @brief Initialize condition variable for result availability signaling.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Creates condition variable used to wake polling threads when results
- * complete.
- */
 extern void initialize_result_condition (struct SocketDNS_T *dns);
-
-/**
- * @brief Initialize all synchronization primitives (mutex + conditions).
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Calls initialize_mutex(), initialize_queue_condition(), and
- * initialize_result_condition().
- */
 extern void initialize_synchronization (struct SocketDNS_T *dns);
-
-/**
- * @brief Create pipe for completion signaling to event loops.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Creates a pipe that can be polled for DNS completion events.
- * Used for integration with SocketPoll.
- *
- * @see @ref event_system::SocketPoll "SocketPoll" for event multiplexing.
- * @see SocketDNS_pollfd() for public API access to this pipe.
- */
 extern void create_completion_pipe (struct SocketDNS_T *dns);
-
-/**
- * @brief Set completion pipe to non-blocking mode.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Ensures pipe reads/writes don't block, preventing deadlocks.
- */
 extern void set_pipe_nonblocking (struct SocketDNS_T *dns);
-
-/**
- * @brief Initialize completion pipe (create + configure).
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Calls create_completion_pipe() and set_pipe_nonblocking().
- */
 extern void initialize_pipe (struct SocketDNS_T *dns);
 
 /* Cleanup and shutdown */
-
-/**
- * @brief Clean up mutex and condition variables.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Destroys mutex and condition variables. Safe to call multiple times.
- */
 extern void cleanup_mutex_cond (struct SocketDNS_T *dns);
-
-/**
- * @brief Clean up completion pipe.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Closes pipe file descriptors and drains any pending data.
- */
 extern void cleanup_pipe (struct SocketDNS_T *dns);
-
-/**
- * @brief Clean up resources based on initialization failure level.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param cleanup_level How much has been initialized (cleanup level).
- *
- * Used during initialization failure to clean up partially initialized state.
- * Cleans up resources in reverse order of initialization.
- */
 extern void cleanup_on_init_failure (struct SocketDNS_T *dns,
                                      enum DnsCleanupLevel cleanup_level);
-
-/**
- * @brief Signal worker threads to shut down.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Sets shutdown flag and broadcasts to wake all waiting threads.
- */
 extern void shutdown_workers (struct SocketDNS_T *dns);
-
-/**
- * @brief Drain all pending completion signals from pipe.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Reads all available bytes from completion pipe to clear pending signals.
- */
 extern void drain_completion_pipe (struct SocketDNS_T *dns);
-
-/**
- * @brief Reset DNS resolver state to uninitialized values.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Clears all pointers and resets counters. Called during destruction.
- */
 extern void reset_dns_state (struct SocketDNS_T *dns);
-
-/**
- * @brief Destroy all DNS resolver resources.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Calls all cleanup functions in proper order. Safe to call on partially
- * initialized instances.
- */
 extern void destroy_dns_resources (struct SocketDNS_T *dns);
-
-/**
- * @brief Free a linked list of DNS requests.
- * @ingroup dns
- * @param head Head of request list to free.
- * @param use_hash_next Whether to use hash_next (1) or queue_next (0) for
- * traversal.
- *
- * Frees all requests in the list and their associated memory.
- */
 extern void free_request_list (struct SocketDNS_Request_T *head,
                                int use_hash_next);
-
-/**
- * @brief Free all requests currently in the processing queue.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Frees requests from queue_head/queue_tail linked list.
- */
 extern void free_queued_requests (struct SocketDNS_T *dns);
-
-/**
- * @brief Free all requests currently in the hash table.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Frees requests from all hash table buckets.
- */
 extern void free_hash_table_requests (struct SocketDNS_T *dns);
-
-/**
- * @brief Free all pending and completed DNS requests.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Calls free_queued_requests() and free_hash_table_requests().
- */
 extern void free_all_requests (struct SocketDNS_T *dns);
 
 /* Request allocation and queue management */
-
-/**
- * @brief Compute hash value for request pointer.
- * @ingroup dns
- * @param req Request to hash.
- * @return Hash value for hash table lookup.
- *
- * Uses socket_util_hash_ptr() for deterministic hashing of request pointers.
- *
- * @see @ref foundation::SocketUtil "SocketUtil" for hash function utilities.
- */
 extern unsigned request_hash_function (const struct SocketDNS_Request_T *req);
-
-/**
- * @brief Allocate uninitialized request structure from resolver arena.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @return Newly allocated request structure.
- *
- * Allocates memory for request structure. Fields must be initialized before
- * use.
- */
 extern struct SocketDNS_Request_T *
 allocate_request_structure (struct SocketDNS_T *dns);
-
-/**
- * @brief Allocate and copy hostname string for request.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to store hostname in.
- * @param host Hostname string to copy.
- * @param host_len Length of hostname string.
- *
- * Allocates hostname buffer from arena and copies host string.
- */
 extern void allocate_request_hostname (struct SocketDNS_T *dns,
                                        struct SocketDNS_Request_T *req,
                                        const char *host, size_t host_len);
-
-/**
- * @brief Initialize request fields after allocation.
- * @ingroup dns
- * @param req Request to initialize.
- * @param port Port number for resolution.
- * @param callback Completion callback (NULL for polling).
- * @param data User data for callback.
- *
- * Sets all request fields except host (which is set separately).
- */
 extern void initialize_request_fields (struct SocketDNS_Request_T *req,
                                        int port, SocketDNS_Callback callback,
                                        void *data);
-
-/**
- * @brief Allocate and initialize complete DNS request.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param host Hostname to resolve.
- * @param host_len Length of hostname.
- * @param port Port number.
- * @param cb Completion callback.
- * @param data User callback data.
- * @return Fully initialized request structure.
- *
- * Combines allocation, hostname copying, and field initialization.
- */
 extern struct SocketDNS_Request_T *
 allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
                   int port, SocketDNS_Callback cb, void *data);
-
-/**
- * @brief Insert request into hash table for O(1) lookup.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to insert.
- *
- * Inserts request into hash table using pre-computed hash value.
- */
 extern void hash_table_insert (struct SocketDNS_T *dns,
                                struct SocketDNS_Request_T *req);
-
-/**
- * @brief Remove request from hash table.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to remove.
- *
- * Removes request from hash table bucket chain.
- */
 extern void hash_table_remove (struct SocketDNS_T *dns,
                                struct SocketDNS_Request_T *req);
-
-/**
- * @brief Append a DNS request to the end of the FIFO processing queue.
- * @ingroup dns
- *
- * Inserts the request into the tail of the queue (FIFO order) and increments
- * the queue_size counter. Updates queue_tail pointer and sets req->queue_next
- * = NULL. Must be called under mutex lock (internal invariant).
- *
- * Queue is singly-linked via SocketDNS_Request_T::queue_next field.
- * Used during request submission after hash table insertion.
- *
- * @param[in,out] dns DNS resolver (queue_head/tail/size modified).
- * @param[in] req Request to append (req->queue_next set to NULL).
- *
- * @threadsafe No - requires exclusive access via dns->mutex.
- *
- *  Usage Example
- *
- * @code{.c}
- * pthread_mutex_lock(&dns->mutex);
- * if (check_queue_limit(dns)) {
- *     // Reject or queue overflow handling
- *     pthread_mutex_unlock(&dns->mutex);
- *     return;
- * }
- * hash_table_insert(dns, req);
- * queue_append(dns, req);
- * pthread_cond_broadcast(&dns->queue_cond);  // Wake workers
- * pthread_mutex_unlock(&dns->mutex);
- * @endcode
- *
- * @complexity O(1) - direct pointer updates, no traversal.
- *
- * @note FIFO ensures fair processing order for submitted requests.
- * @note Called only from submit_dns_request() under lock.
- *
- * @warning Invalid if called without holding dns->mutex (race conditions).
- * @warning req must not already be in queue or hash table.
- *
- * @see queue_remove() for removal operations.
- * @see check_queue_limit() for capacity check before append.
- * @see submit_dns_request() coordinating insert + append + signal.
- * @see dequeue_request() for head removal by workers.
- */
-
-/**
- * @brief Remove request from queue head position.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to remove (must be at queue head).
- *
- * Optimized removal when request is at queue head.
- */
 extern void remove_from_queue_head (struct SocketDNS_T *dns,
                                     struct SocketDNS_Request_T *req);
-
-/**
- * @brief Remove request from middle of queue.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to remove (not at head).
- *
- * Traverses queue to find and remove request from middle.
- */
 extern void remove_from_queue_middle (struct SocketDNS_T *dns,
                                       struct SocketDNS_Request_T *req);
-
-/**
- * @brief Remove request from processing queue.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to remove.
- *
- * Dispatches to head or middle removal based on position.
- */
 extern void queue_remove (struct SocketDNS_T *dns,
                           struct SocketDNS_Request_T *req);
-
-/**
- * @brief Check if queue has reached capacity limit.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @return 1 if at limit, 0 if can accept more requests.
- *
- * Compares current queue size against max_pending limit.
- */
 extern int check_queue_limit (const struct SocketDNS_T *dns);
-
-/**
- * @brief Submit request for processing by worker threads.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to submit.
- *
- * Inserts into hash table and queue, then signals workers.
- */
 extern void submit_dns_request (struct SocketDNS_T *dns,
                                 struct SocketDNS_Request_T *req);
-
-/**
- * @brief Cancel a pending request before it starts processing.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to cancel.
- *
- * Removes from queue and hash table, marks as cancelled.
- */
 extern void cancel_pending_request (struct SocketDNS_T *dns,
                                     struct SocketDNS_Request_T *req);
 
 /* Timeout handling */
-
-/**
- * @brief Get effective timeout for request (with fallback to default).
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to check.
- * @return Effective timeout in milliseconds.
- *
- * Returns req->timeout_override_ms if >= 0, otherwise dns->request_timeout_ms.
- */
 extern int
 request_effective_timeout_ms (const struct SocketDNS_T *dns,
                               const struct SocketDNS_Request_T *req);
-
-/**
- * @brief Check if request has exceeded its timeout.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to check.
- * @return 1 if timed out, 0 if still within timeout.
- *
- * Compares elapsed time since submission against effective timeout.
- *
- * @see @ref foundation::SocketTimer "SocketTimer" for timer management
- * utilities.
- */
 extern int request_timed_out (const struct SocketDNS_T *dns,
                               const struct SocketDNS_Request_T *req);
-
-/**
- * @brief Mark request as timed out with appropriate error code.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to mark as timed out.
- *
- * Sets state to REQ_COMPLETE, error to EAI_NONAME, and clears result.
- */
 extern void mark_request_timeout (struct SocketDNS_T *dns,
                                   struct SocketDNS_Request_T *req);
-
-/**
- * @brief Handle timeout for a specific request.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request that has timed out.
- *
- * Calls mark_request_timeout() and signals completion.
- */
 extern void handle_request_timeout (struct SocketDNS_T *dns,
                                     struct SocketDNS_Request_T *req);
 
 /* Worker thread and resolution */
-
-/**
- * @brief Initialize addrinfo hints structure with defaults.
- * @ingroup dns
- * @param hints Hints structure to initialize.
- *
- * Sets AF_UNSPEC, SOCK_STREAM, and AI_NUMERICSERV flags.
- */
 extern void initialize_addrinfo_hints (struct addrinfo *hints);
-
-/**
- * @brief Main worker thread function for DNS resolution.
- * @ingroup dns
- * @param arg Pointer to SocketDNS_T instance.
- * @return NULL (threads run until shutdown).
- *
- * Worker thread main loop: wait for requests, process them, repeat.
- * Handles shutdown signaling gracefully.
- */
 extern void *worker_thread (void *arg);
-
-/**
- * @brief Prepare addrinfo hints for specific request.
- * @ingroup dns
- * @param local_hints Output hints structure.
- * @param base_hints Base hints to copy from.
- * @param req Request providing port/service information.
- *
- * Copies base hints and sets port from request.
- */
 extern void prepare_local_hints (struct addrinfo *local_hints,
                                  const struct addrinfo *base_hints,
                                  const struct SocketDNS_Request_T *req);
-
-/**
- * @brief Handle result of DNS resolution attempt.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request that was resolved.
- * @param result Resolution result (NULL on error).
- * @param res Error code from getaddrinfo().
- *
- * Updates request state, stores result, and signals completion.
- */
 extern void handle_resolution_result (struct SocketDNS_T *dns,
                                       struct SocketDNS_Request_T *req,
                                       struct addrinfo *result, int res);
-
-/**
- * @brief Process a single DNS request from the queue.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to process.
- * @param base_hints Base addrinfo hints for resolution.
- *
- * Performs DNS resolution using getaddrinfo() with timeout checking.
- * Updates request state and signals completion on finish.
- */
 extern void process_single_request (struct SocketDNS_T *dns,
                                     struct SocketDNS_Request_T *req,
                                     const struct addrinfo *base_hints);
-
-/**
- * @brief Remove and return next request from processing queue.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @return Next request to process, or NULL if queue empty.
- *
- * Removes from queue head and updates queue_size counter.
- */
 extern struct SocketDNS_Request_T *dequeue_request (struct SocketDNS_T *dns);
-
-/**
- * @brief Wait for a request to become available in the queue.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @return Next request to process.
- *
- * Blocks until request available or shutdown signaled.
- */
 extern struct SocketDNS_Request_T *wait_for_request (struct SocketDNS_T *dns);
-
-/**
- * @brief Signal completion of DNS request to waiting threads/polls.
- * @ingroup dns
- * @param dns DNS resolver instance.
- *
- * Writes completion byte to pipe for SocketPoll integration.
- */
 extern void signal_completion (struct SocketDNS_T *dns);
-
-/**
- * @brief Store DNS resolution result in request structure.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Request to update.
- * @param result Resolution result (NULL on error).
- * @param error Error code (0 on success).
- *
- * Updates request state to REQ_COMPLETE and stores result/error.
- */
 extern void store_resolution_result (struct SocketDNS_T *dns,
                                      struct SocketDNS_Request_T *req,
                                      struct addrinfo *result, int error);
-
-/**
- * @brief Get error code indicating request was cancelled.
- * @ingroup dns
- * @return Error code for cancelled requests.
- *
- * Returns EAI_NONAME as cancellation indicator.
- */
 extern int dns_cancellation_error (void);
-
-/**
- * @brief Perform actual DNS resolution using getaddrinfo().
- * @ingroup dns
- * @param req Request containing hostname and port.
- * @param hints addrinfo hints for resolution.
- * @param result Output parameter for result.
- * @return 0 on success, getaddrinfo error code on failure.
- *
- * Calls getaddrinfo() with hostname and service from request.
- */
 extern int perform_dns_resolution (const struct SocketDNS_Request_T *req,
                                    const struct addrinfo *hints,
                                    struct addrinfo **result);
-
-/**
- * @brief Invoke user callback for completed request.
- * @ingroup dns
- * @param dns DNS resolver instance.
- * @param req Completed request with result.
- *
- * Calls req->callback with request, result, error, and user data.
- * Callback executes in worker thread context.
- */
 extern void invoke_callback (struct SocketDNS_T *dns,
                              struct SocketDNS_Request_T *req);
 
-/*
- * =============================================================================
- * Forward Declarations - SocketDNS.c
- *
- * Validation functions used by both public API and internal implementation.
- * =============================================================================
- */
-
-/* Validation */
-
-/**
- * @brief Validate hostname and port parameters for DNS resolution.
- * @ingroup dns
- * @param host Hostname string to validate.
- * @param port Port number to validate.
- *
- * Validates that host is non-NULL, non-empty, and port is in valid range
- * (1-65535). Raises SocketDNS_Failed exception on invalid parameters.
- */
+/* Forward Declarations - SocketDNS.c */
 extern void validate_resolve_params (const char *host, int port);
-
 extern struct SocketDNS_T *allocate_dns_resolver (void);
 
 #endif /* SOCKETDNS_PRIVATE_INCLUDED */

--- a/include/dns/SocketDNS.h
+++ b/include/dns/SocketDNS.h
@@ -98,60 +98,6 @@
  * @{
  */
 
-/**
- * @file SocketDNS.h
- * @ingroup dns
- * @brief Asynchronous DNS resolution API for non-blocking network
- * applications.
- *
- * Header for the SocketDNS module providing thread-pool based async
- * getaddrinfo() replacement. Eliminates blocking DNS lookups that can hang
- * applications for 30+ seconds, with built-in DoS protection, timeout
- * guarantees, and SocketPoll integration.
- *
- * ## Features
- *
- * - Async resolution via worker threads (no main thread block)
- * - Callback or polling completion modes
- * - Bounded queue to prevent memory exhaustion DoS
- * - Per-request and default timeouts
- * - Sync wrapper with guaranteed timeout
- * - Thread-safe; integrates with event loops
- *
- * ## Typical Usage Patterns
- *
- * ### Async with Callback
- * Submit requests; callback handles result in worker thread (thread-safe impl
- * required).
- *
- * ### Async Polling
- * Submit, monitor pollfd, drain check(), fetch results.
- *
- * ### Sync with Timeout
- * Use resolve_sync for blocking but protected calls.
- *
- * ## Platform Requirements
- *
- * - POSIX threads (pthreads)
- * - getaddrinfo(3) support
- * - CLOCK_MONOTONIC for timeouts
- * - Unix-like pipe for signaling
- *
- * ## Related Headers
- *
- * - core/Except.h: Exception handling
- * - core/Arena.h: Internal memory (opaque)
- * - poll/SocketPoll.h: Event integration
- * - socket/SocketCommon.h: Address utils
- *
- * @see @defgroup dns for module overview.
- * @see SocketDNS_new() initialization.
- * @see SocketDNS_resolve() core async API.
- * @see docs/ASYNC_IO.md detailed async patterns.
- * @see docs/SECURITY.md DoS protections.
- * @see docs/ERROR_HANDLING.md error codes.
- */
-
 #define T SocketDNS_T
 /**
  * @brief Opaque type for DNS resolver instances.
@@ -169,11 +115,6 @@ typedef struct SocketDNS_Request_T SocketDNS_Request_T;
  * @ingroup dns
  */
 typedef SocketDNS_Request_T *Request_T;
-
-/* ============================================================================
- * Exception Types
- * ============================================================================
- */
 
 /**
  * @brief DNS resolution operation failure exception.
@@ -237,86 +178,15 @@ typedef void (*SocketDNS_Callback) (SocketDNS_Request_T *req,
  * @ingroup dns
  *
  * Initializes a thread pool-based DNS resolver that offloads getaddrinfo()
- * calls to worker threads, preventing blocking in the main application thread.
- * Supports both callback and polling modes for completion notification, with
- * built-in DoS protection via queue limits and timeouts.
+ * calls to worker threads. Supports callback and polling completion modes
+ * with DoS protection via queue limits and timeouts.
  *
- * The resolver allocates an internal Arena for memory management, creates
- * synchronization primitives (mutex, condition variables, completion pipe),
- * and spawns worker threads. Default configuration:
+ * @return New DNS resolver instance.
+ * @throws SocketDNS_Failed on allocation/thread/pipe initialization failure.
+ * @threadsafe Yes.
  *
- * ## Default Configuration
- *
- * | Setting | Value | Description |
- * |---------|-------|-------------|
- * | num_workers | SOCKET_DNS_DEFAULT_NUM_WORKERS | Typically # of CPU cores |
- * | max_pending | SOCKET_DNS_MAX_PENDING | Default 1000 queued requests |
- * | timeout_ms | SOCKET_DNS_DEFAULT_TIMEOUT_MS | Default 5000ms per request |
- *
- * Edge cases:
- * - Thread creation failure (e.g., system limits): raises SocketDNS_Failed
- * - Pipe creation failure: raises SocketDNS_Failed
- * - Arena allocation failure: raises SocketDNS_Failed
- *
- * @return New DNS resolver instance or NULL on failure (check exception).
- *
- * @throws SocketDNS_Failed on memory allocation failure, mutex/pipe/thread
- * initialization errors, or worker startup issues. Common causes: EMFILE (too
- * many files), EAGAIN (resources exhausted).
- *
- * @threadsafe Yes - creates independent instance; safe from any thread.
- *
- * ## Basic Usage
- *
- * @code{.c}
- * SocketDNS_T dns = SocketDNS_new();
- * if (!dns) {
- *     // Handle failure (exception already raised via TRY/EXCEPT if used)
- *     return -1;
- * }
- *
- * // Configure optional settings
- * SocketDNS_settimeout(dns, 3000);  // 3s timeout
- * SocketDNS_setmaxpending(dns, 500); // Limit queue to 500
- *
- * // Submit resolutions...
- * SocketDNS_resolve(dns, "example.com", 443, callback, userdata);
- *
- * SocketDNS_free(&dns);
- * @endcode
- *
- * ## With Exception Handling
- *
- * @code{.c}
- * TRY {
- *     SocketDNS_T dns = SocketDNS_new();
- *     SocketDNS_Request_T req = SocketDNS_resolve(dns, host, port, NULL,
- * NULL); // Polling mode
- *     // Wait or poll for completion...
- * } EXCEPT(SocketDNS_Failed) {
- *     SOCKET_LOG_ERROR_MSG("DNS init or resolve failed: %s",
- * Socket_GetLastError());
- *     // Cleanup resources...
- * } END_TRY;
- * @endcode
- *
- * @note Worker threads are created immediately and run indefinitely until
- * SocketDNS_free(). Use SocketDNS_setmaxpending() to limit memory usage under
- * high load.
- * @warning Do not call SocketDNS_new() from signal handlers or
- * non-async-signal-safe contexts.
- *
- * @complexity O(num_workers) - time for thread creation and startup; space
- * O(num_workers * stack_size)
- *
- * @see SocketDNS_free() for resource cleanup and shutdown.
- * @see SocketDNS_settimeout() for configuring timeouts.
- * @see SocketDNS_setmaxpending() for queue limits.
+ * @see SocketDNS_free() for cleanup.
  * @see SocketDNS_resolve() for submitting requests.
- * @see SocketDNS_resolve_sync() for synchronous alternative.
- * @see docs/ASYNC_IO.md for thread pool details.
- * @see docs/SECURITY.md for DoS protection via limits.
- * @see docs/ERROR_HANDLING.md for failure diagnosis.
  */
 extern T SocketDNS_new (void);
 
@@ -324,72 +194,16 @@ extern T SocketDNS_new (void);
  * @brief Dispose of DNS resolver and release all resources.
  * @ingroup dns
  *
- * Gracefully shuts down the DNS resolver: signals workers to stop, cancels
- * pending requests, drains the completion pipe, joins worker threads, and
- * frees internal resources (arena, mutex, pipe, etc.). Ensures no resource
- * leaks or zombie threads.
- *
- * Pending requests receive EAI_CANCELED error and are removed. Completed but
- * unretrieved results are discarded (potential leak if not fetched via
- * getresult before free). In-progress requests complete or cancel based on
- * state.
- *
- * Safe to call on NULL pointer (no-op). Concurrent resolutions may race: some
- * may complete post-free if not synchronized.
+ * Signals workers to stop, cancels pending requests, drains completion pipe,
+ * joins threads, and frees all internal resources. Safe to call on NULL.
  *
  * @param[in,out] dns Pointer to resolver instance (set to NULL on success).
+ * @threadsafe Conditional - ensure no concurrent resolve/getresult calls.
  *
- * @return void
- *
- * @throws None - fails silently on errors (logs warnings); already-freed or
- * NULL handled gracefully.
- *
- * @threadsafe Conditional - safe if no concurrent
- * SocketDNS_resolve()/getresult() calls; may leak unretrieved results under
- * race conditions. Recommend drain pending before free.
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Basic cleanup
- * SocketDNS_free(&dns);
- *
- * // With pending drain
- * while (SocketDNS_check(dns) > 0) { // Drain completions
- *     // Optionally fetch results for tracked requests
- * }
- * SocketDNS_free(&dns);
- * @endcode
- *
- * ## Safe Shutdown Pattern
- *
- * @code{.c}
- * TRY {
- *     // ... use dns ...
- * } FINALLY {
- *     // Cancel tracked requests
- *     for each pending req: SocketDNS_cancel(dns, req);
- *     // Drain pipe
- *     SocketDNS_check(dns);
- *     SocketDNS_free(&dns);
- * } END_TRY;
- * @endcode
- *
- * @note Worker threads joined; completion pipe closed. All Request_T handles
- * invalid post-free.
- * @warning Unretrieved completed results lost (memory leak). Always fetch or
- * cancel before free.
- * @note Logs warnings on shutdown errors (e.g., pthread_join timeout); does
- * not raise exceptions.
- *
- * @complexity O(pending + num_workers) - cancel/drain/join time
+ * @warning Unretrieved completed results are lost. Drain pending before free.
  *
  * @see SocketDNS_new() for paired creation.
- * @see SocketDNS_cancel() for explicit request cleanup.
  * @see SocketDNS_check() for draining before shutdown.
- * @see SocketDNS_getresult() to retrieve pending results.
- * @see docs/MEMORY_MANAGEMENT.md for resource lifecycle.
- * @see docs/ASYNC_IO.md for shutdown in event loops.
  */
 extern void SocketDNS_free (T *dns);
 
@@ -397,122 +211,22 @@ extern void SocketDNS_free (T *dns);
  * @brief Start asynchronous DNS resolution.
  * @ingroup dns
  *
- * Submits a DNS resolution request to the thread pool for non-blocking
- * processing. Supports IP addresses (fast-path, no lookup), hostnames (async
- * getaddrinfo()), and wildcard binds (AI_PASSIVE flag). Queue protected by
- * mutex; workers process in FIFO order.
+ * Submits a DNS resolution request to the thread pool. Supports callback mode
+ * (provide callback) or polling mode (NULL callback, use pollfd/check/getresult).
  *
- * Two completion modes:
- * - **Callback**: Provide callback; invoked from worker thread on
- * completion/cancel/timeout.
- * - **Polling**: NULL callback; monitor SocketDNS_pollfd() via SocketPoll,
- * drain with check().
- *
- * Validation: Hostname RFC 1123 compliant; port 0-65535 (0=no service lookup).
- * IP addresses bypass workers for instant "resolution". Queue full raises
- * exception (DoS protection).
- *
- * Request lifecycle: Valid until result fetched, cancelled, or resolver freed.
- * Per-request timeout override via SocketDNS_request_settimeout() post-submit.
- *
- * @param[in] dns Resolver instance (validated non-NULL).
- * @param[in] host Hostname/IP or NULL (wildcard bind, sets AI_PASSIVE).
- * @param[in] port Port (0-65535; 0 omits service resolution in hints).
+ * @param[in] dns Resolver instance.
+ * @param[in] host Hostname/IP or NULL (wildcard bind).
+ * @param[in] port Port (0-65535).
  * @param[in] callback Completion callback or NULL (polling mode).
- * @param[in] data Opaque user data passed to callback (ignored if NULL
- * callback).
+ * @param[in] data User data passed to callback.
+ * @return Request handle.
+ * @throws SocketDNS_Failed on invalid params, queue full, or allocation failure.
+ * @threadsafe Yes.
  *
- * @return Valid Request_T handle (never NULL on success).
+ * @warning Callbacks run in worker threads - must be thread-safe.
  *
- * @throws SocketDNS_Failed on invalid params (bad host/port), queue full
- * (max_pending exceeded), allocation failure, or resolver invalid. Use
- * TRY/EXCEPT for handling.
- *
- * @threadsafe Yes - internal mutex serializes queue/hash operations.
- *
- * ## Error Codes from getaddrinfo()
- *
- * | Code | Meaning | Retryable |
- * |------|---------|-----------|
- * | 0 | Success | - |
- * | EAI_AGAIN | Temporary failure (server busy/DNS down) | Yes |
- * | EAI_NONAME | Host not found | No |
- * | EAI_FAIL | Non-recoverable failure | No |
- * | EAI_SYSTEM | System error (errno details) | Depends on errno |
- * | EAI_CANCELED | User cancelled | No (retry new request) |
- *
- * ## Callback Mode Usage
- *
- * @code{.c}
- * static void my_dns_callback(SocketDNS_Request_T *req, struct addrinfo *res,
- *                             int err, void *data) {
- *     if (err == 0 && res) {
- *         // Use res (caller owns; freeaddrinfo(res))
- *         connect_via_addrinfo((MyContext*)data, res);
- *         freeaddrinfo(res);
- *     } else {
- *         // Handle error (retry logic based on err)
- *         SOCKET_LOG_WARN_MSG("DNS failed for %s: %s", req->host,
- * gai_strerror(err));
- *     }
- *     // Do NOT free req; owned by resolver
- * }
- *
- * // Submit
- * SocketDNS_Request_T *req = SocketDNS_resolve(dns, "api.example.com", 443,
- *                                              my_dns_callback, ctx);
- * @endcode
- *
- * ## Polling Mode Usage (Event Loop)
- *
- * @code{.c}
- * // Track requests in application state
- * struct PendingDNS { SocketDNS_Request_T *req; void *userdata; };
- * PendingDNS pending[] = {...};
- *
- * // Submit
- * pending[i].req = SocketDNS_resolve(dns, host, port, NULL, NULL);
- * pending[i].userdata = ctx;
- *
- * // In event loop
- * int fd = SocketDNS_pollfd(dns);
- * SocketPoll_add(poll, fd, POLL_READ, NULL);
- *
- * // On POLL_READ event
- * int drained = SocketDNS_check(dns);
- * for (int j = 0; j < drained; j++) { // But actually check specific reqs
- *     for each tracked req:
- *         struct addrinfo *res = SocketDNS_getresult(dns, req);
- *         if (res) {
- *             int err = SocketDNS_geterror(dns, req);
- *             if (err == 0) {
- *                 // Success: use res
- *             } else {
- *                 // Error: handle
- *             }
- *             freeaddrinfo(res);
- *             // Remove from tracked
- *         }
- * }
- * @endcode
- *
- * @note Fast-path for IPs/NULL host: may complete synchronously before return.
- * @warning Callbacks run in workers: thread-safe impl required; no blocking
- * ops; own res immediately.
- * @note Request handle invalid post-result/cancel/free; do not store
- * long-term.
- *
- * @complexity O(1) average - queue append + hash insert; O(n) worst hash
- * collision.
- *
- * @see SocketDNS_Callback detailed safety rules and ownership.
- * @see SocketDNS_cancel() for aborting requests.
- * @see SocketDNS_request_settimeout() per-request timeout override.
- * @see SocketDNS_getresult() and SocketDNS_geterror() for polling retrieval.
- * @see SocketDNS_pollfd() and SocketDNS_check() for event integration.
- * @see docs/ASYNC_IO.md worker threads and callback patterns.
- * @see docs/SECURITY.md queue limits for DoS mitigation.
- * @see docs/ERROR_HANDLING.md getaddrinfo error categorization.
+ * @see SocketDNS_Callback for callback safety rules.
+ * @see SocketDNS_pollfd() and SocketDNS_check() for polling mode.
  */
 extern Request_T SocketDNS_resolve (T dns, const char *host, int port,
                                     SocketDNS_Callback callback, void *data);
@@ -575,69 +289,17 @@ extern int SocketDNS_gettimeout (T dns);
 extern void SocketDNS_settimeout (T dns, int timeout_ms);
 
 /**
- * @brief Get file descriptor for integration with SocketPoll (completion
- * notifications).
+ * @brief Get file descriptor for integration with SocketPoll.
  * @ingroup dns
  *
- * Provides the read end of the internal completion pipe (or eventfd on some
- * platforms). Becomes readable (POLL_READ/POLLIN) when one or more requests
- * complete, cancel, or timeout. Designed for edge/level-triggered event loops;
- * multiple events coalesced into one signal.
- *
- * FD lifetime: Valid from SocketDNS_new() to SocketDNS_free(); closed during
- * shutdown. Post-free: Invalid; polling returns error or EOF.
+ * Returns the read end of the completion pipe. Becomes readable when requests
+ * complete, cancel, or timeout. Use with SocketPoll for event loop integration.
  *
  * @param[in] dns Resolver instance.
- * @return Valid FD (>=0) or -1 (NULL dns or shutdown state).
+ * @return Valid FD (>=0) or -1 on error.
+ * @threadsafe Yes.
  *
- * @throws None.
- *
- * @threadsafe Yes - atomic read of stable FD value; no mutex needed.
- *
- * ## Event Loop Integration
- *
- * @code{.c}
- * // Setup
- * int dns_fd = SocketDNS_pollfd(dns);
- * if (dns_fd >= 0) {
- *     SocketPoll_add(poll, dns_fd, POLL_READ, dns_userdata);
- * }
- *
- * // In poll loop
- * int n_events = SocketPoll_wait(poll, events, timeout);
- * for (int i = 0; i < n_events; i++) {
- *     if (events[i].socket == dns_fd && (events[i].events & POLL_READ)) {
- *         int drained = SocketDNS_check(dns);
- *         SOCKET_LOG_DEBUG_MSG("DNS: drained %d completions", drained);
- *         // Now check tracked requests for results
- *         process_dns_completions(dns, tracked_requests);
- *     }
- * }
- * @endcode
- *
- * ## Best Practices
- *
- * - **Drain Fully**: Call SocketDNS_check() in loop until EAGAIN to handle
- * coalesced signals.
- * - **Edge-Triggered**: Safe; but level-triggered requires full drain to clear
- * POLL_READ.
- * - **Error Handling**: On POLLERR/POLLHUP: check resolver state; likely
- * shutdown.
- * - **High Load**: Buffer pipe reads prevent overflow (internal buffering
- * limited).
- *
- * @note Not a socket FD; do not close() or use socket ops; only poll/read via
- * check().
- * @warning Do not block on read(); SocketDNS_check() is non-blocking.
- * @note Multiple resolvers: separate FD per instance; aggregate in one poll.
- *
- * @complexity O(1) - simple FD return.
- *
- * @see SocketPoll_add() for registering the FD.
- * @see SocketDNS_check() for draining signals post-event.
- * @see SocketEvent_T for poll events structure.
- * @see docs/ASYNC_IO.md event loop patterns with pipes.
- * @see docs/POLL.md cross-platform polling notes.
+ * @see SocketDNS_check() for draining signals.
  */
 extern int SocketDNS_pollfd (T dns);
 
@@ -660,83 +322,18 @@ extern int SocketDNS_pollfd (T dns);
 extern int SocketDNS_check (T dns);
 
 /**
- * @brief Retrieve completed DNS resolution result, transferring ownership to
- * caller.
+ * @brief Retrieve completed DNS resolution result.
  * @ingroup dns
  *
- * Fetches addrinfo for completed requests in polling mode (no callback).
- * Performs ownership transfer: clears internal result pointer, removes request
- * from hash table, invalidates handle. Callback mode returns NULL (result
- * already transferred to callback).
- *
- * NULL return conditions:
- * - Request pending/processing (call after SocketDNS_check() signals).
- * - Cancelled (use SocketDNS_geterror() for EAI_CANCELED).
- * - Failed resolution (error code via geterror()).
- * - Invalid handle or ownership mismatch (cross-resolver).
- * - Callback mode (result consumed by callback).
- *
- * Security: Validates ownership via back-pointer to prevent corruption from
- * invalid handles.
+ * Fetches addrinfo for completed polling-mode requests. Transfers ownership
+ * to caller and invalidates the request handle.
  *
  * @param[in] dns Resolver owning the request.
- * @param[in] req Request handle from this resolver's SocketDNS_resolve().
+ * @param[in] req Request handle.
+ * @return addrinfo chain (caller must freeaddrinfo()) or NULL if pending/failed.
+ * @threadsafe Yes.
  *
- * @return addrinfo chain (caller owns; free with freeaddrinfo()) or NULL (see
- * conditions).
- *
- * @throws None - returns NULL on invalid/pending; logs debug warnings.
- *
- * @threadsafe Yes - acquires mutex for hash lookup and transfer.
- *
- * ## Polling Completion Pattern
- *
- * @code{.c}
- * // After SocketDNS_check(dns) > 0
- * struct addrinfo *res = SocketDNS_getresult(dns, tracked_req);
- * if (res) {
- *     int err = SocketDNS_geterror(dns, tracked_req);
- *     if (err == 0) {
- *         // Success: use res for connect/bind/etc.
- *         Socket_T sock = Socket_new_from_addrinfo(res); // Example helper
- *         // ... connect or bind ...
- *         freeaddrinfo(res);
- *     } else {
- *         // Failure: err from getaddrinfo()
- *         SOCKET_LOG_ERROR_MSG("DNS error %d: %s", err, gai_strerror(err));
- *     }
- *     // req now invalid; remove from tracking
- * } // else still pending or invalid
- * @endcode
- *
- * ## Error Check Always
- *
- * Always pair with SocketDNS_geterror() even on non-NULL res (paranoia):
- *
- * @code{.c}
- * struct addrinfo *res = SocketDNS_getresult(dns, req);
- * int err = SocketDNS_geterror(dns, req);
- * if (res && err == 0) {
- *     // Valid success
- * } else {
- *     // Handle error or pending (NULL res)
- * }
- * @endcode
- *
- * @note Ownership transfer semantics: Caller MUST freeaddrinfo() on success.
- * @warning Invalid req/dns mismatch: Silent NULL (no crash, but debug log).
- * @note Post-call: req invalid; do not reuse or pass to other functions.
- * @note Callback mode: Always NULL; use callback for result.
- *
- * @complexity O(1) average - hash lookup; O(n) worst collision chain.
- *
- * @see freeaddrinfo() required cleanup (or SocketCommon_free_addrinfo()
- * wrapper).
- * @see SocketDNS_geterror() mandatory error check.
- * @see SocketDNS_resolve() polling mode (NULL callback).
- * @see SocketDNS_cancel() alternative for pending.
- * @see docs/MEMORY_MANAGEMENT.md addrinfo ownership.
- * @see docs/ERROR_HANDLING.md getaddrinfo codes.
+ * @see SocketDNS_geterror() for error code on failure.
  */
 extern struct addrinfo *SocketDNS_getresult (T dns, Request_T req);
 
@@ -794,68 +391,27 @@ extern Request_T
 SocketDNS_create_completed_request (T dns, struct addrinfo *result, int port);
 
 /**
- * @brief Synchronous DNS resolution with optional timeout guarantee.
+ * @brief Synchronous DNS resolution with timeout guarantee.
  * @ingroup dns
  *
- * Performs blocking DNS resolution with configurable timeout when using a
- * resolver instance. For NULL dns, falls back to direct getaddrinfo() (no
- * timeout protection - use with caution). Internal: Uses async machinery for
- * timeout enforcement via worker + condvar wait.
+ * Performs blocking DNS resolution with configurable timeout. Uses async
+ * machinery internally to enforce timeout, preventing unbounded blocking.
  *
- * Ideal for cases needing simple blocking call but with DoS protection
- * (timeout). IP addresses resolve instantly. Handles hints for
- * family/type/protocol prefs.
- *
- * Timeout: 0 = resolver default or infinite (NULL dns). Negative sanitized.
- * Throws on timeout (SocketDNS_Failed with timeout message) or resolution
- * error.
- *
- * @param[in] dns Resolver for timeout/queue (NULL = direct getaddrinfo, no
- * timeout).
- * @param[in] host Host/IP or NULL (AI_PASSIVE wildcard).
- * @param[in] port Port (appended to hints.ai_addr if resolved).
- * @param[in] hints getaddrinfo hints or NULL (defaults: AF_UNSPEC,
- * SOCK_STREAM, AI_ADDRCONFIG|AI_V4MAPPED).
- * @param[in] timeout_ms Max wait ms (0=use dns default/infinite; ignored for
- * NULL dns).
- *
- * @return Allocated addrinfo (free with freeaddrinfo()) or NULL + exception on
- * failure.
- *
- * @throws SocketDNS_Failed on resolution failure, timeout, invalid params, or
- * internal error. For NULL dns: Raw getaddrinfo errors wrapped as Failed.
- *
- * @threadsafe Yes - mutex for shared state; condvar wait atomic.
- *
- * This function provides synchronous DNS resolution with GUARANTEED timeout.
- * Unlike raw getaddrinfo() which can block for 30+ seconds, this function
- * uses the async DNS worker thread pool internally and enforces the specified
- * timeout using condition variable wait.
- *
- * Use this function when you need blocking DNS resolution but cannot afford
- * unbounded blocking time (e.g., in network servers handling untrusted input).
- *
- * For IP addresses, resolution is instant (no DNS lookup needed).
- *
- * Usage:
- *   struct addrinfo *res = SocketDNS_resolve_sync(dns, "example.com", 80,
- *                                                  NULL, 5000);
- *   // Use res...
- *   freeaddrinfo(res);
+ * @param[in] dns Resolver (NULL = direct getaddrinfo, no timeout protection).
+ * @param[in] host Host/IP or NULL (wildcard bind).
+ * @param[in] port Port number.
+ * @param[in] hints getaddrinfo hints or NULL for defaults.
+ * @param[in] timeout_ms Max wait (0 = use resolver default).
+ * @return addrinfo (caller must freeaddrinfo()).
+ * @throws SocketDNS_Failed on resolution failure or timeout.
+ * @threadsafe Yes.
  *
  * @see SocketDNS_resolve() for asynchronous resolution.
- * @see @ref foundation for arena allocation patterns.
- * @see @ref dns for asynchronous DNS resolution overview.
  */
 extern struct addrinfo *SocketDNS_resolve_sync (T dns, const char *host,
                                                 int port,
                                                 const struct addrinfo *hints,
                                                 int timeout_ms);
-
-/* ============================================================================
- * DNS Cache Control
- * ============================================================================
- */
 
 /**
  * @brief Cache statistics structure.
@@ -1027,11 +583,6 @@ extern void SocketDNS_cache_set_max_entries (T dns, size_t max_entries);
  * @see SocketDNS_cache_clear() to reset cache.
  */
 extern void SocketDNS_cache_stats (T dns, SocketDNS_CacheStats *stats);
-
-/* ============================================================================
- * DNS Configuration
- * ============================================================================
- */
 
 /**
  * @brief Set IPv6 preference for DNS resolution.


### PR DESCRIPTION
## Summary
- Remove excessive and redundant documentation from DNS header files
- Streamline verbose function documentation while preserving essential info
- Remove duplicate @file block that repeated @defgroup content
- Consolidate internal function prototypes without verbose per-function docs

Fixes #22

## Test plan
- [x] Build passes
- [x] All 70 tests pass with sanitizers enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)