### PR TITLE
chore: update skill file paths to match codebase

### DIFF
--- a/.claude/skills/dns/SKILL.md
+++ b/.claude/skills/dns/SKILL.md
@@ -272,6 +272,5 @@ TRY {
 |------|---------|
 | `include/dns/SocketDNS.h` | DNS resolver API |
 | `src/dns/SocketDNS.c` | Main implementation |
-| `src/dns/SocketDNS-cache.c` | DNS caching |
-| `src/dns/SocketDNS-pool.c` | Thread pool |
-| `src/test/test_dns.c` | DNS tests |
+| `src/dns/SocketDNS-internal.c` | Internal helpers |
+| `src/test/test_socketdns.c` | DNS tests |

--- a/.claude/skills/happy-eyeballs/SKILL.md
+++ b/.claude/skills/happy-eyeballs/SKILL.md
@@ -327,7 +327,5 @@ void connect_async(const char *host, int port, ConnectCallback cb) {
 | File | Purpose |
 |------|---------|
 | `include/socket/SocketHappyEyeballs.h` | Happy Eyeballs API |
-| `src/socket/SocketHappyEyeballs.c` | Main implementation |
-| `src/socket/SocketHappyEyeballs-sort.c` | Address sorting (RFC 6724) |
-| `src/socket/SocketHappyEyeballs-cache.c` | Family caching |
+| `src/socket/SocketHappyEyeballs.c` | Implementation (sorting, racing, caching) |
 | `src/test/test_happy_eyeballs.c` | Racing tests |

--- a/.claude/skills/http2/SKILL.md
+++ b/.claude/skills/http2/SKILL.md
@@ -188,8 +188,10 @@ if (stream->send_window > MAX_WINDOW_SIZE) {
 |------|---------|
 | `include/http/SocketHTTP2.h` | HTTP/2 API |
 | `include/http/SocketHPACK.h` | HPACK API |
-| `src/http/SocketHTTP2-frames.c` | Frame processing |
-| `src/http/SocketHTTP2-streams.c` | Stream state machine |
+| `src/http/SocketHTTP2-frame.c` | Frame processing |
+| `src/http/SocketHTTP2-stream.c` | Stream state machine |
+| `src/http/SocketHTTP2-connection.c` | Connection management |
+| `src/http/SocketHTTP2-flow.c` | Flow control |
 | `src/http/SocketHPACK.c` | Header compression |
 | `src/http/SocketHPACK-huffman.c` | Huffman codec |
 | `src/test/test_http2.c` | Test patterns |

--- a/.claude/skills/pool/SKILL.md
+++ b/.claude/skills/pool/SKILL.md
@@ -299,7 +299,10 @@ TRY {
 |------|---------|
 | `include/pool/SocketPool.h` | Pool API |
 | `include/pool/SocketPoolHealth.h` | Health monitoring |
-| `src/pool/SocketPool.c` | Pool implementation |
+| `src/pool/SocketPool-core.c` | Core pool implementation |
+| `src/pool/SocketPool-connections.c` | Connection management |
 | `src/pool/SocketPool-drain.c` | Drain state machine |
-| `src/pool/SocketPoolHealth.c` | Health metrics |
+| `src/pool/SocketPool-health.c` | Health metrics |
+| `src/pool/SocketPool-ops.c` | Pool operations |
+| `src/pool/SocketPool-ratelimit.c` | Rate limiting |
 | `src/test/test_socketpool.c` | Pool tests |

--- a/.claude/skills/proxy/SKILL.md
+++ b/.claude/skills/proxy/SKILL.md
@@ -401,6 +401,7 @@ const char *socks5_strerror(uint8_t code) {
 |------|---------|
 | `include/socket/SocketProxy.h` | Proxy API |
 | `src/socket/SocketProxy.c` | Main implementation |
-| `src/socket/SocketProxy-socks.c` | SOCKS4/5 protocols |
+| `src/socket/SocketProxy-socks4.c` | SOCKS4/4a protocol |
+| `src/socket/SocketProxy-socks5.c` | SOCKS5 protocol |
 | `src/socket/SocketProxy-http.c` | HTTP CONNECT |
 | `src/test/test_proxy.c` | Proxy tests |

--- a/.claude/skills/tls/SKILL.md
+++ b/.claude/skills/tls/SKILL.md
@@ -169,6 +169,7 @@ Note: Some servers (e.g., httpbin.org) only support TLS 1.2, so TLS 1.3-only pol
 | `include/tls/SocketTLS.h` | Main TLS API |
 | `include/tls/SocketTLSContext.h` | Context configuration |
 | `include/tls/SocketDTLS.h` | DTLS for UDP |
-| `src/tls/SocketTLS.c` | TLS implementation |
-| `src/tls/SocketTLS-handshake.c` | Handshake state machine |
+| `src/tls/SocketTLS.c` | TLS implementation (includes handshake) |
+| `src/tls/SocketTLS-ktls.c` | Kernel TLS offload |
+| `src/tls/SocketTLSContext-*.c` | Context modules (certs, session, pinning, etc.) |
 | `src/test/test_tls_*.c` | Test patterns to follow |


### PR DESCRIPTION
## Summary
- Fixed incorrect file path references in 6 skill files under `.claude/skills/`
- Skills now reference actual source file names in the codebase

### Files Fixed
| Skill | Issue |
|-------|-------|
| http2 | `SocketHTTP2-frames.c` → `SocketHTTP2-frame.c` (singular) |
| tls | Removed non-existent `SocketTLS-handshake.c` |
| dns | Removed non-existent `SocketDNS-cache.c`, `SocketDNS-pool.c` |
| pool | Updated to match split file structure |
| proxy | `SocketProxy-socks.c` → `socks4.c` + `socks5.c` |
| happy-eyeballs | Removed non-existent split files |

Fixes #77

## Test plan
- [x] Build passes
- [x] Skills still load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)