### PR TITLE
feat: extend Simple API with buf, timer, happyeyeballs, reconnect, and tcp options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -320,6 +320,10 @@ set(LIB_SOURCES
     src/simple/SocketSimple-http-server.c
     src/simple/SocketSimple-security.c
     src/simple/SocketSimple-async.c
+    src/simple/SocketSimple-buf.c
+    src/simple/SocketSimple-timer.c
+    src/simple/SocketSimple-happyeyeballs.c
+    src/simple/SocketSimple-reconnect.c
 )
 
 # Add TLS sources if enabled (split for maintainability)
@@ -528,6 +532,10 @@ set(SIMPLE_HEADERS
     include/simple/SocketSimple-http-server.h
     include/simple/SocketSimple-ratelimit.h
     include/simple/SocketSimple-security.h
+    include/simple/SocketSimple-buf.h
+    include/simple/SocketSimple-timer.h
+    include/simple/SocketSimple-happyeyeballs.h
+    include/simple/SocketSimple-reconnect.h
 )
 
 install(TARGETS socket_static socket_shared

--- a/include/simple/SocketSimple-buf.h
+++ b/include/simple/SocketSimple-buf.h
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETSIMPLE_BUF_INCLUDED
+#define SOCKETSIMPLE_BUF_INCLUDED
+
+/**
+ * @file SocketSimple-buf.h
+ * @brief Simple circular buffer API for socket I/O operations.
+ *
+ * Provides a return-code based wrapper around SocketBuf_T for efficient
+ * buffering without exception handling. Useful for protocol parsing,
+ * message framing, and zero-copy I/O operations.
+ *
+ * ## Quick Start
+ *
+ * ```c
+ * #include <simple/SocketSimple.h>
+ *
+ * // Create a 4KB buffer
+ * SocketSimple_Buf_T buf = Socket_simple_buf_new(4096);
+ * if (!buf) {
+ *     fprintf(stderr, "Error: %s\n", Socket_simple_error());
+ *     return 1;
+ * }
+ *
+ * // Write data
+ * if (Socket_simple_buf_write(buf, "Hello", 5) != 5) {
+ *     fprintf(stderr, "Write failed\n");
+ * }
+ *
+ * // Read data
+ * char data[64];
+ * ssize_t n = Socket_simple_buf_read(buf, data, sizeof(data));
+ *
+ * // Clean up
+ * Socket_simple_buf_free(&buf);
+ * ```
+ */
+
+#include <stddef.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============================================================================
+ * Opaque Handle Type
+ *============================================================================*/
+
+/**
+ * @brief Opaque circular buffer handle.
+ */
+typedef struct SocketSimple_Buf *SocketSimple_Buf_T;
+
+/*============================================================================
+ * Buffer Creation and Destruction
+ *============================================================================*/
+
+/**
+ * @brief Create a new circular buffer.
+ *
+ * @param capacity Initial buffer size in bytes (must be > 0).
+ * @return Buffer handle on success, NULL on error.
+ *
+ * Example:
+ * @code
+ * SocketSimple_Buf_T buf = Socket_simple_buf_new(4096);
+ * if (!buf) {
+ *     fprintf(stderr, "Error: %s\n", Socket_simple_error());
+ *     return 1;
+ * }
+ * @endcode
+ */
+extern SocketSimple_Buf_T Socket_simple_buf_new(size_t capacity);
+
+/**
+ * @brief Free a buffer and release resources.
+ *
+ * Sets *buf to NULL after freeing.
+ *
+ * @param buf Pointer to buffer handle.
+ */
+extern void Socket_simple_buf_free(SocketSimple_Buf_T *buf);
+
+/*============================================================================
+ * Write Operations
+ *============================================================================*/
+
+/**
+ * @brief Write data into the buffer.
+ *
+ * @param buf Buffer handle.
+ * @param data Data to write.
+ * @param len Number of bytes to write.
+ * @return Number of bytes written (may be less than len if full), -1 on error.
+ */
+extern ssize_t Socket_simple_buf_write(SocketSimple_Buf_T buf,
+                                        const void *data,
+                                        size_t len);
+
+/**
+ * @brief Get direct write pointer for zero-copy writes.
+ *
+ * After writing to the returned pointer, call Socket_simple_buf_commit()
+ * to mark the bytes as written.
+ *
+ * @param buf Buffer handle.
+ * @param len Output: maximum contiguous bytes available for writing.
+ * @return Pointer to write location, or NULL if no space or error.
+ *
+ * Example:
+ * @code
+ * size_t avail;
+ * void *ptr = Socket_simple_buf_writeptr(buf, &avail);
+ * if (ptr) {
+ *     ssize_t n = recv(fd, ptr, avail, 0);
+ *     if (n > 0) Socket_simple_buf_commit(buf, n);
+ * }
+ * @endcode
+ */
+extern void *Socket_simple_buf_writeptr(SocketSimple_Buf_T buf, size_t *len);
+
+/**
+ * @brief Commit bytes written via direct write pointer.
+ *
+ * @param buf Buffer handle.
+ * @param len Number of bytes written.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_buf_commit(SocketSimple_Buf_T buf, size_t len);
+
+/*============================================================================
+ * Read Operations
+ *============================================================================*/
+
+/**
+ * @brief Read and remove data from the buffer.
+ *
+ * @param buf Buffer handle.
+ * @param data Destination buffer.
+ * @param len Maximum bytes to read.
+ * @return Number of bytes read, 0 if empty, -1 on error.
+ */
+extern ssize_t Socket_simple_buf_read(SocketSimple_Buf_T buf,
+                                       void *data,
+                                       size_t len);
+
+/**
+ * @brief Peek at data without removing it.
+ *
+ * @param buf Buffer handle.
+ * @param data Destination buffer.
+ * @param len Maximum bytes to peek.
+ * @return Number of bytes copied, 0 if empty, -1 on error.
+ */
+extern ssize_t Socket_simple_buf_peek(SocketSimple_Buf_T buf,
+                                       void *data,
+                                       size_t len);
+
+/**
+ * @brief Get direct read pointer for zero-copy reads.
+ *
+ * After consuming data, call Socket_simple_buf_consume() to remove it.
+ *
+ * @param buf Buffer handle.
+ * @param len Output: contiguous bytes available for reading.
+ * @return Pointer to readable data, or NULL if empty or error.
+ *
+ * Example:
+ * @code
+ * size_t avail;
+ * const void *ptr = Socket_simple_buf_readptr(buf, &avail);
+ * if (ptr) {
+ *     ssize_t n = send(fd, ptr, avail, 0);
+ *     if (n > 0) Socket_simple_buf_consume(buf, n);
+ * }
+ * @endcode
+ */
+extern const void *Socket_simple_buf_readptr(SocketSimple_Buf_T buf,
+                                              size_t *len);
+
+/**
+ * @brief Discard data from the front of the buffer.
+ *
+ * @param buf Buffer handle.
+ * @param len Number of bytes to discard.
+ * @return 0 on success, -1 on error (e.g., len > available).
+ */
+extern int Socket_simple_buf_consume(SocketSimple_Buf_T buf, size_t len);
+
+/**
+ * @brief Read a line (up to and including newline).
+ *
+ * @param buf Buffer handle.
+ * @param line Destination buffer.
+ * @param maxlen Maximum bytes to read (including null terminator).
+ * @return Line length (excluding null), or -1 if no newline found or error.
+ */
+extern ssize_t Socket_simple_buf_readline(SocketSimple_Buf_T buf,
+                                           char *line,
+                                           size_t maxlen);
+
+/*============================================================================
+ * Buffer State Query
+ *============================================================================*/
+
+/**
+ * @brief Get number of bytes available for reading.
+ *
+ * @param buf Buffer handle.
+ * @return Bytes in buffer, or 0 if invalid/empty.
+ */
+extern size_t Socket_simple_buf_available(SocketSimple_Buf_T buf);
+
+/**
+ * @brief Get free space available for writing.
+ *
+ * @param buf Buffer handle.
+ * @return Free space in bytes, or 0 if invalid/full.
+ */
+extern size_t Socket_simple_buf_space(SocketSimple_Buf_T buf);
+
+/**
+ * @brief Get total buffer capacity.
+ *
+ * @param buf Buffer handle.
+ * @return Capacity in bytes, or 0 if invalid.
+ */
+extern size_t Socket_simple_buf_capacity(SocketSimple_Buf_T buf);
+
+/**
+ * @brief Check if buffer is empty.
+ *
+ * @param buf Buffer handle.
+ * @return 1 if empty, 0 if not empty or invalid.
+ */
+extern int Socket_simple_buf_empty(SocketSimple_Buf_T buf);
+
+/**
+ * @brief Check if buffer is full.
+ *
+ * @param buf Buffer handle.
+ * @return 1 if full, 0 if not full or invalid.
+ */
+extern int Socket_simple_buf_full(SocketSimple_Buf_T buf);
+
+/*============================================================================
+ * Buffer Management
+ *============================================================================*/
+
+/**
+ * @brief Clear the buffer (reset to empty).
+ *
+ * @param buf Buffer handle.
+ */
+extern void Socket_simple_buf_clear(SocketSimple_Buf_T buf);
+
+/**
+ * @brief Securely clear buffer contents (overwrites with zeros).
+ *
+ * Use for sensitive data (passwords, keys, etc.).
+ *
+ * @param buf Buffer handle.
+ */
+extern void Socket_simple_buf_clear_secure(SocketSimple_Buf_T buf);
+
+/**
+ * @brief Ensure minimum write space is available.
+ *
+ * May resize the buffer if necessary.
+ *
+ * @param buf Buffer handle.
+ * @param min_space Required minimum free space.
+ * @return 0 on success (space available), -1 on error.
+ */
+extern int Socket_simple_buf_reserve(SocketSimple_Buf_T buf, size_t min_space);
+
+/**
+ * @brief Compact buffer (move data to front).
+ *
+ * Maximizes contiguous write space.
+ *
+ * @param buf Buffer handle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_buf_compact(SocketSimple_Buf_T buf);
+
+/*============================================================================
+ * Search Operations
+ *============================================================================*/
+
+/**
+ * @brief Search for a byte sequence in the buffer.
+ *
+ * @param buf Buffer handle.
+ * @param needle Sequence to find.
+ * @param needle_len Length of needle.
+ * @return Offset from start where needle found, or -1 if not found.
+ *
+ * Example:
+ * @code
+ * // Find HTTP header end
+ * ssize_t pos = Socket_simple_buf_find(buf, "\r\n\r\n", 4);
+ * if (pos >= 0) {
+ *     // Headers end at pos + 4
+ * }
+ * @endcode
+ */
+extern ssize_t Socket_simple_buf_find(SocketSimple_Buf_T buf,
+                                       const void *needle,
+                                       size_t needle_len);
+
+/*============================================================================
+ * Scatter-Gather I/O
+ *============================================================================*/
+
+#include <sys/uio.h>
+
+/**
+ * @brief Scatter read from buffer into multiple iovecs.
+ *
+ * @param buf Buffer handle.
+ * @param iov Array of iovec structures.
+ * @param iovcnt Number of iovec entries.
+ * @return Total bytes read, -1 on error.
+ */
+extern ssize_t Socket_simple_buf_readv(SocketSimple_Buf_T buf,
+                                        const struct iovec *iov,
+                                        int iovcnt);
+
+/**
+ * @brief Gather write from multiple iovecs into buffer.
+ *
+ * @param buf Buffer handle.
+ * @param iov Array of iovec structures.
+ * @param iovcnt Number of iovec entries.
+ * @return Total bytes written, -1 on error.
+ */
+extern ssize_t Socket_simple_buf_writev(SocketSimple_Buf_T buf,
+                                         const struct iovec *iov,
+                                         int iovcnt);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOCKETSIMPLE_BUF_INCLUDED */

--- a/include/simple/SocketSimple-happyeyeballs.h
+++ b/include/simple/SocketSimple-happyeyeballs.h
@@ -1,0 +1,159 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETSIMPLE_HAPPYEYEBALLS_INCLUDED
+#define SOCKETSIMPLE_HAPPYEYEBALLS_INCLUDED
+
+/**
+ * @file SocketSimple-happyeyeballs.h
+ * @brief RFC 8305 Happy Eyeballs v2 dual-stack connection racing.
+ *
+ * Provides fast dual-stack connection establishment by racing IPv4 and IPv6
+ * connections. Uses the winning connection and cancels the other.
+ *
+ * ## Quick Start
+ *
+ * ```c
+ * #include <simple/SocketSimple.h>
+ *
+ * // Simple dual-stack connect (uses best available connection)
+ * SocketSimple_Socket_T sock = Socket_simple_happyeyeballs_connect(
+ *     "example.com", 443, 5000);
+ * if (!sock) {
+ *     fprintf(stderr, "Error: %s\n", Socket_simple_error());
+ *     return 1;
+ * }
+ *
+ * // Use socket normally
+ * Socket_simple_send(sock, "GET / HTTP/1.1\r\n", 16);
+ * Socket_simple_close(&sock);
+ * ```
+ *
+ * ## Algorithm (RFC 8305)
+ *
+ * 1. Resolve hostname to both IPv6 and IPv4 addresses
+ * 2. Start IPv6 connection first (preferred)
+ * 3. If IPv6 doesn't complete within delay (250ms default), start IPv4
+ * 4. Return the first successful connection
+ * 5. Cancel any pending connections
+ */
+
+#include "SocketSimple-tcp.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============================================================================
+ * Configuration
+ *============================================================================*/
+
+/**
+ * @brief Happy Eyeballs connection configuration.
+ */
+typedef struct SocketSimple_HappyEyeballs_Config {
+    int resolution_delay_ms;  /**< Delay before starting parallel resolution (default: 50) */
+    int connection_delay_ms;  /**< Delay before starting IPv4 after IPv6 (default: 250) */
+    int prefer_ipv6;          /**< 1 to prefer IPv6, 0 to prefer IPv4 (default: 1) */
+    int max_attempts;         /**< Max addresses to try per family (0=unlimited, default: 0) */
+} SocketSimple_HappyEyeballs_Config;
+
+/*============================================================================
+ * Connection Functions
+ *============================================================================*/
+
+/**
+ * @brief Connect using Happy Eyeballs algorithm (RFC 8305).
+ *
+ * Races IPv4 and IPv6 connections to minimize connection time on
+ * dual-stack networks.
+ *
+ * @param host Hostname or IP address.
+ * @param port Port number (1-65535).
+ * @param timeout_ms Overall timeout in milliseconds.
+ * @return Socket handle on success, NULL on error.
+ *
+ * Example:
+ * @code
+ * SocketSimple_Socket_T sock = Socket_simple_happyeyeballs_connect(
+ *     "www.google.com", 443, 10000);
+ * if (!sock) {
+ *     fprintf(stderr, "Connect failed: %s\n", Socket_simple_error());
+ * }
+ * @endcode
+ */
+extern SocketSimple_Socket_T Socket_simple_happyeyeballs_connect(
+    const char *host,
+    int port,
+    int timeout_ms);
+
+/**
+ * @brief Connect using Happy Eyeballs with custom configuration.
+ *
+ * @param host Hostname or IP address.
+ * @param port Port number.
+ * @param timeout_ms Overall timeout.
+ * @param config Custom configuration (NULL for defaults).
+ * @return Socket handle on success, NULL on error.
+ */
+extern SocketSimple_Socket_T Socket_simple_happyeyeballs_connect_config(
+    const char *host,
+    int port,
+    int timeout_ms,
+    const SocketSimple_HappyEyeballs_Config *config);
+
+/*============================================================================
+ * Configuration Helpers
+ *============================================================================*/
+
+/**
+ * @brief Initialize configuration with default values.
+ *
+ * Default values per RFC 8305:
+ * - resolution_delay_ms: 50
+ * - connection_delay_ms: 250
+ * - prefer_ipv6: 1
+ * - max_attempts: 0 (unlimited)
+ *
+ * @param config Configuration structure to initialize.
+ */
+extern void Socket_simple_happyeyeballs_config_defaults(
+    SocketSimple_HappyEyeballs_Config *config);
+
+/*============================================================================
+ * Query Functions
+ *============================================================================*/
+
+/**
+ * @brief Get address family of connected socket.
+ *
+ * @param sock Socket handle.
+ * @return AF_INET (2) for IPv4, AF_INET6 (10) for IPv6, -1 on error.
+ */
+extern int Socket_simple_get_family(SocketSimple_Socket_T sock);
+
+/**
+ * @brief Check if socket is using IPv6.
+ *
+ * @param sock Socket handle.
+ * @return 1 if IPv6, 0 if IPv4, -1 on error.
+ */
+extern int Socket_simple_is_ipv6(SocketSimple_Socket_T sock);
+
+/**
+ * @brief Check if socket is using IPv4.
+ *
+ * @param sock Socket handle.
+ * @return 1 if IPv4, 0 if IPv6, -1 on error.
+ */
+extern int Socket_simple_is_ipv4(SocketSimple_Socket_T sock);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOCKETSIMPLE_HAPPYEYEBALLS_INCLUDED */

--- a/include/simple/SocketSimple-reconnect.h
+++ b/include/simple/SocketSimple-reconnect.h
@@ -1,0 +1,357 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETSIMPLE_RECONNECT_INCLUDED
+#define SOCKETSIMPLE_RECONNECT_INCLUDED
+
+/**
+ * @file SocketSimple-reconnect.h
+ * @brief Automatic reconnection with exponential backoff and circuit breaker.
+ *
+ * Provides resilient TCP connections that automatically reconnect on failure
+ * with configurable retry policies and circuit breaker protection.
+ *
+ * ## Quick Start
+ *
+ * ```c
+ * #include <simple/SocketSimple.h>
+ *
+ * // Create reconnecting connection
+ * SocketSimple_Reconnect_T conn = Socket_simple_reconnect_new(
+ *     "database.example.com", 5432, NULL);
+ *
+ * // Connect (will auto-reconnect on failure)
+ * if (Socket_simple_reconnect_connect(conn) < 0) {
+ *     fprintf(stderr, "Initial connect failed\n");
+ * }
+ *
+ * // Use passthrough I/O (auto-reconnects on error)
+ * const char *query = "SELECT 1";
+ * ssize_t n = Socket_simple_reconnect_send(conn, query, strlen(query));
+ *
+ * // Event loop integration
+ * while (running) {
+ *     int timeout = Socket_simple_reconnect_next_timeout(conn);
+ *     // ... poll for events with timeout ...
+ *     Socket_simple_reconnect_tick(conn);
+ * }
+ *
+ * Socket_simple_reconnect_free(&conn);
+ * ```
+ */
+
+#include "SocketSimple-tcp.h"
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*============================================================================
+ * Opaque Handle Type
+ *============================================================================*/
+
+/**
+ * @brief Opaque reconnecting connection handle.
+ */
+typedef struct SocketSimple_Reconnect *SocketSimple_Reconnect_T;
+
+/*============================================================================
+ * Connection States
+ *============================================================================*/
+
+/**
+ * @brief Reconnection state machine states.
+ */
+typedef enum {
+    SIMPLE_RECONNECT_DISCONNECTED = 0, /**< Not connected */
+    SIMPLE_RECONNECT_CONNECTING,       /**< Connection in progress */
+    SIMPLE_RECONNECT_CONNECTED,        /**< Successfully connected */
+    SIMPLE_RECONNECT_BACKOFF,          /**< Waiting before retry */
+    SIMPLE_RECONNECT_CIRCUIT_OPEN      /**< Circuit breaker open */
+} SocketSimple_Reconnect_State;
+
+/*============================================================================
+ * Policy Configuration
+ *============================================================================*/
+
+/**
+ * @brief Reconnection policy configuration.
+ */
+typedef struct SocketSimple_Reconnect_Policy {
+    /* Exponential backoff */
+    int initial_delay_ms;     /**< First retry delay (default: 100) */
+    int max_delay_ms;         /**< Maximum retry delay (default: 30000) */
+    double multiplier;        /**< Backoff multiplier (default: 2.0) */
+    double jitter;            /**< Jitter factor 0.0-1.0 (default: 0.25) */
+    int max_attempts;         /**< Max attempts, 0=unlimited (default: 10) */
+
+    /* Circuit breaker */
+    int circuit_threshold;    /**< Failures to open circuit (default: 5) */
+    int circuit_reset_ms;     /**< Time before circuit probe (default: 60000) */
+
+    /* Health checking */
+    int health_interval_ms;   /**< Health check interval (default: 30000) */
+    int health_timeout_ms;    /**< Health check timeout (default: 5000) */
+} SocketSimple_Reconnect_Policy;
+
+/*============================================================================
+ * Callbacks
+ *============================================================================*/
+
+/**
+ * @brief State change callback.
+ *
+ * @param conn Reconnection handle.
+ * @param old_state Previous state.
+ * @param new_state New state.
+ * @param userdata User data from creation.
+ */
+typedef void (*SocketSimple_Reconnect_Callback)(
+    SocketSimple_Reconnect_T conn,
+    SocketSimple_Reconnect_State old_state,
+    SocketSimple_Reconnect_State new_state,
+    void *userdata);
+
+/**
+ * @brief Custom health check callback.
+ *
+ * @param conn Reconnection handle.
+ * @param sock Underlying socket to check.
+ * @param timeout_ms Maximum time for check.
+ * @param userdata User data.
+ * @return 1 if healthy, 0 if unhealthy.
+ */
+typedef int (*SocketSimple_Reconnect_HealthCheck)(
+    SocketSimple_Reconnect_T conn,
+    SocketSimple_Socket_T sock,
+    int timeout_ms,
+    void *userdata);
+
+/*============================================================================
+ * Lifecycle Functions
+ *============================================================================*/
+
+/**
+ * @brief Create a reconnecting connection.
+ *
+ * @param host Target hostname.
+ * @param port Target port.
+ * @param policy Custom policy (NULL for defaults).
+ * @return Handle on success, NULL on error.
+ */
+extern SocketSimple_Reconnect_T Socket_simple_reconnect_new(
+    const char *host,
+    int port,
+    const SocketSimple_Reconnect_Policy *policy);
+
+/**
+ * @brief Free a reconnection handle.
+ *
+ * @param conn Pointer to handle (set to NULL after freeing).
+ */
+extern void Socket_simple_reconnect_free(SocketSimple_Reconnect_T *conn);
+
+/**
+ * @brief Initialize policy with default values.
+ *
+ * @param policy Policy structure to initialize.
+ */
+extern void Socket_simple_reconnect_policy_defaults(
+    SocketSimple_Reconnect_Policy *policy);
+
+/*============================================================================
+ * Connection Control
+ *============================================================================*/
+
+/**
+ * @brief Start connection (or queue retry if in backoff).
+ *
+ * @param conn Reconnection handle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_connect(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Disconnect gracefully (no auto-reconnect).
+ *
+ * @param conn Reconnection handle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_disconnect(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Reset state machine and statistics.
+ *
+ * @param conn Reconnection handle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_reset(SocketSimple_Reconnect_T conn);
+
+/*============================================================================
+ * State Query
+ *============================================================================*/
+
+/**
+ * @brief Get current connection state.
+ *
+ * @param conn Reconnection handle.
+ * @return Current state.
+ */
+extern SocketSimple_Reconnect_State Socket_simple_reconnect_state(
+    SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Get state name for logging.
+ *
+ * @param state State value.
+ * @return Static string name.
+ */
+extern const char *Socket_simple_reconnect_state_name(
+    SocketSimple_Reconnect_State state);
+
+/**
+ * @brief Check if currently connected.
+ *
+ * @param conn Reconnection handle.
+ * @return 1 if connected, 0 otherwise.
+ */
+extern int Socket_simple_reconnect_is_connected(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Get number of connection attempts.
+ *
+ * @param conn Reconnection handle.
+ * @return Attempt count.
+ */
+extern int Socket_simple_reconnect_attempts(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Get consecutive failure count.
+ *
+ * @param conn Reconnection handle.
+ * @return Failure count.
+ */
+extern int Socket_simple_reconnect_failures(SocketSimple_Reconnect_T conn);
+
+/*============================================================================
+ * Event Loop Integration
+ *============================================================================*/
+
+/**
+ * @brief Get file descriptor for polling.
+ *
+ * @param conn Reconnection handle.
+ * @return FD if connected/connecting, -1 otherwise.
+ */
+extern int Socket_simple_reconnect_fd(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Get timeout until next event.
+ *
+ * Use as timeout for poll/select.
+ *
+ * @param conn Reconnection handle.
+ * @return Milliseconds until next event, -1 if none.
+ */
+extern int Socket_simple_reconnect_next_timeout(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Process timers and state transitions.
+ *
+ * Call periodically in event loop.
+ *
+ * @param conn Reconnection handle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_tick(SocketSimple_Reconnect_T conn);
+
+/**
+ * @brief Process I/O events.
+ *
+ * Call when fd becomes readable/writable.
+ *
+ * @param conn Reconnection handle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_process(SocketSimple_Reconnect_T conn);
+
+/*============================================================================
+ * Passthrough I/O (Auto-reconnect on error)
+ *============================================================================*/
+
+/**
+ * @brief Send data with auto-reconnect on error.
+ *
+ * @param conn Reconnection handle.
+ * @param data Data to send.
+ * @param len Data length.
+ * @return Bytes sent, 0 if not connected, -1 on error.
+ */
+extern ssize_t Socket_simple_reconnect_send(SocketSimple_Reconnect_T conn,
+                                             const void *data,
+                                             size_t len);
+
+/**
+ * @brief Receive data with auto-reconnect on error.
+ *
+ * @param conn Reconnection handle.
+ * @param buf Receive buffer.
+ * @param len Buffer size.
+ * @return Bytes received, 0 on disconnect/not connected, -1 on error.
+ */
+extern ssize_t Socket_simple_reconnect_recv(SocketSimple_Reconnect_T conn,
+                                             void *buf,
+                                             size_t len);
+
+/*============================================================================
+ * Configuration
+ *============================================================================*/
+
+/**
+ * @brief Set state change callback.
+ *
+ * @param conn Reconnection handle.
+ * @param callback Callback function (NULL to disable).
+ * @param userdata User data passed to callback.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_set_callback(
+    SocketSimple_Reconnect_T conn,
+    SocketSimple_Reconnect_Callback callback,
+    void *userdata);
+
+/**
+ * @brief Set custom health check.
+ *
+ * @param conn Reconnection handle.
+ * @param check Health check function (NULL for default).
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_reconnect_set_health_check(
+    SocketSimple_Reconnect_T conn,
+    SocketSimple_Reconnect_HealthCheck check);
+
+/*============================================================================
+ * Underlying Socket Access
+ *============================================================================*/
+
+/**
+ * @brief Get underlying socket when connected.
+ *
+ * @param conn Reconnection handle.
+ * @return Socket handle if connected, NULL otherwise.
+ *
+ * @note Do not close the returned socket directly.
+ */
+extern SocketSimple_Socket_T Socket_simple_reconnect_get_socket(
+    SocketSimple_Reconnect_T conn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOCKETSIMPLE_RECONNECT_INCLUDED */

--- a/include/simple/SocketSimple-tcp.h
+++ b/include/simple/SocketSimple-tcp.h
@@ -263,6 +263,373 @@ extern ssize_t Socket_simple_udp_recvfrom(SocketSimple_Socket_T sock,
                                            size_t host_len,
                                            int *from_port);
 
+/*============================================================================
+ * UDP Advanced Features (Multicast, Broadcast)
+ *============================================================================*/
+
+/**
+ * @brief Join a multicast group.
+ *
+ * @param sock UDP socket handle.
+ * @param group Multicast group address (e.g., "224.0.0.1").
+ * @param iface Local interface address (NULL for default).
+ * @return 0 on success, -1 on error.
+ *
+ * Example:
+ * @code
+ * SocketSimple_Socket_T sock = Socket_simple_udp_bind("0.0.0.0", 5000);
+ * if (Socket_simple_udp_join_multicast(sock, "239.255.0.1", NULL) < 0) {
+ *     fprintf(stderr, "Error: %s\n", Socket_simple_error());
+ * }
+ * @endcode
+ */
+extern int Socket_simple_udp_join_multicast(SocketSimple_Socket_T sock,
+                                             const char *group,
+                                             const char *iface);
+
+/**
+ * @brief Leave a multicast group.
+ *
+ * @param sock UDP socket handle.
+ * @param group Multicast group address.
+ * @param iface Local interface (NULL for default).
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_leave_multicast(SocketSimple_Socket_T sock,
+                                              const char *group,
+                                              const char *iface);
+
+/**
+ * @brief Set multicast TTL (Time To Live).
+ *
+ * @param sock UDP socket handle.
+ * @param ttl TTL value (1-255, typically 1 for LAN only).
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_set_multicast_ttl(SocketSimple_Socket_T sock,
+                                                int ttl);
+
+/**
+ * @brief Enable/disable multicast loopback.
+ *
+ * @param sock UDP socket handle.
+ * @param enable 1 to enable, 0 to disable.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_set_multicast_loopback(SocketSimple_Socket_T sock,
+                                                     int enable);
+
+/**
+ * @brief Set the interface for outgoing multicast packets.
+ *
+ * @param sock UDP socket handle.
+ * @param iface Interface address (NULL for default).
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_set_multicast_interface(SocketSimple_Socket_T sock,
+                                                      const char *iface);
+
+/**
+ * @brief Enable UDP broadcast.
+ *
+ * @param sock UDP socket handle.
+ * @param enable 1 to enable, 0 to disable.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_set_broadcast(SocketSimple_Socket_T sock,
+                                            int enable);
+
+/**
+ * @brief Set TTL for unicast packets.
+ *
+ * @param sock UDP socket handle.
+ * @param ttl TTL value (1-255).
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_set_ttl(SocketSimple_Socket_T sock, int ttl);
+
+/**
+ * @brief Connect UDP socket to a specific peer.
+ *
+ * After connecting, can use send/recv instead of sendto/recvfrom.
+ *
+ * @param sock UDP socket handle.
+ * @param host Peer hostname or IP address.
+ * @param port Peer port.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_udp_connect(SocketSimple_Socket_T sock,
+                                      const char *host,
+                                      int port);
+
+/**
+ * @brief Send data on a connected UDP socket.
+ *
+ * @param sock UDP socket handle (must be connected).
+ * @param data Data to send.
+ * @param len Data length.
+ * @return Bytes sent, or -1 on error.
+ */
+extern ssize_t Socket_simple_udp_send(SocketSimple_Socket_T sock,
+                                       const void *data,
+                                       size_t len);
+
+/**
+ * @brief Receive data on a connected UDP socket.
+ *
+ * @param sock UDP socket handle (must be connected).
+ * @param buf Receive buffer.
+ * @param len Buffer size.
+ * @return Bytes received, or -1 on error.
+ */
+extern ssize_t Socket_simple_udp_recv(SocketSimple_Socket_T sock,
+                                       void *buf,
+                                       size_t len);
+
+/*============================================================================
+ * Unix Domain Socket Functions
+ *============================================================================*/
+
+/**
+ * @brief Connect to a Unix domain socket.
+ *
+ * @param path Socket path (e.g., "/var/run/app.sock").
+ * @return Socket handle on success, NULL on error.
+ *
+ * Example:
+ * @code
+ * SocketSimple_Socket_T sock = Socket_simple_connect_unix("/var/run/docker.sock");
+ * if (!sock) {
+ *     fprintf(stderr, "Error: %s\n", Socket_simple_error());
+ * }
+ * @endcode
+ */
+extern SocketSimple_Socket_T Socket_simple_connect_unix(const char *path);
+
+/**
+ * @brief Create a listening Unix domain socket.
+ *
+ * @param path Socket path to bind.
+ * @param backlog Listen queue size.
+ * @return Socket handle on success, NULL on error.
+ *
+ * @note Removes any existing socket file at the path before binding.
+ */
+extern SocketSimple_Socket_T Socket_simple_listen_unix(const char *path,
+                                                        int backlog);
+
+/*============================================================================
+ * TCP Socket Options
+ *============================================================================*/
+
+/**
+ * @brief Enable/disable TCP_NODELAY (Nagle's algorithm).
+ *
+ * Disabling Nagle's algorithm reduces latency for small messages.
+ *
+ * @param sock Socket handle.
+ * @param enable 1 to disable Nagle (low latency), 0 to enable Nagle.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_set_nodelay(SocketSimple_Socket_T sock, int enable);
+
+/**
+ * @brief Get TCP_NODELAY state.
+ *
+ * @param sock Socket handle.
+ * @return 1 if Nagle disabled, 0 if enabled, -1 on error.
+ */
+extern int Socket_simple_get_nodelay(SocketSimple_Socket_T sock);
+
+/**
+ * @brief Configure TCP keepalive.
+ *
+ * @param sock Socket handle.
+ * @param enable 1 to enable, 0 to disable.
+ * @param idle_secs Seconds before first probe (0 for system default).
+ * @param interval_secs Seconds between probes (0 for system default).
+ * @param count Number of failed probes before disconnect (0 for system default).
+ * @return 0 on success, -1 on error.
+ *
+ * Example:
+ * @code
+ * // Enable keepalive: probe after 60s idle, every 10s, fail after 3 misses
+ * Socket_simple_set_keepalive(sock, 1, 60, 10, 3);
+ * @endcode
+ */
+extern int Socket_simple_set_keepalive(SocketSimple_Socket_T sock,
+                                        int enable,
+                                        int idle_secs,
+                                        int interval_secs,
+                                        int count);
+
+/**
+ * @brief Get keepalive settings.
+ *
+ * @param sock Socket handle.
+ * @param enabled Output: 1 if enabled, 0 if disabled.
+ * @param idle_secs Output: idle time (may be NULL).
+ * @param interval_secs Output: interval (may be NULL).
+ * @param count Output: probe count (may be NULL).
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_get_keepalive(SocketSimple_Socket_T sock,
+                                        int *enabled,
+                                        int *idle_secs,
+                                        int *interval_secs,
+                                        int *count);
+
+/**
+ * @brief Set send buffer size.
+ *
+ * @param sock Socket handle.
+ * @param size Buffer size in bytes.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_set_sndbuf(SocketSimple_Socket_T sock, int size);
+
+/**
+ * @brief Get send buffer size.
+ *
+ * @param sock Socket handle.
+ * @return Buffer size, or -1 on error.
+ */
+extern int Socket_simple_get_sndbuf(SocketSimple_Socket_T sock);
+
+/**
+ * @brief Set receive buffer size.
+ *
+ * @param sock Socket handle.
+ * @param size Buffer size in bytes.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_set_rcvbuf(SocketSimple_Socket_T sock, int size);
+
+/**
+ * @brief Get receive buffer size.
+ *
+ * @param sock Socket handle.
+ * @return Buffer size, or -1 on error.
+ */
+extern int Socket_simple_get_rcvbuf(SocketSimple_Socket_T sock);
+
+/**
+ * @brief Set socket to blocking or non-blocking mode.
+ *
+ * @param sock Socket handle.
+ * @param blocking 1 for blocking, 0 for non-blocking.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_set_blocking(SocketSimple_Socket_T sock, int blocking);
+
+/**
+ * @brief Check if socket is in blocking mode.
+ *
+ * @param sock Socket handle.
+ * @return 1 if blocking, 0 if non-blocking, -1 on error.
+ */
+extern int Socket_simple_is_blocking(SocketSimple_Socket_T sock);
+
+/**
+ * @brief Enable/disable SO_REUSEADDR.
+ *
+ * Allows reusing local addresses for bind.
+ *
+ * @param sock Socket handle.
+ * @param enable 1 to enable, 0 to disable.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_set_reuseaddr(SocketSimple_Socket_T sock, int enable);
+
+/**
+ * @brief Enable/disable SO_REUSEPORT.
+ *
+ * Allows multiple sockets to bind to the same port.
+ *
+ * @param sock Socket handle.
+ * @param enable 1 to enable, 0 to disable.
+ * @return 0 on success, -1 on error.
+ *
+ * @note Not available on all platforms.
+ */
+extern int Socket_simple_set_reuseport(SocketSimple_Socket_T sock, int enable);
+
+/*============================================================================
+ * Socket Address Information
+ *============================================================================*/
+
+/**
+ * @brief Get local address of socket.
+ *
+ * @param sock Socket handle.
+ * @param host Output buffer for IP address (at least 46 bytes for IPv6).
+ * @param host_len Size of host buffer.
+ * @param port Output: local port number.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_get_local_addr(SocketSimple_Socket_T sock,
+                                         char *host,
+                                         size_t host_len,
+                                         int *port);
+
+/**
+ * @brief Get peer address of connected socket.
+ *
+ * @param sock Socket handle.
+ * @param host Output buffer for IP address.
+ * @param host_len Size of host buffer.
+ * @param port Output: peer port number.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_get_peer_addr(SocketSimple_Socket_T sock,
+                                        char *host,
+                                        size_t host_len,
+                                        int *port);
+
+/**
+ * @brief Get peer credentials for Unix domain socket.
+ *
+ * @param sock Unix domain socket handle.
+ * @param pid Output: peer process ID (may be NULL).
+ * @param uid Output: peer user ID (may be NULL).
+ * @param gid Output: peer group ID (may be NULL).
+ * @return 0 on success, -1 on error or not a Unix socket.
+ */
+extern int Socket_simple_get_peer_creds(SocketSimple_Socket_T sock,
+                                         int *pid,
+                                         int *uid,
+                                         int *gid);
+
+/*============================================================================
+ * Scatter-Gather I/O
+ *============================================================================*/
+
+#include <sys/uio.h>
+
+/**
+ * @brief Send data from multiple buffers (gather write).
+ *
+ * @param sock Socket handle.
+ * @param iov Array of iovec structures.
+ * @param iovcnt Number of iovec entries.
+ * @return Bytes sent, or -1 on error.
+ */
+extern ssize_t Socket_simple_sendv(SocketSimple_Socket_T sock,
+                                    const struct iovec *iov,
+                                    int iovcnt);
+
+/**
+ * @brief Receive data into multiple buffers (scatter read).
+ *
+ * @param sock Socket handle.
+ * @param iov Array of iovec structures.
+ * @param iovcnt Number of iovec entries.
+ * @return Bytes received, 0 on close, -1 on error.
+ */
+extern ssize_t Socket_simple_recvv(SocketSimple_Socket_T sock,
+                                    struct iovec *iov,
+                                    int iovcnt);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/simple/SocketSimple-timer.h
+++ b/include/simple/SocketSimple-timer.h
@@ -1,0 +1,260 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETSIMPLE_TIMER_INCLUDED
+#define SOCKETSIMPLE_TIMER_INCLUDED
+
+/**
+ * @file SocketSimple-timer.h
+ * @brief Simple timer API for event loop integration.
+ *
+ * Provides one-shot and repeating timers that integrate with
+ * SocketSimple_Poll for event-driven timeout handling.
+ *
+ * ## Quick Start
+ *
+ * ```c
+ * #include <simple/SocketSimple.h>
+ *
+ * void on_timeout(void *data) {
+ *     printf("Timer fired! data=%p\n", data);
+ * }
+ *
+ * // Create poll with timer support
+ * SocketSimple_Poll_T poll = Socket_simple_poll_new(64);
+ *
+ * // Add a one-shot timer (fires after 1000ms)
+ * SocketSimple_Timer_T timer = Socket_simple_timer_add(poll, 1000, on_timeout, mydata);
+ *
+ * // Add a repeating timer (fires every 5000ms)
+ * SocketSimple_Timer_T repeat = Socket_simple_timer_add_repeating(poll, 5000, on_tick, NULL);
+ *
+ * // Event loop
+ * SocketSimple_PollEvent events[64];
+ * while (running) {
+ *     int timeout = Socket_simple_timer_next_timeout(poll);
+ *     int n = Socket_simple_poll_wait(poll, events, 64, timeout);
+ *     // Process socket events...
+ *     Socket_simple_timer_process(poll);  // Fire expired timers
+ * }
+ *
+ * Socket_simple_timer_cancel(poll, repeat);
+ * Socket_simple_poll_free(&poll);
+ * ```
+ */
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward declaration */
+typedef struct SocketSimple_Poll *SocketSimple_Poll_T;
+
+/*============================================================================
+ * Opaque Handle Type
+ *============================================================================*/
+
+/**
+ * @brief Opaque timer handle.
+ */
+typedef struct SocketSimple_Timer *SocketSimple_Timer_T;
+
+/*============================================================================
+ * Timer Callback
+ *============================================================================*/
+
+/**
+ * @brief Timer callback function type.
+ *
+ * @param userdata User data provided when timer was created.
+ */
+typedef void (*SocketSimple_TimerCallback)(void *userdata);
+
+/*============================================================================
+ * Timer Creation
+ *============================================================================*/
+
+/**
+ * @brief Add a one-shot timer.
+ *
+ * The timer fires once after the specified delay and is automatically removed.
+ *
+ * @param poll Poll instance to attach timer to.
+ * @param delay_ms Delay in milliseconds before firing.
+ * @param callback Function to call when timer fires.
+ * @param userdata User data passed to callback.
+ * @return Timer handle on success, NULL on error.
+ *
+ * Example:
+ * @code
+ * SocketSimple_Timer_T timer = Socket_simple_timer_add(poll, 5000, on_timeout, ctx);
+ * if (!timer) {
+ *     fprintf(stderr, "Timer error: %s\n", Socket_simple_error());
+ * }
+ * @endcode
+ */
+extern SocketSimple_Timer_T Socket_simple_timer_add(SocketSimple_Poll_T poll,
+                                                     int64_t delay_ms,
+                                                     SocketSimple_TimerCallback callback,
+                                                     void *userdata);
+
+/**
+ * @brief Add a repeating timer.
+ *
+ * The timer fires repeatedly at the specified interval until cancelled.
+ *
+ * @param poll Poll instance to attach timer to.
+ * @param interval_ms Interval in milliseconds between firings.
+ * @param callback Function to call when timer fires.
+ * @param userdata User data passed to callback.
+ * @return Timer handle on success, NULL on error.
+ *
+ * Example:
+ * @code
+ * // Heartbeat every 30 seconds
+ * SocketSimple_Timer_T heartbeat = Socket_simple_timer_add_repeating(
+ *     poll, 30000, send_heartbeat, conn);
+ * @endcode
+ */
+extern SocketSimple_Timer_T Socket_simple_timer_add_repeating(SocketSimple_Poll_T poll,
+                                                               int64_t interval_ms,
+                                                               SocketSimple_TimerCallback callback,
+                                                               void *userdata);
+
+/*============================================================================
+ * Timer Control
+ *============================================================================*/
+
+/**
+ * @brief Cancel a pending timer.
+ *
+ * @param poll Poll instance the timer belongs to.
+ * @param timer Timer handle to cancel.
+ * @return 0 on success, -1 if timer invalid or already fired.
+ */
+extern int Socket_simple_timer_cancel(SocketSimple_Poll_T poll,
+                                       SocketSimple_Timer_T timer);
+
+/**
+ * @brief Reschedule a timer with a new delay.
+ *
+ * @param poll Poll instance the timer belongs to.
+ * @param timer Timer handle to reschedule.
+ * @param new_delay_ms New delay in milliseconds.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_timer_reschedule(SocketSimple_Poll_T poll,
+                                           SocketSimple_Timer_T timer,
+                                           int64_t new_delay_ms);
+
+/**
+ * @brief Pause a timer.
+ *
+ * Preserves remaining time for later resumption.
+ *
+ * @param poll Poll instance the timer belongs to.
+ * @param timer Timer handle to pause.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_timer_pause(SocketSimple_Poll_T poll,
+                                      SocketSimple_Timer_T timer);
+
+/**
+ * @brief Resume a paused timer.
+ *
+ * @param poll Poll instance the timer belongs to.
+ * @param timer Timer handle to resume.
+ * @return 0 on success, -1 on error.
+ */
+extern int Socket_simple_timer_resume(SocketSimple_Poll_T poll,
+                                       SocketSimple_Timer_T timer);
+
+/*============================================================================
+ * Timer Query
+ *============================================================================*/
+
+/**
+ * @brief Get milliseconds remaining until timer fires.
+ *
+ * @param poll Poll instance the timer belongs to.
+ * @param timer Timer handle to query.
+ * @return Milliseconds remaining (>=0), or -1 if invalid/cancelled.
+ */
+extern int64_t Socket_simple_timer_remaining(SocketSimple_Poll_T poll,
+                                              SocketSimple_Timer_T timer);
+
+/**
+ * @brief Check if timer is valid and pending.
+ *
+ * @param poll Poll instance the timer belongs to.
+ * @param timer Timer handle to check.
+ * @return 1 if valid and pending, 0 otherwise.
+ */
+extern int Socket_simple_timer_is_pending(SocketSimple_Poll_T poll,
+                                           SocketSimple_Timer_T timer);
+
+/*============================================================================
+ * Timer Processing (Event Loop Integration)
+ *============================================================================*/
+
+/**
+ * @brief Get timeout for next timer expiry.
+ *
+ * Use this as the timeout for Socket_simple_poll_wait().
+ *
+ * @param poll Poll instance.
+ * @return Milliseconds until next timer, or -1 if no timers pending.
+ *
+ * Example:
+ * @code
+ * while (running) {
+ *     int timeout = Socket_simple_timer_next_timeout(poll);
+ *     int n = Socket_simple_poll_wait(poll, events, max, timeout);
+ *     // Handle socket events...
+ *     Socket_simple_timer_process(poll);
+ * }
+ * @endcode
+ */
+extern int Socket_simple_timer_next_timeout(SocketSimple_Poll_T poll);
+
+/**
+ * @brief Process expired timers.
+ *
+ * Fires callbacks for all expired timers. Call this after poll_wait().
+ * For repeating timers, reschedules them for the next interval.
+ *
+ * @param poll Poll instance.
+ * @return Number of timers fired, or -1 on error.
+ */
+extern int Socket_simple_timer_process(SocketSimple_Poll_T poll);
+
+/**
+ * @brief Cancel all pending timers.
+ *
+ * @param poll Poll instance.
+ * @return Number of timers cancelled, or -1 on error.
+ */
+extern int Socket_simple_timer_cancel_all(SocketSimple_Poll_T poll);
+
+/*============================================================================
+ * Timer Statistics
+ *============================================================================*/
+
+/**
+ * @brief Get number of active timers.
+ *
+ * @param poll Poll instance.
+ * @return Number of active timers, or -1 on error.
+ */
+extern int Socket_simple_timer_count(SocketSimple_Poll_T poll);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SOCKETSIMPLE_TIMER_INCLUDED */

--- a/include/simple/SocketSimple.h
+++ b/include/simple/SocketSimple.h
@@ -173,8 +173,14 @@ extern void Socket_simple_clear_error(void);
 /* Infrastructure */
 #include "SocketSimple-pool.h"
 #include "SocketSimple-poll.h"
+#include "SocketSimple-timer.h"
 #include "SocketSimple-proxy.h"
 #include "SocketSimple-ratelimit.h"
+#include "SocketSimple-buf.h"
+
+/* Connection Management */
+#include "SocketSimple-happyeyeballs.h"
+#include "SocketSimple-reconnect.h"
 
 /* Servers */
 #include "SocketSimple-http-server.h"

--- a/src/simple/SocketSimple-buf.c
+++ b/src/simple/SocketSimple-buf.c
@@ -1,0 +1,534 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketSimple-buf.c
+ * @brief Circular buffer implementation for Simple API.
+ */
+
+#include "SocketSimple-internal.h"
+
+#include "core/Arena.h"
+#include "socket/SocketBuf.h"
+
+/*============================================================================
+ * Internal Buffer Handle Structure
+ *============================================================================*/
+
+struct SocketSimple_Buf
+{
+  Arena_T arena;
+  SocketBuf_T buf;
+  size_t initial_capacity;
+};
+
+/*============================================================================
+ * Buffer Creation and Destruction
+ *============================================================================*/
+
+SocketSimple_Buf_T
+Socket_simple_buf_new (size_t capacity)
+{
+  Socket_simple_clear_error ();
+
+  if (capacity == 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Buffer capacity must be > 0");
+      return NULL;
+    }
+
+  struct SocketSimple_Buf *handle = calloc (1, sizeof (*handle));
+  if (!handle)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Memory allocation failed");
+      return NULL;
+    }
+
+  TRY
+  {
+    handle->arena = Arena_new ();
+    handle->buf = SocketBuf_new (handle->arena, capacity);
+    handle->initial_capacity = capacity;
+  }
+  EXCEPT (Arena_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Arena allocation failed");
+    free (handle);
+    return NULL;
+  }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Buffer allocation failed");
+    if (handle->arena)
+      Arena_dispose (&handle->arena);
+    free (handle);
+    return NULL;
+  }
+  END_TRY;
+
+  return handle;
+}
+
+void
+Socket_simple_buf_free (SocketSimple_Buf_T *buf)
+{
+  if (!buf || !*buf)
+    return;
+
+  struct SocketSimple_Buf *b = *buf;
+
+  if (b->buf)
+    {
+      SocketBuf_release (&b->buf);
+    }
+
+  if (b->arena)
+    {
+      Arena_dispose (&b->arena);
+    }
+
+  free (b);
+  *buf = NULL;
+}
+
+/*============================================================================
+ * Write Operations
+ *============================================================================*/
+
+ssize_t
+Socket_simple_buf_write (SocketSimple_Buf_T buf, const void *data, size_t len)
+{
+  volatile size_t written = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!data && len > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid data pointer");
+      return -1;
+    }
+
+  if (len == 0)
+    return 0;
+
+  TRY { written = SocketBuf_write (buf->buf, data, len); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer write failed");
+    return -1;
+  }
+  END_TRY;
+
+  return (ssize_t)written;
+}
+
+void *
+Socket_simple_buf_writeptr (SocketSimple_Buf_T buf, size_t *len)
+{
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf || !len)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return NULL;
+    }
+
+  return SocketBuf_writeptr (buf->buf, len);
+}
+
+int
+Socket_simple_buf_commit (SocketSimple_Buf_T buf, size_t len)
+{
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  TRY { SocketBuf_written (buf->buf, len); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer commit failed");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+/*============================================================================
+ * Read Operations
+ *============================================================================*/
+
+ssize_t
+Socket_simple_buf_read (SocketSimple_Buf_T buf, void *data, size_t len)
+{
+  volatile size_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!data && len > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid data pointer");
+      return -1;
+    }
+
+  if (len == 0)
+    return 0;
+
+  TRY { n = SocketBuf_read (buf->buf, data, len); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer read failed");
+    return -1;
+  }
+  END_TRY;
+
+  return (ssize_t)n;
+}
+
+ssize_t
+Socket_simple_buf_peek (SocketSimple_Buf_T buf, void *data, size_t len)
+{
+  volatile size_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!data && len > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid data pointer");
+      return -1;
+    }
+
+  if (len == 0)
+    return 0;
+
+  TRY { n = SocketBuf_peek (buf->buf, data, len); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer peek failed");
+    return -1;
+  }
+  END_TRY;
+
+  return (ssize_t)n;
+}
+
+const void *
+Socket_simple_buf_readptr (SocketSimple_Buf_T buf, size_t *len)
+{
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf || !len)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return NULL;
+    }
+
+  return SocketBuf_readptr (buf->buf, len);
+}
+
+int
+Socket_simple_buf_consume (SocketSimple_Buf_T buf, size_t len)
+{
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (len > SocketBuf_available (buf->buf))
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Cannot consume more than available");
+      return -1;
+    }
+
+  TRY { SocketBuf_consume (buf->buf, len); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer consume failed");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+ssize_t
+Socket_simple_buf_readline (SocketSimple_Buf_T buf, char *line, size_t maxlen)
+{
+  volatile ssize_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!line || maxlen == 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Invalid line buffer");
+      return -1;
+    }
+
+  TRY { n = SocketBuf_readline (buf->buf, line, maxlen); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer readline failed");
+    return -1;
+  }
+  END_TRY;
+
+  return n;
+}
+
+/*============================================================================
+ * Buffer State Query
+ *============================================================================*/
+
+size_t
+Socket_simple_buf_available (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return 0;
+  return SocketBuf_available (buf->buf);
+}
+
+size_t
+Socket_simple_buf_space (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return 0;
+  return SocketBuf_space (buf->buf);
+}
+
+size_t
+Socket_simple_buf_capacity (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return 0;
+  return SocketBuf_available (buf->buf) + SocketBuf_space (buf->buf);
+}
+
+int
+Socket_simple_buf_empty (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return 1;
+  return SocketBuf_empty (buf->buf);
+}
+
+int
+Socket_simple_buf_full (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return 0;
+  return SocketBuf_full (buf->buf);
+}
+
+/*============================================================================
+ * Buffer Management
+ *============================================================================*/
+
+void
+Socket_simple_buf_clear (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return;
+
+  TRY { SocketBuf_clear (buf->buf); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    /* Silently ignore errors on clear */
+  }
+  END_TRY;
+}
+
+void
+Socket_simple_buf_clear_secure (SocketSimple_Buf_T buf)
+{
+  if (!buf || !buf->buf)
+    return;
+
+  TRY { SocketBuf_secureclear (buf->buf); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    /* Silently ignore errors on secure clear */
+  }
+  END_TRY;
+}
+
+int
+Socket_simple_buf_reserve (SocketSimple_Buf_T buf, size_t min_space)
+{
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  TRY { SocketBuf_reserve (buf->buf, min_space); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Buffer reserve failed");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+int
+Socket_simple_buf_compact (SocketSimple_Buf_T buf)
+{
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  TRY { SocketBuf_compact (buf->buf); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer compact failed");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+/*============================================================================
+ * Search Operations
+ *============================================================================*/
+
+ssize_t
+Socket_simple_buf_find (SocketSimple_Buf_T buf, const void *needle,
+                         size_t needle_len)
+{
+  volatile ssize_t pos = -1;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!needle && needle_len > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid needle");
+      return -1;
+    }
+
+  TRY { pos = SocketBuf_find (buf->buf, needle, needle_len); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer find failed");
+    return -1;
+  }
+  END_TRY;
+
+  return pos;
+}
+
+/*============================================================================
+ * Scatter-Gather I/O
+ *============================================================================*/
+
+ssize_t
+Socket_simple_buf_readv (SocketSimple_Buf_T buf, const struct iovec *iov,
+                          int iovcnt)
+{
+  volatile ssize_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!iov && iovcnt > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid iovec");
+      return -1;
+    }
+
+  TRY { n = SocketBuf_readv (buf->buf, iov, iovcnt); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer readv failed");
+    return -1;
+  }
+  END_TRY;
+
+  return n;
+}
+
+ssize_t
+Socket_simple_buf_writev (SocketSimple_Buf_T buf, const struct iovec *iov,
+                           int iovcnt)
+{
+  volatile ssize_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!buf || !buf->buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  if (!iov && iovcnt > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid iovec");
+      return -1;
+    }
+
+  TRY { n = SocketBuf_writev (buf->buf, iov, iovcnt); }
+  EXCEPT (SocketBuf_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_IO, "Buffer writev failed");
+    return -1;
+  }
+  END_TRY;
+
+  return n;
+}

--- a/src/simple/SocketSimple-happyeyeballs.c
+++ b/src/simple/SocketSimple-happyeyeballs.c
@@ -1,0 +1,168 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketSimple-happyeyeballs.c
+ * @brief Happy Eyeballs (RFC 8305) implementation for Simple API.
+ */
+
+#include "SocketSimple-internal.h"
+#include "simple/SocketSimple-happyeyeballs.h"
+
+#include "socket/SocketHappyEyeballs.h"
+
+#include <sys/socket.h>
+
+/*============================================================================
+ * Configuration Helpers
+ *============================================================================*/
+
+void
+Socket_simple_happyeyeballs_config_defaults (
+    SocketSimple_HappyEyeballs_Config *config)
+{
+  if (!config)
+    return;
+
+  config->resolution_delay_ms = 50;
+  config->connection_delay_ms = 250;
+  config->prefer_ipv6 = 1;
+  config->max_attempts = 0;
+}
+
+/*============================================================================
+ * Connection Functions
+ *============================================================================*/
+
+SocketSimple_Socket_T
+Socket_simple_happyeyeballs_connect (const char *host, int port, int timeout_ms)
+{
+  return Socket_simple_happyeyeballs_connect_config (host, port, timeout_ms,
+                                                      NULL);
+}
+
+SocketSimple_Socket_T
+Socket_simple_happyeyeballs_connect_config (
+    const char *host, int port, int timeout_ms,
+    const SocketSimple_HappyEyeballs_Config *config)
+{
+  volatile Socket_T sock = NULL;
+
+  Socket_simple_clear_error ();
+
+  if (!host || host[0] == '\0')
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid host");
+      return NULL;
+    }
+
+  if (port <= 0 || port > 65535)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
+      return NULL;
+    }
+
+  if (timeout_ms <= 0)
+    {
+      timeout_ms = 30000; /* Default 30 seconds */
+    }
+
+  /* Build core config from simple config */
+  SocketHE_Config_T core_config;
+  SocketHappyEyeballs_config_defaults (&core_config);
+
+  /* Map simple config fields to core config fields */
+  core_config.total_timeout_ms = timeout_ms;
+
+  if (config)
+    {
+      core_config.dns_timeout_ms = config->resolution_delay_ms;
+      core_config.first_attempt_delay_ms = config->connection_delay_ms;
+      core_config.prefer_ipv6 = config->prefer_ipv6;
+      if (config->max_attempts > 0)
+        core_config.max_attempts = config->max_attempts;
+    }
+
+  TRY { sock = SocketHappyEyeballs_connect (host, port, &core_config); }
+  EXCEPT (SocketHE_Failed)
+  {
+    int err = Socket_geterrno ();
+    if (err == ETIMEDOUT)
+      {
+        simple_set_error (SOCKET_SIMPLE_ERR_TIMEOUT, "Connection timed out");
+      }
+    else
+      {
+        simple_set_error_errno (SOCKET_SIMPLE_ERR_CONNECT,
+                                "Happy Eyeballs connect failed");
+      }
+    if (sock)
+      Socket_free ((Socket_T *)&sock);
+    return NULL;
+  }
+  EXCEPT (Socket_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_CONNECT, "Connection failed");
+    if (sock)
+      Socket_free ((Socket_T *)&sock);
+    return NULL;
+  }
+  END_TRY;
+
+  SocketSimple_Socket_T handle = simple_create_handle (sock, 0, 0);
+  if (!handle)
+    {
+      Socket_free ((Socket_T *)&sock);
+    }
+  return handle;
+}
+
+/*============================================================================
+ * Query Functions
+ *============================================================================*/
+
+int
+Socket_simple_get_family (SocketSimple_Socket_T sock)
+{
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  if (fd < 0)
+    return -1;
+
+  struct sockaddr_storage addr;
+  socklen_t addrlen = sizeof (addr);
+  if (getsockname (fd, (struct sockaddr *)&addr, &addrlen) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get socket family");
+      return -1;
+    }
+
+  return addr.ss_family;
+}
+
+int
+Socket_simple_is_ipv6 (SocketSimple_Socket_T sock)
+{
+  int family = Socket_simple_get_family (sock);
+  if (family < 0)
+    return -1;
+  return (family == AF_INET6) ? 1 : 0;
+}
+
+int
+Socket_simple_is_ipv4 (SocketSimple_Socket_T sock)
+{
+  int family = Socket_simple_get_family (sock);
+  if (family < 0)
+    return -1;
+  return (family == AF_INET) ? 1 : 0;
+}

