### PR TITLE
refactor: comment cleanup in include/core/

### DIFF
--- a/src/core/Except.c
+++ b/src/core/Except.c
@@ -12,8 +12,6 @@
 
 #include "core/Except.h"
 
- */
-
 /* Mark function as never returning */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define EXCEPT_NORETURN _Noreturn
@@ -39,8 +37,6 @@
 #define EXCEPT_NONNULL(...)
 #endif
 
- */
-
 /* Default string for unknown file locations */
 #define EXCEPT_UNKNOWN_FILE "unknown"
 
@@ -60,8 +56,6 @@
   "This indicates a programming error in exception usage"
 #define EXCEPT_ABORTING_FMT "aborting..."
 
- */
-
 /* Thread-local exception stack - each thread maintains its own */
 #ifdef _WIN32
 __declspec (thread) Except_Frame *Except_stack = NULL;
@@ -69,11 +63,7 @@ __declspec (thread) Except_Frame *Except_stack = NULL;
 __thread Except_Frame *Except_stack = NULL;
 #endif
 
- */
-
 const Except_T Assert_Failed = { &Assert_Failed, "Assertion failed" };
-
- */
 
 static inline void
 except_flush_stderr (void)
@@ -144,7 +134,6 @@ except_finish_abort (void)
   abort ();
 }
 
- */
 
 EXCEPT_COLD static void
 except_validate_not_null (const Except_T *e)
@@ -157,7 +146,6 @@ except_validate_not_null (const Except_T *e)
   except_finish_abort ();
 }
 
- */
 
 EXCEPT_COLD EXCEPT_NORETURN EXCEPT_NONNULL (1)
 static void
@@ -168,8 +156,6 @@ except_abort_uncaught (const Except_T *e, const char *file, int line)
   except_emit_location (file, line);
   except_finish_abort ();
 }
-
- */
 
 EXCEPT_NONNULL (1, 2)
 static inline void
@@ -201,8 +187,6 @@ except_jump_to_handler (Except_Frame *frame)
   /* Cast away volatile - jmp_buf contents already saved by setjmp */
   longjmp (*(jmp_buf *)&frame->env, Except_raised);
 }
-
- */
 
 EXCEPT_NORETURN void
 Except_raise (const Except_T *e, const char *file, int line)

--- a/src/core/HashTable.c
+++ b/src/core/HashTable.c
@@ -15,14 +15,12 @@
 
 #define T HashTable_T
 
- */
 
 const Except_T HashTable_Failed
     = { &HashTable_Failed, "Hash table operation failed" };
 
 SOCKET_DECLARE_MODULE_EXCEPTION (HashTable);
 
- */
 
 struct T
 {
@@ -35,7 +33,6 @@ struct T
   Arena_T arena; /* NULL=malloc */
 };
 
- */
 
 static void
 validate_config (const HashTable_Config *config)
@@ -92,7 +89,6 @@ set_next (T table, void *entry, void *next)
   *next_ptr = next;
 }
 
- */
 
 T
 HashTable_new (Arena_T arena, const HashTable_Config *config)
@@ -148,7 +144,6 @@ HashTable_free (T *table)
   *table = NULL;
 }
 
- */
 
 void *
 HashTable_find (T table, const void *key, void **prev_out)

--- a/src/core/SocketCrypto.c
+++ b/src/core/SocketCrypto.c
@@ -27,7 +27,6 @@
 #include <unistd.h>
 #endif
 
- */
 
 #define WEBSOCKET_KEY_RANDOM_BYTES 16 /* 16 bytes = 128 bits per RFC 6455 */
 #define WEBSOCKET_KEY_BASE64_LEN (SOCKET_CRYPTO_WEBSOCKET_KEY_SIZE - 1)
@@ -36,7 +35,6 @@
 #define BASE64_INVALID_CHAR 255
 #define BASE64_MAX_PADDING 2
 
- */
 
 const Except_T SocketCrypto_Failed
     = { &SocketCrypto_Failed, "Cryptographic operation failed" };
