### PR TITLE
refactor: comment cleanup in include/http/, include/socket/, include/tls/

### DIFF
--- a/include/http/SocketHTTPClient-config.h
+++ b/include/http/SocketHTTPClient-config.h
@@ -6,58 +6,15 @@
 
 /**
  * @file SocketHTTPClient-config.h
- * @brief Configuration constants for HTTP client with compile-time override
- * support.
+ * @brief Configuration constants for HTTP client with compile-time override.
  * @ingroup http_client
  *
  * Centralized configuration for HTTP client module.
- * All magic numbers are defined here with compile-time override support.
- *
- * Configurable Limits Summary:
- *
- * All limits can be overridden at compile time with -D flags or at runtime
- * via SocketHTTPClient_Config fields.
- *
- * Resource Limits:
- * - HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE: 10MB - Max response body size
- * (0=unlimited via config)
- * - HTTPCLIENT_DEFAULT_MAX_CONNS_PER_HOST: 6 - Per-host connection limit
- * - HTTPCLIENT_DEFAULT_MAX_TOTAL_CONNS: 100 - Total connection limit
- * - HTTPCLIENT_DEFAULT_MAX_REDIRECTS: 10 - Max redirect hops
- * - HTTPCLIENT_MAX_AUTH_RETRIES: 2 - Max auth retry attempts
- *
- * Timeout Limits:
- * - HTTPCLIENT_DEFAULT_CONNECT_TIMEOUT_MS: 30s - Connection establishment
- * timeout
- * - HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS: 60s - Full request completion
- * timeout
- * - HTTPCLIENT_DEFAULT_DNS_TIMEOUT_MS: 10s - DNS resolution timeout
- * - HTTPCLIENT_DEFAULT_IDLE_TIMEOUT_MS: 60s - Idle connection timeout
- *
- * Enforcement:
- * - max_response_size: Checked during body accumulation (raises
- * SocketHTTPClient_ResponseTooLarge)
- * - max_conns_per_host: Enforced by connection pool
- * - max_redirects: Checked before each redirect (raises
- * SocketHTTPClient_TooManyRedirects)
- *
- * Metrics:
- * - SOCKET_CTR_LIMIT_RESPONSE_SIZE_EXCEEDED incremented on size violation
- *
- * Constants grouped by category:
- * - Error buffers
- * - Connection pool
- * - Timeouts
- * - Connection limits
- * - Retry configuration
- * - Cookie configuration
- * - Authentication buffers
- * - Request/Response limits
- * - Encoding flags
+ * All constants can be overridden at compile time with -D flags
+ * or at runtime via SocketHTTPClient_Config fields.
  *
  * @see SocketHTTPClient_config_defaults() for runtime defaults.
  * @see SocketHTTPClient_Config for full structure.
- * @see @ref http "HTTP Module" for related components.
  */
 
 #ifndef SOCKETHTTPCLIENT_CONFIG_INCLUDED
@@ -68,13 +25,7 @@
  * ============================================================================
  */
 
-/**
- * @brief Size of internal buffer for formatting HTTP client error messages.
- * @ingroup http_client
- * Used in SocketHTTPClient_error_format() and related functions to prevent
- * buffer overflows.
- * @see SocketHTTPClient_Error
- */
+/** @brief Size of error message buffer for SocketHTTPClient_error_format(). */
 #ifndef HTTPCLIENT_ERROR_BUFSIZE
 #define HTTPCLIENT_ERROR_BUFSIZE 256
 #endif
@@ -84,76 +35,22 @@
  * ============================================================================
  */
 
-/**
- * @brief Default initial hash table size for HTTP client connection pool.
- * @ingroup http_client
- * Prime number 127 chosen for good distribution with low load factor.
- * Automatically resizes to larger table when exceeding
- * HTTPCLIENT_POOL_LARGE_THRESHOLD connections.
- * @see HTTPCLIENT_POOL_LARGE_HASH_SIZE
- * @see SocketHTTPClient_pool_init()
- */
+/** @brief Initial hash table size for connection pool (prime for distribution). */
 #ifndef HTTPCLIENT_POOL_HASH_SIZE
 #define HTTPCLIENT_POOL_HASH_SIZE 127
 #endif
 
-/**
- * @brief Larger hash table size for HTTP client connection pools exceeding 100
- * connections.
- * @ingroup http_client
- *
- * Prime number 251 selected for optimal hash distribution under higher load
- * factors. Automatically used when pool connection count exceeds
- * HTTPCLIENT_POOL_LARGE_THRESHOLD. Helps maintain O(1) average lookup
- * performance in larger pools.
- *
- * @see HTTPCLIENT_POOL_HASH_SIZE for initial small-pool hash table.
- * @see HTTPCLIENT_POOL_LARGE_THRESHOLD for automatic resize trigger.
- * @see SocketHTTPClient_Config::max_total_connections for pool capacity
- * configuration.
- * @see SocketHTTPClient_pool_init() internal pool initialization
- * (implementation detail).
- */
+/** @brief Larger hash table size when pool exceeds LARGE_THRESHOLD connections. */
 #ifndef HTTPCLIENT_POOL_LARGE_HASH_SIZE
 #define HTTPCLIENT_POOL_LARGE_HASH_SIZE 251
 #endif
 
-/**
- * @brief Threshold for switching to larger hash table in connection pool.
- * @ingroup http_client
- *
- * When active connection count exceeds this value, the pool resizes its
- * internal hash table from HTTPCLIENT_POOL_HASH_SIZE to
- * HTTPCLIENT_POOL_LARGE_HASH_SIZE. Prevents performance degradation due to
- * hash collisions in growing pools.
- *
- * Default 100 balances memory usage and performance for typical workloads.
- *
- * @see HTTPCLIENT_POOL_HASH_SIZE initial table size.
- * @see HTTPCLIENT_POOL_LARGE_HASH_SIZE enlarged table size.
- * @see SocketHTTPClient_Config::max_total_connections influences when resize
- * occurs.
- */
+/** @brief Connection count triggering resize to larger hash table. */
 #ifndef HTTPCLIENT_POOL_LARGE_THRESHOLD
 #define HTTPCLIENT_POOL_LARGE_THRESHOLD 100
 #endif
 
-/**
- * @brief I/O buffer size for pooled connections in HTTP client.
- * @ingroup http_client
- *
- * Size of read/write buffers allocated per connection in the pool.
- * 8KB (8192 bytes) chosen as efficient size for typical HTTP
- * requests/responses while minimizing memory overhead. Affects performance for
- * small vs. large payloads.
- *
- * Larger buffers reduce system call overhead for large transfers but increase
- * memory usage per connection. Adjustable at compile-time for tuning.
- *
- * @see SocketHTTPClient_Config::enable_connection_pool to enable pooling.
- * @see SocketBuf_T underlying buffer implementation in core I/O.
- * @see HTTPCLIENT_REQUEST_BUFFER_SIZE for request serialization buffer.
- */
+/** @brief I/O buffer size per pooled connection. */
 #ifndef HTTPCLIENT_IO_BUFFER_SIZE
 #define HTTPCLIENT_IO_BUFFER_SIZE 8192
 #endif
@@ -163,1125 +60,307 @@
  * ============================================================================
  */
 
-/**
- * @brief Default timeout for establishing new connections (30 seconds).
- * @ingroup http_client
- * Applies to TCP connect, TLS handshake, and proxy connections.
- * Override via SocketHTTPClient_Config.connect_timeout_ms or per-request.
- * @see Socket_connect()
- * @see SocketTLS_handshake()
- * @see SocketHTTPClient_Request_timeout()
- */
+/** @brief Connection establishment timeout (TCP + TLS + proxy). */
 #ifndef HTTPCLIENT_DEFAULT_CONNECT_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_CONNECT_TIMEOUT_MS 30000
 #endif
 
-/**
- * @brief Default timeout for full HTTP request completion (60 seconds).
- * @ingroup http_client
- *
- * Total time allowed from request start to final response receipt, including
- * DNS, connect, TLS handshake, sending request, and receiving response.
- * Exceeding this raises SocketHTTPClient_Timeout exception.
- *
- * Override via SocketHTTPClient_Config.request_timeout_ms or per-request
- * timeout. 60s suitable for most APIs; reduce for latency-sensitive
- * operations.
- *
- * @see HTTPCLIENT_DEFAULT_CONNECT_TIMEOUT_MS for connect-only timeout.
- * @see SocketHTTPClient_Timeout exception details.
- * @see SocketHTTPClient_Config::request_timeout_ms runtime override.
- * @see SocketHTTPClient_Request_timeout() per-request override.
- */
+/** @brief Full request completion timeout (DNS + connect + send + receive). */
 #ifndef HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS 60000
 #endif
 
-/**
- * @brief Default timeout for DNS resolution (10 seconds).
- * @ingroup http_client
- *
- * Maximum time allowed for hostname resolution via SocketDNS.
- * Includes query submission, worker thread processing, and result retrieval.
- * Exceeding this raises SocketHTTPClient_DNSFailed or contributes to overall
- * timeout.
- *
- * 10s accommodates slow DNS servers or network latency; reduce for faster
- * failure detection. Override via SocketHTTPClient_Config.dns_timeout_ms.
- *
- * @see SocketDNS for underlying async DNS implementation.
- * @see SocketHTTPClient_DNSFailed exception on resolution failure.
- * @see SocketHTTPClient_Config::dns_timeout_ms for runtime configuration.
- * @see HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS includes this timeout.
- */
+/** @brief DNS resolution timeout. */
 #ifndef HTTPCLIENT_DEFAULT_DNS_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_DNS_TIMEOUT_MS 10000
 #endif
 
-/**
- * @brief Default idle timeout for pooled connections (60 seconds).
- * @ingroup http_client
- *
- * Time after which idle (unused) connections in the pool are closed and
- * removed. Prevents resource leaks from stale connections and reduces server
- * load. 60s allows reuse for typical web browsing patterns while reclaiming
- * unused slots.
- *
- * Override via SocketHTTPClient_Config.idle_timeout_ms. Set to 0 to disable
- * (not recommended). Affects pool efficiency and memory usage.
- *
- * @see SocketHTTPClient_Config::enable_connection_pool must be enabled.
- * @see SocketHTTPClient_Config::max_total_connections pool limits.
- * @see SocketPool_cleanup() underlying pool maintenance.
- */
+/** @brief Idle timeout for pooled connections before cleanup. */
 #ifndef HTTPCLIENT_DEFAULT_IDLE_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_IDLE_TIMEOUT_MS 60000
 #endif
 
-/**
- * @defgroup http_client_limits Connection and Resource Limits
- * @brief Limits on redirects, connections, and retries for safety and
- * performance.
- * @ingroup http_client
- *
- * Prevents abuse, loops, and resource exhaustion. Configurable for different
- * workloads.
- *
- * @see SocketHTTPClient_Config for runtime overrides where applicable.
- * @see SocketPool for connection pooling limits.
- * @{
- *
- * ============================================================================
+/* ============================================================================
  * Connection Limits
  * ============================================================================
  */
 
-/**
- * @brief Default maximum number of redirects to follow (10).
- * @ingroup http_client
- *
- * Limits automatic redirect following to prevent infinite loops or excessive
- * hops. Exceeding this raises SocketHTTPClient_TooManyRedirects exception. 10
- * allows for common redirect chains (e.g., www -> non-www -> https) with
- * margin.
- *
- * Only follows 3xx status codes (301, 302, 303, 307, 308) per RFC 7231.
- * POST redirects converted to GET unless redirect_on_post configured.
- * Override via SocketHTTPClient_Config.follow_redirects (0 to disable).
- *
- * @see SocketHTTPClient_TooManyRedirects exception on limit exceed.
- * @see SocketHTTPClient_Config::follow_redirects runtime override.
- * @see SocketHTTPClient_Config::redirect_on_post for POST handling.
- */
+/** @brief Maximum redirect hops (raises SocketHTTPClient_TooManyRedirects). */
 #ifndef HTTPCLIENT_DEFAULT_MAX_REDIRECTS
 #define HTTPCLIENT_DEFAULT_MAX_REDIRECTS 10
 #endif
 
-/**
- * @brief Default maximum concurrent connections per host (6).
- * @ingroup http_client
- *
- * Limits parallel connections to a single host to prevent overwhelming servers
- * and respect typical server connection limits. Matches common browser
- * behavior (Chrome/Firefox default ~6 per domain).
- *
- * Exceeding limit blocks new requests until connections free up or timeout.
- * Helps with fair resource sharing in multi-host scenarios.
- * Override via SocketHTTPClient_Config.max_connections_per_host.
- *
- * @see HTTPCLIENT_DEFAULT_MAX_TOTAL_CONNS global limit.
- * @see SocketHTTPClient_Config::max_connections_per_host runtime override.
- * @see SocketPool for underlying connection pooling mechanics.
- */
+/** @brief Maximum concurrent connections per host. */
 #ifndef HTTPCLIENT_DEFAULT_MAX_CONNS_PER_HOST
 #define HTTPCLIENT_DEFAULT_MAX_CONNS_PER_HOST 6
 #endif
 
-/**
- * @brief Default total maximum connections across all hosts (100).
- * @ingroup http_client
- *
- * Global limit on pooled connections regardless of host. Prevents uncontrolled
- * memory and FD growth when connecting to many different hosts.
- * 100 suitable for client applications; servers may need higher.
- *
- * When reached, new connections block or fail based on acquire_timeout_ms.
- * Influences hash table resize via HTTPCLIENT_POOL_LARGE_THRESHOLD.
- * Override via SocketHTTPClient_Config.max_total_connections.
- *
- * @see HTTPCLIENT_DEFAULT_MAX_CONNS_PER_HOST per-host sub-limit.
- * @see SocketHTTPClient_Config::max_total_connections runtime override.
- * @see HTTPCLIENT_POOL_LARGE_THRESHOLD related pool performance tuning.
- */
+/** @brief Total maximum connections across all hosts. */
 #ifndef HTTPCLIENT_DEFAULT_MAX_TOTAL_CONNS
 #define HTTPCLIENT_DEFAULT_MAX_TOTAL_CONNS 100
 #endif
 
-/**
- * @brief Maximum retries for HTTP authentication challenges (2).
- * @ingroup http_client
- * @ingroup http_client_limits
- *
- * Limits automatic retries on 401 Unauthorized responses when credentials are
- * provided. Prevents infinite loops from servers repeatedly challenging
- * without accepting valid creds. 2 allows for nonce refresh in Digest auth or
- * transient server issues.
- *
- * Applies to Basic (preemptive), Digest (challenge-response), and Bearer
- * (token validation). Exceeding limit raises SocketHTTPClient_ProtocolError or
- * falls back to 401 response. Not configurable at runtime; compile-time only
- * for security.
- *
- * @see SocketHTTPClient_Auth for configuring credentials.
- * @see HTTP_AUTH_DIGEST handling of stale nonces.
- * @see SocketHTTPClient_Config no direct field; fixed limit.
- */
+/** @brief Maximum authentication retries on 401 responses. */
 #ifndef HTTPCLIENT_MAX_AUTH_RETRIES
 #define HTTPCLIENT_MAX_AUTH_RETRIES 2
 #endif
 
-/** @} */ /* end of http_client_limits group */
-
-/**
- * @defgroup http_client_retry Retry Configuration Constants
- * @brief Parameters for automatic retry logic on transient failures.
- * @ingroup http_client
- *
- * Enables resilient client behavior with configurable backoff and conditions.
- * Disabled by default; exponential backoff with jitter for safety.
- * Only retry idempotent operations to avoid side effects.
- *
- * @see SocketHTTPClient_Config::enable_retry master switch.
- * @see SocketHTTPClient_error_is_retryable() error classification.
- * @{
- *
- * ============================================================================
+/* ============================================================================
  * Retry Configuration
  * ============================================================================
- *
- * Automatic retry for transient failures (DNS, connect, timeout).
- * Uses exponential backoff with jitter to prevent thundering herd.
- *
- * SAFETY: Only idempotent requests should enable retry_on_5xx.
- * Non-idempotent requests (POST/PUT/DELETE) may cause duplicate actions.
  */
 
-/**
- * @brief Flag to enable automatic retry logic for transient failures.
- * @ingroup http_client
- * @ingroup http_client_retry
- * Default: 0 (disabled) for backward compatibility.
- * When enabled, client retries on connect errors, timeouts, and optionally 5xx
- * responses. Uses configured backoff parameters for exponential retry with
- * jitter.
- * @see HTTPCLIENT_DEFAULT_RETRY_ON_CONNECT connection-specific flag.
- * @see SocketHTTPClient_Config::enable_retry runtime master switch.
- * @see @ref http_client_retry "Retry Configuration Constants" for details.
- */
+/** @brief Enable automatic retry on transient failures (0=disabled). */
 #ifndef HTTPCLIENT_DEFAULT_ENABLE_RETRY
 #define HTTPCLIENT_DEFAULT_ENABLE_RETRY 0
 #endif
 
-/**
- * @brief Default maximum number of retry attempts for transient failures (3).
- * @ingroup http_client
- *
- * Limits retries for retryable errors (connect, timeout, DNS) when
- * enable_retry is true. Prevents excessive retries on persistent failures. 3
- * attempts with exponential backoff provides good balance of resilience and
- * efficiency.
- *
- * Total attempts = 1 initial + max_retries. Does not retry non-retryable
- * errors (TLS, protocol, redirects, size limits). Override via
- * SocketHTTPClient_Config.max_retries.
- *
- * @see HTTPCLIENT_DEFAULT_ENABLE_RETRY to enable retry logic.
- * @see SocketHTTPClient_error_is_retryable() determines retry eligibility.
- * @see SocketHTTPClient_Config::max_retries runtime override.
- * @see HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS backoff configuration.
- */
+/** @brief Maximum retry attempts for retryable errors. */
 #ifndef HTTPCLIENT_DEFAULT_MAX_RETRIES
 #define HTTPCLIENT_DEFAULT_MAX_RETRIES 3
 #endif
 
-/**
- * @brief Default initial backoff delay for retries (100ms).
- * @ingroup http_client
- *
- * Starting delay before first retry attempt. Subsequent retries use
- * exponential backoff: delay *= HTTPCLIENT_RETRY_MULTIPLIER + jitter. Short
- * initial delay (100ms) allows quick recovery from transient issues without
- * overwhelming servers.
- *
- * Jitter (HTTPCLIENT_RETRY_JITTER_FACTOR) adds randomness to prevent
- * thundering herd. Override via
- * SocketHTTPClient_Config.retry_initial_delay_ms.
- *
- * @see HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS upper bound on backoff.
- * @see HTTPCLIENT_RETRY_MULTIPLIER backoff factor (2.0).
- * @see HTTPCLIENT_RETRY_JITTER_FACTOR randomization (0.25).
- * @see SocketHTTPClient_Config::retry_initial_delay_ms runtime override.
- */
+/** @brief Initial backoff delay before first retry (ms). */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS
 #define HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS 100
 #endif
 
-/**
- * @brief Default maximum backoff delay between retries (10 seconds).
- * @ingroup http_client
- *
- * Caps exponential backoff to prevent excessively long waits on repeated
- * failures. After reaching this, further retries use this fixed delay (no
- * further increase). 10s prevents client from hanging indefinitely while
- * allowing recovery time.
- *
- * Combined with initial delay and multiplier, provides graceful degradation.
- * Override via SocketHTTPClient_Config.retry_max_delay_ms.
- *
- * @see HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS starting delay.
- * @see HTTPCLIENT_RETRY_MULTIPLIER exponential factor.
- * @see SocketHTTPClient_Config::retry_max_delay_ms runtime override.
- * @see SocketHTTPClient_error_is_retryable() for retry conditions.
- */
+/** @brief Maximum backoff delay cap (ms). */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS
 #define HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS 10000
 #endif
 
-/**
- * @brief Default flag to retry on connection establishment errors (1 =
- * enabled).
- * @ingroup http_client
- *
- * When enabled (and overall retry enabled), retries on TCP connect failures
- * like ECONNREFUSED (server down), ENETUNREACH (network issue), ETIMEDOUT.
- * Common transient errors where server/network may recover quickly.
- *
- * Does not retry permanent errors (e.g., invalid address). Uses backoff logic.
- * Override via SocketHTTPClient_Config.retry_on_connection_error.
- *
- * @see SocketHTTPClient_ConnectFailed underlying exception.
- * @see SocketError_is_retryable_errno() for errno classification.
- * @see SocketHTTPClient_Config::retry_on_connection_error runtime flag.
- * @see HTTPCLIENT_DEFAULT_ENABLE_RETRY master retry switch.
- */
+/** @brief Retry on connection errors (ECONNREFUSED, ETIMEDOUT). */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_ON_CONNECT
 #define HTTPCLIENT_DEFAULT_RETRY_ON_CONNECT 1
 #endif
 
-/**
- * @brief Default flag to retry on request timeouts (1 = enabled).
- * @ingroup http_client
- *
- * When enabled (with overall retry), retries requests that exceed
- * request_timeout_ms. Timeouts often transient due to network congestion, slow
- * servers, or temporary load. Uses backoff to avoid immediate re-failure.
- *
- * Caution: May amplify load on struggling servers. Monitor metrics for retry
- * loops. Override via SocketHTTPClient_Config.retry_on_timeout.
- *
- * @see SocketHTTPClient_Timeout exception triggered by timeout.
- * @see HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS configurable timeout.
- * @see SocketHTTPClient_Config::retry_on_timeout runtime flag.
- * @see HTTPCLIENT_DEFAULT_ENABLE_RETRY required for any retries.
- */
+/** @brief Retry on request timeouts. */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_ON_TIMEOUT
 #define HTTPCLIENT_DEFAULT_RETRY_ON_TIMEOUT 1
 #endif
 
 /**
- * @brief Default flag to retry on 5xx server errors (0 = disabled).
- * @ingroup http_client
- * @ingroup http_client_retry
- *
- * When enabled (with overall retry), retries requests receiving 5xx status
- * codes (500 Internal Server Error, 503 Service Unavailable, etc.) indicating
- * server-side issues. Disabled by default due to risk of duplicate side
- * effects on non-idempotent methods (POST).
- *
- * Only recommended for safe methods: GET, HEAD, OPTIONS, PUT, DELETE.
- * Servers may recover from temporary overload or bugs.
- * Override via SocketHTTPClient_Config.retry_on_5xx.
- *
- * @warning Enabling for POST/PATCH may cause unintended duplicate actions.
- * @see SocketHTTP_status_category() for 5xx classification.
- * @see SocketHTTPClient_Config::retry_on_5xx runtime flag.
- * @see HTTPCLIENT_DEFAULT_ENABLE_RETRY prerequisite.
- * @see docs/SECURITY_GUIDE.md idempotency considerations.
+ * @brief Retry on 5xx server errors (0=disabled).
+ * @warning Only enable for idempotent requests (GET, HEAD, PUT, DELETE).
  */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_ON_5XX
 #define HTTPCLIENT_DEFAULT_RETRY_ON_5XX 0
 #endif
 
-/**
- * @brief Exponential backoff multiplier for retry delays (2.0 = doubling).
- * @ingroup http_client
- * @ingroup http_client_retry
- *
- * Controls how aggressively delays grow between retry attempts.
- * Formula: delay_n = initial_delay * pow(multiplier, n-1), capped at max_delay.
- *
- * 2.0 doubles delay each attempt (100ms -> 200ms -> 400ms -> ...).
- * Values >1.0 provide exponential backoff; =1.0 gives constant delay.
- *
- * @note Fixed at compile-time; not configurable per-client at runtime.
- * @warning Values >4.0 may cause very long delays after few attempts.
- * @see HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS starting delay.
- * @see HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS backoff cap.
- * @see SOCKET_RETRY_DEFAULT_MULTIPLIER underlying SocketRetry default.
- */
+/** @brief Exponential backoff multiplier (delay doubles each attempt). */
 #ifndef HTTPCLIENT_RETRY_MULTIPLIER
 #define HTTPCLIENT_RETRY_MULTIPLIER 2.0
 #endif
 
-/**
- * @brief Jitter factor for randomizing retry delays (0.25 = +/-25%).
- * @ingroup http_client
- * @ingroup http_client_retry
- *
- * Adds randomness to computed delays to prevent thundering herd problem when
- * multiple clients retry simultaneously after a server outage.
- *
- * Formula: jittered = delay * (1 + jitter * (2*rand() - 1))
- * 0.25 means +/-25% variation (e.g., 100ms becomes 75-125ms).
- *
- * Range 0.0 to 1.0:
- * - 0.0: No jitter (exact calculated delays)
- * - 0.25: Moderate (recommended, prevents synchronization)
- * - 1.0: Full jitter (delays vary 0% to 200%)
- *
- * @note Fixed at compile-time; not configurable per-client at runtime.
- * @see HTTPCLIENT_RETRY_MULTIPLIER exponential factor.
- * @see SOCKET_RETRY_DEFAULT_JITTER underlying SocketRetry default.
- */
+/** @brief Jitter factor to prevent thundering herd (+/-25% variation). */
 #ifndef HTTPCLIENT_RETRY_JITTER_FACTOR
 #define HTTPCLIENT_RETRY_JITTER_FACTOR 0.25
 #endif
 
-/**
- * @brief Minimum delay returned on invalid retry input (1 ms).
- * @ingroup http_client
- * @ingroup http_client_retry
- *
- * Fallback value when httpclient_calculate_retry_delay() receives invalid
- * parameters (NULL client or attempt < 1). Ensures at least minimal delay
- * rather than immediate retry on misconfiguration.
- *
- * @note Internal constant; not typically overridden.
- * @see httpclient_calculate_retry_delay() usage context.
- */
+/** @brief Minimum delay on invalid retry input (ms). */
 #ifndef HTTPCLIENT_MIN_DELAY_MS
 #define HTTPCLIENT_MIN_DELAY_MS 1
 #endif
 
