### PR TITLE
chore: remove AI attribution from commit message template

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,13 +33,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 <body>
 
 Fixes #<issue>
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-
-Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
 Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `perf`
+
+**IMPORTANT**: Do NOT add "Generated with Claude Code", "Co-Authored-By: Claude", or any AI attribution to commit messages. Keep commits clean and professional.
 
 ## Build Commands
 


### PR DESCRIPTION
## Summary
- Remove "Generated with Claude Code" and "Co-Authored-By: Claude" from commit format template
- Add explicit instruction to NOT add AI attribution to commits

Fixes #80

## Test plan
- [x] Verified commit message hook strips attribution (this commit has none)