@@ -65,7 +63,6 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketCrypto);
   SOCKET_RAISE_MSG (SocketCrypto, SocketCrypto_Failed,                        \
                     "%s computation failed", name)
 
- */
 
 static const char base64_alphabet[]
     = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
@@ -96,7 +93,6 @@ static const unsigned char base64_decode_table[256] = {
 static const char hex_lower[] = "0123456789abcdef";
 static const char hex_upper[] = "0123456789ABCDEF";
 
- */
 
 #if SOCKET_HAS_TLS
 /* Common EVP digest computation: init, update, final */
@@ -184,7 +180,6 @@ SocketCrypto_md5 (const void *input, size_t input_len,
 #endif
 }
 
- */
 
 void
 SocketCrypto_hmac_sha256 (const void *key, size_t key_len, const void *data,
@@ -234,7 +229,6 @@ SocketCrypto_hmac_sha256 (const void *key, size_t key_len, const void *data,
 #endif
 }
 
- */
 
 size_t
 SocketCrypto_base64_encoded_size (size_t input_len)
@@ -491,7 +485,6 @@ SocketCrypto_base64_decode (const char *input, size_t input_len,
   return (ssize_t)out_pos;
 }
 
- */
 
 void
 SocketCrypto_hex_encode (const void *input, size_t input_len, char *output,
@@ -577,7 +570,6 @@ SocketCrypto_hex_decode (const char *input, size_t input_len,
   return (ssize_t)(input_len / 2);
 }
 
- */
 
 #if !SOCKET_HAS_TLS
 static pthread_mutex_t urand_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -673,7 +665,6 @@ SocketCrypto_cleanup (void)
 #endif
 }
 
- */
 
 int
 SocketCrypto_websocket_accept (
@@ -749,7 +740,6 @@ SocketCrypto_websocket_key (char output[SOCKET_CRYPTO_WEBSOCKET_KEY_SIZE])
   return 0;
 }
 
- */
 
 int
 SocketCrypto_secure_compare (const void *a, const void *b, size_t len)

--- a/src/core/SocketIPTracker.c
+++ b/src/core/SocketIPTracker.c
@@ -26,14 +26,12 @@
 
 #define T SocketIPTracker_T
 
- */
 
 const Except_T SocketIPTracker_Failed
     = { &SocketIPTracker_Failed, "IP tracker operation failed" };
 
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketIPTracker);
 
- */
 
 typedef struct IPEntry
 {
@@ -108,7 +106,6 @@ validate_ip (const char *ip, const char *caller)
   return IP_ADVANCED_INVALID;
 }
 
- */
 
 /* Uses DJB2 string hash with seed for DoS resistance */
 static unsigned
@@ -146,7 +143,6 @@ find_entry (const T tracker, const char *ip, IPEntry **prev_out)
 
   return (IPEntry *)HashTable_find (tracker->table, ip, (void **)prev_out);
 }
- */
 
 static void *
 tracker_alloc_raw (const T tracker, size_t size)
@@ -165,7 +161,6 @@ tracker_free_raw (const T tracker, void *ptr)
     free (ptr);
 }
 
- */
 
 static IPEntry *
 allocate_entry (const T tracker)
@@ -206,7 +201,6 @@ create_and_insert_entry (T tracker, const char *ip, int initial_count)
   return entry;
 }
 
- */
 
 /* O(1) removal with prev pointer, caller must hold mutex */
 static void
@@ -221,7 +215,6 @@ unlink_entry (T tracker, IPEntry *entry, IPEntry *prev)
   tracker_free_raw (tracker, entry);
 }
 
- */
 
 static int
 free_entry_callback (void *entry, void *context)
@@ -238,7 +231,6 @@ free_all_entries (T tracker)
     HashTable_foreach (tracker->table, free_entry_callback, tracker);
 }
 
- */
 
 static T
 allocate_tracker (Arena_T arena)