-/** @} */ /* end of http_client_retry group */
-
-/**
- * @brief Default flag to enforce SameSite cookie attribute in matching logic
- * (1 = enabled).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * When enabled, respects SameSite=Strict/Lax/None attributes per RFC 6265bis
- * during cookie inclusion in requests. Enhances security against CSRF attacks.
- * Strict: No cross-site cookies; Lax: Safe methods on top-level; None: All
- * (requires Secure).
- *
- * Disabled allows legacy cookies but reduces security. Modern browsers enforce
- * by default. Runtime override via SocketHTTPClient_Config.enforce_samesite.
- *
- * @see SocketHTTPClient_SameSite enum values.
- * @see SocketHTTPClient_Cookie::same_site cookie attribute.
- * @see SocketHTTPClient_Config::enforce_samesite runtime flag.
- * @see docs/SECURITY_GUIDE.md for SameSite best practices and CSRF protection.
+/* ============================================================================
+ * Cookie Configuration
+ * ============================================================================
  */
+
+/** @brief Enforce SameSite cookie attribute for CSRF protection. */
 #ifndef HTTPCLIENT_DEFAULT_ENFORCE_SAMESITE
 #define HTTPCLIENT_DEFAULT_ENFORCE_SAMESITE 1
 #endif
 
-/**
- * @brief Maximum total cookies allowed in a single cookie jar (10000).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Hard limit on stored cookies to prevent DoS via cookie flooding (Set-Cookie
- * headers). Exceeding triggers eviction of oldest/least-used cookies per
- * domain. 10000 accommodates large sites with session + tracking cookies;
- * adjust lower for embedded.
- *
- * Not runtime configurable; compile-time for memory predictability.
- * Monitors via SocketHTTPClient_pool_stats() or custom metrics.
- *
- * @see SocketHTTPClient_CookieJar_T management.
- * @see HTTPCLIENT_COOKIE_MAX_CHAIN_LEN per-chain limit for hash DoS
- * protection.
- * @see SocketHTTPClient_CookieJar_set() insertion with eviction logic.
- * @see http_client_cookie group for related constants.
- */
+/** @brief Maximum cookies in a single jar (DoS protection). */
 #ifndef HTTPCLIENT_MAX_COOKIES
 #define HTTPCLIENT_MAX_COOKIES 10000
 #endif
 
-/**
- * @brief Default maximum size for HTTP response bodies (10MB).
- * @ingroup http_client
- * @details 0 in SocketHTTPClient_Config allows unlimited, but compile-time
- * default is 10MB to mitigate DoS.
- *
- * ENFORCEMENT: During response body accumulation in HTTP/1.1 parsing.
- * If exceeded, raises SocketHTTPClient_ResponseTooLarge exception.
- * Increments SOCKET_CTR_LIMIT_RESPONSE_SIZE_EXCEEDED metric for monitoring.
- *
- * Recommendation: Keep non-zero in production; adjust based on expected
- * payload sizes (e.g., 1MB for APIs, larger for file downloads). Override at
- * runtime via SocketHTTPClient_Config.max_response_size.
- *
- * @see SocketHTTPClient_ResponseTooLarge
- * @see SocketHTTPClient_Config::max_response_size
- * @see SocketMetrics for counter details.
- */
-#ifndef HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE
-#define HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE                                  \
-  (10ULL * 1024 * 1024) /* 10MB default to prevent DoS */
-#endif
-
-/**
- * @defgroup http_client_cookie Cookie Configuration Constants
- * @brief Limits and buffer sizes for HTTP client cookie handling and jar
- management.
- * @ingroup http_client
- *
- * Controls cookie parsing, storage, and serialization for compliance with RFC
- 6265.
- * Includes hash table sizing, string limits, and DoS protections.
- *
- * @see SocketHTTPClient_CookieJar_T
- * @see SocketHTTPClient_set_cookie_jar()
- * @{
-
- */
-
-/**
- * @brief Initial hash table size for cookie jar (prime 127 for distribution).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Size of hash table buckets for storing cookies by domain/path.
- * Prime number minimizes collisions for typical cookie counts per domain.
- * Fixed size; no dynamic resize to simplify implementation and bound memory.
- *
- * @see socket_util_hash_djb2() underlying hash function for keys.
- * @see HTTPCLIENT_COOKIE_MAX_CHAIN_LEN max chain length before eviction.
- * @see SocketHTTPClient_CookieJar_new() jar initialization.
- */
+/** @brief Hash table size for cookie jar (prime for distribution). */
 #ifndef HTTPCLIENT_COOKIE_HASH_SIZE
 #define HTTPCLIENT_COOKIE_HASH_SIZE 127
 #endif
 
-/**
- * @brief Maximum allowed length for cookie names (256 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Limits cookie name strings during parsing and storage from Set-Cookie
- * headers. Exceeding truncates or rejects cookie, preventing buffer overflows
- * and DoS. 256 bytes ample for standard names; RFC 6265 recommends short
- * names.
- *
- * @see SocketHTTPClient_Cookie::name field.
- * @see HTTPCLIENT_COOKIE_MAX_VALUE_LEN for value limit.
- * @see SocketHTTP_Headers_get() header parsing integration.
- */
+/** @brief Maximum cookie name length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_NAME_LEN
 #define HTTPCLIENT_COOKIE_MAX_NAME_LEN 256
 #endif
 
-/**
- * @brief Maximum allowed length for cookie values (4096 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Limits cookie value strings to prevent memory exhaustion from
- * large/malicious cookies. Values may contain session data or tokens; 4KB
- * sufficient for most use cases. Exceeding rejects or truncates during
- * Set-Cookie parsing.
- *
- * @see SocketHTTPClient_Cookie::value field.
- * @see HTTPCLIENT_COOKIE_MAX_NAME_LEN for name limit.
- * @see RFC 6265 section 5.1.1 for value syntax (octets excluding control
- * chars).
- */
+/** @brief Maximum cookie value length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_VALUE_LEN
 #define HTTPCLIENT_COOKIE_MAX_VALUE_LEN 4096
 #endif
 
-/**
- * @brief Maximum allowed length for cookie domain attributes (256 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Limits Domain= attribute in Set-Cookie for scope matching.
- * Domains typically short (e.g., example.com); 256 covers FQDNs with paths.
- * Used for exact/subdomain matching per RFC 6265.
- * Exceeding rejects cookie.
- *
- * @see SocketHTTPClient_Cookie::domain field.
- * @see SocketHTTP_URI for domain parsing from requests.
- * @see RFC 6265 section 5.2.3 domain matching rules.
- */
+/** @brief Maximum cookie domain attribute length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_DOMAIN_LEN
 #define HTTPCLIENT_COOKIE_MAX_DOMAIN_LEN 256
 #endif
 
-/**
- * @brief Maximum allowed length for cookie path attributes (1024 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Limits Path= attribute in Set-Cookie for URI path matching.
- * Paths can be longer for deep hierarchies; 1KB sufficient.
- * Prefix matching used: cookie path must be prefix of request path.
- * Exceeding rejects cookie.
- *
- * @see SocketHTTPClient_Cookie::path field.
- * @see SocketHTTP_URI::path for request path extraction.
- * @see RFC 6265 section 5.2.4 path matching rules.
- */
+/** @brief Maximum cookie path attribute length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_PATH_LEN
 #define HTTPCLIENT_COOKIE_MAX_PATH_LEN 1024
 #endif
 
-/**
- * @brief Buffer size for parsing cookie files in Netscape format (4096 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Line buffer for reading cookie files (cookies.txt format used by curl,
- * wget). Supports loading persistent cookies from disk. 4KB handles long lines
- * with many attributes or tabs.
- *
- * @see SocketHTTPClient_CookieJar load from file functionality (future).
- * @see Netscape cookie file format spec for structure.
- * @see HTTPCLIENT_COOKIE_MAX_NAME_LEN etc. for field limits.
- */
+/** @brief Line buffer size for Netscape cookie file parsing. */
 #ifndef HTTPCLIENT_COOKIE_FILE_LINE_SIZE
 #define HTTPCLIENT_COOKIE_FILE_LINE_SIZE 4096
 #endif
 
-/**
- * @brief Maximum length for Max-Age attribute string parsing (32 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Buffer size for parsing Max-Age= value in Set-Cookie (seconds until expiry).
- * Supports large values up to HTTPCLIENT_MAX_COOKIE_AGE_SEC; 32 chars for
- * digits + sign. Used during attribute parsing to prevent overflow.
- *
- * @see SocketHTTPClient_Cookie::expires computed from Max-Age or Expires.
- * @see HTTPCLIENT_MAX_COOKIE_AGE_SEC absolute max age limit.
- * @see RFC 6265 section 5.2.2 Set-Cookie syntax.
- */
+/** @brief Buffer for parsing Max-Age attribute. */
 #ifndef HTTPCLIENT_COOKIE_MAX_AGE_SIZE
 #define HTTPCLIENT_COOKIE_MAX_AGE_SIZE 32
 #endif
 
-/**
- * @brief Maximum length for SameSite attribute value strings (16 bytes).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Buffer for parsing SameSite=[Strict|Lax|None] from Set-Cookie.
- * Values are short enums; 16 allows variants or future extensions + null
- * terminator. Case-insensitive matching per spec.
- *
- * @see SocketHTTPClient_SameSite enum mapping.
- * @see SocketHTTPClient_Cookie::same_site parsed value.
- * @see HTTPCLIENT_DEFAULT_ENFORCE_SAMESITE enforcement flag.
- * @see RFC 6265bis draft for SameSite specification.
- */
+/** @brief Buffer for parsing SameSite attribute. */
 #ifndef HTTPCLIENT_COOKIE_SAMESITE_SIZE
 #define HTTPCLIENT_COOKIE_SAMESITE_SIZE 16
 #endif
 
-/**
- * @brief Absolute maximum cookie lifetime in seconds (10 years).
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Hard cap on cookie expiry from Max-Age or Expires attributes to prevent
- * near-permanent cookies causing storage bloat or security issues.
- * 10 years (~315360000 seconds) far exceeds typical session/persistent needs.
- * Exceeding clamped to this value; rejects invalid negative/zero ages
- * appropriately.
- *
- * @see SocketHTTPClient_Cookie::expires absolute expiry time.
- * @see HTTPCLIENT_COOKIE_MAX_AGE_SIZE parsing buffer.
- * @see RFC 6265 section 5.3 expiry time calculation.
- * @see time_t for underlying time representation limits.
- */
+/** @brief Maximum cookie lifetime (10 years). */
 #ifndef HTTPCLIENT_MAX_COOKIE_AGE_SEC
 #define HTTPCLIENT_MAX_COOKIE_AGE_SEC (365LL * 24 * 3600 * 10)
 #endif
 
-/**
- * @brief Maximum allowed length of hash chains in cookie jar hash table.
- * @ingroup http_client
- * @ingroup http_client_cookie
- *
- * Exceeding this limit during insertion triggers eviction of oldest cookies
- * per bucket. Protects against hash collision DoS attacks where attacker
- * forces long chains degrading lookup to O(n). Value 100 balances security
- * (low collision risk) with memory efficiency (allows some chaining).
- *
- * Monitored during SocketHTTPClient_CookieJar_set() and related operations.
- *
- * @see @ref http_client_cookie "Cookie Configuration Constants"
- * @see SocketHTTPClient_CookieJar_set() insertion with collision handling.
- * @see HTTPCLIENT_COOKIE_HASH_SIZE table sizing impact.
- * @see socket_util_hash_djb2() hash function used for domain keys.
- */
+/** @brief Maximum hash chain length before eviction (DoS protection). */
 #ifndef HTTPCLIENT_COOKIE_MAX_CHAIN_LEN
 #define HTTPCLIENT_COOKIE_MAX_CHAIN_LEN 100
 #endif
 
-/** @} */ /* end of http_client_cookie group */
-
-/**
- * @defgroup http_client_auth Authentication Buffer Constants
- * @brief Internal buffer sizes for HTTP authentication header generation and
- * computation.
- * @ingroup http_client
- *
- * Constants for Basic, Digest, and Bearer auth schemes. Sized conservatively
- * to handle long credentials, nonces, and params without overflows. Used in
- * temporary computations.
- *
- * @see SocketHTTPClient_Auth for credential configuration.
- * @see HTTP_AUTH_BASIC, HTTP_AUTH_DIGEST, HTTP_AUTH_BEARER enum.
- * @see RFC 7235 HTTP Authentication-Info and Authorization headers.
- * @{
- *
- * ============================================================================
- * Authentication Buffer Sizes
- *
- * These are internal buffer sizes for authentication header generation.
- * They are sized to handle typical use cases with some margin.
+/* ============================================================================
+ * Response Limits
  * ============================================================================
  */
 
 /**
- * @brief Buffer size for Basic auth credentials string (username:password, 512
- * bytes).
- * @ingroup http_client
- *
- * Temporary buffer for concatenating username:password before Base64 encoding
- * in Basic auth. 512 bytes accommodates long usernames/passwords with margin;
- * prevents overflows. Used in SocketHTTPClient_Auth for header generation.
- *
- * @see SocketHTTPClient_Auth::username and ::password fields.
- * @see HTTPCLIENT_AUTH_HEADER_SIZE encoded header buffer.
- * @see RFC 7617 Basic Authentication scheme.
+ * @brief Default maximum response body size (10MB).
+ * Set to 0 in config for unlimited. Raises SocketHTTPClient_ResponseTooLarge.
  */
+#ifndef HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE
+#define HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE (10ULL * 1024 * 1024)
+#endif
+
+/* ============================================================================
+ * Authentication Buffers
+ * ============================================================================
+ */
+
+/** @brief Buffer for Basic auth credentials (username:password). */
 #ifndef HTTPCLIENT_AUTH_CREDENTIALS_SIZE
 #define HTTPCLIENT_AUTH_CREDENTIALS_SIZE 512
 #endif
 
-/**
- * @brief Buffer size for Digest auth A1/A2 intermediate hashes (512 bytes).
- * @ingroup http_client
- *
- * Internal buffer for computing HA1 = MD5(username:realm:password) and
- * HA2 = MD5(method:digest-uri) used in Digest response calculation.
- * 512 bytes safe for hash outputs + temporary strings; prevents overflows in
- * crypto ops.
- *
- * @see HTTP_AUTH_DIGEST scheme requiring these intermediates.
- * @see HTTPCLIENT_DIGEST_RESPONSE_SIZE for final response.
- * @see RFC 7616 Digest Access Authentication.
- */
+/** @brief Buffer for Digest auth A1/A2 intermediate hashes. */
 #ifndef HTTPCLIENT_DIGEST_A_BUFFER_SIZE
 #define HTTPCLIENT_DIGEST_A_BUFFER_SIZE 512
 #endif
 
-/**
- * @brief Buffer size for Digest auth response value (256 bytes).
- * @ingroup http_client
- *
- * Holds final response-digest = KD(HA1, nonce:nonce-count:cnonce:qop:HA2)
- * or without qop. Sufficient for hex-encoded MD5 (32 chars) + params.
- * Used in Authorization header construction.
- *
- * @see HTTPCLIENT_DIGEST_A_BUFFER_SIZE intermediates.
- * @see HTTP_AUTH_DIGEST response calculation.
- * @see RFC 7616 section 3.4 response computation.
- */
+/** @brief Buffer for Digest auth response value. */
 #ifndef HTTPCLIENT_DIGEST_RESPONSE_SIZE
 #define HTTPCLIENT_DIGEST_RESPONSE_SIZE 256
 #endif
 
-/**
- * @brief Size of client nonce (cnonce) in bytes for Digest auth (16 bytes
- * random).
- * @ingroup http_client
- *
- * Random data generated per request for replay protection in Digest auth.
- * 16 bytes (128 bits) provides sufficient entropy against guessing.
- * Hex-encoded to 32 chars in header.
- *
- * @see HTTPCLIENT_DIGEST_CNONCE_HEX_SIZE encoded string size.
- * @see RFC 7616 section 3.2.1 client nonce requirement.
- * @see SocketCrypto for random generation (if available).
- */
+/** @brief Client nonce size for Digest auth (16 bytes = 128 bits entropy). */
 #ifndef HTTPCLIENT_DIGEST_CNONCE_SIZE
 #define HTTPCLIENT_DIGEST_CNONCE_SIZE 16
 #endif
 
-/**
- * @brief Size of hex-encoded client nonce string for Digest auth headers (33
- * bytes).
- * @ingroup http_client
- *
- * Buffer for ASCII hex representation of cnonce (2 hex chars per byte + null
- * terminator). For 16-byte cnonce: 32 hex chars + NUL = 33 bytes. Included in
- * Authorization header as cnonce param.
- *
- * @see HTTPCLIENT_DIGEST_CNONCE_SIZE binary cnonce size.
- * @see RFC 7616 section 3.2.1 nonce format (hex lowercase recommended).
- * @see HTTPCLIENT_AUTH_HEADER_SIZE overall auth header buffer.
- */
+/** @brief Hex-encoded cnonce buffer (32 hex chars + null). */
 #ifndef HTTPCLIENT_DIGEST_CNONCE_HEX_SIZE
 #define HTTPCLIENT_DIGEST_CNONCE_HEX_SIZE 33
 #endif
 
-/**
- * @brief Buffer size for Digest auth nonce-count (nc) hex string (16 bytes).
- * @ingroup http_client
- *
- * Holds 8-digit hex nonce count (00000001 to FFFFFFFF) + null terminator.
- * Incremented per request with same nonce for replay detection.
- * 16 bytes allows padding and future extensions.
- *
- * @see RFC 7616 section 3.2.2 nonce-count format (8 hex digits).
- * @see HTTPCLIENT_AUTH_HEADER_SIZE including nc in header.
- * @see Digest auth state management for rollover handling.
- */
+/** @brief Buffer for nonce-count hex string (8 hex digits). */
 #ifndef HTTPCLIENT_DIGEST_NC_SIZE
 #define HTTPCLIENT_DIGEST_NC_SIZE 16
 #endif
 
-/** @} */ /* end of http_client_auth group */
-
-/**
- * @defgroup http_client_buffers Request/Response Buffer Constants
- * @brief Buffer sizes for HTTP request serialization, response reading, and
- * headers.
- * @ingroup http_client
- *
- * Limits for temporary buffers during request building, body accumulation, and
- * header construction. Sized for efficiency and security (DoS prevention).
- *
- * @see SocketHTTPClient_Request for request building.
- * @see SocketHTTPClient_Response for response handling.
- * @see SocketHTTP1 for protocol-level buffering.
- * @{
- *
- * ============================================================================
- * Request/Response Buffer Limits
+/* ============================================================================
+ * Request/Response Buffers
  * ============================================================================
  */
 
-/**
- * @brief Buffer size for serializing HTTP request lines and headers (8192
- * bytes).
- * @ingroup http_client
- *
- * Temporary buffer for building complete request string before sending.
- * 8KB handles typical requests with many headers (e.g., cookies, auth).
- * Prevents reallocations during header accumulation.
- *
- * @see SocketHTTP1_serialize_request() underlying serialization.
- * @see HTTPCLIENT_AUTH_HEADER_SIZE for auth-specific buffers.
- * @see SocketHTTPClient_Request_header() adding custom headers.
- */
+/** @brief Buffer for serializing request line and headers. */
 #ifndef HTTPCLIENT_REQUEST_BUFFER_SIZE
 #define HTTPCLIENT_REQUEST_BUFFER_SIZE 8192
 #endif
 
-/**
- * @brief Chunk size for reading response bodies incrementally (4096 bytes).
- * @ingroup http_client
- *
- * Size of buffers used to read and accumulate response body data from socket.
- * 4KB balances I/O efficiency with memory usage during body parsing.
- * Used in chunked, content-length, or connection-close modes.
- *
- * Larger chunks reduce syscalls but increase latency for small responses.
- * Contributes to HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE limit checks.
- *
- * @see HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE total body limit.
- * @see Socket_recvv() or similar for underlying I/O.
- * @see SocketHTTPClient_Response::body accumulated result.
- */
+/** @brief Chunk size for incremental response body reads. */
 #ifndef HTTPCLIENT_BODY_CHUNK_SIZE
 #define HTTPCLIENT_BODY_CHUNK_SIZE 4096
 #endif
 
-/**
- * @brief Initial buffer capacity for HTTP/2 response body accumulation (64KB).
- * @ingroup http_client
- *
- * Initial allocation size for HTTP/2 response body buffer when max_response_size
- * is unlimited. Buffer grows dynamically by doubling when full.
- * 64KB balances memory usage with allocation overhead for typical responses.
- *
- * When max_response_size is set, that value is used as initial capacity instead.
- *
- * @see HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE for body size limits.
- * @see execute_http2_request() HTTP/2 response body handling.
- */
+/** @brief Initial HTTP/2 response body buffer (grows dynamically). */
 #ifndef HTTPCLIENT_H2_BODY_INITIAL_CAPACITY
 #define HTTPCLIENT_H2_BODY_INITIAL_CAPACITY (64 * 1024)
 #endif
 
-/**
- * @brief Buffer size for generating Host header (256 bytes).
- * @ingroup http_client
- *
- * Temporary buffer for "Host: hostname:port" construction per RFC 7230.
- * 256 bytes covers long FQDNs + port + optional userinfo.
- * Automatically included unless suppressed.
- *
- * @see SocketHTTP_URI for host/port extraction from URL.
- * @see SocketHTTP_Headers_add() header insertion.
- * @see RFC 7230 section 5.4 Host header requirements.
- */
+/** @brief Buffer for Host header construction. */
 #ifndef HTTPCLIENT_HOST_HEADER_SIZE
 #define HTTPCLIENT_HOST_HEADER_SIZE 256
 #endif
 
-/**
- * @brief Buffer size for serializing Cookie header in outgoing requests (4096
- * bytes).
- * @ingroup http_client
- *
- * Accumulates "Cookie: name1=value1; name2=value2; ..." from jar matching
- * current request. 4KB handles sites with many cookies (analytics, session,
- * prefs). Truncates if exceeds (rare); logs warning.
- *
- * @see SocketHTTPClient_CookieJar for source jar.
- * @see SocketHTTPClient_set_cookie_jar() associating jar with client.
- * @see RFC 6265 section 5.4 Cookie header format.
- */
+/** @brief Buffer for Cookie header serialization. */
 #ifndef HTTPCLIENT_COOKIE_HEADER_SIZE
 #define HTTPCLIENT_COOKIE_HEADER_SIZE 4096
 #endif
 
-/**
- * @brief Buffer size for standard Authorization headers (Basic/Digest/Bearer,
- * 512 bytes).
- * @ingroup http_client
- *
- * For Basic: "Basic base64(creds)"; Digest: full params; Bearer: "Bearer
- * token". 512 bytes covers typical cases; see LARGE variant for complex
- * Digest.
- *
- * @see SocketHTTPClient_Auth for credential types.
- * @see HTTPCLIENT_AUTH_HEADER_LARGE_SIZE for extended Digest params.
- * @see RFC 7235 HTTP Authentication framework.
- */
+/** @brief Standard Authorization header buffer. */
 #ifndef HTTPCLIENT_AUTH_HEADER_SIZE
 #define HTTPCLIENT_AUTH_HEADER_SIZE 512
 #endif
 
-/**
- * @brief Larger buffer for complex Authorization headers, e.g., Digest with
- * long nonces (1024 bytes).
- * @ingroup http_client
- *
- * Extended size for cases where standard buffer insufficient, like verbose
- * Digest params or long bearer tokens. Fallback or realloc if needed. Used
- * when params exceed HTTPCLIENT_AUTH_HEADER_SIZE.
- *
- * @see HTTPCLIENT_AUTH_HEADER_SIZE standard size.
- * @see HTTP_AUTH_DIGEST full param list potential length.
- * @see RFC 7616 Digest auth header format.
- */
+/** @brief Extended Authorization buffer for complex Digest params. */
 #ifndef HTTPCLIENT_AUTH_HEADER_LARGE_SIZE
 #define HTTPCLIENT_AUTH_HEADER_LARGE_SIZE 1024
 #endif
 
-/**
- * @brief Buffer size for URI string in Digest auth calculations (512 bytes).
- * @ingroup http_client
- *
- * Holds normalized request-uri for HA2 hash (method:uri without query per
- * RFC). 512 bytes for long paths/queries; used in digest-uri param.
- *
- * @see SocketHTTP_URI for URI parsing/normalization.
- * @see HTTPCLIENT_DIGEST_A_BUFFER_SIZE including HA2 computation.
- * @see RFC 7616 section 3.4.2 digest-uri definition.
- */
+/** @brief Buffer for URI in Digest auth calculations. */
 #ifndef HTTPCLIENT_URI_BUFFER_SIZE
 #define HTTPCLIENT_URI_BUFFER_SIZE 512
 #endif
 
-/**
- * @brief Maximum Set-Cookie headers processed per HTTP response (16).
- * @ingroup http_client
- *
- * Limits parsing of multiple Set-Cookie headers to prevent DoS from header
- * flooding. Servers rarely send >5-10; 16 provides margin for complex apps.
- * Excess ignored with warning log.
- *
- * @see SocketHTTP_Headers for header parsing.
- * @see SocketHTTPClient_CookieJar_set() per-cookie insertion.
- * @see HTTPCLIENT_MAX_COOKIES total jar limit.
- * @see RFC 6265 multiple Set-Cookie handling.
- */
+/** @brief Maximum Set-Cookie headers processed per response. */
 #ifndef HTTPCLIENT_MAX_SET_COOKIES
 #define HTTPCLIENT_MAX_SET_COOKIES 16
 #endif
 