--- a/src/simple/SocketSimple-poll.c
+++ b/src/simple/SocketSimple-poll.c
@@ -389,3 +389,16 @@ Socket_simple_poll_set_timeout (SocketSimple_Poll_T poll, int timeout_ms)
 
   return 0;
 }
+
+/* ============================================================================
+ * Internal Helper: Access core poll handle (used by timer module)
+ * ============================================================================
+ */
+
+SocketPoll_T
+simple_poll_get_core (SocketSimple_Poll_T poll)
+{
+  if (!poll)
+    return NULL;
+  return poll->poll;
+}

--- a/src/simple/SocketSimple-reconnect.c
+++ b/src/simple/SocketSimple-reconnect.c
@@ -1,0 +1,458 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketSimple-reconnect.c
+ * @brief Automatic reconnection implementation for Simple API.
+ */
+
+#include "SocketSimple-internal.h"
+#include "simple/SocketSimple-reconnect.h"
+
+#include "socket/SocketReconnect.h"
+
+/*============================================================================
+ * Internal Structure
+ *============================================================================*/
+
+struct SocketSimple_Reconnect
+{
+  SocketReconnect_T core;
+  SocketSimple_Reconnect_Callback user_callback;
+  void *user_data;
+  SocketSimple_Socket_T simple_socket; /* Wrapper for underlying socket */
+};
+
+/*============================================================================
+ * Internal Callback Wrapper
+ *============================================================================*/
+
+static void
+state_callback_wrapper (SocketReconnect_T core __attribute__ ((unused)),
+                         SocketReconnect_State old_state,
+                         SocketReconnect_State new_state, void *userdata)
+{
+  struct SocketSimple_Reconnect *conn
+      = (struct SocketSimple_Reconnect *)userdata;
+  if (conn && conn->user_callback)
+    {
+      conn->user_callback (conn, (SocketSimple_Reconnect_State)old_state,
+                           (SocketSimple_Reconnect_State)new_state,
+                           conn->user_data);
+    }
+}
+
+/*============================================================================
+ * Policy Helpers
+ *============================================================================*/
+
+void
+Socket_simple_reconnect_policy_defaults (SocketSimple_Reconnect_Policy *policy)
+{
+  if (!policy)
+    return;
+
+  policy->initial_delay_ms = 100;
+  policy->max_delay_ms = 30000;
+  policy->multiplier = 2.0;
+  policy->jitter = 0.25;
+  policy->max_attempts = 10;
+  policy->circuit_threshold = 5;
+  policy->circuit_reset_ms = 60000;
+  policy->health_interval_ms = 30000;
+  policy->health_timeout_ms = 5000;
+}
+
+/*============================================================================
+ * Lifecycle Functions
+ *============================================================================*/
+
+SocketSimple_Reconnect_T
+Socket_simple_reconnect_new (const char *host, int port,
+                              const SocketSimple_Reconnect_Policy *policy)
+{
+  volatile SocketReconnect_T core = NULL;
+
+  Socket_simple_clear_error ();
+
+  if (!host || host[0] == '\0')
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid host");
+      return NULL;
+    }
+
+  if (port <= 0 || port > 65535)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
+      return NULL;
+    }
+
+  struct SocketSimple_Reconnect *handle = calloc (1, sizeof (*handle));
+  if (!handle)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Memory allocation failed");
+      return NULL;
+    }
+
+  /* Build core policy */
+  SocketReconnect_Policy_T core_policy;
+  SocketReconnect_policy_defaults (&core_policy);
+
+  if (policy)
+    {
+      core_policy.initial_delay_ms = policy->initial_delay_ms;
+      core_policy.max_delay_ms = policy->max_delay_ms;
+      core_policy.multiplier = policy->multiplier;
+      core_policy.jitter = policy->jitter;
+      core_policy.max_attempts = policy->max_attempts;
+      core_policy.circuit_failure_threshold = policy->circuit_threshold;
+      core_policy.circuit_reset_timeout_ms = policy->circuit_reset_ms;
+      core_policy.health_check_interval_ms = policy->health_interval_ms;
+      core_policy.health_check_timeout_ms = policy->health_timeout_ms;
+    }
+
+  TRY
+  {
+    core = SocketReconnect_new (host, port, &core_policy,
+                                 state_callback_wrapper, handle);
+    handle->core = core;
+  }
+  EXCEPT (SocketReconnect_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_CONNECT,
+                      "Failed to create reconnect handle");
+    free (handle);
+    return NULL;
+  }
+  END_TRY;
+
+  return handle;
+}
+
+void
+Socket_simple_reconnect_free (SocketSimple_Reconnect_T *conn)
+{
+  if (!conn || !*conn)
+    return;
+
+  struct SocketSimple_Reconnect *c = *conn;
+
+  if (c->simple_socket)
+    {
+      /* Don't free socket - it's owned by core */
+      c->simple_socket->socket = NULL;
+      free (c->simple_socket);
+    }
+
+  if (c->core)
+    {
+      SocketReconnect_free (&c->core);
+    }
+
+  free (c);
+  *conn = NULL;
+}
+
+/*============================================================================
+ * Connection Control
+ *============================================================================*/
+
+int
+Socket_simple_reconnect_connect (SocketSimple_Reconnect_T conn)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  TRY { SocketReconnect_connect (conn->core); }
+  EXCEPT (SocketReconnect_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_CONNECT, "Connect failed");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+int
+Socket_simple_reconnect_disconnect (SocketSimple_Reconnect_T conn)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  SocketReconnect_disconnect (conn->core);
+  return 0;
+}
+
+int
+Socket_simple_reconnect_reset (SocketSimple_Reconnect_T conn)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  SocketReconnect_reset (conn->core);
+  return 0;
+}
+
+/*============================================================================
+ * State Query
+ *============================================================================*/
+
+SocketSimple_Reconnect_State
+Socket_simple_reconnect_state (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return SIMPLE_RECONNECT_DISCONNECTED;
+
+  return (SocketSimple_Reconnect_State)SocketReconnect_state (conn->core);
+}
+
+const char *
+Socket_simple_reconnect_state_name (SocketSimple_Reconnect_State state)
+{
+  switch (state)
+    {
+    case SIMPLE_RECONNECT_DISCONNECTED:
+      return "disconnected";
+    case SIMPLE_RECONNECT_CONNECTING:
+      return "connecting";
+    case SIMPLE_RECONNECT_CONNECTED:
+      return "connected";
+    case SIMPLE_RECONNECT_BACKOFF:
+      return "backoff";
+    case SIMPLE_RECONNECT_CIRCUIT_OPEN:
+      return "circuit_open";
+    default:
+      return "unknown";
+    }
+}
+
+int
+Socket_simple_reconnect_is_connected (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return 0;
+
+  return SocketReconnect_isconnected (conn->core);
+}
+
+int
+Socket_simple_reconnect_attempts (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return 0;
+
+  return SocketReconnect_attempts (conn->core);
+}
+
+int
+Socket_simple_reconnect_failures (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return 0;
+
+  return SocketReconnect_failures (conn->core);
+}
+
+/*============================================================================
+ * Event Loop Integration
+ *============================================================================*/
+
+int
+Socket_simple_reconnect_fd (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return -1;
+
+  return SocketReconnect_pollfd (conn->core);
+}
+
+int
+Socket_simple_reconnect_next_timeout (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return -1;
+
+  return SocketReconnect_next_timeout_ms (conn->core);
+}
+
+int
+Socket_simple_reconnect_tick (SocketSimple_Reconnect_T conn)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  SocketReconnect_tick (conn->core);
+  return 0;
+}
+
+int
+Socket_simple_reconnect_process (SocketSimple_Reconnect_T conn)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  SocketReconnect_process (conn->core);
+  return 0;
+}
+
+/*============================================================================
+ * Passthrough I/O
+ *============================================================================*/
+
+ssize_t
+Socket_simple_reconnect_send (SocketSimple_Reconnect_T conn, const void *data,
+                               size_t len)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  if (!data && len > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid data");
+      return -1;
+    }
+
+  ssize_t n = SocketReconnect_send (conn->core, data, len);
+  if (n < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SEND, "Send failed");
+    }
+
+  return n;
+}
+
+ssize_t
+Socket_simple_reconnect_recv (SocketSimple_Reconnect_T conn, void *buf,
+                               size_t len)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  if (!buf && len > 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid buffer");
+      return -1;
+    }
+
+  ssize_t n = SocketReconnect_recv (conn->core, buf, len);
+  if (n < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_RECV, "Receive failed");
+    }
+
+  return n;
+}
+
+/*============================================================================
+ * Configuration
+ *============================================================================*/
+
+int
+Socket_simple_reconnect_set_callback (SocketSimple_Reconnect_T conn,
+                                       SocketSimple_Reconnect_Callback callback,
+                                       void *userdata)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  conn->user_callback = callback;
+  conn->user_data = userdata;
+  return 0;
+}
+
+int
+Socket_simple_reconnect_set_health_check (
+    SocketSimple_Reconnect_T conn, SocketSimple_Reconnect_HealthCheck check)
+{
+  Socket_simple_clear_error ();
+
+  if (!conn || !conn->core)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid handle");
+      return -1;
+    }
+
+  /* Note: Custom health check integration requires internal wrapper.
+   * For now, just allow disabling by passing NULL. */
+  if (check)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
+                        "Custom health checks not yet supported");
+      return -1;
+    }
+
+  SocketReconnect_set_health_check (conn->core, NULL);
+  return 0;
+}
+
+/*============================================================================
+ * Underlying Socket Access
+ *============================================================================*/
+
+SocketSimple_Socket_T
+Socket_simple_reconnect_get_socket (SocketSimple_Reconnect_T conn)
+{
+  if (!conn || !conn->core)
+    return NULL;
+
+  Socket_T core_sock = SocketReconnect_socket (conn->core);
+  if (!core_sock)
+    return NULL;
+
+  /* Create/update wrapper if needed */
+  if (!conn->simple_socket)
+    {
+      conn->simple_socket = calloc (1, sizeof (struct SocketSimple_Socket));
+      if (!conn->simple_socket)
+        return NULL;
+    }
+
+  conn->simple_socket->socket = core_sock;
+  conn->simple_socket->is_connected = 1;
+
+  return conn->simple_socket;
+}