@@ -334,7 +326,6 @@ cleanup_failed_tracker (T tracker)
     }
 }
 
- */
 
 static bool
 is_unlimited_mode (const T tracker)
@@ -396,7 +387,6 @@ track_internal (T tracker, const char *ip)
   return increment_existing_entry (tracker, entry);
 }
 
- */
 
 T
 SocketIPTracker_new (Arena_T arena, int max_per_ip)

--- a/src/core/SocketMetrics.c
+++ b/src/core/SocketMetrics.c
@@ -19,7 +19,6 @@
 #include "core/SocketMetrics.h"
 #include "core/SocketUtil.h"
 
- */
 
 #define PERCENTILE_P50 50.0
 #define PERCENTILE_P75 75.0
@@ -36,7 +35,6 @@ static const char *const STATSD_PCT_P50 = "p50";
 static const char *const STATSD_PCT_P95 = "p95";
 static const char *const STATSD_PCT_P99 = "p99";
 
- */
 
 #define METRICS_LOG_DEBUG_MSG(fmt, ...)                                       \
   SocketLog_emitf (SOCKET_LOG_DEBUG, "metrics", fmt, ##__VA_ARGS__)
@@ -47,13 +45,11 @@ static const char *const STATSD_PCT_P99 = "p99";
 #define METRICS_LOG_DEBUG(msg) ((void)0)
 #endif
 
- */
 
 #define COUNTER_VALID(m) ((m) >= 0 && (m) < SOCKET_COUNTER_METRIC_COUNT)
 #define GAUGE_VALID(m) ((m) >= 0 && (m) < SOCKET_GAUGE_METRIC_COUNT)
 #define HISTOGRAM_VALID(m) ((m) >= 0 && (m) < SOCKET_HISTOGRAM_METRIC_COUNT)
 
- */
 
 
 typedef struct Histogram
@@ -68,7 +64,6 @@ typedef struct Histogram
   int initialized;
 } Histogram;
 
- */
 
 static _Atomic int metrics_initialized = 0;
 static _Atomic uint64_t counter_values[SOCKET_COUNTER_METRIC_COUNT];
@@ -77,7 +72,6 @@ static Histogram histogram_values[SOCKET_HISTOGRAM_METRIC_COUNT];
 static pthread_mutex_t metrics_global_mutex = PTHREAD_MUTEX_INITIALIZER;
 static _Atomic int peak_socket_count = 0;
 
- */
 
 static const char *const counter_names[SOCKET_COUNTER_METRIC_COUNT] = {
   /* Pool */
@@ -262,7 +256,6 @@ static const char *const histogram_help[SOCKET_HISTOGRAM_METRIC_COUNT] = {
 static const char *const category_names[SOCKET_METRIC_CAT_COUNT]
     = { "pool", "http_client", "http_server", "tls", "dns", "socket", "poll" };
 
- */
 
 static inline int
 histogram_is_valid (SocketHistogramMetric metric)
@@ -272,7 +265,6 @@ histogram_is_valid (SocketHistogramMetric metric)
   return histogram_values[metric].initialized;
 }
 
- */
 
 static int
 compare_double (const void *a, const void *b)
@@ -310,7 +302,6 @@ percentile_from_sorted (const double *sorted, size_t n, double percentile)
   return sorted[lower] * (1.0 - frac) + sorted[upper] * frac;
 }
 
- */
 
 static void
 histogram_init (Histogram *h)
@@ -514,7 +505,6 @@ histogram_reset (Histogram *h)
   atomic_store (&h->count, 0);
 }
 
- */
 
 int
 SocketMetrics_init (void)
@@ -559,7 +549,6 @@ SocketMetrics_shutdown (void)
   METRICS_LOG_DEBUG ("Metrics subsystem shutdown");
 }
 
- */
 
 void
 SocketMetrics_counter_inc (SocketCounterMetric metric)
@@ -585,7 +574,6 @@ SocketMetrics_counter_get (SocketCounterMetric metric)
   return atomic_load (&counter_values[metric]);
 }
 
