### PR TITLE
refactor: comment cleanup in src/core/

### DIFF
--- a/src/core/Except.c
+++ b/src/core/Except.c
@@ -12,7 +12,6 @@
 
 #include "core/Except.h"
 
-/* Mark function as never returning */
 #if defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
 #define EXCEPT_NORETURN _Noreturn
 #elif defined(__GNUC__) || defined(__clang__)
@@ -23,14 +22,12 @@
 #define EXCEPT_NORETURN
 #endif
 
-/* Mark function as unlikely to be called */
 #if defined(__GNUC__) || defined(__clang__)
 #define EXCEPT_COLD __attribute__ ((cold))
 #else
 #define EXCEPT_COLD
 #endif
 
-/* Mark pointer parameters as non-null */
 #if defined(__GNUC__) || defined(__clang__)
 #define EXCEPT_NONNULL(...) __attribute__ ((nonnull (__VA_ARGS__)))
 #else
@@ -87,7 +84,6 @@ except_emit_reason (const Except_T *e)
            e->reason != NULL ? e->reason : "(no reason provided)");
 }
 
-/* Extract filename from full path to prevent leaking directory structure */
 static const char *
 except_basename (const char *path)
 {

--- a/src/core/SocketRetry.c
+++ b/src/core/SocketRetry.c
@@ -177,7 +177,6 @@ exponential_backoff (const SocketRetry_Policy *policy, int attempt)
   multiplier_pow = power_double (policy->multiplier, attempt - 1);
   base_delay = (double)policy->initial_delay_ms * multiplier_pow;
 
-  /* Handle FP overflow/NaN */
   if (isinf (base_delay) || isnan (base_delay))
     base_delay = (double)policy->max_delay_ms;
 
@@ -202,7 +201,6 @@ apply_jitter_to_delay (double base_delay, const SocketRetry_Policy *policy,
       jittered_delay += jitter_offset;
     }
 
-  /* Handle FP overflow/NaN after jitter */
   if (isinf (jittered_delay) || isnan (jittered_delay) || jittered_delay < 0.0)
     jittered_delay = (double)policy->max_delay_ms;
 
@@ -212,7 +210,6 @@ apply_jitter_to_delay (double base_delay, const SocketRetry_Policy *policy,
 static double
 clamp_final_delay (double delay)
 {
-  /* Ensure positive delay after jitter */
   if (delay < RETRY_MIN_DELAY_MS)
     delay = RETRY_MIN_DELAY_MS;
 
@@ -291,7 +288,6 @@ SocketRetry_new (const SocketRetry_Policy *policy)
 {
   T retry;
 
-  /* Use calloc for zero-initialization of stats */
   retry = calloc (1, sizeof (*retry));
   if (retry == NULL)
     SOCKET_RAISE_MSG (SocketRetry, SocketRetry_Failed,
@@ -338,7 +334,6 @@ static int
 should_continue_retry (const T retry, int result, int attempt,
                        SocketRetry_ShouldRetry should_retry, void *context)
 {
-  /* Check user callback */
   if (should_retry != NULL && !should_retry (result, attempt, context))
     {
       SOCKET_LOG_DEBUG_MSG ("Retry aborted by callback for error %d", result);


### PR DESCRIPTION
## Summary
- Remove redundant comments in `Except.c` and `SocketRetry.c`
- Removed 9 lines of obvious/redundant comments that don't add value
- Preserves all meaningful comments (security notes, algorithm explanations, locking requirements)

### Changes
- **Except.c**: Remove macro description comments (NORETURN, COLD, NONNULL) - the macro names are self-explanatory
- **Except.c**: Remove duplicate comment about basename extraction (already documented earlier)
- **SocketRetry.c**: Remove obvious FP overflow handling comments
- **SocketRetry.c**: Remove redundant "ensure positive delay" comment
- **SocketRetry.c**: Remove obvious calloc comment
- **SocketRetry.c**: Remove obvious "check user callback" comment

Fixes #74

## Test plan
- [x] Build passes
- [x] All 70 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)