### PR TITLE
refactor: comment cleanup in include/dns/

### DIFF
--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -14,7 +14,6 @@
  * @warning INTERNAL USE ONLY - unstable ABI, may change without notice.
  */
 
-/* System headers */
 #include <netdb.h>
 #include <pthread.h>
 #include <stdbool.h>
@@ -274,7 +273,6 @@ struct SocketDNS_T
     }                                                                         \
   while (0)
 
-/* Thread-local exception - extern declaration (defined in SocketDNS.c) */
 extern const Except_T SocketDNS_Failed;
 
 /* NOTE: Error raising uses SOCKET_RAISE_MSG/FMT directly (combined


### PR DESCRIPTION
## Summary
- Remove redundant comments in `include/dns/SocketDNS-private.h`
- Remove `/* System headers */` comment - obvious from includes
- Remove misleading `/* Thread-local exception */` comment

Fixes #42

## Test plan
- [x] All 70 tests pass with sanitizers enabled
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`

🤖 Generated with [Claude Code](https://claude.com/claude-code)