- */
 
 void
 SocketMetrics_gauge_set (SocketGaugeMetric metric, int64_t value)
@@ -627,7 +615,6 @@ SocketMetrics_gauge_get (SocketGaugeMetric metric)
   return atomic_load (&gauge_values[metric]);
 }
 
- */
 
 void
 SocketMetrics_histogram_observe (SocketHistogramMetric metric, double value)
@@ -691,7 +678,6 @@ SocketMetrics_histogram_snapshot (SocketHistogramMetric metric,
   histogram_fill_snapshot (&histogram_values[metric], snapshot);
 }
 
- */
 
 void
 SocketMetrics_get (SocketMetrics_Snapshot *snapshot)
@@ -759,7 +745,6 @@ SocketMetrics_reset_histograms (void)
     }
 }
 
- */
 
 static size_t
 export_append (char *buffer, size_t buffer_size, size_t *pos, const char *fmt,
@@ -864,7 +849,6 @@ export_histogram_prometheus (char *buffer, size_t buffer_size, size_t *pos,
   export_prometheus_histogram_summary (buffer, buffer_size, pos, name, h);
 }
 
- */
 
 size_t
 SocketMetrics_export_prometheus (char *buffer, size_t buffer_size)
@@ -1080,7 +1064,6 @@ SocketMetrics_export_json (char *buffer, size_t buffer_size)
   return pos;
 }
 
- */
 
 const char *
 SocketMetrics_counter_name (SocketCounterMetric metric)
@@ -1138,7 +1121,6 @@ SocketMetrics_category_name (SocketMetricCategory category)
   return category_names[category];
 }
 
- */
 
 int
 SocketMetrics_get_socket_count (void)

--- a/src/core/SocketRetry.c
+++ b/src/core/SocketRetry.c
@@ -21,7 +21,6 @@
 #include "core/SocketSecurity.h"
 #include "core/SocketUtil.h"
 
- */
 
 #define RETRY_MIN_DELAY_MS 1.0
 #define SOCKET_RETRY_MAX_MULTIPLIER 16.0
@@ -41,7 +40,6 @@ const Except_T SocketRetry_Failed
 
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketRetry);
 
- */
 
 struct T
 {
@@ -50,7 +48,6 @@ struct T
   unsigned int random_state; /* xorshift32 PRNG state */
 };
 
- */
 
 static int
 try_crypto_random (unsigned int *out)
@@ -87,7 +84,6 @@ retry_random_double (unsigned int *state)
   return (double)*state / UINT32_MAX_DOUBLE;
 }
 
- */
 
 void
 SocketRetry_policy_defaults (SocketRetry_Policy *policy)
@@ -134,7 +130,6 @@ validate_policy (const SocketRetry_Policy *policy)
   return 1;
 }
 
- */
 
 /* Compute base^exp iteratively to avoid pow() overhead */
 static double
@@ -261,7 +256,6 @@ SocketRetry_calculate_delay (const SocketRetry_Policy *policy, int attempt)
   return calculate_backoff_delay (policy, attempt, &state);
 }
 
- */
 
 /* Sleep with EINTR handling via nanosleep */
 static void
@@ -284,7 +278,6 @@ retry_sleep_ms (int ms)
     }
 }
 
- */
 
 static unsigned int
 init_random_state (void)
@@ -339,7 +332,6 @@ SocketRetry_free (T *retry)
   *retry = NULL;
 }
 
- */
 
 static void
 reset_retry_stats (T retry)
@@ -408,7 +400,6 @@ perform_single_attempt (T retry, SocketRetry_Operation operation,
   return result;
 }
 