-/**
- * @brief Buffer size for constructing Accept-Encoding request header (64
- * bytes).
- * @ingroup http_client
- *
- * Builds "Accept-Encoding: gzip, deflate, br" based on config flags.
- * Small size sufficient for standard encodings; extensible.
- *
- * @see @ref http_client_encoding "Content-Encoding Flags": GZIP, DEFLATE, BR.
- * @see SocketHTTPClient_Config::accept_encoding bitmask.
- * @see RFC 9110 Content-Encoding and Accept-Encoding.
- */
+/** @brief Buffer for Accept-Encoding header construction. */
 #ifndef HTTPCLIENT_ACCEPT_ENCODING_SIZE
 #define HTTPCLIENT_ACCEPT_ENCODING_SIZE 64
 #endif
 
-/**
- * @brief Buffer size for Content-Length header value string (32 bytes).
- * @ingroup http_client
- *
- * Formats numeric body length up to ~10^18 bytes (far beyond practical
- * limits). 32 chars for digits + "Content-Length: " prefix space.
- *
- * @see RFC 7230 section 3.3.2 Content-Length.
- * @see SocketHTTPClient_Request_body() setting body length.
- * @see HTTPCLIENT_REQUEST_BUFFER_SIZE including this in request.
- */
+/** @brief Buffer for Content-Length header value. */
 #ifndef HTTPCLIENT_CONTENT_LENGTH_SIZE
 #define HTTPCLIENT_CONTENT_LENGTH_SIZE 32
 #endif
-
-/**
- * @brief Default retry backoff parameters: jitter factor (0.25) and multiplier
- * (2.0).
- * @ingroup http_client
- *
- * Jitter: Random variation +/- jitter_factor * delay to prevent synchronized
- * retries (thundering herd) across clients. 25% provides good randomization
- * without excessive variance.
- *
- * Multiplier: Exponential backoff factor. delay_{n} = min(max_delay,
- * delay_{n-1} * multiplier). 2.0 standard for doubling delays (100ms -> 200 ->
- * 400 -> ... capped at max).
- *
- * Both used in retry logic when HTTPCLIENT_DEFAULT_ENABLE_RETRY active.
- * Not runtime configurable; compile-time constants.
- *
- * @see HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS starting delay.
- * @see HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS cap.
- * @see SocketHTTPClient_Config::enable_retry prerequisite.
- * @see Exponential backoff with jitter best practices.
- */
-#ifndef HTTPCLIENT_RETRY_JITTER_FACTOR
-#define HTTPCLIENT_RETRY_JITTER_FACTOR 0.25
-#define HTTPCLIENT_RETRY_MULTIPLIER 2.0
-#endif
-
-/** @} */ /* end of http_client_buffers group */
 
 /* ============================================================================
  * Default User-Agent
  * ============================================================================
  */
 
-/**
- * @brief Default User-Agent header string sent in requests.
- * @ingroup http_client
- *
- * Simple identifier "SocketHTTPClient/1.0" for library requests.
- * Servers may use for rate limiting or logging; override for
- * application-specific ID. Includes version for compatibility tracking.
- * Configurable via SocketHTTPClient_Config.user_agent (NULL uses default).
- *
- * @see SocketHTTPClient_Config::user_agent runtime override.
- * @see RFC 7231 section 5.5.3 User-Agent header.
- * @see SocketHTTP_Headers_add() header insertion.
- */
+/** @brief Default User-Agent header (override via config.user_agent). */
 #ifndef HTTPCLIENT_DEFAULT_USER_AGENT
 #define HTTPCLIENT_DEFAULT_USER_AGENT "SocketHTTPClient/1.0"
 #endif
 
-/**
- * @defgroup http_client_encoding Content-Encoding Flags
- * @brief Bit flags indicating supported Content-Encoding methods for HTTP
- * client.
- * @ingroup http_client
- *
- * These flags are combined (bitwise OR) in
- * SocketHTTPClient_Config.accept_encoding to specify which encoding methods
- * the client supports in Accept-Encoding header and can decompress in
- * responses.
- *
- * Default: GZIP | DEFLATE (Brotli optional for smaller payloads).
- *
- * @see SocketHTTPClient_Config::accept_encoding
- * @see SocketHTTPClient_config_defaults()
- * @{
+/* ============================================================================
+ * Content-Encoding Flags
+ * ============================================================================
  */
 
-/**
- * @brief Identity (no compression) encoding flag.
- * @ingroup http_client
- * @details Bit value 0x00. Represents uncompressed data transfer.
- * Used as base flag or when no encoding is applied.
- * @see @ref http_client_encoding "Content-Encoding Flags"
- */
+/** @brief Identity (no compression) encoding. */
 #define HTTPCLIENT_ENCODING_IDENTITY 0x00
-/**
- * @brief GZIP compression encoding flag.
- * @ingroup http_client
- * @details Bit value 0x01. Supports gzip compression (RFC 9110, formerly RFC
- * 7230). Advertises "gzip" in Accept-Encoding header. Client must decompress
- * gzip-encoded responses.
- * @see @ref http_client_encoding "Content-Encoding Flags"
- * @see SocketHTTPClient.c for header construction and decompression logic.
- */
-#define HTTPCLIENT_ENCODING_GZIP 0x01
-/**
- * @brief DEFLATE compression encoding flag.
- * @ingroup http_client
- * @details Bit value 0x02. Supports deflate compression (RFC 9110).
- * Advertises "deflate" in Accept-Encoding. Note: zlib wrapper often used; raw
- * deflate deprecated. Client handles decompression for responses with this
- * encoding.
- * @see @ref http_client_encoding "Content-Encoding Flags"
- * @see SocketHTTPClient.c line ~918 for Accept-Encoding handling.
- */
-#define HTTPCLIENT_ENCODING_DEFLATE 0x02
-/**
- * @brief Brotli compression encoding flag.
- * @ingroup http_client
- * @details Bit value 0x04. Supports Brotli compression (RFC 7932).
- * Advertises "br" in Accept-Encoding header. Modern, efficient for text;
- * requires Brotli library support. Client decompresses br-encoded responses if
- * enabled.
- * @see @ref http_client_encoding "Content-Encoding Flags"
- * @note Brotli support may require additional dependencies or conditional
- * compilation.
- */
-#define HTTPCLIENT_ENCODING_BR 0x04
 
-/** @} */ /* end of http_client_encoding group */
+/** @brief GZIP compression (RFC 9110). */
+#define HTTPCLIENT_ENCODING_GZIP 0x01
+
+/** @brief DEFLATE compression (RFC 9110). */
+#define HTTPCLIENT_ENCODING_DEFLATE 0x02
+
+/** @brief Brotli compression (RFC 7932). */
+#define HTTPCLIENT_ENCODING_BR 0x04
 
 #endif /* SOCKETHTTPCLIENT_CONFIG_INCLUDED */

--- a/include/socket/SocketReconnect.h
+++ b/include/socket/SocketReconnect.h
@@ -4,6 +4,24 @@
  * https://x.com/tetsuoai
  */
 
+/**
+ * @file SocketReconnect.h
+ * @ingroup connection_mgmt
+ * @brief Automatic reconnection with exponential backoff and circuit breaker.
+ *
+ * Provides resilient TCP connections with:
+ * - Exponential backoff with jitter
+ * - Circuit breaker pattern
+ * - Periodic health checks
+ * - Event loop integration
+ * - Transparent send/recv with auto-reconnect
+ *
+ * Thread safety: Instances are NOT thread-safe. Use one per thread.
+ *
+ * @see SocketReconnect_new() for creation
+ * @see docs/RECONNECT.md for configuration guide
+ */
+
 #ifndef SOCKETRECONNECT_INCLUDED
 #define SOCKETRECONNECT_INCLUDED
 
@@ -12,214 +30,17 @@
 #include <stddef.h>
 #include <sys/types.h>
 
-/**
- * @file SocketReconnect.h
- * @ingroup connection_mgmt
- * @brief Automatic reconnection framework for resilient TCP connections with
- * backoff and circuit breaker patterns.
- *
- * This header provides a robust reconnection mechanism for network
- * applications, implementing exponential backoff, jitter to avoid thundering
- * herd, circuit breaker to prevent cascading failures, and optional health
- * checks. The module integrates seamlessly with event loops and provides
- * transparent I/O wrappers that automatically handle disconnections and
- * reconnections.
- *
- * ## Features
- * - Exponential backoff with configurable initial delay, multiplier, max
- * delay, and jitter
- * - Circuit breaker pattern with failure threshold and reset timeout
- * - Periodic health checks with custom callback support
- * - State machine tracking connection lifecycle
- * - Event callbacks for state transitions
- * - Transparent send/recv with auto-reconnect on errors
- * - Event loop integration via pollfd, process, and tick functions
- * - Statistics query for attempts and failures
- *
- * ## Architecture Overview
- *
- * ```
- * ┌─────────────────────────────┐
- * │    Application Layer        │
- * │ SocketPool, HTTPClient, etc.│
- * └─────────────┬───────────────┘
- *               │ Uses
- * ┌─────────────▼───────────────┐
- * │   SocketReconnect_T         │
- * │  - State Machine            │
- * │  - Backoff Timer            │
- * │  - Circuit Breaker          │
- * │  - Health Check             │
- * └─────────────┬───────────────┘
- *               │ Uses
- * ┌─────────────▼───────────────┐
- * │     Core I/O Layer          │
- * │     Socket_T                │
- * └─────────────────────────────┘
- *               │ Uses
- * ┌─────────────▼───────────────┐
- * │   Foundation Layer          │
- * │   Arena, Except, Timer      │
- * └─────────────────────────────┘
- * ```
- *
- * ## Module Relationships
- * - **Depends on**: @ref core_io (Socket_T for underlying connections), @ref
- * foundation (Arena for memory, Except for error handling, SocketTimer for
- * internal timing)
- * - **Used by**: @ref connection_mgmt (SocketPool for pooled reconnections),
- * @ref http (SocketHTTPClient for resilient HTTP requests)
- * - **Integrates with**: @ref event_system (SocketPoll for event handling)
- *
- * ## Platform Requirements
- * - POSIX-compliant system (Linux, BSD, macOS)
- * - Support for non-blocking sockets and poll/epoll/kqueue
- * - CLOCK_MONOTONIC for accurate timing
- * - No external dependencies beyond standard library and socket primitives
- *
- * ## Typical Usage Patterns
- *
- * ### Simple I/O Passthrough
- *
- * @code{.c}
- * SocketReconnect_Policy_T policy;
- * SocketReconnect_policy_defaults(&policy);
- * SocketReconnect_T conn = SocketReconnect_new("example.com", 443, &policy,
- * NULL, NULL); SocketReconnect_connect(conn);
- *
- * // Send/Recv automatically handle reconnections
- * ssize_t sent = SocketReconnect_send(conn, data, len);
- * ssize_t recv = SocketReconnect_recv(conn, buf, buflen);
- *
- * SocketReconnect_free(&conn);
- * @endcode
- *
- * ### Event Loop Integration
- *
- * @code{.c}
- * // In event loop
- * int fd = SocketReconnect_pollfd(conn);
- * if (fd >= 0) {
- *     // Poll fd for events
- *     SocketReconnect_process(conn);  // On events
- * }
- *
- * int timeout = SocketReconnect_next_timeout_ms(conn);
- * // Use timeout for poll
- *
- * SocketReconnect_tick(conn);  // Periodic call
- * @endcode
- *
- * ## Thread Safety
- * - Individual SocketReconnect_T instances must be accessed from a single
- * thread
- * - Multiple independent instances can run concurrently from different threads
- * - Callbacks execute in the thread that calls process() or tick()
- *
- * @warning Do not call free() from within callbacks to avoid use-after-free
- * @note Host resolution is synchronous; for async DNS use SocketDNS
- * integration externally
- * @complexity Most operations O(1); connection attempts O(1) per attempt
- *
- * @see SocketReconnect_new() Primary entry point
- * @see SocketReconnect_policy_defaults() For policy configuration
- * @see docs/RECONNECT.md for advanced configuration guide
- */
-
 #define T SocketReconnect_T
+
 /**
  * @brief Opaque handle for a reconnecting socket connection.
  * @ingroup connection_mgmt
- *
- * Represents a resilient TCP connection that automatically manages
- * reconnections using a state machine with exponential backoff, circuit
- * breaker protection, and health monitoring.
- *
- * The handle encapsulates:
- * - Internal state machine tracking DISCONNECTED, CONNECTING, CONNECTED,
- * BACKOFF, CIRCUIT_OPEN states
- * - Timers for backoff delays, circuit reset, and health checks
- * - Underlying Socket_T instance when connected
- * - Statistics for attempts and failures
- * - Optional callbacks for state changes and custom health checks
- *
- * ## Lifecycle Management
- *
- * 1. Create with SocketReconnect_new()
- * 2. Configure policy, callbacks, health check if needed
- * 3. Call SocketReconnect_connect() to start
- * 4. Integrate with event loop or use passthrough I/O
- * 5. Call SocketReconnect_free() to cleanup
- *
- * @code{.c}
- * // Full lifecycle
- * SocketReconnect_T conn = SocketReconnect_new(host, port, NULL, state_cb,
- * userdata); SocketReconnect_connect(conn);
- *
- * while (SocketReconnect_isconnected(conn)) {
- *     // Use conn...
- * }
- *
- * SocketReconnect_free(&conn);
- * @endcode
- *
- * ## Thread Safety Characteristics
- * - Not thread-safe: All operations must occur from the same thread
- * - Callbacks execute in the caller's thread context
- * - Internal state protected by non-reentrant design
- *
- * ## Integration Notes
- * - For event-driven apps: Use pollfd(), process(), tick(), next_timeout_ms()
- * - For simple apps: Use send()/recv() wrappers for auto-reconnect
- * - Combine with SocketPool for managing multiple reconnections
- * - Host/port are fixed at creation; for dynamic endpoints create new
- * instances
- *
- * @note Underlying socket is created/destroyed internally; do not access
- * directly except via SocketReconnect_socket()
- * @warning Frequent state changes may indicate network issues; monitor via
- * callbacks and statistics
- * @complexity State queries and timers O(1); connection establishment depends
- * on network latency
- *
- * @see SocketReconnect_new() Creation
- * @see SocketReconnect_free() Destruction
- * @see SocketReconnect_state() Current state
- * @see SocketReconnect_socket() Underlying socket access
- * @see SocketReconnect_Policy_T Configuration options
  */
 typedef struct T *T;
 
 /**
- * @brief Exception type for errors in the reconnection module.
+ * @brief Exception for reconnection module errors.
  * @ingroup connection_mgmt
- *
- * This exception is raised for configuration errors, resource allocation
- * failures, or internal state inconsistencies. Common triggers include:
- * - Invalid policy values (negative delays, multiplier <=1.0, jitter <0 or >1)
- * - Arena allocation failure during initialization
- * - Invalid host/port parameters
- * - Unrecoverable state machine errors (rare)
- *
- * ## Handling Pattern
- *
- * @code{.c}
- * TRY {
- *     SocketReconnect_T conn = SocketReconnect_new(host, port, &policy, NULL,
- * NULL);
- *     // Use conn...
- * } EXCEPT(SocketReconnect_Failed) {
- *     fprintf(stderr, "Reconnect failed: %s\n",
- * Except_message(&Except_stack));
- *     // Log or retry with different params
- * } END_TRY;
- * @endcode
- *
- * @note Always check Socket_GetLastError() or Except_message() for detailed
- * error information
- * @see SocketReconnect_new() Primary raise point
- * @see core/Except.h Base exception handling framework
- * @see Socket_GetLastError() For system error details if applicable
  */
 extern const Except_T SocketReconnect_Failed;
 
@@ -229,76 +50,16 @@ extern const Except_T SocketReconnect_Failed;
  */
 
 /**
- * @brief States of the reconnection state machine for tracking connection
- * lifecycle and backoff status.
+ * @brief Reconnection state machine states.
  * @ingroup connection_mgmt
- *
- * The state machine transitions as follows:
- * - DISCONNECTED: Idle state, ready for connect() or after graceful disconnect
- * - CONNECTING: Active connection attempt in progress (non-blocking connect)
- * - CONNECTED: Successfully established and healthy connection
- * - BACKOFF: Waiting exponential delay before next retry after failure
- * - CIRCUIT_OPEN: Circuit breaker tripped, blocking attempts until reset
- * timeout
- *
- * Transitions are triggered by connect(), process(), tick(), send/recv errors,
- * health checks, and timeouts.
- *
- * ## State Transition Diagram
- *
- * ```
- * +-------------+     connect()     +-------------+
- * | DISCONNECTED| ----------------> | CONNECTING  |
- * +-------------+                  +-------------+
- *      ^                                   |
- *      | disconnect()                      | success/fail
- *      |                                   v
- * +-------------+    timeout/error    +-------------+    health fail
- * | CIRCUIT_OPEN| <-------------------|   BACKOFF   | <-------------- |
- * +-------------+                     +-------------+                 |
- *      ^                                             |                |
- *      | timeout                                     |                |
- *      |                                             |                |
- *      +--------------------------- reset() ---------+                |
- *                                                             failure |
- *                                                              |     |
- *                                                              v     |
- *                                                       +-------------+
- *                                                       | CONNECTED   |
- *                                                       +-------------+
- *                                                              |
- *                                                         send/recv |
- *                                                              |
- *                                                       disconnect() |
- *                                                              v
- *                                                       DISCONNECTED
- * ```
- *
- * ## State Properties Table
- *
- * | State | Description | pollfd() | send/recv | Actions |
- * |-------|-------------|----------|-----------|---------|
- * | DISCONNECTED | Not connected, idle | -1 | Block/0 | connect() starts
- * transition | | CONNECTING | Non-blocking connect in progress | Valid FD |
- * Block | process() completes | | CONNECTED | Active connection | Valid FD |
- * Available | Errors trigger BACKOFF | | BACKOFF | Exponential wait | -1 |
- * Block | tick() advances timer | | CIRCUIT_OPEN | Breaker open, no attempts |
- * -1 | Block | tick() resets after timeout |
- *
- * @note Use SocketReconnect_state_name() for logging/debugging state strings
- * @warning Avoid direct state manipulation; use public API functions
- *
- * @see SocketReconnect_state() Query current state
- * @see SocketReconnect_state_name() Human-readable names
- * @see SocketReconnect_Callback() For state change notifications
  */
 typedef enum
 {
   RECONNECT_DISCONNECTED = 0, /**< Not connected, not attempting */
   RECONNECT_CONNECTING,       /**< Connection attempt in progress */
   RECONNECT_CONNECTED,        /**< Successfully connected */
-  RECONNECT_BACKOFF,     /**< Waiting before retry (exponential backoff) */
-  RECONNECT_CIRCUIT_OPEN /**< Circuit breaker open, blocking attempts */
+  RECONNECT_BACKOFF,          /**< Waiting before retry */
+  RECONNECT_CIRCUIT_OPEN      /**< Circuit breaker open */
 } SocketReconnect_State;
 
 /* ============================================================================
@@ -307,137 +68,27 @@ typedef enum
  */
 
 /**
- * @brief Configuration structure defining backoff policy, circuit breaker
- * thresholds, and health check parameters for SocketReconnect_T.
+ * @brief Backoff policy and circuit breaker configuration.
  * @ingroup connection_mgmt
  *
- * This structure allows fine-tuning of the reconnection behavior:
- * - **Backoff Settings**: Control retry timing with exponential growth and
- * randomization
- * - **Circuit Breaker**: Prevent connection storms after repeated failures
- * - **Health Monitoring**: Periodic checks to detect connection degradation
- * early
- *
- * All fields are optional if using defaults via
- * SocketReconnect_policy_defaults(). Invalid values (e.g., negative delays,
- * multiplier <= 1.0) may raise SocketReconnect_Failed.
- *
- * ## Field Documentation
- *
- * See individual field comments for details. Recommended to start with
- * defaults and tune based on application needs.
- *
- * ## Default Values Table
- *
- * | Field | Default Value | Range/Notes |
- * |-------|---------------|-------------|
- * | initial_delay_ms | 100 | >0, first retry delay |
- * | max_delay_ms | 30000 | > initial, cap for backoff |
- * | multiplier | 2.0 | >1.0, exponential factor |
- * | jitter | 0.25 | 0.0-1.0, randomization % |
- * | max_attempts | 10 | >0 or 0=unlimited |
- * | circuit_failure_threshold | 5 | >0, consecutive fails to open |
- * | circuit_reset_timeout_ms | 60000 | >0, time to attempt recovery |
- * | health_check_interval_ms | 30000 | >0 or 0=disabled |
- * | health_check_timeout_ms | 5000 | >0, max block time for check |
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketReconnect_Policy_T policy;
- * SocketReconnect_policy_defaults(&policy);
- *
- * // Customize for aggressive retry
- * policy.initial_delay_ms = 50;
- * policy.max_delay_ms = 10000;
- * policy.multiplier = 1.5;
- * policy.max_attempts = 0;  // Unlimited
- *
- * SocketReconnect_T conn = SocketReconnect_new(host, port, &policy, NULL,
- * NULL);
- * @endcode
- *
- * @note Changes take effect only at creation; recreate instance to apply new
- * policy
- * @threadsafe Yes - plain struct, safe to initialize concurrently
- * @warning Setting jitter=0 may cause thundering herd in multi-instance
- * scenarios
- * @see SocketReconnect_policy_defaults() Initialize with safe defaults
- * @see SocketReconnect_new() Apply policy during creation
+ * Use SocketReconnect_policy_defaults() to initialize with safe defaults.
  */
 typedef struct SocketReconnect_Policy
 {
   /* Exponential backoff settings */
-  int initial_delay_ms; /**< @brief Initial delay before first retry after
-                         * failure (default: 100ms). Must be positive (>0).
-                         * This is the starting point for exponential backoff:
-                         * delay = initial * (multiplier ^ attempt) +/- jitter.
-                         * @note Too small values may overload the target
-                         * during recovery.
-                         */
-  int max_delay_ms; /**< @brief Maximum delay cap for backoff (default: 30000ms
-                     * / 30s). Prevents unbounded growth. Actual delay clamped
-                     * to this value.
-                     * @warning Set higher than typical outage duration but low
-                     * enough to meet SLA.
-                     */
-  double multiplier; /**< @brief Multiplier for exponential backoff
-                      * (default: 2.0). New delay = previous * multiplier. Must
-                      * be >1.0 for growth. Common values: 1.5
-                      * (aggressive), 2.0 (standard), 3.0 (conservative).
-                      * @note Values <=1.0 will raise SocketReconnect_Failed.
-                      */
-  double jitter; /**< @brief Jitter factor for randomization (default: 0.25 /
-                  * 25%). Adds +/- jitter * delay randomness to avoid
-                  * synchronized retries (thundering herd). Range: 0.0 (no
-                  * jitter) to 1.0 (full randomization).
-                  * @warning Jitter=0 with multiple instances may cause retry
-                  * storms.
-                  */
-  int max_attempts; /**< @brief Maximum retry attempts before permanent failure
-                     * (default: 10). 0 means unlimited retries (use with
-                     * caution to avoid infinite loops). Counts only connection
-                     * attempts, not health check failures.
-                     * @note Reset via SocketReconnect_reset() to retry
-                     * indefinitely.
-                     */
+  int initial_delay_ms; /**< First retry delay (default: 100ms) */
+  int max_delay_ms;     /**< Maximum delay cap (default: 30000ms) */
+  double multiplier;    /**< Backoff multiplier (default: 2.0, must be >1.0) */
+  double jitter;        /**< Randomization factor 0.0-1.0 (default: 0.25) */
+  int max_attempts;     /**< Max retries, 0=unlimited (default: 10) */
 
   /* Circuit breaker settings */
-  int circuit_failure_threshold; /**< @brief Consecutive failures to trigger
-                                  * circuit open (default: 5). After this many
-                                  * rapid failures, enters CIRCUIT_OPEN state
-                                  * blocking further attempts. Helps prevent
-                                  * cascading failures during outages.
-                                  * @note Failures include connect errors and
-                                  * immediate post-connect issues.
-                                  */
-  int circuit_reset_timeout_ms;  /**< @brief Time in CIRCUIT_OPEN before
-                                  * attempting recovery probe (default: 60000ms
-                                  * / 60s).  During this period, all connect()
-                                  * calls are ignored.  After timeout,
-                                  * transitions to CONNECTING for one probe
-                                  * attempt.
-                                  * @warning Too short may retry into ongoing
-                                  * outage; too long delays recovery.
-                                  */
+  int circuit_failure_threshold; /**< Failures to open circuit (default: 5) */
+  int circuit_reset_timeout_ms;  /**< Cooldown before probe (default: 60000ms) */
 
   /* Health monitoring settings */
-  int health_check_interval_ms; /**< @brief Interval between health checks when
-                                 * CONNECTED (default: 30000ms / 30s). 0
-                                 * disables health checks entirely. Checks run
-                                 * via tick() or internal timer. Failed check
-                                 * triggers transition to BACKOFF.
-                                 * @note Overhead: Each check blocks briefly
-                                 * (up to health_check_timeout_ms).
-                                 */
-  int health_check_timeout_ms;  /**< @brief Maximum time a health check may
-                                 * block (default: 5000ms / 5s).  Custom health
-                                 * callbacks must respect this limit to avoid
-                                 * DoS.  Default check polls socket for
-                                 * readability.
-                                 * @warning Exceeding this may cause
-                                 * tick()/process() to hang.
-                                 */
+  int health_check_interval_ms; /**< Check interval, 0=disabled (default: 30000ms) */
+  int health_check_timeout_ms;  /**< Check timeout (default: 5000ms) */
 } SocketReconnect_Policy_T;
 
 /* Default policy values */