--- a/src/simple/SocketSimple-tcp.c
+++ b/src/simple/SocketSimple-tcp.c
@@ -590,3 +590,953 @@ Socket_simple_udp_recvfrom (SocketSimple_Socket_T sock, void *buf, size_t len,
 
   return received;
 }
+
+/* ============================================================================
+ * UDP Advanced Features (Multicast, Broadcast)
+ * ============================================================================
+ */
+
+#include <netinet/in.h>
+#include <arpa/inet.h>
+
+int
+Socket_simple_udp_join_multicast (SocketSimple_Socket_T sock, const char *group,
+                                   const char *iface)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram || !group)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  TRY { SocketDgram_joinmulticast (sock->dgram, group, iface); }
+  EXCEPT (SocketDgram_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                            "Failed to join multicast group");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+int
+Socket_simple_udp_leave_multicast (SocketSimple_Socket_T sock,
+                                    const char *group, const char *iface)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram || !group)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  TRY { SocketDgram_leavemulticast (sock->dgram, group, iface); }
+  EXCEPT (SocketDgram_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                            "Failed to leave multicast group");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+int
+Socket_simple_udp_set_multicast_ttl (SocketSimple_Socket_T sock, int ttl)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  if (ttl < 0 || ttl > 255)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "TTL must be 0-255");
+      return -1;
+    }
+
+  int fd = SocketDgram_fd (sock->dgram);
+  unsigned char ttl_val = (unsigned char)ttl;
+
+  if (setsockopt (fd, IPPROTO_IP, IP_MULTICAST_TTL, &ttl_val, sizeof (ttl_val))
+      < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set multicast TTL");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_udp_set_multicast_loopback (SocketSimple_Socket_T sock,
+                                           int enable)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = SocketDgram_fd (sock->dgram);
+  unsigned char loop = enable ? 1 : 0;
+
+  if (setsockopt (fd, IPPROTO_IP, IP_MULTICAST_LOOP, &loop, sizeof (loop)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set multicast loopback");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_udp_set_multicast_interface (SocketSimple_Socket_T sock,
+                                            const char *iface)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = SocketDgram_fd (sock->dgram);
+  struct in_addr addr;
+
+  if (iface)
+    {
+      if (inet_pton (AF_INET, iface, &addr) != 1)
+        {
+          simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                            "Invalid interface address");
+          return -1;
+        }
+    }
+  else
+    {
+      addr.s_addr = INADDR_ANY;
+    }
+
+  if (setsockopt (fd, IPPROTO_IP, IP_MULTICAST_IF, &addr, sizeof (addr)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set multicast interface");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_udp_set_broadcast (SocketSimple_Socket_T sock, int enable)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = SocketDgram_fd (sock->dgram);
+  int val = enable ? 1 : 0;
+
+  if (setsockopt (fd, SOL_SOCKET, SO_BROADCAST, &val, sizeof (val)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set broadcast");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_udp_set_ttl (SocketSimple_Socket_T sock, int ttl)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  if (ttl < 0 || ttl > 255)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "TTL must be 0-255");
+      return -1;
+    }
+
+  int fd = SocketDgram_fd (sock->dgram);
+
+  if (setsockopt (fd, IPPROTO_IP, IP_TTL, &ttl, sizeof (ttl)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET, "Failed to set TTL");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_udp_connect (SocketSimple_Socket_T sock, const char *host,
+                            int port)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram || !host)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  if (port <= 0 || port > 65535)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
+      return -1;
+    }
+
+  TRY { SocketDgram_connect (sock->dgram, host, port); }
+  EXCEPT (SocketDgram_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_CONNECT, "UDP connect failed");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+ssize_t
+Socket_simple_udp_send (SocketSimple_Socket_T sock, const void *data,
+                         size_t len)
+{
+  volatile ssize_t sent = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram || !data)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  TRY { sent = SocketDgram_send (sock->dgram, data, len); }
+  EXCEPT (SocketDgram_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_SEND, "UDP send failed");
+    return -1;
+  }
+  END_TRY;
+
+  return sent;
+}
+
+ssize_t
+Socket_simple_udp_recv (SocketSimple_Socket_T sock, void *buf, size_t len)
+{
+  volatile ssize_t received = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->dgram || !buf)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  TRY { received = SocketDgram_recv (sock->dgram, buf, len); }
+  EXCEPT (SocketDgram_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_RECV, "UDP receive failed");
+    return -1;
+  }
+  END_TRY;
+
+  return received;
+}
+
+/* ============================================================================
+ * Unix Domain Socket Functions
+ * ============================================================================
+ */
+
+#include <sys/un.h>
+#include <unistd.h>
+
+SocketSimple_Socket_T
+Socket_simple_connect_unix (const char *path)
+{
+  volatile Socket_T sock = NULL;
+
+  Socket_simple_clear_error ();
+
+  if (!path || path[0] == '\0')
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket path");
+      return NULL;
+    }
+
+  TRY
+  {
+    sock = Socket_new (AF_UNIX, SOCK_STREAM, 0);
+    Socket_connect_unix (sock, path);
+  }
+  EXCEPT (Socket_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_CONNECT,
+                            "Unix socket connect failed");
+    if (sock)
+      Socket_free ((Socket_T *)&sock);
+    return NULL;
+  }
+  END_TRY;
+
+  SocketSimple_Socket_T handle = simple_create_handle (sock, 0, 0);
+  if (!handle)
+    {
+      Socket_free ((Socket_T *)&sock);
+    }
+  return handle;
+}
+
+SocketSimple_Socket_T
+Socket_simple_listen_unix (const char *path, int backlog)
+{
+  volatile Socket_T sock = NULL;
+
+  Socket_simple_clear_error ();
+
+  if (!path || path[0] == '\0')
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket path");
+      return NULL;
+    }
+
+  /* Remove existing socket file if it exists */
+  unlink (path);
+
+  TRY
+  {
+    sock = Socket_new (AF_UNIX, SOCK_STREAM, 0);
+    Socket_bind_unix (sock, path);
+    Socket_listen (sock, backlog > 0 ? backlog : 128);
+  }
+  EXCEPT (Socket_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_LISTEN,
+                            "Unix socket listen failed");
+    if (sock)
+      Socket_free ((Socket_T *)&sock);
+    return NULL;
+  }
+  END_TRY;
+
+  SocketSimple_Socket_T handle = simple_create_handle (sock, 1, 0);
+  if (!handle)
+    {
+      Socket_free ((Socket_T *)&sock);
+    }
+  return handle;
+}
+
+/* ============================================================================
+ * TCP Socket Options
+ * ============================================================================
+ */
+
+#include <netinet/tcp.h>
+#include <fcntl.h>
+
+int
+Socket_simple_set_nodelay (SocketSimple_Socket_T sock, int enable)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  TRY { Socket_setnodelay (sock->socket, enable); }
+  EXCEPT (Socket_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                            "Failed to set TCP_NODELAY");
+    return -1;
+  }
+  END_TRY;
+
+  return 0;
+}
+
+int
+Socket_simple_get_nodelay (SocketSimple_Socket_T sock)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int val = 0;
+  socklen_t len = sizeof (val);
+
+  if (getsockopt (fd, IPPROTO_TCP, TCP_NODELAY, &val, &len) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get TCP_NODELAY");
+      return -1;
+    }
+
+  return val ? 1 : 0;
+}
+
+int
+Socket_simple_set_keepalive (SocketSimple_Socket_T sock, int enable,
+                              int idle_secs, int interval_secs, int count)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int val = enable ? 1 : 0;
+
+  if (setsockopt (fd, SOL_SOCKET, SO_KEEPALIVE, &val, sizeof (val)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set SO_KEEPALIVE");
+      return -1;
+    }
+
+  if (enable)
+    {
+#ifdef TCP_KEEPIDLE
+      if (idle_secs > 0)
+        {
+          if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, &idle_secs,
+                          sizeof (idle_secs))
+              < 0)
+            {
+              simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                                      "Failed to set TCP_KEEPIDLE");
+              return -1;
+            }
+        }
+#endif
+#ifdef TCP_KEEPINTVL
+      if (interval_secs > 0)
+        {
+          if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, &interval_secs,
+                          sizeof (interval_secs))
+              < 0)
+            {
+              simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                                      "Failed to set TCP_KEEPINTVL");
+              return -1;
+            }
+        }
+#endif
+#ifdef TCP_KEEPCNT
+      if (count > 0)
+        {
+          if (setsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, &count, sizeof (count))
+              < 0)
+            {
+              simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                                      "Failed to set TCP_KEEPCNT");
+              return -1;
+            }
+        }
+#endif
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_get_keepalive (SocketSimple_Socket_T sock, int *enabled,
+                              int *idle_secs, int *interval_secs, int *count)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket || !enabled)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int val = 0;
+  socklen_t len = sizeof (val);
+
+  if (getsockopt (fd, SOL_SOCKET, SO_KEEPALIVE, &val, &len) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get SO_KEEPALIVE");
+      return -1;
+    }
+
+  *enabled = val ? 1 : 0;
+
+#ifdef TCP_KEEPIDLE
+  if (idle_secs)
+    {
+      len = sizeof (*idle_secs);
+      getsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, idle_secs, &len);
+    }
+#endif
+#ifdef TCP_KEEPINTVL
+  if (interval_secs)
+    {
+      len = sizeof (*interval_secs);
+      getsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, interval_secs, &len);
+    }
+#endif
+#ifdef TCP_KEEPCNT
+  if (count)
+    {
+      len = sizeof (*count);
+      getsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, count, &len);
+    }
+#endif
+
+  return 0;
+}
+
+int
+Socket_simple_set_sndbuf (SocketSimple_Socket_T sock, int size)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+
+  if (setsockopt (fd, SOL_SOCKET, SO_SNDBUF, &size, sizeof (size)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set SO_SNDBUF");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_get_sndbuf (SocketSimple_Socket_T sock)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int val = 0;
+  socklen_t len = sizeof (val);
+
+  if (getsockopt (fd, SOL_SOCKET, SO_SNDBUF, &val, &len) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get SO_SNDBUF");
+      return -1;
+    }
+
+  return val;
+}
+
+int
+Socket_simple_set_rcvbuf (SocketSimple_Socket_T sock, int size)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+
+  if (setsockopt (fd, SOL_SOCKET, SO_RCVBUF, &size, sizeof (size)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set SO_RCVBUF");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_get_rcvbuf (SocketSimple_Socket_T sock)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int val = 0;
+  socklen_t len = sizeof (val);
+
+  if (getsockopt (fd, SOL_SOCKET, SO_RCVBUF, &val, &len) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get SO_RCVBUF");
+      return -1;
+    }
+
+  return val;
+}
+
+int
+Socket_simple_set_blocking (SocketSimple_Socket_T sock, int blocking)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int flags = fcntl (fd, F_GETFL, 0);
+
+  if (flags < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get socket flags");
+      return -1;
+    }
+
+  if (blocking)
+    flags &= ~O_NONBLOCK;
+  else
+    flags |= O_NONBLOCK;
+
+  if (fcntl (fd, F_SETFL, flags) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set socket flags");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_is_blocking (SocketSimple_Socket_T sock)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int flags = fcntl (fd, F_GETFL, 0);
+
+  if (flags < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get socket flags");
+      return -1;
+    }
+
+  return (flags & O_NONBLOCK) ? 0 : 1;
+}
+
+int
+Socket_simple_set_reuseaddr (SocketSimple_Socket_T sock, int enable)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  int fd = Socket_fd (sock->socket);
+  int val = enable ? 1 : 0;
+
+  if (setsockopt (fd, SOL_SOCKET, SO_REUSEADDR, &val, sizeof (val)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set SO_REUSEADDR");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_set_reuseport (SocketSimple_Socket_T sock, int enable)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+#ifdef SO_REUSEPORT
+  int fd = Socket_fd (sock->socket);
+  int val = enable ? 1 : 0;
+
+  if (setsockopt (fd, SOL_SOCKET, SO_REUSEPORT, &val, sizeof (val)) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to set SO_REUSEPORT");
+      return -1;
+    }
+
+  return 0;
+#else
+  simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
+                    "SO_REUSEPORT not available on this platform");
+  return -1;
+#endif
+}
+
+/* ============================================================================
+ * Socket Address Information
+ * ============================================================================
+ */
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+int
+Socket_simple_get_local_addr (SocketSimple_Socket_T sock, char *host,
+                               size_t host_len, int *port)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  const char *addr = Socket_getlocaladdr (sock->socket);
+  if (addr && host && host_len > 0)
+    {
+      strncpy (host, addr, host_len - 1);
+      host[host_len - 1] = '\0';
+    }
+
+  if (port)
+    *port = Socket_getlocalport (sock->socket);
+
+  return 0;
+}
+
+int
+Socket_simple_get_peer_addr (SocketSimple_Socket_T sock, char *host,
+                              size_t host_len, int *port)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  const char *addr = Socket_getpeeraddr (sock->socket);
+  if (addr && host && host_len > 0)
+    {
+      strncpy (host, addr, host_len - 1);
+      host[host_len - 1] = '\0';
+    }
+
+  if (port)
+    *port = Socket_getpeerport (sock->socket);
+
+  return 0;
+}
+
+int
+Socket_simple_get_peer_creds (SocketSimple_Socket_T sock, int *pid, int *uid,
+                               int *gid)
+{
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+#if defined(SO_PEERCRED)
+  int fd = Socket_fd (sock->socket);
+  struct ucred cred;
+  socklen_t len = sizeof (cred);
+
+  if (getsockopt (fd, SOL_SOCKET, SO_PEERCRED, &cred, &len) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get peer credentials");
+      return -1;
+    }
+
+  if (pid)
+    *pid = cred.pid;
+  if (uid)
+    *uid = cred.uid;
+  if (gid)
+    *gid = cred.gid;
+
+  return 0;
+#elif defined(LOCAL_PEERCRED)
+  int fd = Socket_fd (sock->socket);
+  struct xucred cred;
+  socklen_t len = sizeof (cred);
+
+  if (getsockopt (fd, 0, LOCAL_PEERCRED, &cred, &len) < 0)
+    {
+      simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                              "Failed to get peer credentials");
+      return -1;
+    }
+
+  if (pid)
+    *pid = -1; /* Not available on BSD */
+  if (uid)
+    *uid = cred.cr_uid;
+  if (gid)
+    *gid = cred.cr_gid;
+
+  return 0;
+#else
+  simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
+                    "Peer credentials not available on this platform");
+  return -1;
+#endif
+}
+
+/* ============================================================================
+ * Scatter-Gather I/O
+ * ============================================================================
+ */
+
+#include <sys/uio.h>
+
+ssize_t
+Socket_simple_sendv (SocketSimple_Socket_T sock, const struct iovec *iov,
+                      int iovcnt)
+{
+  volatile ssize_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  if (!iov || iovcnt <= 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid iovec");
+      return -1;
+    }
+
+  TRY { n = Socket_sendv (sock->socket, iov, iovcnt); }
+  EXCEPT (Socket_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_SEND, "Send failed");
+    return -1;
+  }
+  EXCEPT (Socket_Closed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_CLOSED, "Connection closed");
+    sock->is_connected = 0;
+    return -1;
+  }
+  END_TRY;
+
+  return n;
+}
+
+ssize_t
+Socket_simple_recvv (SocketSimple_Socket_T sock, struct iovec *iov, int iovcnt)
+{
+  volatile ssize_t n = 0;
+
+  Socket_simple_clear_error ();
+
+  if (!sock || !sock->socket)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid socket");
+      return -1;
+    }
+
+  if (!iov || iovcnt <= 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid iovec");
+      return -1;
+    }
+
+  TRY { n = Socket_recvv (sock->socket, iov, iovcnt); }
+  EXCEPT (Socket_Failed)
+  {
+    simple_set_error_errno (SOCKET_SIMPLE_ERR_RECV, "Receive failed");
+    return -1;
+  }
+  EXCEPT (Socket_Closed)
+  {
+    sock->is_connected = 0;
+    return 0;
+  }
+  END_TRY;
+
+  if (n == 0)
+    {
+      sock->is_connected = 0;
+    }
+  return n;
+}