- */
 
 int
 SocketRetry_execute (T retry, SocketRetry_Operation operation,
@@ -450,7 +441,6 @@ SocketRetry_execute_simple (T retry, SocketRetry_Operation operation,
   return SocketRetry_execute (retry, operation, NULL, context);
 }
 
- */
 
 void
 SocketRetry_get_stats (const T retry, SocketRetry_Stats *stats)

--- a/src/core/SocketSYNProtect-ip.c
+++ b/src/core/SocketSYNProtect-ip.c
@@ -13,8 +13,6 @@
 #include <arpa/inet.h>
 #include <string.h>
 
- */
-
 static int
 parse_ipv4_address (const char *ip, uint8_t *addr_bytes)
 {
@@ -84,8 +82,6 @@ ip_addresses_equal (const char *ip1, const char *ip2)
   return memcmp (bytes1, bytes2, cmp_len) == 0;
 }
 
- */
-
 static int
 cidr_full_bytes_match (const uint8_t *ip_bytes, const uint8_t *entry_bytes,
                        int bytes)
@@ -134,8 +130,6 @@ ip_matches_cidr (const char *ip, const SocketSYN_WhitelistEntry *entry)
     return 0;
   return ip_matches_cidr_bytes (family, ip_bytes, entry);
 }
-
- */
 
 /* Compares parsed bytes to prevent bypass via alternate IP formats */
 static int
@@ -232,8 +226,6 @@ whitelist_check (SocketSYNProtect_T protect, const char *ip)
 
   return whitelist_check_all_cidrs_bytes (protect, family, ip_bytes, bucket);
 }
-
- */
 
 void
 remove_ip_entry_from_hash (SocketSYNProtect_T protect, SocketSYN_IPEntry *entry)

--- a/src/core/SocketSYNProtect-list.c
+++ b/src/core/SocketSYNProtect-list.c
@@ -14,8 +14,6 @@
 #include <assert.h>
 #include <stdlib.h>
 
- */
-
 void
 lru_remove (SocketSYNProtect_T protect, SocketSYN_IPEntry *entry)
 {

--- a/src/core/SocketSYNProtect.c
+++ b/src/core/SocketSYNProtect.c
@@ -26,14 +26,12 @@
 
 #define T SocketSYNProtect_T
 
- */
 
 const Except_T SocketSYNProtect_Failed
     = { &SocketSYNProtect_Failed, "SYN protection operation failed" };
 
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketSYNProtect);
 
- */
 
 static const char *const action_names[]
     = { "ALLOW", "THROTTLE", "CHALLENGE", "BLOCK" };
@@ -45,7 +43,6 @@ static const char *const reputation_names[]
 #define REPUTATION_NAMES_COUNT                                                \
   (sizeof (reputation_names) / sizeof (reputation_names[0]))
 
- */
 
 /* Generate fallback seed from multiple entropy sources */
 static unsigned
@@ -77,7 +74,6 @@ synprotect_get_fallback_seed (void)
   return seed;
 }
 
- */
 
 static void
 safe_copy_ip (char *dest, const char *src)
@@ -85,7 +81,6 @@ safe_copy_ip (char *dest, const char *src)
   socket_util_safe_copy_ip (dest, src, SOCKET_IP_MAX_LEN);
 }
 
- */
 
 static void *
 alloc_zeroed (T protect, size_t count, size_t size)
@@ -97,7 +92,6 @@ alloc_zeroed (T protect, size_t count, size_t size)
 
 
 
- */
 
 static void
 lru_push_front (T protect, SocketSYN_IPEntry *entry)
@@ -123,7 +117,6 @@ lru_touch (T protect, SocketSYN_IPEntry *entry)
     }
 }
 
- */
 
 static SocketSYN_IPEntry *
 find_ip_entry (T protect, const char *ip)
@@ -213,7 +206,6 @@ get_or_create_ip_entry (T protect, const char *ip, int64_t now_ms)
   return create_ip_entry (protect, ip, now_ms);
 }
 