@@ -483,59 +134,14 @@ typedef struct SocketReconnect_Policy
  */
 
 /**
- * @brief Callback invoked on reconnection state transitions for monitoring and
- * custom logic.
+ * @brief State transition callback.
  * @ingroup connection_mgmt
- * @param[in] conn The SocketReconnect_T instance changing state
- * @param[in] old_state State before the transition
- * @param[in] new_state State after the transition
- * @param[in] userdata User data provided at SocketReconnect_new()
+ * @param conn Reconnection instance
+ * @param old_state Previous state
+ * @param new_state New state
+ * @param userdata User data from creation
  *
- * This callback is invoked synchronously from the thread calling process(),
- * tick(), or I/O functions that trigger state changes. Useful for:
- * - Logging state transitions for debugging
- * - Updating metrics (e.g., increment failure counters)
- * - Triggering application-level actions (e.g., alert on CIRCUIT_OPEN)
- * - Custom backoff adjustments (but avoid blocking)
- *
- * ## Invocation Guarantees
- * - Called exactly once per state transition
- * - Non-reentrant: No nested calls from within callback
- * - Short-lived: Should complete quickly to avoid delaying I/O processing
- *
- * ## Usage Example
- *
- * @code{.c}
- * static void
- * state_change_cb(SocketReconnect_T conn, SocketReconnect_State old,
- * SocketReconnect_State new, void *ud) { const char *old_name =
- * SocketReconnect_state_name(old); const char *new_name =
- * SocketReconnect_state_name(new); SOCKET_LOG_INFO_MSG("Reconnect %p: %s ->
- * %s", conn, old_name, new_name);
- *
- *     if (new == RECONNECT_CIRCUIT_OPEN) {
- *         // Alert or log outage
- *         // ud might be app context
- *     } else if (new == RECONNECT_CONNECTED) {
- *         // Resume operations
- *     }
- * }
- *
- * // Register at creation
- * SocketReconnect_T conn = SocketReconnect_new(host, port, NULL,
- * state_change_cb, app_context);
- * @endcode
- *
- * @note Do not call SocketReconnect_free(), connect(), or other mutating
- * functions from within the callback to avoid recursion or use-after-free
- * @warning Blocking operations (e.g., I/O, sleeps) in callback may stall the
- * event loop
- * @threadsafe No - executes in caller's thread; ensure caller is
- * single-threaded per instance
- *
- * @see SocketReconnect_new() Register callback during creation
- * @see SocketReconnect_state() Query state directly
- * @see SocketReconnect_state_name() String names for logging
+ * @warning Do not call free() or connect() from within callback.
  */
 typedef void (*SocketReconnect_Callback) (T conn,
                                           SocketReconnect_State old_state,
@@ -543,150 +149,32 @@ typedef void (*SocketReconnect_Callback) (T conn,
                                           void *userdata);
 
 /**
- * @brief Custom health check callback to verify connection liveness beyond
- * basic connectivity.
+ * @brief Custom health check callback.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context performing the check
- * @param[in] socket Underlying connected Socket_T to test
- * @param[in] timeout_ms Maximum milliseconds to block/wait for the check;
- * 0=non-blocking
- * @param[in] userdata User data from SocketReconnect_new() or
- * set_health_check()
- *
- * @return 1 if healthy (connection responsive), 0 if unhealthy (triggers
- * BACKOFF transition)
- *
- * Invoked periodically (per policy.health_check_interval_ms) during CONNECTED
- * state to proactively detect issues like high latency or partial failures.
- * The check should verify application-level health if possible (e.g., ping
- * endpoint, read heartbeat).
- *
- * ## Requirements
- * - Must complete within timeout_ms or risk blocking the event loop
- * - Non-blocking preferred when timeout_ms=0
- * - Return 0 on any failure to err on side of caution
- * - Default: Polls socket for readability (detects dead peers)
- *
- * ## Security Considerations
- * - Respect timeout to prevent DoS from slow/malicious health checks
- * - Avoid external calls (DNS, HTTP) that could be exploited
- * - Use Socket_set_timeout() on socket if needed for check operations
- *
- * ## Usage Example
- *
- * @code{.c}
- * static int
- * my_health_check(SocketReconnect_T conn, Socket_T sock, int timeout_ms, void
- * *ud) {
- *     // Simple ping: send heartbeat, expect response within timeout
- *     char ping[] = "PING";
- *     char buf[64];
- *
- *     ssize_t sent = Socket_send(sock, ping, sizeof(ping)-1);
- *     if (sent < 0) return 0;
- *
- *     struct pollfd pfd = { Socket_fd(sock), POLLIN, 0 };
- *     int ready = poll(&pfd, 1, timeout_ms);
- *     if (ready <= 0) return 0;  // Timeout or error
- *
- *     ssize_t rcvd = Socket_recv(sock, buf, sizeof(buf)-1);
- *     return (rcvd > 0 && strncmp(buf, "PONG", 4) == 0);
- * }
- *
- * // Set after creation
- * SocketReconnect_set_health_check(conn, my_health_check);
- * @endcode
- *
- * @warning Exceeding timeout_ms may cause overall system hangs; always check
- * time remaining
- * @note Custom checks run in caller's thread; ensure non-blocking where
- * possible
- * @threadsafe No - executes in tick()/process() caller's context
- *
- * @see SocketReconnect_set_health_check() Register custom check
- * @see SocketReconnect_Policy_T::health_check_interval_ms Control frequency
- * @see SocketReconnect_Policy_T::health_check_timeout_ms Set max block time
+ * @param conn Reconnection context
+ * @param socket Connected socket to test
+ * @param timeout_ms Maximum time to block
+ * @param userdata User data
+ * @return 1 if healthy, 0 if unhealthy (triggers BACKOFF)
  */
 typedef int (*SocketReconnect_HealthCheck) (T conn, Socket_T socket,
                                             int timeout_ms, void *userdata);
-/* Additional note: timeout_ms added in v1.1 for DoS protection.
- * Custom implementations must respect this limit.
- */
+
 /* ============================================================================
  * Context Creation and Destruction
  * ============================================================================
  */
 
 /**
- * @brief Create a new SocketReconnect_T instance configured for a specific
- * host and port.
+ * @brief Create reconnection context for a host:port endpoint.
  * @ingroup connection_mgmt
- * @param[in] host Target hostname (e.g., "example.com") or IP address
- * (IPv4/IPv6)
- * @param[in] port Target port (1-65535); 0 invalid and will raise exception
- * @param[in] policy Optional custom policy (NULL uses defaults from
- * SocketReconnect_policy_defaults())
- * @param[in] callback Optional state transition callback (NULL to disable)
- * @param[in] userdata User data passed unchanged to callbacks (may be NULL)
- *
- * @return New opaque SocketReconnect_T handle in DISCONNECTED state
- * @throws SocketReconnect_Failed On invalid parameters (null host, invalid
- * port, bad policy values), Arena allocation failure, or internal init errors
- *
- * Initializes a reconnection context with the specified endpoint. Hostname is
- * resolved synchronously using getaddrinfo(); for async resolution integrate
- * with SocketDNS externally. The instance starts in RECONNECT_DISCONNECTED
- * state. No connection attempt is made until SocketReconnect_connect() is
- * called. Resources (timers, state) are allocated from internal Arena; freed
- * on SocketReconnect_free().
- *
- * ## Validation Rules
- * - host must be non-null and valid (checked via getaddrinfo)
- * - port 1-65535
- * - policy values validated (positive delays, multiplier >1, etc.)
- * - callback may be NULL
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Basic creation with defaults
- * TRY {
- *     SocketReconnect_T conn = SocketReconnect_new("api.example.com", 443,
- * NULL, NULL, NULL); SocketReconnect_connect(conn);
- *     // Now integrate with loop or use I/O wrappers
- * } EXCEPT(SocketReconnect_Failed) {
- *     // Handle init failure (e.g., invalid host)
- * } END_TRY;
- * @endcode
- *
- * ## Advanced Configuration
- *
- * @code{.c}
- * SocketReconnect_Policy_T policy;
- * SocketReconnect_policy_defaults(&policy);
- * policy.max_attempts = 0;  // Unlimited retries
- * policy.health_check_interval_ms = 10000;  // Check every 10s
- *
- * static void state_cb(SocketReconnect_T c, SocketReconnect_State o,
- * SocketReconnect_State n, void *ud) {
- *     // Log transition
- * }
- *
- * SocketReconnect_T conn = SocketReconnect_new("db.internal", 5432, &policy,
- * state_cb, app_ctx);
- * @endcode
- *
- * @threadsafe Yes - each instance independent; safe from any thread but use
- * single-thread per instance thereafter
- * @complexity O(1) setup + O(n) getaddrinfo() where n=address families
- * @note Host/port fixed at creation; for dynamic targets create new instances
- * or use SocketProxy
- * @warning Synchronous DNS may block briefly; consider caching resolved
- * addresses for performance
- * @see SocketReconnect_policy_defaults() Safe default policy
- * @see SocketReconnect_connect() Start connection process
- * @see SocketReconnect_free() Cleanup resources
- * @see SocketReconnect_set_health_check() Post-creation health customization
+ * @param host Target hostname or IP address
+ * @param port Target port (1-65535)
+ * @param policy Optional policy (NULL for defaults)
+ * @param callback Optional state change callback
+ * @param userdata User data for callbacks
+ * @return New handle in DISCONNECTED state
+ * @throws SocketReconnect_Failed on invalid parameters or allocation failure
  */
 extern T SocketReconnect_new (const char *host, int port,
                               const SocketReconnect_Policy_T *policy,
@@ -694,44 +182,9 @@ extern T SocketReconnect_new (const char *host, int port,
                               void *userdata);
 
 /**
- * @brief Destroy a SocketReconnect_T instance and release all associated
- * resources.
+ * @brief Destroy reconnection context and release resources.
  * @ingroup connection_mgmt
- * @param[in,out] conn Pointer to the SocketReconnect_T handle (set to NULL on
- * success)
- *
- * Performs immediate cleanup:
- * - If CONNECTED or CONNECTING: Calls underlying socket shutdown/close
- * - Cancels any pending timers or health checks
- * - Releases internal memory allocations
- * - Invokes no callbacks (safe during destruction)
- * - Sets *conn to NULL to prevent use-after-free
- *
- * ## Cleanup Guarantees
- * - Graceful shutdown of socket if possible (SOCKET_SHUT_RDWR)
- * - All resources returned to system (no leaks)
- * - Underlying Socket_T freed internally
- * - Statistics reset (not preserved)
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketReconnect_T conn = SocketReconnect_new(host, port, NULL, NULL, NULL);
- * // ... use connection ...
- *
- * SocketReconnect_disconnect(conn);  // Optional graceful close
- * SocketReconnect_free(&conn);       // Required cleanup
- * assert(conn == NULL);
- * @endcode
- *
- * @threadsafe No - must be called from the thread managing the instance
- * @complexity O(1) - socket close is O(1), timers cancelled instantly
- * @note Always pair with SocketReconnect_new(); unpaired frees undefined
- * @warning Calling on NULL or already-freed pointer is safe (no-op)
- * @see SocketReconnect_new() Creation counterpart
- * @see SocketReconnect_disconnect() Graceful disconnect without full cleanup
- * @see Socket_debug_live_count() Verify no leaks in tests (should be 0 after
- * free)
+ * @param conn Pointer to handle (set to NULL after cleanup)
  */
 extern void SocketReconnect_free (T *conn);
 
@@ -741,80 +194,26 @@ extern void SocketReconnect_free (T *conn);
  */
 
 /**
- * @brief Initiate or queue a connection attempt according to current state and
- * policy.
+ * @brief Initiate connection attempt.
  * @ingroup connection_mgmt
- * @param[in] conn SocketReconnect_T instance to connect
+ * @param conn Reconnection context
  *
- * Triggers transition from DISCONNECTED to CONNECTING if possible.
- * Behavior based on current state:
- * - DISCONNECTED: Starts non-blocking connect to resolved host/port
- * - CONNECTING: No-op (already attempting)
- * - CONNECTED: No-op (already connected)
- * - BACKOFF: Queues retry after current backoff timer expires (via tick())
- * - CIRCUIT_OPEN: Ignored until reset timeout elapses
- *
- * Success/failure detected via SocketReconnect_process() on poll events or
- * timeouts. Failed attempts increment statistics and may trigger backoff or
- * circuit open.
- *
- * ## State Transitions Triggered
- * - DISCONNECTED -> CONNECTING (immediate)
- * - BACKOFF -> CONNECTING (after delay)
- * - CIRCUIT_OPEN -> ignored
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketReconnect_T conn = SocketReconnect_new("example.com", 80, NULL, NULL,
- * NULL);
- *
- * SocketReconnect_connect(conn);  // Start first attempt
- *
- * // In event loop:
- * int fd = SocketReconnect_pollfd(conn);
- * if (event on fd ) { // e.g., POLLOUT or POLLIN
- *     SocketReconnect_process(conn);
- * }
- *
- * // After failure, auto-retries per policy
- * @endcode
- *
- * @threadsafe No - state mutation not safe across threads
- * @complexity O(1) - defers actual connect to non-blocking socket call
- * @note getaddrinfo() cached from creation; no repeated DNS lookups
- * @warning Calling repeatedly in rapid succession wastes CPU; rely on
- * auto-retry
- * @see SocketReconnect_state() Check if connect was accepted
- * @see SocketReconnect_process() Handle connection completion events
- * @see SocketReconnect_tick() Advance timers for queued retries
- * @see SocketReconnect_disconnect() Stop and reset without retry
+ * Transitions DISCONNECTED -> CONNECTING. No-op if already connecting/connected.
+ * Ignored if CIRCUIT_OPEN until reset timeout elapses.
  */
 extern void SocketReconnect_connect (T conn);
 
 /**
  * @brief Gracefully disconnect without triggering reconnect.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- * @threadsafe No.
- * @note Disconnects without triggering reconnection logic. Resets attempt
- * counter.
- * @note Use this for intentional disconnection (e.g., shutdown).
- * @see SocketReconnect_connect() for starting connections.
- * @see SocketReconnect_free() for complete cleanup.
+ * @param conn Reconnection context
  */
 extern void SocketReconnect_disconnect (T conn);
 
 /**
- * @brief Reset reconnection statistics and state machine.
+ * @brief Reset statistics and circuit breaker state.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- * @threadsafe No.
- * @note Clears attempt counter, consecutive failures, and circuit breaker
- * state.
- * @note Does not disconnect if connected. Use after external recovery.
- * @see SocketReconnect_connect() for initiating reconnection.
- * @see SocketReconnect_state() for current state.
+ * @param conn Reconnection context
  */
 extern void SocketReconnect_reset (T conn);
 
@@ -824,15 +223,11 @@ extern void SocketReconnect_reset (T conn);
  */
 
 /**
- * @brief Get the underlying Socket_T when connected.
+ * @brief Get underlying socket when connected.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- * @return Connected socket, or NULL if not connected.
- * @threadsafe No.
- * @note Returns the underlying socket only when in RECONNECT_CONNECTED state.
- * @note Do not close or free the returned socket directly.
- * @see SocketReconnect_state() for connection state.
- * @see SocketReconnect_isconnected() for boolean check.
+ * @param conn Reconnection context
+ * @return Connected socket, or NULL if not connected
+ * @warning Do not close or free the returned socket directly.
  */
 extern Socket_T SocketReconnect_socket (T conn);
 
@@ -842,72 +237,34 @@ extern Socket_T SocketReconnect_socket (T conn);
  */
 
 /**
- * @brief Query the current state of the reconnection instance.
+ * @brief Get current state.
  * @ingroup connection_mgmt
- * @param[in] conn SocketReconnect_T to query
- *
- * @return Current SocketReconnect_State (e.g., RECONNECT_CONNECTED)
- * @threadsafe No - but read-only, safe if no concurrent mutations
- *
- * Provides snapshot of internal state machine for decision making or logging.
- * States reflect connection status, backoff timers, and circuit breaker.
- * Use in conditionals to gate operations (e.g., only send when CONNECTED).
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketReconnect_State st = SocketReconnect_state(conn);
- * switch (st) {
- *     case RECONNECT_CONNECTED:
- *         // Safe to send/recv
- *         break;
- *     case RECONNECT_CIRCUIT_OPEN:
- *         // Outage detected, alert
- *         break;
- *     default:
- *         // Wait or retry
- * }
- *
- * // Log with name
- * SOCKET_LOG_DEBUG_MSG("State: %s", SocketReconnect_state_name(st));
- * @endcode
- *
- * @complexity O(1)
- * @note State may change immediately after call due to async nature; check in
- * event handlers
- * @see SocketReconnect_isconnected() Convenience for CONNECTED check
- * @see SocketReconnect_state_name() String representation for logs
- * @see SocketReconnect_Callback() Asynchronous state notifications
+ * @param conn Reconnection context
+ * @return Current state
  */
 extern SocketReconnect_State SocketReconnect_state (T conn);
 
 /**
- * @brief Check if reconnection is currently in connected state.
+ * @brief Check if currently connected.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- *
+ * @param conn Reconnection context
  * @return 1 if connected, 0 otherwise
- * @threadsafe No
  */
 extern int SocketReconnect_isconnected (T conn);
 
 /**
- * @brief Get number of connection attempts since last success or reset.
+ * @brief Get connection attempt count since last success/reset.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- *
- * @return Number of connection attempts since last success or reset
- * @threadsafe No
+ * @param conn Reconnection context
+ * @return Number of attempts
  */
 extern int SocketReconnect_attempts (T conn);
 
 /**
- * @brief Get count of consecutive connection failures.
+ * @brief Get consecutive failure count.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- *
- * @return Number of consecutive failures (for circuit breaker)
- * @threadsafe No
+ * @param conn Reconnection context
+ * @return Number of consecutive failures
  */
 extern int SocketReconnect_failures (T conn);
 
@@ -917,149 +274,37 @@ extern int SocketReconnect_failures (T conn);
  */
 
 /**
- * @brief Retrieve file descriptor for event loop integration
- * (poll/epoll/kqueue/select).
+ * @brief Get file descriptor for polling.
  * @ingroup connection_mgmt
- * @param[in] conn SocketReconnect_T instance
- *
- * @return Valid FD (>=0) during CONNECTING/CONNECTED states for polling
- * read/write events, -1 otherwise (no polling needed)
- *
- * Provides the underlying socket file descriptor for multiplexing with other
- * FDs in event loops. Usage:
- * - During CONNECTING: Poll for write (connect completion) or error
- * - During CONNECTED: Poll for read (data available) or write (send buffer
- * ready)
- * - Other states: -1 (no FD to poll; use next_timeout_ms() for timers)
- *
- * Always pair with SocketReconnect_process() when events occur on this FD.
- * FD changes on reconnect (new socket created); re-add to epoll etc. after
- * state change callbacks.
- *
- * ## Event Loop Integration Example
- *
- * @code{.c}
- * // Single instance loop example
- * SocketReconnect_T conn = SocketReconnect_new(...);
- * SocketReconnect_connect(conn);
- *
- * while (running) {
- *     int fd = SocketReconnect_pollfd(conn);
- *     int timeout = SocketReconnect_next_timeout_ms(conn);
- *
- *     // Poll setup (pseudocode)
- *     if (fd >= 0) poll_add(fd, POLLIN | POLLOUT | POLLERR | POLLHUP);
- *
- *     int ready = poll_events(timeout);  // Implement poll loop
- *
- *     if (fd >= 0 && event_on_fd(ready)) {
- *         SocketReconnect_process(conn);
- *     }
- *
- *     SocketReconnect_tick(conn);  // Advance timers
- * }
- * @endcode
- *
- * @threadsafe No - FD may change concurrently if multi-threaded (avoid)
- * @complexity O(1)
- * @note FD valid only while returned >=0; do not close or modify directly
- * @warning In epoll/kqueue, use edge-triggered mode carefully; level-triggered
- * safer
- * @see SocketReconnect_process() Process events on this FD
- * @see SocketReconnect_next_timeout_ms() Timer integration
- * @see SocketReconnect_tick() Periodic timer advancement
- * @see poll/SocketPoll.h For high-performance multiplexing
+ * @param conn Reconnection context
+ * @return Valid FD (>=0) during CONNECTING/CONNECTED, -1 otherwise
  */
 extern int SocketReconnect_pollfd (T conn);
 
 /**
- * @brief Process I/O events from poll loop.
+ * @brief Process I/O events.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
+ * @param conn Reconnection context
  *
- * @threadsafe No
- *
- * Call when SocketReconnect_pollfd() becomes readable/writable.
- * Handles connection completion, detects disconnection, etc.
+ * Call when pollfd() becomes readable/writable.
  */
 extern void SocketReconnect_process (T conn);
 
 /**
- * @brief Calculate milliseconds until next timer event or action.
+ * @brief Get milliseconds until next timer event.
  * @ingroup connection_mgmt
- * @param conn Reconnection context.
- *
+ * @param conn Reconnection context
  * @return Milliseconds until next timeout, or -1 if none pending
- * @threadsafe No
- *
- * Returns the time until:
- * - Next backoff retry
- * - Circuit breaker probe
- * - Health check
- *
- * Use as timeout for poll/select.
  */
 extern int SocketReconnect_next_timeout_ms (T conn);
 
 /**
- * @brief Advance timers and perform periodic maintenance for state transitions
- * and checks.
+ * @brief Advance timers and perform periodic maintenance.
  * @ingroup connection_mgmt
- * @param[in] conn SocketReconnect_T to tick
+ * @param conn Reconnection context
  *
- * Essential function for timer-driven operations:
- * - Advances backoff timers (may trigger CONNECTING from BACKOFF)
- * - Checks circuit reset timeout (may allow new attempts)
- * - Performs health checks if interval elapsed (in CONNECTED)
- * - Detects timeouts for ongoing connects
- * - No-op if no timers pending
- *
- * Call this:
- * - Periodically in main loop (e.g., every 100ms or after poll timeout)
- * - Immediately after SocketReconnect_next_timeout_ms() returns <=0
- * - Does not block; quick execution unless health check active
- *
- * ## Integration Patterns
- *
- * ### With Event Loop
- *
- * @code{.c}
- * while (running) {
- *     int timeout = SocketReconnect_next_timeout_ms(conn);
- *     timeout = MIN(timeout, 100);  // Cap for responsiveness
- *
- *     // Poll with timeout
- *     poll_wait(timeout);
- *
- *     SocketReconnect_tick(conn);  // Handle expired timers
- *
- *     int fd = SocketReconnect_pollfd(conn);
- *     if (event_on_fd(fd)) {
- *         SocketReconnect_process(conn);
- *     }
- * }
- * @endcode
- *
- * ### Standalone Periodic Call
- *
- * @code{.c}
- * // In timer thread or main loop
- * static int64_t last_tick = 0;
- * int64_t now = Socket_get_monotonic_ms();
- * if (now - last_tick >= 50) {  // 50ms granularity
- *     SocketReconnect_tick(conn);
- *     last_tick = now;
- * }
- * @endcode
- *
- * @threadsafe No - modifies timers and may change state
- * @complexity O(1) average; O(health check time) if check runs
- * @note Use Socket_get_monotonic_ms() internally for precision
- * @warning Infrequent calls (> policy intervals) may delay detections; call
- * regularly
- * @see SocketReconnect_next_timeout_ms() Determine optimal call frequency
- * @see SocketReconnect_process() Handle FD events (complement)
- * @see SocketReconnect_HealthCheck Custom check during tick
+ * Call periodically or after poll timeout. Handles backoff timers,
+ * circuit reset, and health checks.
  */
 extern void SocketReconnect_tick (T conn);
 
@@ -1069,45 +314,10 @@ extern void SocketReconnect_tick (T conn);
  */
 
 /**
- * @brief Register a custom health check callback for proactive connection
- * validation.
+ * @brief Register custom health check callback.
  * @ingroup connection_mgmt
- * @param[in] conn SocketReconnect_T to configure
- * @param[in] check Custom health check function (NULL to revert to default)
- *
- * Overrides the default health check behavior used during CONNECTED state.
- * The default check simply polls the socket for readability within the
- * configured timeout to detect dead peers. Custom checks can perform
- * application-specific validation (e.g., send ping, check latency).
- *
- * Changes take effect on next health check interval (no immediate invocation).
- * If health checks disabled (interval=0), this has no effect.
- *
- * ## Default vs Custom
- * - **Default**: Socket_poll for POLLIN within timeout_ms (lightweight,
- * detects closes)
- * - **Custom**: Caller-defined; must return 1=healthy, 0=unhealthy quickly
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Set custom check after creation
- * SocketReconnect_set_health_check(conn, my_app_ping_check);
- *
- * // Or revert to default
- * SocketReconnect_set_health_check(conn, NULL);
- * @endcode
- *
- * @threadsafe No - modifies instance configuration
- * @complexity O(1) - simple assignment
- * @note Callback userdata is from creation (not set here); for per-check data
- * use conn context
- * @warning Custom checks blocking > timeout_ms will hang tick()/process();
- * always respect limit
- * @see SocketReconnect_HealthCheck Callback type definition and requirements
- * @see SocketReconnect_Policy_T::health_check_interval_ms Enable/disable
- * checks
- * @see SocketReconnect_Policy_T::health_check_timeout_ms Set timeout limit
+ * @param conn Reconnection context
+ * @param check Custom check function (NULL for default)
  */
 extern void
 SocketReconnect_set_health_check (T conn, SocketReconnect_HealthCheck check);
@@ -1118,50 +328,9 @@ SocketReconnect_set_health_check (T conn, SocketReconnect_HealthCheck check);
  */
 
 /**
- * @brief Populate a SocketReconnect_Policy_T with safe, production-recommended
- * default values.
+ * @brief Initialize policy with production-safe defaults.
  * @ingroup connection_mgmt
- * @param[out] policy Pointer to structure to initialize (overwritten)
- *
- * Sets balanced defaults suitable for most TCP services:
- * - Conservative backoff to avoid overload
- * - Circuit breaker to prevent storms
- * - Health checks for proactive failure detection
- *
- * ## Defaults Table
- *
- * | Setting | Value | Rationale |
- * |---------|-------|-----------|
- * | initial_delay_ms | 100 | Quick first retry without overwhelming |
- * | max_delay_ms | 30000 | 30s cap prevents long hangs |
- * | multiplier | 2.0 | Standard exponential growth |
- * | jitter | 0.25 | 25% randomization avoids herd |
- * | max_attempts | 10 | Limit retries to prevent infinite loops |
- * | circuit_failure_threshold | 5 | Quick detection of outages |
- * | circuit_reset_timeout_ms | 60000 | 1min cooldown before probe |
- * | health_check_interval_ms | 30000 | Check every 30s, low overhead |
- * | health_check_timeout_ms | 5000 | 5s max to avoid blocking |
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketReconnect_Policy_T policy;
- * SocketReconnect_policy_defaults(&policy);
- *
- * // Optional tweaks
- * policy.initial_delay_ms = 200;  // Slower start for busy servers
- *
- * SocketReconnect_T conn = SocketReconnect_new(host, port, &policy, NULL,
- * NULL);
- * @endcode
- *
- * @return void (populates policy in place)
- * @threadsafe Yes - pure function, no side effects
- * @complexity O(1) - simple assignment
- * @note Always use this before custom modifications to ensure valid base
- * @warning Modifying after SocketReconnect_new() requires new instance
- * @see SocketReconnect_Policy_T Full field documentation
- * @see SocketReconnect_new() Apply initialized policy
+ * @param policy Policy structure to initialize
  */
 extern void SocketReconnect_policy_defaults (SocketReconnect_Policy_T *policy);
 
@@ -1171,128 +340,22 @@ extern void SocketReconnect_policy_defaults (SocketReconnect_Policy_T *policy);
  */
 
 /**
- * @brief Send data over the reconnection-managed connection with automatic
- * retry on transient errors.
+ * @brief Send data with automatic reconnect on error.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- * @param[in] buf Buffer containing data to send
- * @param[in] len Number of bytes from buf to send (0 valid, no-op)
- *
- * @return Number of bytes sent (>0 success), 0 if not connected
- * (DISCONNECTED/BACKOFF/CIRCUIT_OPEN), -1 on error
- *
- * Convenience wrapper providing transparent I/O over the managed connection.
- * Behavior:
- * - If CONNECTED: Delegates to Socket_send() on underlying socket
- * - If not connected: Returns 0 immediately (no blocking)
- * - On send error or disconnection: Triggers reconnect logic, sets errno to
- * ENOTCONN, returns -1
- * - Partial sends possible (like Socket_send); caller must handle retries if
- * needed
- *
- * Does not buffer unsent data; for reliability use higher-level protocols (TCP
- * ensures delivery if connected).
- *
- * ## Error Handling
- * - errno=ENOTCONN: Not connected or lost connection (reconnect queued)
- * - errno=ECONNRESET/EPIPE: Peer closed, triggers reconnect
- * - Other errnos propagated from underlying socket
- *
- * ## Usage Example - Transparent Send
- *
- * @code{.c}
- * // Assume conn connected
- * const char *msg = "Hello Server";
- * ssize_t sent = SocketReconnect_send(conn, msg, strlen(msg));
- * if (sent < 0) {
- *     if (errno == ENOTCONN) {
- *         // Reconnect will happen automatically
- *         SOCKET_LOG_WARN_MSG("Send failed, reconnecting...");
- *     } else {
- *         // Handle other errors
- *     }
- * } else {
- *     // sent bytes transmitted or queued in TCP
- * }
- * @endcode
- *
- * ## When to Use vs Direct Socket
- * - Use this for simple apps wanting auto-reconnect without event loop
- * - For performance/control: Get socket with SocketReconnect_socket() and use
- * Socket_sendv() etc.
- * - Buffering? Use SocketPool or application-level queues
- *
- * @threadsafe No - modifies internal state
- * @complexity O(len) - underlying send syscall
- * @note SIGPIPE handled internally (no signal sent)
- * @warning Not for large data; consider Socket_sendfile() or chunking for big
- * transfers
- * @see SocketReconnect_recv() Counterpart receive wrapper
- * @see SocketReconnect_socket() Direct access for advanced I/O
- * @see Socket_send() Underlying primitive
+ * @param conn Reconnection context
+ * @param buf Data to send
+ * @param len Length in bytes
+ * @return Bytes sent (>0), 0 if not connected, -1 on error
  */
 extern ssize_t SocketReconnect_send (T conn, const void *buf, size_t len);
 
 /**
- * @brief Receive data from the reconnection-managed connection,
- * auto-reconnecting on close or errors.
+ * @brief Receive data with automatic reconnect on disconnect.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- * @param[out] buf Buffer to receive data into
- * @param[in] len Maximum bytes to receive into buf (must >0)
- *
- * @return Bytes received (>0), 0 on EOF/disconnect (triggers reconnect), -1 on
- * error
- *
- * Symmetric to SocketReconnect_send(): Provides transparent recv with
- * auto-recovery. Behavior:
- * - If CONNECTED: Delegates to Socket_recv() on underlying socket
- * - If not connected: Returns 0 immediately (would block)
- * - On recv error, EOF (0 bytes), or disconnect: Triggers reconnection,
- * returns 0
- * - Partial receives possible; loop until 0 for full messages
- *
- * TCP ensures ordered delivery when connected; 0 indicates clean close or
- * abrupt disconnect.
- *
- * ## Error Handling
- * - Return 0: EOF or error triggering reconnect (check state after)
- * - errno=EAGAIN: Would block (non-blocking mode); try again later
- * - Other errnos from underlying recv propagated
- *
- * ## Usage Example - Transparent Recv Loop
- *
- * @code{.c}
- * char buf[1024];
- * while (running && SocketReconnect_isconnected(conn)) {
- *     ssize_t rcvd = SocketReconnect_recv(conn, buf, sizeof(buf));
- *     if (rcvd > 0) {
- *         // Process data
- *         process_data(buf, rcvd);
- *     } else if (rcvd == 0) {
- *         SOCKET_LOG_INFO_MSG("Connection closed, reconnecting...");
- *         // Auto-reconnect happens
- *         break;  // Or continue to wait
- *     } else {  // -1
- *         if (errno != EAGAIN) {
- *             // Handle error
- *         }
- *     }
- * }
- * @endcode
- *
- * ## Performance Notes
- * - For high-throughput: Use recvv() variants via direct socket access
- * - Buffering: No internal queue; data lost on disconnect before recv
- * - Non-blocking: Safe in event loops; returns EAGAIN if no data
- *
- * @threadsafe No - may trigger state changes
- * @complexity O(len) - underlying recv syscall
- * @note Handles partial reads; application must loop for complete messages
- * @warning Recv in non-connected state wastes CPU; check isconnected() first
- * @see SocketReconnect_send() Send counterpart
- * @see SocketReconnect_socket() For recvv, peek, etc.
- * @see Socket_recv() Underlying primitive
+ * @param conn Reconnection context
+ * @param buf Buffer to receive into
+ * @param len Buffer size
+ * @return Bytes received (>0), 0 on EOF/disconnect, -1 on error
  */
 extern ssize_t SocketReconnect_recv (T conn, void *buf, size_t len);
 
@@ -1302,12 +365,10 @@ extern ssize_t SocketReconnect_recv (T conn, void *buf, size_t len);
  */
 
 /**
- * @brief Get human-readable name for a reconnection state.
+ * @brief Get human-readable state name.
  * @ingroup connection_mgmt
- * @param state Reconnection state enum value.
- *
- * @return Static string with state name
- * @threadsafe Yes
+ * @param state State enum value
+ * @return Static string
  */
 extern const char *SocketReconnect_state_name (SocketReconnect_State state);
 
@@ -1317,57 +378,18 @@ extern const char *SocketReconnect_state_name (SocketReconnect_State state);
  */
 
 #if SOCKET_HAS_TLS
-/* Temporarily undefine T to avoid conflict with TLS headers' T macro */
 #undef T
 #include "tls/SocketTLS.h"
 #include "tls/SocketTLSContext.h"
-/* Restore T for remaining function declarations */
 #define T SocketReconnect_T
 
 /**
  * @brief Configure TLS for reconnecting connections.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- * @param[in] ctx TLS context (caller retains ownership; must outlive conn)
- * @param[in] hostname SNI hostname for certificate verification (copied)
- *
- * Enables TLS on all future connections made by this reconnection instance.
- * The TLS context is NOT owned by SocketReconnect - caller must ensure it
- * remains valid for the lifetime of the reconnection instance.
- *
- * After TCP connect completes, TLS handshake is performed automatically.
- * The hostname is used for:
- * - SNI (Server Name Indication) extension per RFC 6066
- * - Certificate hostname verification via X509_check_host()
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketTLSContext_T ctx = SocketTLSContext_new_client(NULL);
- * SocketReconnect_T conn = SocketReconnect_new("api.example.com", 443,
- *                                               NULL, NULL, NULL);
- * SocketReconnect_set_tls(conn, ctx, "api.example.com");
- * SocketReconnect_connect(conn);
- *
- * // TLS handshake happens automatically after TCP connect
- * while (!SocketReconnect_isconnected(conn)) {
- *     SocketReconnect_tick(conn);
- * }
- *
- * // Now using encrypted connection
- * SocketReconnect_send(conn, data, len);  // Uses SocketTLS_send internally
- * @endcode
- *
- * @note Call before SocketReconnect_connect() for first connection
- * @note Can be called while disconnected to change TLS settings
- * @warning Calling while connected has no effect until next reconnect
- * @threadsafe No - must be called from same thread as other operations
- *
+ * @param conn Reconnection context
+ * @param ctx TLS context (caller retains ownership)
+ * @param hostname SNI hostname for verification
  * @throws SocketReconnect_Failed if hostname is NULL or too long
- *
- * @see SocketReconnect_disable_tls() to remove TLS configuration
- * @see SocketReconnect_tls_enabled() to query TLS state
- * @see SocketTLSContext_new_client() for context creation
  */
 extern void SocketReconnect_set_tls (T conn, SocketTLSContext_T ctx,
                                      const char *hostname);
@@ -1375,88 +397,47 @@ extern void SocketReconnect_set_tls (T conn, SocketTLSContext_T ctx,
 /**
  * @brief Disable TLS for future connections.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- *
- * Clears TLS configuration. Future connections will be plain TCP.
- * If currently connected with TLS, the connection remains encrypted
- * until disconnect; the next reconnect will be unencrypted.
- *
- * @note Does not affect current connection if active
- * @threadsafe No
- *
- * @see SocketReconnect_set_tls() to enable TLS
+ * @param conn Reconnection context
  */
 extern void SocketReconnect_disable_tls (T conn);
 
 /**
- * @brief Check if TLS is configured for this connection.
+ * @brief Check if TLS is configured.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- *
- * @return 1 if TLS is configured (context set), 0 otherwise
- * @threadsafe Yes - reads only
- *
- * @see SocketReconnect_set_tls() to configure TLS
+ * @param conn Reconnection context
+ * @return 1 if TLS configured, 0 otherwise
  */
 extern int SocketReconnect_tls_enabled (T conn);
 
 /**
- * @brief Get the configured TLS hostname.
+ * @brief Get configured TLS hostname.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- *
+ * @param conn Reconnection context
  * @return SNI hostname or NULL if TLS not configured
- * @threadsafe Yes - returns internal pointer (valid until set_tls/free)
- *
- * @see SocketReconnect_set_tls() to set hostname
  */
 extern const char *SocketReconnect_get_tls_hostname (T conn);
 
 /**
- * @brief Get current TLS handshake state.
+ * @brief Get TLS handshake state.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- *
- * Returns the current TLS handshake progress. Useful for debugging
- * and advanced event loop integration.
- *
- * @return Current TLSHandshakeState, or TLS_HANDSHAKE_NOT_STARTED if
- *         TLS not enabled or no handshake in progress
- * @threadsafe Yes - reads only
- *
- * @see TLSHandshakeState for state descriptions
+ * @param conn Reconnection context
+ * @return Current handshake state
  */
 extern TLSHandshakeState SocketReconnect_tls_handshake_state (T conn);
 
 /**
- * @brief Enable TLS session resumption for faster reconnects.
+ * @brief Enable/disable TLS session resumption.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- * @param[in] enable 1 to enable session caching, 0 to disable
- *
- * When enabled, successful TLS sessions are saved and restored on
- * reconnect attempts, enabling abbreviated handshakes (0-RTT for TLS 1.3).
- * This significantly reduces reconnection latency.
- *
- * @note Enabled by default when TLS is configured
- * @note Session data stored internally; cleared on disable_tls or free
- * @threadsafe No
- *
- * @see SocketTLS_is_session_reused() to check if resumption worked
+ * @param conn Reconnection context
+ * @param enable 1 to enable, 0 to disable
  */
 extern void SocketReconnect_set_session_resumption (T conn, int enable);
 
 /**
  * @brief Check if last connection used session resumption.
  * @ingroup connection_mgmt
- * @param[in] conn Reconnection context
- *
- * @return 1 if session was resumed (abbreviated handshake),
- *         0 if full handshake was performed,
- *         -1 if not connected or TLS not enabled
- * @threadsafe Yes - reads only
- *
- * @see SocketReconnect_set_session_resumption() to enable caching
+ * @param conn Reconnection context
+ * @return 1 if resumed, 0 if full handshake, -1 if not connected
  */
 extern int SocketReconnect_is_session_reused (T conn);
 

--- a/include/tls/SocketTLSContext.h
+++ b/include/tls/SocketTLSContext.h
@@ -4,6 +4,28 @@
  * https://x.com/tetsuoai
  */
 
+/**
+ * @file SocketTLSContext.h
+ * @ingroup security
+ * @brief TLS context management with secure defaults and certificate handling.
+ *
+ * Features:
+ * - TLS 1.3 preferred, modern cipher suites
+ * - Certificate/CA loading with verification
+ * - ALPN protocol negotiation
+ * - Session caching and tickets
+ * - OCSP stapling (client and server)
+ * - Certificate pinning (SPKI SHA256)
+ * - Certificate Transparency (RFC 6962)
+ * - CRL with auto-refresh
+ *
+ * Thread safety: Contexts NOT thread-safe during modification. Share read-only
+ * after setup. SSL objects created from context are per-connection.
+ *
+ * @see SocketTLS.h for socket integration
+ * @see docs/SECURITY.md for TLS hardening
+ */
+
 #ifndef SOCKETTLSCONTEXT_INCLUDED
 #define SOCKETTLSCONTEXT_INCLUDED
 
@@ -14,207 +36,24 @@
 
 #if SOCKET_HAS_TLS
 
-#include <openssl/ssl.h>      /* For SSL_VERIFY_* and X509_STORE_CTX */
-#include <openssl/x509_vfy.h> /* For X509_STORE_CTX */
+#include <openssl/ssl.h>
+#include <openssl/x509_vfy.h>
 
 #define T SocketTLSContext_T
-typedef struct T *T; /* Opaque pointer to TLS context */
+typedef struct T *T;
 
-/**
- * @defgroup tls_context TLS Context Management
- * @brief Secure TLS context configuration, certificate handling, and advanced
- * features like OCSP stapling, pinning, and CT.
- * @ingroup security
- *
- * ## Architecture Overview
- *
- * ```
- * ┌───────────────────────────────────────────────────────────┐
- * │                    Application Layer                      │
- * │  SocketHTTPClient, SocketHTTPServer, Custom Services      │
- * └─────────────────────┬─────────────────────────────────────┘
- *                       │ Uses (applies context via enable)
- * ┌─────────────────────▼─────────────────────────────────────┐
- * │              TLS Context Layer                            │
- * │  SocketTLSContext: Certs/Keys, Protocols, ALPN, Sessions  │
- * │  - Pinning, OCSP, CRL, CT Verification                    │
- * └─────────────────────┬─────────────────────────────────────┘
- *                       │ Wraps/Integrates
- * ┌─────────────────────▼─────────────────────────────────────┐
- * │                 OpenSSL Layer                             │
- * │  SSL_CTX, X509_STORE, OCSP, CT Logs, Session Cache        │
- * └─────────────────────┬─────────────────────────────────────┘
- *                       │ Uses
- * ┌─────────────────────▼─────────────────────────────────────┐
- * │              Socket Library Foundation                    │
- * │  Arena (alloc), Except (errors), SocketTLS (I/O), Config  │
- * └───────────────────────────────────────────────────────────┘
- * ```
- *
- * ## Module Relationships
- *
- * - **Depends on**: @ref foundation (Arena_T for zero-leak memory, Except_T
- * for errors), SocketTLS.h for socket integration, SocketTLSConfig.h for
- * structs/enums
- * - **Used by**: SocketTLS_enable() to secure sockets; HTTP modules for HTTPS;
- * custom apps for secure connections
- * - **Platform**: Requires OpenSSL 1.1.1+ for full TLS1.3/OCSP/CT support;
- * auto-detects LibreSSL
- * - **Security**: Enforces modern TLS (1.3 preferred), PFS ciphers, secure
- * defaults; optional features like pinning/CRL for enhanced protection
- *
- * @see @ref security "Security Modules" for TLS, SYN protect, etc.
- * @see SocketTLS.h for TLS-secured socket operations
- * @see docs/SECURITY.md for TLS hardening guide
- * @{
- *
- * @file SocketTLSContext.h
- * @brief TLS context management with secure defaults and certificate handling.
- *
- * Manages OpenSSL SSL_CTX objects with socket library integration. Provides
- * secure defaults (TLS1.3-only, modern ciphers), certificate loading, protocol
- * configuration, and session caching. Supports both client and server contexts
- * with Arena-based memory management for zero-leak operation.
- *
- * Features:
- * - TLS1.3-only enforcement for forward secrecy and security
- * - Modern cipher suites (ECDHE + AES-GCM/ChaCha20-Poly1305)
- * - Certificate verification with CA loading and hostname validation
- * - ALPN protocol negotiation support
- * - Session resumption via cache for performance
- * - Non-blocking compatible configuration
- * - Exception-based error handling with detailed OpenSSL error messages
- * - Advanced: OCSP stapling, certificate pinning (SPKI), Certificate
- * Transparency (CT), CRL auto-refresh
- *
- * Thread safety: Contexts are not thread-safe for modification after creation.
- * Share read-only after full setup, or use per-thread contexts.
- * SSL objects created from context are per-connection and thread-safe.
- *
- * ## Platform Requirements
- *
- * - OpenSSL 1.1.1+ or LibreSSL (TLS1.3, OCSP, CT)
- * - POSIX system with threads (pthreads)
- * - File system access for cert/CA/CRL loading
- *
- * ## Usage Patterns
- *
- * ### Server Context
- * @code{.c}
- * TRY {
- *     SocketTLSContext_T ctx = SocketTLSContext_new_server("server.crt",
- * "server.key", "ca-bundle.pem");
- *     // Optional: SocketTLSContext_load_crl(ctx, "crl-dir/");
- *     // Optional: SocketTLSContext_add_pin_from_cert(ctx,
- * "backup-server.crt"); SocketTLSContext_enable_ocsp_stapling(ctx);
- *     // Apply to listening socket
- *     SocketTLS_enable(server_sock, ctx);
- * } EXCEPT(SocketTLS_Failed) {
- *     // Handle error: invalid cert, OpenSSL init fail
- * } END_TRY;
- * @endcode
- *
- * ### Client Context with Pinning
- * @code{.c}
- * TRY {
- *     SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- *     SocketTLSContext_enable_ct(ctx, CT_VALIDATION_STRICT);
- *     SocketTLSContext_add_pin_hex(ctx, "sha256//your-pin-hash-here");
- *     SocketTLSContext_set_pin_enforcement(ctx, 1); // Strict
- *     // Connect and enable
- *     Socket_T sock = Socket_connect("example.com", 443);
- *     SocketTLS_enable(sock, ctx);
- *     SocketTLS_set_hostname(sock, "example.com"); // For SNI/verify
- *     SocketTLS_handshake_auto(sock);
- * } EXCEPT(SocketTLS_PinVerifyFailed) {
- *     // MITM detected or bad pin
- * } END_TRY;
- * @endcode
- *
- * @warning Always load trusted CAs; disabling verification (TLS_VERIFY_NONE)
- * exposes to MITM
- * @warning Configure pins before production; test with
- * SocketTLSContext_verify_pin()
- * @complexity Context creation O(1) + cert parse time; verification O(chain
- * length)
- *
- * @see SocketTLSContext_new_server() for server setup
- * @see SocketTLSContext_new_client() for client setup
- * @see SocketTLSContext_free() for cleanup
- * @see SocketTLS_enable() for socket integration
- * @see @ref SocketDTLSContext_T for UDP/DTLS variant
- * @see docs/ASYNC_IO.md for non-blocking TLS patterns
- * @see docs/SECURITY.md#tls-configuration for best practices
+/* ============================================================================
+ * Context Creation
+ * ============================================================================
  */
 
-/* TLS context creation */
 /**
  * @brief Create server TLS context with cert/key.
- * @ingroup security
- * @param[in] cert_file Path to server certificate file (PEM format)
- * @param[in] key_file Path to private key file (PEM format)
- * @param[in] ca_file Optional path to CA file/directory for client auth (NULL
- * to disable)
- *
- * Creates a server-side TLS context, loads server cert/key, sets TLS1.3-only,
- * modern ciphers (ECDHE + AES-GCM/ChaCha20-Poly1305 for PFS), and optionally
- * CA for client verification. Security: Enforces TLS 1.3-only protocol;
- * disables renegotiation, compression, and legacy features; server cipher
- * preference; peer verification configurable; securely clears sensitive
- * keys/material on free.
- *
- * ## Usage Example
- *
- * @code{.c}
- * TRY {
- *     SocketTLSContext_T ctx = SocketTLSContext_new_server("server.crt",
- * "server.key", "ca-bundle.pem");
- *     // Optional: Load CRL for revocation checking
- *     SocketTLSContext_load_crl(ctx, "/path/to/crl/");
- *     // Optional: Enable OCSP stapling for clients
- *     SocketTLSContext_enable_ocsp_stapling(ctx);
- *     // Apply to server socket
- *     SocketTLS_enable(server_sock, ctx);
- * } EXCEPT(SocketTLS_Failed) {
- *     // Handle: invalid cert/key, file I/O error, OpenSSL init fail
- *     fprintf(stderr, "Server TLS setup failed: %s\n", Socket_GetLastError());
- * } FINALLY {
- *     if (ctx) SocketTLSContext_free(&ctx); // Ensure cleanup
- * } END_TRY;
- * @endcode
- *
- * ## Advanced Usage with SNI and Pinning
- *
- * @code{.c}
- * SocketTLSContext_T ctx = SocketTLSContext_new_server("default.crt",
- * "default.key", NULL);
- * // Add SNI certs
- * SocketTLSContext_add_certificate(ctx, "www.example.com", "example.crt",
- * "example.key"); SocketTLSContext_add_certificate(ctx, "api.example.com",
- * "api.crt", "api.key");
- * // Pin backup key for resilience
- * SocketTLSContext_add_pin_from_cert(ctx, "backup.crt");
- * SocketTLSContext_set_pin_enforcement(ctx, 1); // Fail if no match
- * @endcode
- *
- * @note Create ctx once at startup; reuse for all connections to same
- * server/domain
- * @warning Match cert to domain; use ECDSA or RSA-4096 keys; rotate
- * periodically
- * @warning ca_file enables client auth; without it, anonymous clients allowed
- * (security risk)
- * @complexity O(1) base + O(n) for cert chain validation and file reads
- * (n=chain length)
- *
- * @return New opaque SocketTLSContext_T instance
- * @throws SocketTLS_Failed on OpenSSL errors, file I/O, or invalid cert/key
- * @see SocketTLSContext_free() for disposing the context.
- * @see SocketTLSContext_new_client() for client-side context.
- * @see SocketTLSContext_load_ca() for additional CA configuration.
- * @see SocketTLS_enable() to apply context to a socket.
- * @see @ref foundation for Arena-based memory management used internally.
- * @see @ref core_io "Socket" for base socket operations secured by TLS.
- * @threadsafe Yes - each call creates independent context
+ * @param cert_file Server certificate (PEM)
+ * @param key_file Private key (PEM)
+ * @param ca_file Optional CA file for client auth (NULL to disable)
+ * @return New context
+ * @throws SocketTLS_Failed on error
  */
 extern T SocketTLSContext_new_server (const char *cert_file,
                                       const char *key_file,
@@ -222,102 +61,48 @@ extern T SocketTLSContext_new_server (const char *cert_file,
 
 /**
  * @brief Create client TLS context.
- * @ingroup security
- * @param[in] ca_file Optional path to CA file/directory for server
- * verification (NULL to disable)
- *
- * Creates a client-side TLS context with TLS1.3-only and modern ciphers (ECDHE
- * + AES-GCM/ChaCha20-Poly1305). Loads CA if provided and enables peer
- * verification by default. Security: Enforces TLS 1.3-only protocol; disables
- * renegotiation and compression; warns on missing CA (MITM risk); peer
- * verification required; securely clears sensitive data on free.
- *
- * ## Usage Example
- *
- * @code{.c}
- * TRY {
- *     SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- *     // Enable advanced features
- *     SocketTLSContext_enable_ct(ctx, CT_VALIDATION_STRICT);
- *     SocketTLSContext_enable_ocsp_stapling(ctx);
- *     // Pin known server key
- *     SocketTLSContext_add_pin_hex(ctx, "sha256//server-pin-hash");
- * } EXCEPT(SocketTLS_Failed) {
- *     // Handle CA load fail or OpenSSL error
- * } END_TRY;
- * @endcode
- *
- * ## With Custom Config
- *
- * @code{.c}
- * SocketTLSConfig_T config = {0};
- * SocketTLSConfig_defaults(&config);
- * config.min_version = TLS1_2_VERSION; // Allow TLS1.2 fallback if needed
- * SocketTLSContext_T ctx = SocketTLSContext_new(&config);
- * @endcode
- *
- * @note Prefer system CA bundle or pinned CAs for production
- * @warning NULL ca_file disables verification - only for testing/internal
- * @complexity O(1) + CA file parse time
- *
- * @return New opaque SocketTLSContext_T instance
- * @throws SocketTLS_Failed on OpenSSL errors or invalid CA
- * @see SocketTLSContext_free() for disposal.
- * @see SocketTLSContext_new_server() for server context.
- * @see SocketTLSContext_set_verify_mode() to adjust verification.
- * @see @ref security for other TLS security features like pinning and OCSP.
- * @threadsafe Yes
+ * @param ca_file Optional CA file for server verification
+ * @return New context
+ * @throws SocketTLS_Failed on error
  */
 extern T SocketTLSContext_new_client (const char *ca_file);
 
 /**
- * @brief Create client TLS context with custom config.
- * @ingroup security
- * @param[in] config Custom TLS configuration (or NULL for defaults)
- *
- * Creates a client-side TLS context with provided configuration.
- * If config NULL, uses secure defaults.
- *
- * @return New opaque SocketTLSContext_T instance
- * @throws SocketTLS_Failed on OpenSSL errors
- * @threadsafe Yes
+ * @brief Create TLS context with custom config.
+ * @param config Configuration (NULL for defaults)
+ * @return New context
+ * @throws SocketTLS_Failed on error
  */
 extern T SocketTLSContext_new (const SocketTLSConfig_T *config);
 
-/* Certificate management */
 /**
- * @brief Load server certificate and private key.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param[in] cert_file Path to certificate file (PEM)
- * @param[in] key_file Path to private key file (PEM)
- *
- * Loads and validates server certificate/private key pair. Verifies key
- * matches cert.
- *
- * @return void
- * @throws SocketTLS_Failed on file errors, format issues, or mismatch
- * @threadsafe No - caller must synchronize configuration changes
+ * @brief Dispose of TLS context.
+ * @param ctx_p Pointer to context (set to NULL)
+ */
+extern void SocketTLSContext_free (T *ctx_p);
+
+/* ============================================================================
+ * Certificate Management
+ * ============================================================================
+ */
+
+/**
+ * @brief Load server certificate and key.
+ * @param ctx TLS context
+ * @param cert_file Certificate (PEM)
+ * @param key_file Private key (PEM)
+ * @throws SocketTLS_Failed on error
  */
 extern void SocketTLSContext_load_certificate (T ctx, const char *cert_file,
                                                const char *key_file);
 
 /**
- * @brief Add certificate mapping for SNI virtual hosting.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param hostname Hostname this certificate is for (NULL for default
- * certificate)
- * @param[in] cert_file Certificate file path (PEM format)
- * @param[in] key_file Private key file path (PEM format)
- *
- * Adds a certificate/key pair for SNI-based virtual hosting. Multiple
- * certificates can be loaded for different hostnames. The first certificate
- * loaded becomes the default if no hostname match is found.
- *
- * @return void
- * @throws SocketTLS_Failed on error (file not found, invalid cert/key,
- * allocation) @threadsafe No - modifies shared context
+ * @brief Add certificate for SNI virtual hosting.
+ * @param ctx TLS context
+ * @param hostname Hostname (NULL for default)
+ * @param cert_file Certificate (PEM)
+ * @param key_file Private key (PEM)
+ * @throws SocketTLS_Failed on error
  */
 extern void SocketTLSContext_add_certificate (T ctx, const char *hostname,
                                               const char *cert_file,
@@ -325,501 +110,123 @@ extern void SocketTLSContext_add_certificate (T ctx, const char *hostname,
 
 /**
  * @brief Load trusted CA certificates.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param[in] ca_file Path to CA file or directory containing PEM CA certs
- *
- * Loads trusted CA certificates from file or directory for peer
- * (client/server) verification. Supports PEM format files or hashed
- * directories (OpenSSL style). Multiple calls accumulate CAs. Essential for
- * preventing MITM by validating peer cert chain against trusted
- * roots/intermediates.
- *
- * Directory mode scans for CA files named by subject hash (e.g., <hash>.0).
- * File mode loads concatenated PEM bundle.
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketTLSContext_T ctx = SocketTLSContext_new_client(NULL); // Start without
- * CA TRY { SocketTLSContext_load_ca(ctx,
- * "/etc/ssl/certs/ca-certificates.crt"); // System bundle
- *     // Or directory:
- *     SocketTLSContext_load_ca(ctx, "/etc/ssl/certs/"); // Ubuntu/Debian style
- *     SocketTLSContext_set_verify_mode(ctx, TLS_VERIFY_PEER); // Require valid
- * cert } EXCEPT(SocketTLS_Failed) {
- *     // Handle: file not found, invalid PEM, OpenSSL parse error
- * } END_TRY;
- * @endcode
- *
- * @note Call after context creation, before handshakes; affects all
- * connections using ctx
- * @warning Use only trusted CAs; avoid self-signed or unverified bundles in
- * production
- * @warning Directory must contain valid CA files; invalid files logged but
- * skipped
- * @complexity O(n) where n=number of certs loaded (parse/verify each)
- *
- * @return void
- * @throws SocketTLS_Failed on load/parse errors (ENOMEM, invalid format, I/O)
- * @threadsafe Yes (internal mutex protects shared store)
- *
- * @see SocketTLSContext_set_verify_mode() to require CA validation
- * @see SocketTLSContext_new_client() which auto-loads if ca_file provided
- * @see SocketTLS_get_verify_result() post-handshake to check verification
- * outcome
+ * @param ctx TLS context
+ * @param ca_file CA file or directory
+ * @throws SocketTLS_Failed on error
  */
 extern void SocketTLSContext_load_ca (T ctx, const char *ca_file);
 
 /**
- * @brief Set certificate verification policy.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param mode Verification mode enum (TLS_VERIFY_NONE, PEER, etc.)
- *
- * Configures peer cert verification behavior, mapping to OpenSSL SSL_VERIFY_*
- * flags.
- *
- * @return void
+ * @brief Set certificate verification mode.
+ * @param ctx TLS context
+ * @param mode TLS_VERIFY_NONE, TLS_VERIFY_PEER, etc.
  * @throws SocketTLS_Failed on invalid mode
- * @threadsafe Yes (mutex protected)
  */
 extern void SocketTLSContext_set_verify_mode (T ctx, TLSVerifyMode mode);
 
-/* Custom Verification Support */
+/* ============================================================================
+ * Custom Verification
+ * ============================================================================
+ */
 
 /**
- * @brief User-defined certificate verification callback.
- * @ingroup security
- * @param preverify_ok OpenSSL pre-verification result (1=OK, 0=fail)
- * @param x509_ctx OpenSSL certificate store context (access cert chain via
- * X509_STORE_CTX_get_current_cert())
- * @param tls_ctx TLS context for shared configuration/data
- * @param socket Associated socket for connection-specific info (e.g.,
- * hostname)
- * @param user_data Opaque user data from SocketTLSContext_set_verify_callback
- *
- * Called during TLS verification to allow custom logic (e.g., pinning, policy
- * checks). Return 1 to accept/continue verification, 0 to fail (aborts
- * handshake). Can raise exceptions for detailed errors.
- *
- * ## Thread Safety
- *
- * **IMPORTANT**: If the same TLS context is shared across multiple threads
- * (e.g., for connection pooling or multi-threaded servers), this callback
- * may be invoked concurrently from multiple threads during parallel TLS
- * handshakes. The callback implementation MUST be thread-safe:
- *
- * - Avoid modifying shared state without synchronization
- * - Use thread-local storage or mutexes for shared data
- * - The tls_ctx and user_data pointers are shared across all invocations
- * - The x509_ctx and socket are per-connection and safe to use without locking
- *
- * If the callback raises an exception (any Except_T), it is caught by the
- * library and converted to a handshake failure with
- * X509_V_ERR_APPLICATION_VERIFICATION.
- *
- * ## Return Value Behavior
- *
- * - Return 1: Continue verification (OpenSSL will proceed to next check)
- * - Return 0: Abort handshake immediately (SocketTLS_HandshakeFailed raised)
- *
- * ## Example
- *
- * @code{.c}
- * int my_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx,
- *                        SocketTLSContext_T tls_ctx, Socket_T socket,
- *                        void *user_data) {
- *     // Thread-safe: only reads from user_data, no shared writes
- *     const char *expected_cn = (const char *)user_data;
- *
- *     if (!preverify_ok) {
- *         // OpenSSL pre-verification failed - get error details
- *         int err = X509_STORE_CTX_get_error(x509_ctx);
- *         printf("Pre-verify failed: %s\n", X509_verify_cert_error_string(err));
- *         return 0; // Reject - will abort handshake
- *     }
- *
- *     // Custom check: verify CN matches expected value
- *     X509 *cert = X509_STORE_CTX_get_current_cert(x509_ctx);
- *     // ... perform custom validation ...
- *
- *     return 1; // Accept - continue verification
- * }
- * @endcode
- *
- * @threadsafe Conditional - callback MUST be thread-safe if context is shared
- *             across threads
- *
- * @see SocketTLSContext_set_verify_callback() to register this callback
- * @see SocketTLSContext_set_verify_mode() for base verification policy
+ * @brief User-defined verification callback.
+ * @param preverify_ok OpenSSL result (1=OK, 0=fail)
+ * @param x509_ctx Certificate store context
+ * @param tls_ctx TLS context
+ * @param socket Socket being verified
+ * @param user_data User data
+ * @return 1 to accept, 0 to reject
+ * @note Callback MUST be thread-safe if context is shared across threads.
  */
 typedef int (*SocketTLSVerifyCallback) (int preverify_ok,
                                         X509_STORE_CTX *x509_ctx, T tls_ctx,
                                         Socket_T socket, void *user_data);
 
 /**
- * @brief Dispose of TLS context and resources.
- * @ingroup security
- * @param[in,out] ctx_p Pointer to context pointer (set to NULL on success)
- *
- * Frees the SSL_CTX, Arena (internal allocations), SNI arrays/certs/keys, ALPN
- * data, and securely wipes sensitive material (e.g., session ticket keys via
- * OPENSSL_cleanse, pinning data via SocketCrypto_secure_clear). Caller must
- * not use context after free. Reverse of new_server/client. Security: Ensures
- * no residual sensitive data in memory; thread-safe but avoid concurrent
- * access.
- *
- * @return void
- * @throws None (safe for NULL)
- * @see SocketTLSContext_new_server(), SocketTLSContext_new_client(),
- * SocketTLSContext_new() for context creation.
- * @see @ref foundation "Except_T" and Arena for exception and memory handling
- * integrated here.
- * @threadsafe Yes (but avoid concurrent use)
- */
-extern void SocketTLSContext_free (T *ctx_p);
-/**
  * @brief Register custom verification callback.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param[in] callback User callback function (NULL to disable custom and use
- * default)
- * @param[in] user_data Opaque data passed to callback (lifetime managed by
- * caller)
- *
- * Sets a custom verification callback that is invoked during the TLS handshake
- * for each certificate in the peer's chain. The callback receives all necessary
- * context: the OpenSSL pre-verification result, X509 store context, the library
- * TLS context, the socket being verified, and user-provided data.
- *
- * ## Callback Behavior
- *
- * - **Return 0**: Immediately aborts the handshake with
- * SocketTLS_HandshakeFailed
- * - **Return 1**: Continues verification (OpenSSL proceeds to next certificate)
- *
- * ## Exception Handling
- *
- * If the callback raises any exception (SocketTLS_Failed or any other Except_T),
- * it is automatically caught by the library wrapper and converted to a handshake
- * failure. The X509 error is set to X509_V_ERR_APPLICATION_VERIFICATION and
- * handshake is aborted. This prevents undefined behavior from uncaught exceptions
- * propagating through OpenSSL's C code.
- *
- * ## Thread Safety
- *
- * **IMPORTANT**: The callback itself MUST be thread-safe if the TLS context is
- * shared across multiple threads (common for server contexts or connection
- * pools). Callbacks may be invoked concurrently from different threads during
- * parallel TLS handshakes. See SocketTLSVerifyCallback documentation for
- * details.
- *
- * Call this function during context setup, before sharing the context across
- * threads.
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Thread-safe callback that rejects expired certificates strictly
- * int strict_expiry_callback(int preverify_ok, X509_STORE_CTX *x509_ctx,
- *                            SocketTLSContext_T tls_ctx, Socket_T socket,
- *                            void *user_data) {
- *     (void)tls_ctx; (void)socket; (void)user_data;
- *
- *     if (!preverify_ok) {
- *         int err = X509_STORE_CTX_get_error(x509_ctx);
- *         if (err == X509_V_ERR_CERT_HAS_EXPIRED) {
- *             // Log and reject expired certs even if OpenSSL would allow
- *             return 0; // Abort handshake
- *         }
- *     }
- *     return preverify_ok; // Otherwise use OpenSSL's decision
- * }
- *
- * // Setup
- * SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- * SocketTLSContext_set_verify_callback(ctx, strict_expiry_callback, NULL);
- * @endcode
- *
- * @return void
- * @throws SocketTLS_Failed if OpenSSL configuration fails
- * @threadsafe Yes - modifies shared context; call before sharing context
- *             across threads
- *
- * @see SocketTLSVerifyCallback for callback signature, thread safety, and
- * examples
- * @see SocketTLSContext_set_verify_mode() for configuring base verification
- * policy
- * @see @ref security for other TLS verification features like CRL and OCSP
+ * @param ctx TLS context
+ * @param callback Verify function (NULL to disable)
+ * @param user_data User data for callback
+ * @throws SocketTLS_Failed on error
  */
 extern void
 SocketTLSContext_set_verify_callback (T ctx, SocketTLSVerifyCallback callback,
                                       void *user_data);
 
+/* ============================================================================
+ * CRL Support
+ * ============================================================================
+ */
+
 /**
- * @brief Load CRL file or directory into verification store.
- * @ingroup security
- * @param ctx TLS context instance
- * @param[in] crl_path Path to CRL file (PEM/DER) or directory of CRL files
- * (hashed names)
- *
- * Loads CRL data into the context's X509_STORE for revocation checking during
- * peer verification. Supports single file or directory (auto-detect via stat).
- * Multiple calls append additional CRLs. Enables CRL_CHECK flags
- * automatically. CRL refresh not implemented (manual reload via re-call).
- *
- * @return void
- * @throws SocketTLS_Failed if load/path invalid or OpenSSL error
- * @threadsafe Yes (mutex protected) - modifies shared store; call during
- * setup Note: Effective only if verify_mode requires peer cert check
- * (PEER/FAIL_IF_NO_PEER)
+ * @brief Load CRL file or directory.
+ * @param ctx TLS context
+ * @param crl_path CRL file or directory
+ * @throws SocketTLS_Failed on error
  */
 extern void SocketTLSContext_load_crl (T ctx, const char *crl_path);
 
-/**
- * @brief Refresh a specific CRL (re-load).
- * @ingroup security
- * @param ctx TLS context
- * @param[in] crl_path Path to refresh
- *
- * @brief Re-loads the CRL from path (appends to store). Use for periodic
- * refresh. For full store refresh, recreate context (CRLs accumulate).
- * @threadsafe Yes (mutex protected)
- * @throws SocketTLS_Failed on load error
- */
+/** @brief Re-load CRL from path. */
 extern void SocketTLSContext_refresh_crl (T ctx, const char *crl_path);
 
-/**
- * @brief Reload CRL from path (alias for refresh_crl).
- * @ingroup security
- * @param ctx TLS context
- * @param[in] crl_path Path to CRL file or directory
- *
- * Reloads the CRL from the specified path. This is an alias for
- * SocketTLSContext_refresh_crl() provided for semantic clarity.
- * Use when you have downloaded an updated CRL and want to reload it.
- *
- * @threadsafe Yes (mutex protected)
- * @throws SocketTLS_Failed on load error
- */
+/** @brief Alias for refresh_crl. */
 extern void SocketTLSContext_reload_crl (T ctx, const char *crl_path);
 
-/* ============================================================================
- * CRL Auto-Refresh Support
- * ============================================================================
- *
- * Automatic CRL refresh for long-running applications. The library will
- * attempt to reload the CRL file at the specified interval. A callback
- * notifies the application of success or failure.
- *
- * IMPORTANT: Auto-refresh requires the application to call
- * SocketTLSContext_crl_check_refresh() periodically (e.g., from event loop).
- * The library does not spawn background threads for refresh.
- *
- * Usage:
- *   SocketTLSContext_set_crl_auto_refresh(ctx, "/path/to/crl.pem",
- *                                          3600, my_callback, data);
- *   // In event loop:
- *   SocketTLSContext_crl_check_refresh(ctx);
- */
-
-/**
- * @brief CRL refresh notification callback.
- * @ingroup security
- * @param ctx TLS context that was refreshed
- * @param path Path to CRL file
- * @param success 1 if refresh succeeded, 0 if failed
- * @param user_data User data from set_crl_auto_refresh
- *
- * Called after each refresh attempt. On failure, the old CRL remains
- * in effect. Application should log failures and potentially alert.
- */
+/** @brief CRL refresh callback. */
 typedef void (*SocketTLSCrlCallback) (T ctx, const char *path, int success,
                                       void *user_data);
 
 /**
  * @brief Enable automatic CRL refresh.
- * @ingroup security
- * @param ctx TLS context instance
- * @param[in] crl_path Path to CRL file (copied to context)
- * @param interval_seconds Refresh interval (minimum 60, 0 to disable)
- * @param callback Optional callback for refresh notifications (may be NULL)
- * @param user_data User data passed to callback
- *
- * Configures automatic CRL refresh. The CRL will be reloaded every
- * interval_seconds. Call SocketTLSContext_crl_check_refresh() from
- * your event loop to trigger scheduled refreshes.
- *
- * @return void
- * @throws SocketTLS_Failed on invalid parameters
- * @threadsafe Yes (mutex protected) - configure before sharing context
+ * @param ctx TLS context
+ * @param crl_path CRL file path
+ * @param interval_seconds Refresh interval (min 60, 0 to disable)
+ * @param callback Optional notification callback
+ * @param user_data User data for callback
  */
 extern void SocketTLSContext_set_crl_auto_refresh (
     T ctx, const char *crl_path, long interval_seconds,
     SocketTLSCrlCallback callback, void *user_data);
 
-/**
- * @brief Disable automatic CRL refresh.
- * @ingroup security
- * @param ctx TLS context instance
- *
- * Cancels any configured automatic refresh. The current CRL remains loaded.
- *
- * @return void
- * @throws None
- * @threadsafe Yes (mutex protected)
- */
+/** @brief Disable automatic CRL refresh. */
 extern void SocketTLSContext_cancel_crl_auto_refresh (T ctx);
 
-/**
- * @brief Check and perform CRL refresh if due.
- * @ingroup security
- * @param ctx TLS context instance
- *
- * Call this periodically from your event loop. If a refresh is scheduled
- * and due, it will reload the CRL and invoke the callback.
- *
- * @return 1 if refresh was performed, 0 if not due or not configured
- * @throws None (errors reported via callback)
- * @threadsafe Yes (mutex protected)
- */
+/** @brief Check and perform CRL refresh if due. Returns 1 if refreshed. */
 extern int SocketTLSContext_crl_check_refresh (T ctx);
 
-/**
- * @brief Get milliseconds until next refresh.
- * @ingroup security
- * @param ctx TLS context instance
- *
- * Returns time until next scheduled CRL refresh. Useful for setting
- * poll/select timeouts in event loops.
- *
- * @return -1 if disabled, 0 if due now/past, positive ms until next, LONG_MAX
- * if far future (overflow prot.) @throws None
- * @threadsafe Yes - read-only
- */
+/** @brief Get ms until next CRL refresh. Returns -1 if disabled. */
 extern long SocketTLSContext_crl_next_refresh_ms (T ctx);
 
-/* OCSP Stapling Support */
+/* ============================================================================
+ * OCSP Support
+ * ============================================================================
+ */
 
 /**
- * @brief Set static OCSP response for stapling.
- * @ingroup security
- * (server)
- * @param ctx TLS context instance
- * @param response OCSP response bytes (DER encoded)
- * @param len Length of response
- *
- * Sets a static OCSP response to staple in server handshakes. Multiple calls
- * override. Validates basic response format.
- *
- * @return void
- * @throws SocketTLS_Failed if invalid response (len=0 or parse fail)
- * @threadsafe Yes (mutex protected)
- * Note: For dynamic, use set_ocsp_callback.
+ * @brief Set static OCSP response for stapling (server).
+ * @param ctx TLS context
+ * @param response DER-encoded OCSP response
+ * @param len Response length
  */
 extern void SocketTLSContext_set_ocsp_response (T ctx,
                                                 const unsigned char *response,
                                                 size_t len);
 
 /**
- * @brief OCSP response generation callback for dynamic stapling on server-side
- * TLS handshakes.
- * @ingroup security
- *
- * @param ssl OpenSSL SSL connection object during handshake (use to get SNI, cert info)
- * @param arg User-provided data from SocketTLSContext_set_ocsp_gen_callback()
- *
- * This callback is invoked by OpenSSL during the TLS handshake when OCSP
- * stapling is requested by the client (via status_request extension). It
- * should generate and return a valid, DER-encoded OCSP response for the
- * server's certificate, allowing the client to verify revocation status
- * without additional round-trips.
- *
- * ## Ownership Semantics (CRITICAL)
- *
- * **OpenSSL TAKES OWNERSHIP of the returned OCSP_RESPONSE***
- *
- * The returned OCSP_RESPONSE* must be freshly allocated (via OCSP_RESPONSE_new()
- * or d2i_OCSP_RESPONSE()). OpenSSL will call OCSP_RESPONSE_free() on it after
- * the handshake completes. Do NOT:
- * - Return a cached/shared OCSP_RESPONSE without duplicating
- * - Free the response after returning (OpenSSL owns it)
- * - Return stack-allocated or static responses
- *
- * To return a cached response, use OCSP_RESPONSE_dup() or reload from storage:
- *
- * @code{.c}
- * OCSP_RESPONSE *my_ocsp_callback(SSL *ssl, void *arg) {
- *     OcspCache *cache = (OcspCache *)arg;
- *
- *     // Get certificate being served (for SNI support)
- *     X509 *cert = SSL_get_certificate(ssl);
- *     if (!cert) return NULL;
- *
- *     // Lookup cached response by certificate fingerprint
- *     unsigned char fp[32];
- *     X509_digest(cert, EVP_sha256(), fp, NULL);
- *
- *     const unsigned char *cached_der;
- *     size_t cached_len;
- *     if (!ocsp_cache_get(cache, fp, &cached_der, &cached_len))
- *         return NULL;  // No cached response
- *
- *     // Parse and return FRESH copy (OpenSSL takes ownership)
- *     const unsigned char *p = cached_der;
- *     return d2i_OCSP_RESPONSE(NULL, &p, cached_len);
- * }
- * @endcode
- *
- * ## Best Practices
- *
- * - **Caching**: Pre-fetch and cache OCSP responses; refresh before nextUpdate
- * - **Freshness**: Ensure response is not expired (clients reject stale responses)
- * - **SNI Support**: Check SSL_get_certificate() for multi-cert servers
- * - **Error Handling**: Return NULL on errors (handshake continues without stapling)
- * - **Performance**: Avoid blocking I/O in callback; use background refresh
- * - **Monitoring**: Log failures for operational visibility
- *
- * ## Error Behavior
- *
- * Returning NULL does NOT abort the handshake. The client may:
- * - Fallback to direct OCSP query (if configured)
- * - Accept the certificate without revocation check (policy-dependent)
- * - Fail the connection (strict OCSP-must-staple policies)
- *
- * ## Thread Safety
- *
- * This callback may be invoked concurrently from multiple threads if the
- * TLS context is shared. Ensure thread-safe access to caches and external
- * resources. Consider per-thread caching or mutex protection.
- *
- * @return OCSP_RESPONSE* - freshly allocated response (OpenSSL takes ownership
- *         and will call OCSP_RESPONSE_free()), or NULL if no response available
- * @throws None - handle errors internally; use SocketLog for logging
- * @threadsafe MUST be reentrant/thread-safe if context is shared across threads
- *
- * @see SocketTLSContext_set_ocsp_gen_callback() to register this callback
- * @see SocketTLSContext_set_ocsp_response() for simpler static response stapling
- * @see SocketTLS_get_ocsp_status() for client-side stapled response verification
- * @see OCSP_RESPONSE_dup() if you need to return a cached response
- * @see SSL_get_certificate() to get the server cert for SNI-aware responses
- * @see @ref security for TLS security features (CRL, pinning, CT)
- * @see docs/SECURITY.md#ocsp-stapling for deployment guide
+ * @brief OCSP response generator callback.
+ * @param ssl SSL connection
+ * @param arg User data
+ * @return Freshly allocated OCSP_RESPONSE (OpenSSL takes ownership), or NULL
+ * @note Callback MUST be thread-safe if context is shared.
  */
 typedef OCSP_RESPONSE *(*SocketTLSOcspGenCallback) (SSL *ssl, void *arg);
 
 /**
- * @brief Register dynamic OCSP response generator.
- * @ingroup security
- * @param ctx TLS context (server)
- * @param cb Callback to generate OCSP response during handshake
- * @param arg User data passed to cb
- *
- * Enables dynamic OCSP stapling. Called during handshake to generate response.
- * Wrapper handles serialization and SSL_set_tlsext_status_ocsp_resp.
- * @threadsafe cb must be; called in handshake thread.
- * @throws SocketTLS_Failed if OpenSSL cb set fails
+ * @brief Register dynamic OCSP response generator (server).
+ * @param ctx TLS context
+ * @param cb Generator callback
+ * @param arg User data
  */
 extern void
 SocketTLSContext_set_ocsp_gen_callback (T ctx, SocketTLSOcspGenCallback cb,
@@ -827,1229 +234,270 @@ SocketTLSContext_set_ocsp_gen_callback (T ctx, SocketTLSOcspGenCallback cb,
 
 /**
  * @brief Get OCSP status after handshake (client).
- * @ingroup security
- * @param socket TLS socket with completed handshake
- *
- * Parses stapled OCSP response from server, validates, returns status.
- * Returns OCSP_STATUS_GOOD=1, REVOKED=2, UNKNOWN=3, NONE=0 if no response.
- * Caller can check for revocation.
- *
- * @return int (OCSP status code)
- * @throws None (returns error code on parse fail)
- * @threadsafe Yes (post-handshake)
+ * @param socket TLS socket
+ * @return OCSP status (GOOD=1, REVOKED=2, UNKNOWN=3, NONE=0)
  */
 extern int SocketTLS_get_ocsp_status (Socket_T socket);
 
-/**
- * @brief Enable OCSP stapling request (client).
- * @ingroup security
- * @param ctx TLS context instance (client only)
- *
- * Configures client context to request OCSP stapled responses from servers
- * during TLS handshake. After handshake, use SocketTLS_get_ocsp_status()
- * to check the stapled response.
- *
- * Note: This enables the STATUS_REQUEST TLS extension. The server must
- * support OCSP stapling and have a valid OCSP response configured.
- *
- * @return void
- * @throws SocketTLS_Failed if server context or OpenSSL error
- * @threadsafe No - caller must synchronize configuration changes
- */
+/** @brief Enable OCSP stapling request (client). */
 extern void SocketTLSContext_enable_ocsp_stapling (T ctx);
 
-/**
- * @brief Check if OCSP stapling is enabled.
- * @ingroup security
- * @param ctx TLS context instance
- *
- * @return 1 if OCSP stapling request enabled, 0 otherwise
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Check if OCSP stapling enabled. */
 extern int SocketTLSContext_ocsp_stapling_enabled (T ctx);
 
-/* ============================================================================
- * OCSP Must-Staple Support (RFC 7633)
- * ============================================================================
- *
- * OCSP Must-Staple is a certificate extension (id-pe-tlsfeature, OID
- * 1.3.6.1.5.5.7.1.24) that indicates the certificate MUST be accompanied
- * by a valid OCSP stapled response. If a certificate has this extension
- * and no valid OCSP response is provided, the connection should be rejected.
- *
- * This provides stronger revocation checking by making OCSP stapling
- * mandatory rather than optional, preventing downgrade attacks where an
- * attacker strips the OCSP response.
- *
- * Usage:
- *   // Enable auto-detection (check cert for must-staple extension)
- *   SocketTLSContext_set_ocsp_must_staple(ctx, OCSP_MUST_STAPLE_AUTO);
- *
- *   // Always require OCSP stapling (regardless of cert extension)
- *   SocketTLSContext_set_ocsp_must_staple(ctx, OCSP_MUST_STAPLE_ALWAYS);
- *
- *   // Disable must-staple checking (default)
- *   SocketTLSContext_set_ocsp_must_staple(ctx, OCSP_MUST_STAPLE_DISABLED);
- *
- * Thread safety: Configuration is NOT thread-safe - perform before sharing.
- */
-
-/**
- * @brief OCSP Must-Staple enforcement mode enumeration.
- * @ingroup security
- *
- * Controls how OCSP Must-Staple (RFC 7633) is enforced during TLS handshake.
- * Must-Staple is a certificate extension indicating that an OCSP response
- * MUST be stapled to the certificate.
- */
+/** @brief OCSP Must-Staple mode (RFC 7633). */
 typedef enum
 {
-  OCSP_MUST_STAPLE_DISABLED
-  = 0, /**< Ignore must-staple extension (default, legacy behavior) */
-  OCSP_MUST_STAPLE_AUTO
-  = 1, /**< Check certificate for must-staple extension; enforce if present */
-  OCSP_MUST_STAPLE_ALWAYS
-  = 2 /**< Always require valid OCSP stapled response, regardless of cert */
+  OCSP_MUST_STAPLE_DISABLED = 0, /**< Ignore must-staple */
+  OCSP_MUST_STAPLE_AUTO = 1,     /**< Check cert for extension */
+  OCSP_MUST_STAPLE_ALWAYS = 2    /**< Always require OCSP response */
 } OCSPMustStapleMode;
 
-/**
- * @brief Set OCSP Must-Staple enforcement mode.
- * @ingroup security
- * @param[in] ctx The TLS context instance (client only)
- * @param mode Enforcement mode (disabled, auto-detect, or always)
- *
- * Configures how OCSP Must-Staple (RFC 7633) is enforced. When enabled,
- * certificates with the id-pe-tlsfeature extension containing status_request
- * will require a valid OCSP stapled response during handshake.
- *
- * ## Modes
- *
- * - **OCSP_MUST_STAPLE_DISABLED**: Default. Ignore must-staple extension.
- *   OCSP stapling is optional even if certificate has the extension.
- *
- * - **OCSP_MUST_STAPLE_AUTO**: Check each server certificate for the
- *   must-staple extension. If present, require a valid OCSP response.
- *   If extension is absent, OCSP stapling remains optional.
- *
- * - **OCSP_MUST_STAPLE_ALWAYS**: Always require a valid OCSP stapled response
- *   regardless of whether the certificate has the must-staple extension.
- *   Use for strict security policies.
- *
- * ## Security Considerations
- *
- * Must-staple prevents downgrade attacks where an attacker strips the OCSP
- * response from the TLS handshake. With must-staple enforcement, such attacks
- * will cause connection failure rather than silent degradation.
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- *
- * // Enable auto-detection: respect certificate's must-staple extension
- * SocketTLSContext_set_ocsp_must_staple(ctx, OCSP_MUST_STAPLE_AUTO);
- *
- * // Also enable OCSP stapling request so server knows to staple
- * SocketTLSContext_enable_ocsp_stapling(ctx);
- *
- * // Connect and handshake
- * SocketTLS_enable(sock, ctx);
- * SocketTLS_handshake_auto(sock); // Fails if must-staple cert has no OCSP
- * @endcode
- *
- * @return void
- * @throws SocketTLS_Failed if called on server context or invalid mode
- * @threadsafe No - call before sharing context across threads
- *
- * @note Automatically enables OCSP stapling request if not already enabled
- * @note Requires server to support OCSP stapling; many CAs issue must-staple certs
- *
- * @see SocketTLSContext_enable_ocsp_stapling() to request stapled responses
- * @see SocketTLS_get_ocsp_response_status() to check stapled response status
- * @see SocketTLSContext_get_ocsp_must_staple() to query current mode
- * @see RFC 7633 "X.509v3 TLS Feature Extension" for specification
- */
+/** @brief Set OCSP Must-Staple mode (client). */
 extern void SocketTLSContext_set_ocsp_must_staple (T ctx,
                                                    OCSPMustStapleMode mode);
 
-/**
- * @brief Get current OCSP Must-Staple enforcement mode.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return Current OCSPMustStapleMode setting
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Get OCSP Must-Staple mode. */
 extern OCSPMustStapleMode SocketTLSContext_get_ocsp_must_staple (T ctx);
 
-/**
- * @brief Check if certificate has OCSP Must-Staple extension.
- * @ingroup security
- * @param[in] cert X509 certificate to check
- *
- * Examines the certificate for the id-pe-tlsfeature extension (OID
- * 1.3.6.1.5.5.7.1.24) containing the status_request (5) value, which
- * indicates OCSP Must-Staple per RFC 7633.
- *
- * @return 1 if certificate has must-staple extension, 0 otherwise
- * @throws None
- * @threadsafe Yes (read-only)
- *
- * @see SocketTLSContext_set_ocsp_must_staple() for enforcement configuration
- * @see RFC 7633 Section 4.1 for extension format
- */
+/** @brief Check if certificate has must-staple extension. */
 extern int SocketTLSContext_cert_has_must_staple (const X509 *cert);
 
 /* ============================================================================
- * Custom Certificate Store Callback
+ * Custom Certificate Lookup
  * ============================================================================
- *
- * For advanced use cases where certificates are loaded from non-filesystem
- * sources (e.g., database, HSM, remote service).
- *
- * Usage:
- *   X509 *my_cert_lookup(X509_STORE_CTX *ctx, X509_NAME *name, void *data) {
- *       // Lookup certificate by subject name
- *       return load_cert_from_database(name);
- *   }
- *   SocketTLSContext_set_cert_lookup_callback(ctx, my_cert_lookup, db_conn);
  */
 
 /**
- * @brief Custom certificate lookup function for loading certs from non-filesystem sources.
- * @ingroup security
- * @param store_ctx OpenSSL store context for current verification (provides chain context)
- * @param name Subject name being looked up (issuer of certificate being verified)
- * @param user_data User data from SocketTLSContext_set_cert_lookup_callback()
- *
- * This callback is invoked during certificate chain building when OpenSSL needs
- * to find issuer certificates. Common use cases include:
- *
- * ## Hardware Security Module (HSM) Integration
- *
- * Load certificates stored in HSMs (e.g., PKCS#11 devices, TPM):
- *
- * @code{.c}
- * X509 *hsm_cert_lookup(X509_STORE_CTX *ctx, X509_NAME *name, void *data) {
- *     PKCS11_Session *session = (PKCS11_Session *)data;
- *
- *     // Convert X509_NAME to searchable format
- *     char subject_str[256];
- *     X509_NAME_oneline(name, subject_str, sizeof(subject_str));
- *
- *     // Query HSM for certificate with matching subject
- *     unsigned char *cert_der = NULL;
- *     size_t cert_len = 0;
- *     if (!pkcs11_find_cert_by_subject(session, subject_str, &cert_der, &cert_len))
- *         return NULL;
- *
- *     // Parse DER to X509 (caller takes ownership)
- *     const unsigned char *p = cert_der;
- *     X509 *cert = d2i_X509(NULL, &p, cert_len);
- *     free(cert_der);
- *     return cert;  // Ownership transferred to caller
- * }
- * @endcode
- *
- * ## Database Integration
- *
- * Load certificates from SQL databases, LDAP, or other storage:
- *
- * @code{.c}
- * X509 *db_cert_lookup(X509_STORE_CTX *ctx, X509_NAME *name, void *data) {
- *     DatabaseConn *db = (DatabaseConn *)data;
- *
- *     // Get subject hash for efficient lookup
- *     unsigned long hash = X509_NAME_hash(name);
- *
- *     // Query database by subject hash
- *     unsigned char *pem_data = NULL;
- *     size_t pem_len = 0;
- *     if (!db_query_cert_by_hash(db, hash, &pem_data, &pem_len))
- *         return NULL;
- *
- *     // Parse PEM to X509
- *     BIO *bio = BIO_new_mem_buf(pem_data, pem_len);
- *     X509 *cert = PEM_read_bio_X509(bio, NULL, NULL, NULL);
- *     BIO_free(bio);
- *     free(pem_data);
- *     return cert;  // Ownership transferred to caller
- * }
- * @endcode
- *
- * ## Ownership Semantics
- *
- * **CRITICAL**: The returned X509 certificate's ownership is transferred to the caller
- * (the library/OpenSSL). The callback must allocate a new X509 object or increment
- * the reference count using X509_up_ref() if returning a shared certificate. The
- * caller will call X509_free() when done.
- *
- * @return X509 certificate if found (caller takes ownership via X509_free()),
- *         NULL if no matching certificate found
- * @throws None - return NULL on errors, do not raise exceptions
- * @threadsafe MUST be thread-safe if TLS context is shared across threads.
- *             Multiple concurrent verifications may invoke this callback simultaneously.
- *
- * @see SocketTLSContext_set_cert_lookup_callback() to register this callback
- * @see X509_NAME_hash() for efficient subject name hashing
- * @see X509_up_ref() if returning a shared/cached certificate
+ * @brief Certificate lookup callback for HSM/database sources.
+ * @param store_ctx OpenSSL store context
+ * @param name Subject name to look up
+ * @param user_data User data
+ * @return X509 certificate (caller takes ownership), or NULL
+ * @note Callback MUST be thread-safe if context is shared.
  */
 typedef X509 *(*SocketTLSCertLookupCallback) (X509_STORE_CTX *store_ctx,
                                               const X509_NAME *name,
                                               void *user_data);
 
 /**
- * @brief Register custom certificate lookup callback for HSM, database, or remote sources.
- * @ingroup security
- * @param ctx TLS context instance
- * @param callback Lookup function (NULL to disable custom lookup)
- * @param user_data User data passed to callback (e.g., database connection, HSM session)
- *
- * Sets a custom callback for certificate lookup during chain verification. This enables
- * loading issuer certificates from non-filesystem sources such as:
- *
- * - **Hardware Security Modules (HSMs)**: PKCS#11 tokens, TPM, smart cards
- * - **Databases**: SQL, NoSQL, LDAP directories
- * - **Remote Services**: REST APIs, certificate repositories
- * - **In-Memory Caches**: Pre-loaded certificate pools
- *
- * ## How It Works
- *
- * During TLS handshake verification, when OpenSSL needs to find an issuer certificate
- * to build the certificate chain, it calls this callback with the required subject name.
- * The callback should search its data source and return a matching certificate.
- *
- * ## Integration with OpenSSL
- *
- * - **OpenSSL 3.0+**: Uses X509_STORE_set_lookup_certs_cb() for seamless, automatic
- *   integration with OpenSSL's chain building. The callback is invoked automatically
- *   during verification when issuer certificates are needed.
- *
- * - **OpenSSL 1.1.x/LibreSSL**: The callback is stored but NOT invoked automatically.
- *   Users must invoke it manually from a custom verification callback
- *   (SocketTLSContext_set_verify_callback) when needed.
- *
- * ## Usage Example (OpenSSL 3.0+)
- *
- * @code{.c}
- * // HSM-backed certificate lookup - automatic invocation
- * PKCS11_Session *hsm_session = pkcs11_open_session(...);
- *
- * SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- * SocketTLSContext_set_cert_lookup_callback(ctx, hsm_cert_lookup, hsm_session);
- *
- * // On OpenSSL 3.0+, verification will automatically query HSM
- * SocketTLS_enable(sock, ctx);
- * SocketTLS_handshake_auto(sock);
- * @endcode
- *
- * ## Usage Example (OpenSSL < 3.0 - Manual Invocation)
- *
- * @code{.c}
- * // For older OpenSSL, invoke callback from custom verify callback
- * int my_verify_callback(int preverify_ok, X509_STORE_CTX *x509_ctx,
- *                        SocketTLSContext_T tls_ctx, Socket_T socket,
- *                        void *user_data) {
- *     // Get the callback from context
- *     SocketTLSCertLookupCallback lookup_cb = user_data->lookup_cb;
- *     if (lookup_cb && need_issuer_cert(x509_ctx)) {
- *         X509_NAME *issuer = X509_get_issuer_name(X509_STORE_CTX_get_current_cert(x509_ctx));
- *         X509 *issuer_cert = lookup_cb(x509_ctx, issuer, user_data->lookup_data);
- *         if (issuer_cert) {
- *             // Add to chain...
- *             X509_free(issuer_cert);
- *         }
- *     }
- *     return preverify_ok;
- * }
- * @endcode
- *
- * ## Thread Safety
- *
- * The callback MUST be thread-safe if the TLS context is shared across threads.
- * Consider using connection pooling for database handles or thread-local HSM sessions.
- *
- * @return void
- * @throws SocketTLS_Failed if OpenSSL store configuration fails
- * @threadsafe Yes (configure before sharing context across threads)
- *
- * @note **OpenSSL 3.0+**: Full automatic integration via X509_STORE_set_lookup_certs_cb()
- * @note **OpenSSL < 3.0**: Callback stored but requires manual invocation from verify callback
- * @warning Callback must not raise exceptions - return NULL on errors
- *
- * @see SocketTLSCertLookupCallback for callback signature and ownership rules
- * @see SocketTLSContext_set_verify_callback() for custom verification logic
- * @see docs/SECURITY.md#hsm-integration for HSM deployment guide
+ * @brief Register certificate lookup callback.
+ * @param ctx TLS context
+ * @param callback Lookup function (NULL to disable)
+ * @param user_data User data
+ * @note OpenSSL 3.0+ uses this automatically; <3.0 requires manual invocation.
  */
 extern void SocketTLSContext_set_cert_lookup_callback (
     T ctx, SocketTLSCertLookupCallback callback, void *user_data);
 
-/* Protocol configuration */
-/**
- * @brief Set minimum supported TLS version.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param version OpenSSL version constant (e.g., TLS1_3_VERSION)
- *
- * Sets min TLS version using set_min_proto_version() with fallback to options.
- *
- * @return void
- * @throws SocketTLS_Failed if cannot set
- * @threadsafe Yes (mutex protected)
+/* ============================================================================
+ * Protocol Configuration
+ * ============================================================================
  */
+
+/** @brief Set minimum TLS version. */
 extern void SocketTLSContext_set_min_protocol (T ctx, int version);
 
-/**
- * @brief Set maximum supported TLS version.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param version OpenSSL version constant (e.g., TLS1_3_VERSION)
- *
- * Sets max TLS version using set_max_proto_version().
- *
- * @return void
- * @throws SocketTLS_Failed if cannot set
- * @threadsafe Yes (mutex protected)
- */
+/** @brief Set maximum TLS version. */
 extern void SocketTLSContext_set_max_protocol (T ctx, int version);
 
-/**
- * @brief Set allowed cipher suites.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param ciphers Cipher list string in OpenSSL format, or NULL for defaults
- *
- * Configures allowed ciphers. Defaults to secure modern list if NULL.
- *
- * @return void
- * @throws SocketTLS_Failed if invalid list
- * @threadsafe Yes (mutex protected)
- */
+/** @brief Set cipher list (OpenSSL format). */
 extern void SocketTLSContext_set_cipher_list (T ctx, const char *ciphers);
 
-/**
- * @brief Validate cipher string without applying it.
- * @ingroup security
- * @param[in] ciphers Cipher list string in OpenSSL format
- *
- * Validates that the cipher string is syntactically correct and contains
- * at least one valid cipher. This allows pre-validation of cipher strings
- * before calling SocketTLSContext_set_cipher_list() to avoid exceptions.
- *
- * ## Usage Example
- *
- * @code{.c}
- * const char *custom_ciphers = "ECDHE+AESGCM:!aNULL";
- * if (SocketTLSContext_validate_cipher_list(custom_ciphers)) {
- *     SocketTLSContext_set_cipher_list(ctx, custom_ciphers);
- * } else {
- *     fprintf(stderr, "Invalid cipher string\n");
- * }
- * @endcode
- *
- * @return 1 if valid cipher string, 0 if invalid or empty
- * @throws None
- * @threadsafe Yes (creates temporary SSL_CTX)
- * @complexity O(n) where n is length of cipher string
- */
+/** @brief Validate cipher list. Returns 1 if valid. */
 extern int SocketTLSContext_validate_cipher_list (const char *ciphers);
 
-/**
- * @brief Set TLS 1.3 ciphersuites.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param ciphersuites TLS 1.3 ciphersuite string, or NULL for defaults
- *
- * Configures TLS 1.3 specific ciphersuites. These are separate from TLS 1.2
- * cipher lists and use a different format. Defaults to SOCKET_TLS13_CIPHERSUITES
- * if NULL (TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256).
- *
- * @return void
- * @throws SocketTLS_Failed if invalid ciphersuite string
- * @threadsafe Yes (mutex protected)
- */
+/** @brief Set TLS 1.3 ciphersuites. */
 extern void SocketTLSContext_set_ciphersuites (T ctx, const char *ciphersuites);
 
-/**
- * @brief Validate TLS 1.3 ciphersuite string without applying it.
- * @ingroup security
- * @param[in] ciphersuites TLS 1.3 ciphersuite string
- *
- * Validates that the ciphersuite string is syntactically correct and contains
- * at least one valid TLS 1.3 ciphersuite.
- *
- * @return 1 if valid ciphersuite string, 0 if invalid or empty
- * @throws None
- * @threadsafe Yes (creates temporary SSL_CTX)
- */
+/** @brief Validate TLS 1.3 ciphersuites. Returns 1 if valid. */
 extern int SocketTLSContext_validate_ciphersuites (const char *ciphersuites);
 
-/* ALPN support */
+/* ============================================================================
+ * ALPN Support
+ * ============================================================================
+ */
+
 /**
- * @brief Advertise ALPN protocols.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param protos Array of null-terminated protocol strings (e.g., "h2",
- * "http/1.1")
+ * @brief Set ALPN protocols.
+ * @param ctx TLS context
+ * @param protos Protocol strings (e.g., "h2", "http/1.1")
  * @param count Number of protocols
- *
- * Sets list of supported ALPN protocols in wire format, allocated from context
- * arena. Validates lengths (1-255 bytes per protocol, max
- * SOCKET_TLS_MAX_ALPN_PROTOCOLS) and contents (full RFC 7301 Section 3.2:
- * printable ASCII 0x21-0x7E only, rejects invalid lists/entries). Invalid
- * names raise SocketTLS_Failed. Uses SocketSecurity limits at runtime.
- *
- * @return void
- * @throws SocketTLS_Failed on invalid protos or allocation error
- * @threadsafe Yes (mutex protected)
- *
- * Note: Protocols advertised in preference order (first preferred).
  */
 extern void SocketTLSContext_set_alpn_protos (T ctx, const char **protos,
                                               size_t count);
 
-/* ALPN callback type for customizable protocol selection */
+/** @brief ALPN selection callback. */
 typedef const char *(*SocketTLSAlpnCallback) (const char **client_protos,
                                               size_t client_count,
                                               void *user_data);
 
-/**
- * @brief Set custom ALPN protocol selection callback.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param callback Function to call for ALPN protocol selection
- * @param user_data User data passed to callback function
- *
- * Sets a custom callback for ALPN protocol selection instead of using default
- * priority order. The callback receives parsed and validated client-offered
- * protocols (library rejects malformed lists per RFC 7301 Section 3.2). Return
- * a const char* to a persistent matching protocol string or NULL to decline.
- * Library validates return (must match offered list, valid length/chars),
- * internally allocates a copy for OpenSSL (avoids UAF if returning temporary
- * ptr), and uses it during handshake.
- *
- * @return void
- * @throws SocketTLS_Failed on invalid parameters
- * @threadsafe Yes (mutex protected)
- *
- * Note: Callback is called during TLS handshake, must be thread-safe if
- * context is shared.
- */
+/** @brief Set custom ALPN selection callback. */
 extern void SocketTLSContext_set_alpn_callback (T ctx,
                                                 SocketTLSAlpnCallback callback,
                                                 void *user_data);
 
-/* Session management */
+/* ============================================================================
+ * Session Management
+ * ============================================================================
+ */
 
 /**
- * @brief Set session ID context for session isolation.
- * @ingroup security
- * @param[in] ctx The TLS context instance (server only)
- * @param[in] context Session ID context bytes (e.g., application name or hash)
- * @param context_len Length of context (1-32 bytes, SSL_MAX_SID_CTX_LENGTH)
- *
- * Sets the session ID context used by OpenSSL to differentiate sessions between
- * different server applications or virtual hosts. Sessions created with one
- * context will not be reused when a client connects to a server with a different
- * context. This prevents session confusion attacks and ensures proper session
- * isolation in multi-tenant or virtual hosting environments.
- *
- * ## When to Use
- *
- * - **Multi-tenant servers**: Different tenants get different session contexts
- * - **Virtual hosting**: Each virtual host should have a unique context
- * - **Load balancing**: Clustered servers sharing session caches need consistent contexts
- * - **Application isolation**: Multiple applications sharing SSL_CTX need separation
- *
- * ## Context Selection
- *
- * For simple applications: Use a fixed unique string (e.g., "myapp-v1")
- * For virtual hosts: Use hostname or derived hash (e.g., SHA256(hostname)[0:16])
- * For clusters: Combine application ID with cluster identifier
- *
- * ## Usage Example
- *
- * @code{.c}
- * SocketTLSContext_T ctx = SocketTLSContext_new_server("cert.pem", "key.pem", NULL);
- *
- * // Simple fixed context for single-application server
- * const char *app_id = "myapp-production-v1";
- * SocketTLSContext_set_session_id_context(ctx,
- *     (const unsigned char *)app_id, strlen(app_id));
- *
- * // Enable session cache after setting context
- * SocketTLSContext_enable_session_cache(ctx, 1000, 300);
- * @endcode
- *
- * @return void
- * @throws SocketTLS_Failed if context is NULL, context_len is 0 or >32, or OpenSSL fails
- * @threadsafe No - call before sharing context across threads
- *
- * @see SocketTLSContext_enable_session_cache() to enable caching
- * @see SSL_CTX_set_session_id_context() OpenSSL function (underlying implementation)
- * @see RFC 5246 Section 7.4.1.2 for TLS session identifier semantics
+ * @brief Set session ID context (server).
+ * @param ctx TLS context
+ * @param context Context bytes
+ * @param context_len Length (1-32 bytes)
  */
 extern void SocketTLSContext_set_session_id_context (
     T ctx, const unsigned char *context, size_t context_len);
 
 /**
  * @brief Enable session caching.
- * @ingroup security
- * infrastructure
- * @param[in] ctx The TLS context instance
- * @param max_sessions Maximum number of sessions to cache (>0), 0 for default
- * @param timeout_seconds Session timeout in seconds, 0 for OpenSSL default
- * (300s)
- *
- * Extends `SocketTLSContext_T` with session cache configuration.
- * Implements session cache using OpenSSL's built-in caching with thread-safe
- * storage. Adds cache size and timeout configuration. Enables statistics
- * tracking.
- *
- * @return void
- * @throws SocketTLS_Failed if cannot enable or configure
- * @threadsafe No - caller must synchronize configuration changes during setup
+ * @param ctx TLS context
+ * @param max_sessions Max sessions (0 for default)
+ * @param timeout_seconds Timeout (0 for default 300s)
  */
 extern void SocketTLSContext_enable_session_cache (T ctx, size_t max_sessions,
                                                    long timeout_seconds);
 
-/**
- * @brief Limit cached sessions.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param size Max number of sessions to cache (>0)
- *
- * Controls memory usage of session cache.
- *
- * @return void
- * @throws SocketTLS_Failed if invalid size or cannot set
- * @threadsafe Yes (mutex protected)
- */
+/** @brief Set session cache size. */
 extern void SocketTLSContext_set_session_cache_size (T ctx, size_t size);
 
-/**
- * @brief Get session cache statistics.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param hits Output: number of cache hits
- * @param misses Output: number of cache misses
- * @param stores Output: number of sessions stored
- *
- * Fills provided pointers with current session cache statistics.
- * Statistics are thread-safe and cumulative since cache enable.
- * If pointers NULL, skipped.
- *
- * @return void
- * @throws None
- * @threadsafe Yes
- */
+/** @brief Get session cache statistics. */
 extern void SocketTLSContext_get_cache_stats (T ctx, size_t *hits,
                                               size_t *misses, size_t *stores);
 
 /**
- * @brief Enable stateless session.
- * @ingroup security
- * resumption using tickets
- * @param[in] ctx The TLS context instance
- * @param key Ticket encryption key material (SOCKET_TLS_TICKET_KEY_LEN bytes
- * required)
- * @param key_len Length of key (must be SOCKET_TLS_TICKET_KEY_LEN = 80 bytes)
- *
- * Implements stateless session resumption using encrypted session tickets.
- * OpenSSL requires 80 bytes: 16 (name) + 32 (AES) + 32 (HMAC).
- * Configures ticket key management, encryption/decryption using provided key.
- * Supports ticket lifetime matching session timeout, and basic rotation.
- * Requires cache enabled for full effect.
- *
- * @return void
- * @throws SocketTLS_Failed if invalid key length or OpenSSL config fails
- * @threadsafe Yes (mutex protected)
+ * @brief Enable session tickets.
+ * @param ctx TLS context
+ * @param key Ticket key (SOCKET_TLS_TICKET_KEY_LEN = 80 bytes)
+ * @param key_len Key length
  */
 extern void SocketTLSContext_enable_session_tickets (T ctx,
                                                      const unsigned char *key,
                                                      size_t key_len);
 
-/**
- * @brief Rotate the session ticket encryption key.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param[in] new_key New ticket encryption key (SOCKET_TLS_TICKET_KEY_LEN bytes)
- * @param new_key_len Length of new key (must be SOCKET_TLS_TICKET_KEY_LEN = 80
- * bytes)
- *
- * Replaces the current session ticket key with a new one. Existing sessions
- * using the old key will fail resumption on next connection (forcing full
- * handshake). For graceful rotation without breaking active sessions, use
- * OpenSSL's multi-key approach or schedule rotation during low-traffic periods.
- *
- * Security: The old key is securely cleared from memory before being replaced.
- * The new key is validated for correct length before installation.
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Periodic key rotation (e.g., daily)
- * unsigned char new_key[80];
- * if (RAND_bytes(new_key, 80) != 1) {
- *     // Handle RNG failure
- * }
- * TRY {
- *     SocketTLSContext_rotate_session_ticket_key(ctx, new_key, 80);
- * } EXCEPT(SocketTLS_Failed) {
- *     // Handle rotation failure
- * } END_TRY;
- * // Securely clear the temporary key
- * OPENSSL_cleanse(new_key, 80);
- * @endcode
- *
- * @return void
- * @throws SocketTLS_Failed if tickets not enabled, invalid key length, or
- * OpenSSL fails
- * @threadsafe Yes (mutex protected)
- *
- * @see SocketTLSContext_enable_session_tickets() to initially enable tickets
- * @see SocketTLSContext_session_tickets_enabled() to check if tickets are
- * enabled
- * @see SOCKET_TLS_TICKET_KEY_LEN for required key length (80 bytes)
- */
+/** @brief Rotate session ticket key. */
 extern void SocketTLSContext_rotate_session_ticket_key (
     T ctx, const unsigned char *new_key, size_t new_key_len);
 
-/**
- * @brief Check if session tickets are enabled.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return 1 if session tickets are enabled, 0 otherwise
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Check if session tickets enabled. */
 extern int SocketTLSContext_session_tickets_enabled (T ctx);
 
-/**
- * @brief Disable session tickets and securely clear the key.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * Disables session ticket support and securely wipes the ticket encryption
- * key from memory. Use when ticket-based resumption is no longer desired
- * or when rotating to a completely new session management approach.
- *
- * @return void
- * @throws None
- * @threadsafe Yes (mutex protected)
- *
- * @see SocketTLSContext_enable_session_tickets() to re-enable
- */
+/** @brief Disable session tickets. */
 extern void SocketTLSContext_disable_session_tickets (T ctx);
 
 /* ============================================================================
  * Certificate Pinning (SPKI SHA256)
  * ============================================================================
- *
- * OWASP-recommended approach: Pin the Subject Public Key Info (SPKI) hash.
- * SPKI pinning survives certificate renewal when the same key is reused,
- * making it more maintainable than full certificate pinning.
- *
- * Usage:
- *   // Create client context
- *   SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- *
- *   // Pin by hex-encoded SHA256 hash
- *   SocketTLSContext_add_pin_hex(ctx,
- *     "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c");
- *
- *   // Or extract from certificate file
- *   SocketTLSContext_add_pin_from_cert(ctx, "server.crt");
- *
- *   // Enable strict enforcement (default, fail if no match)
- *   SocketTLSContext_set_pin_enforcement(ctx, 1);
- *
- * Generate pin from certificate:
- *   openssl x509 -in cert.pem -pubkey -noout | \
- *     openssl pkey -pubin -outform DER | \
- *     openssl dgst -sha256 -hex
- *
- * Thread safety: Pin configuration is NOT thread-safe. Configure all pins
- * before sharing the context across threads. Verification is read-only
- * and thread-safe.
  */
 
-/**
- * @brief Add SPKI SHA256 pin (binary format).
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param sha256_hash 32-byte SHA256 hash of the SPKI DER encoding
- *
- * Adds a certificate pin using raw binary hash. The hash is copied to
- * context-owned storage. Duplicate pins are silently ignored.
- *
- * @return void
- * @throws SocketTLS_Failed if hash is NULL or max pins exceeded
- * @see SocketTLS_PinVerifyFailed for the exception raised on mismatch.
- * @see SocketTLSContext_add_pin_hex() for hex-encoded input.
- * @see SocketTLSContext_add_pin_from_cert() to generate from file.
- * @see SocketTLSContext_set_pin_enforcement() to control failure behavior.
- * @threadsafe No - caller must synchronize configuration changes
- */
+/** @brief Add pin (32-byte SHA256 hash). */
 extern void SocketTLSContext_add_pin (T ctx, const unsigned char *sha256_hash);
 
-/**
- * @brief Add SPKI SHA256 pin (hex string).
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param[in] hex_hash 64-character hex string (optionally prefixed with
- * "sha256//")
- *
- * Adds a certificate pin using hex-encoded SHA256 hash of the peer's SPKI.
- * Validates format (64 hex chars or prefixed), decodes to binary, stores in
- * context (duplicates ignored). Pins checked during verification; mismatch
- * raises SocketTLS_PinVerifyFailed if enforced.
- *
- * Hex format: 64 lowercase/uppercase digits; supports HPKP-style "sha256//"
- * prefix (base64-decoded but here hex for simplicity). Max pins limited by
- * config (default 32).
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Pin example.com's known server key
- * const char *pin =
- * "b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b878ae4944c"; TRY {
- *     SocketTLSContext_add_pin_hex(ctx, pin);
- *     // Or with prefix for HPKP compat
- *     SocketTLSContext_add_pin_hex(ctx, "sha256//base64-pin=="); // But use
- * hex SocketTLSContext_set_pin_enforcement(ctx, 1); // Fail on mismatch }
- * EXCEPT(SocketTLS_Failed) {
- *     // Invalid format or max exceeded
- * } END_TRY;
- * @endcode
- *
- * ## Generating Pins
- *
- * Use OpenSSL to extract SPKI hash:
- * @code{.sh}
- * openssl x509 -in server.crt -pubkey -noout | openssl pkey -pubin -outform
- * DER | openssl dgst -sha256 -hex | cut -d' ' -f2
- * @endcode
- *
- * @note Pins survive cert renewal if key unchanged; prefer over full cert
- * pinning
- * @warning Test pins with SocketTLSContext_verify_pin() before deploy
- * @warning Limit pins to known/trusted endpoints; too many degrade perf
- * @complexity O(1) decode + hash compare during verify
- *
- * @return void
- * @throws SocketTLS_Failed if invalid hex format, decode fail, or max pins
- * exceeded (SOCKET_TLS_MAX_PINS ~32)
- * @threadsafe Yes (mutex protected) - safe for concurrent add/verify
- *
- * @see SocketTLSContext_add_pin() for binary input
- * @see SocketTLSContext_add_pin_from_cert() for file-based
- * @see SocketTLS_PinVerifyFailed exception on mismatch
- * @see SocketTLSContext_set_pin_enforcement() to toggle strict mode
- * @see docs/SECURITY.md#certificate-pinning for strategy
- */
+/** @brief Add pin (64-char hex string, optionally "sha256//" prefixed). */
 extern void SocketTLSContext_add_pin_hex (T ctx, const char *hex_hash);
 
-/**
- * @brief Extract and add pin from certificate.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param[in] cert_file Path to PEM-encoded certificate file
- *
- * Loads certificate, extracts SPKI, computes SHA256, and adds as pin.
- * Useful for pinning leaf certificates or intermediate CAs.
- *
- * @return void
- * @throws SocketTLS_Failed if file invalid, parse error, or max pins exceeded
- * @threadsafe No - caller must synchronize configuration changes
- */
+/** @brief Add pin from certificate file. */
 extern void SocketTLSContext_add_pin_from_cert (T ctx, const char *cert_file);
 
-/**
- * @brief Add pin from X509 certificate object.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param cert OpenSSL X509 certificate object
- *
- * Extracts SPKI hash from provided X509 and adds as pin. The certificate
- * is not freed by this function; caller retains ownership.
- *
- * @return void
- * @throws SocketTLS_Failed if cert NULL, extraction fails, or max exceeded
- * @threadsafe No - caller must synchronize configuration changes
- */
+/** @brief Add pin from X509 object. */
 extern void SocketTLSContext_add_pin_from_x509 (T ctx, const X509 *cert);
 
-/**
- * @brief Remove all certificate pins.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * Securely clears all configured pins. Memory is zeroed before release.
- * Pin enforcement mode is preserved.
- *
- * @return void
- * @throws None
- * @threadsafe No - caller must synchronize configuration changes
- */
+/** @brief Remove all pins. */
 extern void SocketTLSContext_clear_pins (T ctx);
 
-/**
- * @brief Set pin enforcement mode.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param enforce 1 = strict (fail on mismatch), 0 = warn only
- *
- * Controls behavior when no pin matches during verification:
- * - enforce=1 (default): Handshake fails with
- * X509_V_ERR_APPLICATION_VERIFICATION
- * - enforce=0: Verification continues, mismatch is logged
- *
- * @return void
- * @throws None
- * @threadsafe No - caller must synchronize configuration changes
- */
+/** @brief Set pin enforcement (1=strict, 0=warn only). */
 extern void SocketTLSContext_set_pin_enforcement (T ctx, int enforce);
 
-/**
- * @brief Get current enforcement mode.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return 1 if strict enforcement, 0 if warn-only
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Get pin enforcement mode. */
 extern int SocketTLSContext_get_pin_enforcement (T ctx);
 
-/**
- * @brief Get number of configured pins.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return Number of pins currently configured
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Get number of configured pins. */
 extern size_t SocketTLSContext_get_pin_count (T ctx);
 
-/**
- * @brief Check if any pins are configured.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return 1 if pins configured, 0 if none
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Check if any pins configured. */
 extern int SocketTLSContext_has_pins (T ctx);
 
-/**
- * @brief Check if hash matches any pin.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param sha256_hash 32-byte hash to check
- *
- * Manual verification without full handshake. Useful for testing
- * or custom verification logic.
- *
- * @return 1 if match found, 0 if no match
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Verify hash against pins. Returns 1 if match. */
 extern int SocketTLSContext_verify_pin (T ctx,
                                         const unsigned char *sha256_hash);
 
-/**
- * @brief Check if certificate matches any pin.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- * @param cert X509 certificate to verify
- *
- * Extracts SPKI hash from certificate and checks against pins.
- * Useful for manual chain verification.
- *
- * @return 1 if match found, 0 if no match
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Verify certificate against pins. Returns 1 if match. */
 extern int SocketTLSContext_verify_cert_pin (T ctx, const X509 *cert);
 
-/* Pinning exception type */
-/**
- * @brief Exception raised when certificate pin verification fails during TLS
- * handshake or manual check.
- * @ingroup security
- *
- * Thrown by pin verification functions when no configured SPKI hash matches
- * the peer certificate's public key. Indicates potential man-in-the-middle
- * attack or misconfiguration.
- *
- * @see SocketTLSContext_add_pin() for adding pins.
- * @see SocketTLSContext_set_pin_enforcement() for enforcement mode.
- * @see SocketTLSContext_verify_pin() for manual checks.
- * @see @ref foundation for exception handling with Except_T.
- */
+/** @brief Exception for pin verification failure. */
 extern const Except_T SocketTLS_PinVerifyFailed;
 
 /* ============================================================================
  * Certificate Transparency (RFC 6962)
  * ============================================================================
- *
- * CT helps detect mis-issued certificates by requiring them to be logged
- * in publicly auditable CT logs. Clients verify Signed Certificate
- * Timestamps (SCTs) embedded in certificates, TLS extensions, or OCSP.
- *
- * Requires OpenSSL 1.1.0+ with CT support compiled in.
- *
- * Usage:
- *   SocketTLSContext_T ctx = SocketTLSContext_new_client("ca-bundle.pem");
- *   SocketTLSContext_enable_ct(ctx, CT_VALIDATION_STRICT);
- *   // ... connections will require valid SCTs
- *
- * Thread safety: Configuration is NOT thread-safe - perform before sharing.
  */
 
-/**
- * @brief Certificate Transparency validation mode enumeration.
- * @ingroup security
- *
- * Controls how Certificate Transparency (RFC 6962) Signed Certificate
- * Timestamps (SCTs) are validated during TLS handshake.
- */
+/** @brief CT validation mode. */
 typedef enum
 {
-  CT_VALIDATION_PERMISSIVE
-  = 0,                     /**< Log missing SCTs but don't fail handshake */
-  CT_VALIDATION_STRICT = 1 /**< Require valid SCTs, fail handshake otherwise */
+  CT_VALIDATION_PERMISSIVE = 0, /**< Log missing SCTs, don't fail */
+  CT_VALIDATION_STRICT = 1      /**< Require valid SCTs */
 } CTValidationMode;
 
-/**
- * @brief Enable Certificate Transparency verification.
- * @ingroup security
- * @param[in] ctx The TLS context instance (client only)
- * @param mode Validation mode (strict or permissive)
- *
- * Enables CT verification for client connections. In strict mode,
- * connections fail if no valid SCTs are present. In permissive mode,
- * missing SCTs are logged but don't cause failure.
- *
- * @return void
- * @throws SocketTLS_Failed if CT not supported or server context
- * @threadsafe No - caller must synchronize configuration changes
- * @ingroup security
- */
+/** @brief Enable CT verification (client). */
 extern void SocketTLSContext_enable_ct (T ctx, CTValidationMode mode);
 
-/**
- * @brief Check if CT verification is enabled.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return 1 if CT enabled, 0 if disabled
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Check if CT enabled. */
 extern int SocketTLSContext_ct_enabled (T ctx);
 
-/**
- * @brief Get current CT validation mode.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * @return CT validation mode (strict or permissive) if enabled, or
- * CT_VALIDATION_PERMISSIVE if disabled @throws None
- * @threadsafe Yes - read-only
- * (read-only)
- */
+/** @brief Get CT validation mode. */
 extern CTValidationMode SocketTLSContext_get_ct_mode (T ctx);
 
-/**
- * @brief Load custom CT log list.
- * @ingroup security
- * @param[in] ctx The TLS context instance (client only)
- * @param log_file Path to CT log list file (OpenSSL format)
- *
- * Loads a custom list of trusted CT logs from file, overriding OpenSSL
- * defaults. Validates file path and format. Call before enable_ct for effect.
- *
- * @return void
- * @throws SocketTLS_Failed if file invalid, load fails, or server context
- * @threadsafe No (config phase only)
- */
+/** @brief Load custom CT log list. */
 extern void SocketTLSContext_set_ctlog_list_file (T ctx, const char *log_file);
 
 /* ============================================================================
- * TLS 1.3 0-RTT Early Data Replay Protection
+ * 0-RTT Early Data Replay Protection
  * ============================================================================
- *
- * 0-RTT early data is vulnerable to replay attacks. Attackers can capture
- * early data and replay it to cause duplicate operations on the server.
- *
- * This API provides a callback mechanism for applications to implement
- * replay detection. The callback is invoked by SocketTLS_accept_early_data()
- * to check if the early data should be accepted.
- *
- * Common replay protection strategies:
- * - Single-use ticket nonces (store used nonces, reject duplicates)
- * - Timestamp-based windows (reject old tickets)
- * - Strike register (Cloudflare-style bloom filter)
- *
- * Thread safety: Configuration is NOT thread-safe - perform before sharing.
- * Callback invocation is serialized per-connection.
  */
 
 /**
- * @brief Callback for 0-RTT early data replay detection.
- * @ingroup security
- * @param ctx TLS context receiving the early data
- * @param session_id Unique session identifier (from session ticket)
- * @param session_id_len Length of session_id
- * @param user_data User-provided data from registration
- *
- * Called by the server when early data is received. The callback must:
- * - Return 1 to ACCEPT the early data (first-seen, safe to process)
- * - Return 0 to REJECT the early data (replay detected or uncertain)
- *
- * The session_id is derived from the session ticket and uniquely identifies
- * the resumption attempt. Store seen session_ids to detect replays.
- *
- * ## Thread Safety Requirements
- *
- * This callback may be invoked concurrently from multiple threads if the
- * TLS context is shared across connections. The implementation MUST be
- * thread-safe. Use appropriate synchronization for shared state.
- *
- * ## Example Implementation
- *
- * @code{.c}
- * int my_replay_check(SocketTLSContext_T ctx,
- *                     const unsigned char *session_id,
- *                     size_t session_id_len,
- *                     void *user_data) {
- *     ReplayStore *store = (ReplayStore *)user_data;
- *
- *     pthread_mutex_lock(&store->lock);
- *     int seen = replay_store_check_and_add(store, session_id, session_id_len);
- *     pthread_mutex_unlock(&store->lock);
- *
- *     return seen ? 0 : 1;  // Reject if seen before, accept if new
- * }
- * @endcode
- *
- * @threadsafe Conditional - callback MUST be thread-safe if context is shared
+ * @brief Early data replay detection callback.
+ * @param ctx TLS context
+ * @param session_id Session identifier
+ * @param session_id_len Length
+ * @param user_data User data
+ * @return 1 to accept, 0 to reject (replay detected)
+ * @note Callback MUST be thread-safe if context is shared.
  */
 typedef int (*SocketTLSEarlyDataReplayCallback) (T ctx,
                                                   const unsigned char *session_id,
                                                   size_t session_id_len,
                                                   void *user_data);
 
-/**
- * @brief Register callback for 0-RTT replay protection.
- * @ingroup security
- * @param ctx TLS context (server only)
- * @param callback Replay detection callback (NULL to disable)
- * @param user_data Opaque data passed to callback
- *
- * Registers a callback that is invoked when early data is received.
- * The callback determines whether to accept or reject the early data
- * based on replay detection logic.
- *
- * If require_protection is set via SocketTLSContext_require_early_data_replay(),
- * early data will be rejected if no callback is registered.
- *
- * @return void
- * @throws SocketTLS_Failed if called on client context
- * @threadsafe No - call during configuration phase only
- *
- * @see SocketTLSEarlyDataReplayCallback for callback implementation
- * @see SocketTLSContext_require_early_data_replay() for enforcement
- * @see SocketTLSContext_enable_early_data() for enabling 0-RTT
- */
+/** @brief Register replay protection callback (server). */
 extern void SocketTLSContext_set_early_data_replay_callback (
     T ctx, SocketTLSEarlyDataReplayCallback callback, void *user_data);
 
-/**
- * @brief Require replay protection for early data acceptance.
- * @ingroup security
- * @param ctx TLS context (server only)
- * @param require 1 = require callback, 0 = allow without callback (default)
- *
- * When enabled, early data is automatically rejected unless a replay
- * callback is registered AND the callback returns 1 (accept).
- *
- * Recommended for production servers accepting 0-RTT early data.
- * Without this, early data is vulnerable to replay attacks.
- *
- * @return void
- * @throws SocketTLS_Failed if called on client context
- * @threadsafe No - call during configuration phase only
- *
- * @see SocketTLSContext_set_early_data_replay_callback() for registration
- * @see SocketTLSContext_enable_early_data() for enabling 0-RTT
- */
+/** @brief Require replay protection for early data (server). */
 extern void SocketTLSContext_require_early_data_replay (T ctx, int require);
 
-/**
- * @brief Check if replay callback is registered.
- * @ingroup security
- * @param ctx TLS context
- *
- * @return 1 if callback registered, 0 if not
- * @throws None
- * @threadsafe Yes (read-only)
- */
+/** @brief Check if replay callback registered. */
 extern int SocketTLSContext_has_early_data_replay_callback (T ctx);
 
-/**
- * @brief Invoke replay callback for early data check.
- * @ingroup security
- * @param ctx TLS context
- * @param session_id Session identifier from ticket
- * @param session_id_len Length of session_id
- *
- * Called internally by SocketTLS_accept_early_data() to check replay.
- * Applications can also call this for custom early data handling.
- *
- * @return 1 if accepted (or no callback/requirement), 0 if rejected
- * @throws None
- * @threadsafe Yes - callback invocation is per-connection
- */
+/** @brief Invoke replay callback. Returns 1 if accepted. */
 extern int SocketTLSContext_check_early_data_replay (
     T ctx, const unsigned char *session_id, size_t session_id_len);
 
-/* Internal functions (not part of public API) */
-/**
- * @brief Get underlying OpenSSL SSL_CTX*.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * Internal access to raw SSL_CTX for SocketTLS_enable() etc.
- *
- * @return void* to SSL_CTX (cast as needed)
- * @throws None
- * @threadsafe Yes
+/* ============================================================================
+ * Internal Functions
+ * ============================================================================
  */
+
+/** @brief Get underlying SSL_CTX*. */
 extern void *SocketTLSContext_get_ssl_ctx (T ctx);
 
-/**
- * @brief Check if context is server-mode.
- * @ingroup security
- * @param[in] ctx The TLS context instance
- *
- * Internal helper to determine client vs server configuration.
- *
- * @return 1 if server, 0 if client
- * @throws None
- * @threadsafe Yes
- */
+/** @brief Check if context is server-mode. */
 extern int SocketTLSContext_is_server (T ctx);
 
-/** @} tls_context */
+/** @} */
 
 #undef T
 


### PR DESCRIPTION
## Summary

- Remove excessive documentation verbosity to match the established standard from include/core/ and include/dns/
- **4141 lines removed**, 460 lines added (net reduction of ~3700 lines)

### Files cleaned:

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| SocketHTTPClient-config.h | 1287 | 367 | 71% |
| SocketHTTPClient.h | ~1500 | ~1360 | ~10% |
| SocketReconnect.h | 1467 | 448 | 70% |
| SocketTLSContext.h | 2058 | 507 | 75% |

### Changes:
- Removed duplicate section summaries in config headers
- Removed ASCII architecture diagrams (belong in docs/)
- Reduced function documentation from 30-90 lines to 5-15 lines
- Removed extensive code examples (belong in docs/)
- Preserved all API signatures and essential documentation

Fixes #52

## Test plan
- [x] All 70 tests pass with sanitizers enabled
- [x] Build succeeds with `-DENABLE_TLS=ON -DENABLE_SANITIZERS=ON`
- [x] No API changes - only comment modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)