--- a/src/simple/SocketSimple-timer.c
+++ b/src/simple/SocketSimple-timer.c
@@ -1,0 +1,416 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketSimple-timer.c
+ * @brief Timer implementation for Simple API.
+ */
+
+#include "SocketSimple-internal.h"
+#include "simple/SocketSimple-timer.h"
+#include "simple/SocketSimple-poll.h"
+
+#include "core/SocketTimer.h"
+#include "poll/SocketPoll.h"
+
+/*============================================================================
+ * Internal Structure
+ *============================================================================*/
+
+struct SocketSimple_Timer
+{
+  SocketTimer_T core_timer;
+  SocketSimple_TimerCallback callback;
+  void *userdata;
+  int is_valid;
+};
+
+/*============================================================================
+ * Forward declaration: Access internal poll structure
+ *============================================================================*/
+
+/* Need access to SocketPoll_T from the Simple poll handle */
+extern SocketPoll_T simple_poll_get_core (SocketSimple_Poll_T poll);
+
+/*============================================================================
+ * Timer Callback Wrapper
+ *============================================================================*/
+
+static void
+timer_callback_wrapper (void *data)
+{
+  struct SocketSimple_Timer *timer = (struct SocketSimple_Timer *)data;
+  if (timer && timer->is_valid && timer->callback)
+    {
+      timer->callback (timer->userdata);
+    }
+}
+
+/*============================================================================
+ * Timer Creation
+ *============================================================================*/
+
+SocketSimple_Timer_T
+Socket_simple_timer_add (SocketSimple_Poll_T poll, int64_t delay_ms,
+                          SocketSimple_TimerCallback callback, void *userdata)
+{
+  volatile SocketTimer_T core_timer = NULL;
+
+  Socket_simple_clear_error ();
+
+  if (!poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      return NULL;
+    }
+
+  if (!callback)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Timer callback required");
+      return NULL;
+    }
+
+  if (delay_ms < 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Delay must be non-negative");
+      return NULL;
+    }
+
+  struct SocketSimple_Timer *handle = calloc (1, sizeof (*handle));
+  if (!handle)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Memory allocation failed");
+      return NULL;
+    }
+
+  handle->callback = callback;
+  handle->userdata = userdata;
+  handle->is_valid = 1;
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      free (handle);
+      return NULL;
+    }
+
+  TRY
+  {
+    core_timer
+        = SocketTimer_add (core_poll, delay_ms, timer_callback_wrapper, handle);
+    handle->core_timer = core_timer;
+  }
+  EXCEPT (SocketTimer_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_POLL, "Failed to add timer");
+    free (handle);
+    return NULL;
+  }
+  END_TRY;
+
+  return handle;
+}
+
+SocketSimple_Timer_T
+Socket_simple_timer_add_repeating (SocketSimple_Poll_T poll,
+                                    int64_t interval_ms,
+                                    SocketSimple_TimerCallback callback,
+                                    void *userdata)
+{
+  volatile SocketTimer_T core_timer = NULL;
+
+  Socket_simple_clear_error ();
+
+  if (!poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      return NULL;
+    }
+
+  if (!callback)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Timer callback required");
+      return NULL;
+    }
+
+  if (interval_ms <= 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Interval must be positive");
+      return NULL;
+    }
+
+  struct SocketSimple_Timer *handle = calloc (1, sizeof (*handle));
+  if (!handle)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Memory allocation failed");
+      return NULL;
+    }
+
+  handle->callback = callback;
+  handle->userdata = userdata;
+  handle->is_valid = 1;
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      free (handle);
+      return NULL;
+    }
+
+  TRY
+  {
+    core_timer = SocketTimer_add_repeating (core_poll, interval_ms,
+                                             timer_callback_wrapper, handle);
+    handle->core_timer = core_timer;
+  }
+  EXCEPT (SocketTimer_Failed)
+  {
+    simple_set_error (SOCKET_SIMPLE_ERR_POLL, "Failed to add repeating timer");
+    free (handle);
+    return NULL;
+  }
+  END_TRY;
+
+  return handle;
+}
+
+/*============================================================================
+ * Timer Control
+ *============================================================================*/
+
+int
+Socket_simple_timer_cancel (SocketSimple_Poll_T poll,
+                             SocketSimple_Timer_T timer)
+{
+  Socket_simple_clear_error ();
+
+  if (!poll || !timer)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  if (!timer->is_valid)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Timer already cancelled or fired");
+      return -1;
+    }
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      return -1;
+    }
+
+  int result = SocketTimer_cancel (core_poll, timer->core_timer);
+  if (result < 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_POLL, "Failed to cancel timer");
+      return -1;
+    }
+
+  timer->is_valid = 0;
+  return 0;
+}
+
+int
+Socket_simple_timer_reschedule (SocketSimple_Poll_T poll,
+                                 SocketSimple_Timer_T timer,
+                                 int64_t new_delay_ms)
+{
+  Socket_simple_clear_error ();
+
+  if (!poll || !timer)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  if (!timer->is_valid)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Timer cancelled or fired");
+      return -1;
+    }
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      return -1;
+    }
+
+  int result
+      = SocketTimer_reschedule (core_poll, timer->core_timer, new_delay_ms);
+  if (result < 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_POLL, "Failed to reschedule timer");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_timer_pause (SocketSimple_Poll_T poll, SocketSimple_Timer_T timer)
+{
+  Socket_simple_clear_error ();
+
+  if (!poll || !timer)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  if (!timer->is_valid)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Timer cancelled or fired");
+      return -1;
+    }
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      return -1;
+    }
+
+  int result = SocketTimer_pause (core_poll, timer->core_timer);
+  if (result < 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_POLL, "Failed to pause timer");
+      return -1;
+    }
+
+  return 0;
+}
+
+int
+Socket_simple_timer_resume (SocketSimple_Poll_T poll,
+                             SocketSimple_Timer_T timer)
+{
+  Socket_simple_clear_error ();
+
+  if (!poll || !timer)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid argument");
+      return -1;
+    }
+
+  if (!timer->is_valid)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Timer cancelled or fired");
+      return -1;
+    }
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid poll handle");
+      return -1;
+    }
+
+  int result = SocketTimer_resume (core_poll, timer->core_timer);
+  if (result < 0)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_POLL, "Failed to resume timer");
+      return -1;
+    }
+
+  return 0;
+}
+
+/*============================================================================
+ * Timer Query
+ *============================================================================*/
+
+int64_t
+Socket_simple_timer_remaining (SocketSimple_Poll_T poll,
+                                SocketSimple_Timer_T timer)
+{
+  if (!poll || !timer || !timer->is_valid)
+    return -1;
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    return -1;
+
+  return SocketTimer_remaining (core_poll, timer->core_timer);
+}
+
+int
+Socket_simple_timer_is_pending (SocketSimple_Poll_T poll,
+                                 SocketSimple_Timer_T timer)
+{
+  if (!poll || !timer)
+    return 0;
+
+  if (!timer->is_valid)
+    return 0;
+
+  SocketPoll_T core_poll = simple_poll_get_core (poll);
+  if (!core_poll)
+    return 0;
+
+  int64_t remaining = SocketTimer_remaining (core_poll, timer->core_timer);
+  return (remaining >= 0) ? 1 : 0;
+}
+
+/*============================================================================
+ * Timer Processing
+ *============================================================================*/
+
+int
+Socket_simple_timer_next_timeout (SocketSimple_Poll_T poll
+                                   __attribute__ ((unused)))
+{
+  /* Timer timeout calculation is handled internally by SocketPoll_wait.
+   * This function is provided for API completeness but returns -1
+   * to indicate the caller should use default timeout. */
+  return -1;
+}
+
+int
+Socket_simple_timer_process (SocketSimple_Poll_T poll
+                              __attribute__ ((unused)))
+{
+  /* Timer processing is handled internally by SocketPoll_wait.
+   * This function is provided for API completeness. */
+  return 0;
+}
+
+int
+Socket_simple_timer_cancel_all (SocketSimple_Poll_T poll
+                                 __attribute__ ((unused)))
+{
+  /* Not currently supported - timers must be cancelled individually. */
+  simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
+                    "Cancel all timers not supported");
+  return -1;
+}
+
+/*============================================================================
+ * Timer Statistics
+ *============================================================================*/
+
+int
+Socket_simple_timer_count (SocketSimple_Poll_T poll __attribute__ ((unused)))
+{
+  /* Timer count not available from core API. */
+  simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
+                    "Timer count not supported");
+  return -1;
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive Simple API wrappers for missing core library features:

### New Modules (4 new files)
- **SocketSimple-buf**: Circular buffer wrapper with zero-copy read/write operations, peek, readline, and scatter-gather I/O
- **SocketSimple-timer**: Timer wheel integration with poll for adding/cancelling timeouts, pause/resume support
- **SocketSimple-happyeyeballs**: RFC 8305 dual-stack connection racing for faster connections on IPv4/IPv6 dual-stack networks
- **SocketSimple-reconnect**: Auto-reconnect with exponential backoff, jitter, and circuit breaker protection

### Extended SocketSimple-tcp
- Unix domain socket support (`Socket_simple_connect_unix`, `Socket_simple_listen_unix`)
- TCP socket options (nodelay, keepalive, send/recv buffer sizes)
- Scatter-gather I/O (`Socket_simple_sendv`, `Socket_simple_recvv`)
- Address query functions (`Socket_simple_get_local_addr`, `Socket_simple_get_peer_addr`)
- Peer credentials for Unix sockets (`Socket_simple_get_peer_creds`)

### Extended UDP
- Multicast operations (join/leave group, TTL, loopback, interface selection)
- Broadcast enable
- Connected UDP mode for send/recv without specifying destination

### Implementation Details
All modules follow Simple API patterns:
- Return codes instead of exceptions
- Thread-local error state with `Socket_simple_error()`/`Socket_simple_code()`
- TRY/EXCEPT wrappers around core library exceptions
- Consistent error handling with errno preservation

Fixes #51

## Test Plan
- [x] Build passes without warnings (`-Wall -Wextra -Werror`)
- [x] All 70 tests pass without sanitizers
- [x] All 70 tests pass with ASan + UBSan enabled
- [ ] Manual testing of new features

🤖 Generated with [Claude Code](https://claude.com/claude-code)