- */
 
 static void
 rotate_window_if_needed (SocketSYN_IPState *state, int64_t now_ms,
@@ -268,7 +260,6 @@ calculate_effective_attempts (const SocketSYN_IPState *state, int64_t now_ms,
          + (uint32_t)(state->attempts_previous * previous_weight);
 }
 
- */
 
 static void
 apply_score_decay (SocketSYN_IPState *state,
@@ -327,7 +318,6 @@ reward_success (SocketSYN_IPState *state,
   update_reputation_from_score (state, config);
 }
 
- */
 
 static int
 is_currently_blocked (const SocketSYN_IPState *state, int64_t now_ms)
@@ -358,7 +348,6 @@ determine_action (const SocketSYN_IPState *state,
   return SYN_ACTION_ALLOW;
 }
 
- */
 
 static int
 parse_ipv4_address (const char *ip, uint8_t *addr_bytes)
@@ -402,7 +391,6 @@ parse_ip_address (const char *ip, uint8_t *addr_bytes, size_t addr_size)
   return 0;
 }
 
- */
 
 static int
 cidr_full_bytes_match (const uint8_t *ip_bytes, const uint8_t *entry_bytes,
@@ -453,7 +441,6 @@ ip_matches_cidr (const char *ip, const SocketSYN_WhitelistEntry *entry)
   return ip_matches_cidr_bytes (family, ip_bytes, entry);
 }
 
- */
 
 static int
 whitelist_check_bucket_bytes (const SocketSYN_WhitelistEntry *entry,
@@ -541,7 +528,6 @@ whitelist_check (T protect, const char *ip)
   return whitelist_check_all_cidrs_bytes (protect, family, ip_bytes, bucket);
 }
 
- */
 
 static int
 blacklist_check (T protect, const char *ip, int64_t now_ms)
@@ -568,7 +554,6 @@ blacklist_check (T protect, const char *ip, int64_t now_ms)
   return 0;
 }
 
- */
 
 static void
 fill_ip_state_out (SocketSYN_IPState *state_out, const char *ip,
@@ -684,7 +669,6 @@ check_whitelist_blacklist (T protect, const char *client_ip, int64_t now_ms,
   return 0;
 }
 
- */
 
 typedef enum
 {
@@ -724,7 +708,6 @@ cleanup_synprotect_init (T protect, SYN_CleanupStage stage)
     }
 }
 
- */
 
 static int
 init_ip_hash_table (T protect)
@@ -776,7 +759,6 @@ init_atomic_stats (T protect)
   atomic_store (&protect->stat_lru_evictions, 0);
 }
 
- */
 
 static void
 free_ip_entries (T protect)
@@ -823,7 +805,6 @@ free_blacklist_entries (T protect)
     }
 }
 
- */
 
 static int
 parse_cidr_notation (const char *cidr, char *ip_out, size_t ip_out_size,
@@ -855,7 +836,6 @@ parse_cidr_notation (const char *cidr, char *ip_out, size_t ip_out_size,
   return 1;
 }
 
- */
 
 static SocketSYN_WhitelistEntry *
 find_whitelist_entry_exact (SocketSYN_WhitelistEntry *bucket_head,
@@ -931,7 +911,6 @@ create_blacklist_entry (T protect, const char *ip, int64_t expires_ms)
   return entry;
 }
 
- */
 
 static int
 check_global_rate_limit (T protect)
@@ -967,7 +946,6 @@ process_tracked_ip (T protect, const char *client_ip, int64_t now_ms,
   return action;
 }
 
- */
 
 void
 SocketSYNProtect_config_defaults (SocketSYNProtect_Config *config)
@@ -1233,7 +1211,6 @@ SocketSYNProtect_configure (T protect, const SocketSYNProtect_Config *config)
   pthread_mutex_unlock (&protect->mutex);
 }
 
- */
 
 SocketSYN_Action
 SocketSYNProtect_check (T protect, const char *client_ip,
@@ -1334,7 +1311,6 @@ SocketSYNProtect_report_failure (T protect, const char *client_ip,
   pthread_mutex_unlock (&protect->mutex);
 }
 
- */
 
 int
 SocketSYNProtect_whitelist_add (T protect, const char *ip)
@@ -1517,7 +1493,6 @@ SocketSYNProtect_whitelist_clear (T protect)
   pthread_mutex_unlock (&protect->mutex);
 }
 
- */
 
 static int64_t
 calculate_expiry_time (int64_t now_ms, int duration_ms)
@@ -1662,7 +1637,6 @@ SocketSYNProtect_blacklist_clear (T protect)
   pthread_mutex_unlock (&protect->mutex);
 }
 
- */
 
 static size_t
 count_currently_blocked (T protect, int64_t now_ms)
@@ -1789,7 +1763,6 @@ SocketSYNProtect_reputation_name (SocketSYN_Reputation rep)
   return "UNKNOWN";
 }
 
- */
 
 static size_t
 cleanup_expired_blacklist (T protect, int64_t now_ms)

--- a/src/core/SocketSecurity.c
+++ b/src/core/SocketSecurity.c
@@ -52,7 +52,6 @@
 #include "tls/SocketTLSConfig.h"
 #endif
 
- */
 
 const Except_T SocketSecurity_SizeExceeded
     = { &SocketSecurity_SizeExceeded,
@@ -62,7 +61,6 @@ const Except_T SocketSecurity_ValidationFailed
     = { &SocketSecurity_ValidationFailed, "Input validation failed" };
 
 
- */
 static void
 populate_memory_limits (SocketSecurityLimits *limits)
 {
@@ -151,7 +149,6 @@ populate_timeout_limits (SocketSecurityLimits *limits)
   limits->timeout_request_ms = SOCKET_SECURITY_MAX_REQUEST_TIMEOUT_MS;
 }
 
- */
 
 /* Set optional output parameter if not NULL */
 #define set_size_ptr(ptr, val)                                                \
@@ -216,7 +213,6 @@ SocketSecurity_get_hpack_limits (size_t *max_table)
   set_size_ptr (max_table, SOCKETHPACK_MAX_TABLE_SIZE);
 }
 
- */
 
 int
 SocketSecurity_check_size (size_t size)

--- a/src/core/SocketUtil.c
+++ b/src/core/SocketUtil.c
@@ -655,8 +655,7 @@ SocketLog_emit_structured (SocketLogLevel level, const char *component,
                                       field_count);
 }
 
- * NOTE: Legacy system for backward compatibility. Prefer SocketMetrics.h.
- */
+/* NOTE: Legacy system for backward compatibility. Prefer SocketMetrics.h. */
 
 static const SocketCounterMetric legacy_to_counter[SOCKET_METRIC_COUNT] = {
     [SOCKET_METRIC_SOCKET_CONNECT_SUCCESS] = SOCKET_CTR_SOCKET_CONNECT_SUCCESS,

--- a/src/core/TimeWindow.c
+++ b/src/core/TimeWindow.c
@@ -13,8 +13,6 @@
 
 #define T TimeWindow_T
 
- */
-
 /* Clamp elapsed time to [0, duration] to handle clock skew */
 static inline int64_t
 timewindow_clamp_to_duration(int64_t elapsed, int duration) {
@@ -27,8 +25,6 @@ timewindow_clamp_to_duration(int64_t elapsed, int duration) {
         return d;
     return elapsed;
 }
-
- */
 
 void
 TimeWindow_init (T *tw, int duration_ms, int64_t now_ms)


### PR DESCRIPTION
## Summary
- Simplified verbose documentation in `include/core/SocketUtil.h` (~900 lines removed)
- Removed excessive `@see` references and redundant descriptions
- Kept essential API documentation and `@threadsafe` annotations
- Fixed broken comment syntax in `src/core/*.c` files (stray `*/` without matching `/*`)

The `src/core/` files had corrupted comments from a previous refactoring that caused build failures. These are now fixed as part of this cleanup.

Fixes #39

## Test plan
- [x] Build passes with sanitizers enabled
- [x] 69/70 tests pass (99%) - one pre-existing test failure unrelated to changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)