### PR TITLE
refactor: comment cleanup in remaining include/http/ headers

### DIFF
--- a/include/http/SocketHPACK-private.h
+++ b/include/http/SocketHPACK-private.h
@@ -30,72 +30,61 @@
 #define HPACK_HUFFMAN_STATE_ACCEPT 0xFE
 typedef struct
 {
-  char *name;       /**< Header name (arena-allocated) */
-  size_t name_len;  /**< Name length */
-  char *value;      /**< Header value (arena-allocated) */
+  char *name;
+  size_t name_len;
+  char *value;
   size_t value_len;
 } HPACK_DynamicEntry;
 struct SocketHPACK_Table
 {
-  HPACK_DynamicEntry *entries; /**< Ring buffer of dynamic entries */
-  size_t capacity;             /**< Maximum number of entries (power-of-2) */
-  size_t head;                 /**< Index of oldest entry */
-  size_t tail;     /**< Index for next insertion (one past newest) */
-  size_t count;    /**< Current number of entries */
-  size_t size;     /**< Current total size in bytes (sum of entry sizes) */
-  size_t max_size; /**< Maximum allowed size in bytes (from settings) */
+  HPACK_DynamicEntry *entries;
+  size_t capacity;
+  size_t head;
+  size_t tail;
+  size_t count;
+  size_t size;
+  size_t max_size;
   Arena_T arena;
 };
 
-/* Find exact or name-only match in dynamic table */
 extern int SocketHPACK_Table_find (SocketHPACK_Table_T table, const char *name,
                                    size_t name_len, const char *value, size_t value_len);
 struct SocketHPACK_Encoder
 {
-  SocketHPACK_Table_T
-      table; /**< Dynamic table shared with decoder if symmetric */
-  size_t
-      pending_table_sizes[2]; /**< Pending dynamic table size updates (RFC 7541 §4.2) */
-  int pending_table_size_count; /**< Number of pending table size updates (0-2) */
-  int huffman_encode; /**< Flag to enable Huffman coding for strings */
-  int use_indexing;   /**< Flag to enable dynamic table indexing */
+  SocketHPACK_Table_T table;
+  size_t pending_table_sizes[2];
+  int pending_table_size_count;
+  int huffman_encode;
+  int use_indexing;
   Arena_T arena;
 };
 struct SocketHPACK_Decoder
 {
-  SocketHPACK_Table_T table; /**< Dynamic table for header field references */
-  size_t
-      max_header_size; /**< Maximum size for a single decoded header field */
-  size_t max_header_list_size; /**< Maximum size for the entire header list */
-  size_t settings_max_table_size; /**< Maximum dynamic table size from peer
-                                     SETTINGS */
-  Arena_T arena;                  /**< Arena for decoded header allocations */
-
-  /* Decompression bomb protection */
-  uint64_t decode_input_bytes; /**< Cumulative input bytes processed in current
-                                  session */
-  uint64_t decode_output_bytes; /**< Cumulative output bytes produced in
-                                   current session */
+  SocketHPACK_Table_T table;
+  size_t max_header_size;
+  size_t max_header_list_size;
+  size_t settings_max_table_size;
+  Arena_T arena;
+  uint64_t decode_input_bytes;
+  uint64_t decode_output_bytes;
   double max_expansion_ratio;
 };
 typedef struct
 {
-  const char *name;  /**< Header field name (compile-time constant string) */
-  const char *value; /**< Header field value (compile-time constant string) */
-  uint8_t name_len;  /**< Length of name in bytes */
+  const char *name;
+  const char *value;
+  uint8_t name_len;
   uint8_t value_len;
 } HPACK_StaticEntry;
 typedef struct
 {
-  uint32_t code; /**< Huffman code bits (left-aligned in 32-bit integer) */
+  uint32_t code;
   uint8_t bits;
 } HPACK_HuffmanSymbol;
 typedef struct
 {
-  uint8_t next_state; /**< Next state in DFA (or special values like
-                         error/accept) */
-  uint8_t flags;      /**< Bit flags controlling output and error handling
-                         (HPACK_DFA_*) */
+  uint8_t next_state;
+  uint8_t flags;
   uint8_t sym;
 } HPACK_HuffmanTransition;
 
@@ -110,11 +99,9 @@ extern const HPACK_HuffmanTransition
 extern const HPACK_StaticEntry
     hpack_static_table[SOCKETHPACK_STATIC_TABLE_SIZE];
 
-/* Evict oldest entries from dynamic table */
 extern size_t hpack_table_evict (SocketHPACK_Table_T table,
                                  size_t required_space);
 
-/* Calculate dynamic table entry size */
 static inline size_t
 hpack_entry_size (size_t name_len, size_t value_len)
 {

--- a/include/http/SocketHPACK.h
+++ b/include/http/SocketHPACK.h
@@ -30,441 +30,174 @@
 #include "core/Arena.h"
 #include "core/Except.h"
 
-/**
- * @brief Default dynamic table size in bytes (RFC 7541 default).
- */
 #ifndef SOCKETHPACK_DEFAULT_TABLE_SIZE
 #define SOCKETHPACK_DEFAULT_TABLE_SIZE 4096
 #endif
 
-/**
- * @brief Maximum allowable dynamic table size in bytes.
- */
 #ifndef SOCKETHPACK_MAX_TABLE_SIZE
 #define SOCKETHPACK_MAX_TABLE_SIZE (64 * 1024)
 #endif
 
-/**
- * @brief Maximum size for individual header (name + value) in bytes.
- */
 #ifndef SOCKETHPACK_MAX_HEADER_SIZE
 #define SOCKETHPACK_MAX_HEADER_SIZE (8 * 1024)
 #endif
 
-/**
- * @brief Maximum total size for decoded header list in bytes.
- */
 #ifndef SOCKETHPACK_MAX_HEADER_LIST_SIZE
 #define SOCKETHPACK_MAX_HEADER_LIST_SIZE (64 * 1024)
 #endif
 
-/**
- * @brief Maximum allowed dynamic table size updates per header block.
- */
 #ifndef SOCKETHPACK_MAX_TABLE_UPDATES
 #define SOCKETHPACK_MAX_TABLE_UPDATES 2
 #endif
 
-/**
- * @brief Size of the static table (RFC 7541 Appendix A).
- */
 #define SOCKETHPACK_STATIC_TABLE_SIZE 61
-
-/**
- * @brief Overhead bytes per dynamic table entry (RFC 7541 Section 4.1).
- */
 #define SOCKETHPACK_ENTRY_OVERHEAD 32
 
-/**
- * @brief SocketHPACK_Error - HPACK operation failure (invalid encoding, size
- * limits, decompression bombs).
- */
 extern const Except_T SocketHPACK_Error;
 
-/**
- * @brief HPACK operation result codes.
- */
 typedef enum
 {
-  HPACK_OK = 0,              /**< Success */
-  HPACK_INCOMPLETE,          /**< Need more data */
-  HPACK_ERROR,               /**< Generic error */
-  HPACK_ERROR_INVALID_INDEX, /**< Index out of range */
-  HPACK_ERROR_HUFFMAN,       /**< Huffman decoding error */
-  HPACK_ERROR_INTEGER,       /**< Integer overflow */
-  HPACK_ERROR_TABLE_SIZE,    /**< Dynamic table size update invalid */
-  HPACK_ERROR_HEADER_SIZE,   /**< Individual header too large */
-  HPACK_ERROR_LIST_SIZE,     /**< Total header list too large */
-  HPACK_ERROR_BOMB           /**< HPACK bomb detected */
+  HPACK_OK = 0,
+  HPACK_INCOMPLETE,
+  HPACK_ERROR,
+  HPACK_ERROR_INVALID_INDEX,
+  HPACK_ERROR_HUFFMAN,
+  HPACK_ERROR_INTEGER,
+  HPACK_ERROR_TABLE_SIZE,
+  HPACK_ERROR_HEADER_SIZE,
+  HPACK_ERROR_LIST_SIZE,
+  HPACK_ERROR_BOMB
 } SocketHPACK_Result;
 
-/**
- * @brief HPACK header field with optional never_index flag for sensitive data.
- */
 typedef struct
 {
-  const char *name;  /**< Header name */
-  size_t name_len;   /**< Name length in bytes */
-  const char *value; /**< Header value */
-  size_t value_len;  /**< Value length in bytes */
-  int never_index;   /**< Sensitive - never add to dynamic table */
+  const char *name;
+  size_t name_len;
+  const char *value;
+  size_t value_len;
+  int never_index;
 } SocketHPACK_Header;
 
-/**
- * @brief HPACK dynamic table (opaque type).
- */
 typedef struct SocketHPACK_Table *SocketHPACK_Table_T;
 
-/**
- * @brief Create dynamic table for header compression (RFC 7541).
- *
- * Uses circular buffer with FIFO eviction when size limits reached.
- * All allocations are arena-managed.
- *
- * @param max_size Maximum table size in bytes (includes 32-byte overhead per
- * entry). Must be 0 <= max_size <= SOCKETHPACK_MAX_TABLE_SIZE.
- * @param arena Arena for all allocations.
- * @return New dynamic table instance.
- * @throws SocketHPACK_Error If max_size invalid.
- * @throws Arena_Failed If allocation fails.
- * @threadsafe Yes (arena must be synchronized if shared).
- * @see https://tools.ietf.org/html/rfc7541#section-4
- */
+/** Create dynamic table with FIFO eviction (RFC 7541 Section 4). */
 extern SocketHPACK_Table_T SocketHPACK_Table_new (size_t max_size,
                                                   Arena_T arena);
 
-/**
- * @brief Free dynamic table and set pointer to NULL.
- *
- * @param table Pointer to table (safe to call on NULL).
- * @threadsafe No
- */
 extern void SocketHPACK_Table_free (SocketHPACK_Table_T *table);
 
-/**
- * @brief Update table maximum size, evicting oldest entries if necessary.
- *
- * Typically triggered by HTTP/2 SETTINGS frame.
- *
- * @param table Dynamic table.
- * @param max_size New maximum size in bytes (must be <= SOCKETHPACK_MAX_TABLE_SIZE).
- * @throws SocketHPACK_Error If max_size invalid.
- * @threadsafe No
- */
+/** Update max size, evicting oldest entries if necessary. */
 extern void SocketHPACK_Table_set_max_size (SocketHPACK_Table_T table,
                                             size_t max_size);
 
-/**
- * @brief Get current table size in bytes (includes 32-byte overhead per entry).
- *
- * @param table Dynamic table.
- * @return Current size (RFC 7541 Section 4.1).
- * @threadsafe No
- */
 extern size_t SocketHPACK_Table_size (SocketHPACK_Table_T table);
-
-/**
- * @brief Get number of entries.
- * @param table Dynamic table.
- * @return Number of entries.
- * @threadsafe No
- */
 extern size_t SocketHPACK_Table_count (SocketHPACK_Table_T table);
-
-/**
- * @brief Get maximum table size.
- * @param table Dynamic table.
- * @return Maximum size in bytes.
- * @threadsafe No
- */
 extern size_t SocketHPACK_Table_max_size (SocketHPACK_Table_T table);
 
-/**
- * @brief Get entry by 1-based index (1 = most recent).
- * @param table Dynamic table.
- * @param index Entry index.
- * @param header Output header.
- * @return HPACK_OK on success, HPACK_ERROR_INVALID_INDEX if out of range.
- * @threadsafe No
- */
+/** Get entry by 1-based index (1 = most recent). */
 extern SocketHPACK_Result SocketHPACK_Table_get (SocketHPACK_Table_T table,
                                                  size_t index,
                                                  SocketHPACK_Header *header);
 
-/**
- * @brief Add entry to table (may evict older entries if size limit exceeded).
- * @param table Dynamic table.
- * @param name Header name.
- * @param name_len Name length.
- * @param value Header value.
- * @param value_len Value length.
- * @return HPACK_OK on success.
- * @threadsafe No
- */
 extern SocketHPACK_Result
 SocketHPACK_Table_add (SocketHPACK_Table_T table, const char *name,
                        size_t name_len, const char *value, size_t value_len);
 
-/**
- * @brief HPACK encoder (opaque type).
- */
 typedef struct SocketHPACK_Encoder *SocketHPACK_Encoder_T;
 
-/**
- * @brief Encoder configuration (table size, Huffman, indexing).
- */
 typedef struct
 {
-  size_t max_table_size; /**< Maximum dynamic table size */
-  int huffman_encode;    /**< Use Huffman encoding (default: 1) */
-  int use_indexing;      /**< Add headers to dynamic table (default: 1) */
+  size_t max_table_size;
+  int huffman_encode;
+  int use_indexing;
 } SocketHPACK_EncoderConfig;
 
-/**
- * @brief Initialize encoder config with defaults.
- * @param config Configuration structure.
- * @threadsafe Yes
- */
 extern void
 SocketHPACK_encoder_config_defaults (SocketHPACK_EncoderConfig *config);
 
-/**
- * @brief Create encoder instance.
- * @param config Configuration (NULL for defaults).
- * @param arena Memory arena.
- * @return New encoder.
- * @throws SocketHPACK_Error on allocation failure.
- * @threadsafe Yes (arena must be thread-safe or thread-local).
- */
 extern SocketHPACK_Encoder_T
 SocketHPACK_Encoder_new (const SocketHPACK_EncoderConfig *config,
                          Arena_T arena);
 
-/**
- * @brief Free encoder.
- * @param encoder Pointer to encoder (set to NULL).
- * @threadsafe No
- */
 extern void SocketHPACK_Encoder_free (SocketHPACK_Encoder_T *encoder);
 
-/**
- * @brief Encode header block.
- * @param encoder Encoder.
- * @param headers Headers to encode.
- * @param count Number of headers.
- * @param output Output buffer.
- * @param output_size Buffer size.
- * @return Bytes written, or -1 on error.
- * @threadsafe No
- */
+/** Encode header block. Returns bytes written, or -1 on error. */
 extern ssize_t SocketHPACK_Encoder_encode (SocketHPACK_Encoder_T encoder,
                                            const SocketHPACK_Header *headers,
                                            size_t count, unsigned char *output,
                                            size_t output_size);
 
-/**
- * @brief Signal table size change (emits update in next header block).
- * @param encoder Encoder.
- * @param max_size New maximum size.
- * @threadsafe No
- */
 extern void SocketHPACK_Encoder_set_table_size (SocketHPACK_Encoder_T encoder,
                                                 size_t max_size);
 
-/**
- * @brief Get encoder's dynamic table.
- * @param encoder Encoder.
- * @return Dynamic table.
- * @threadsafe No
- */
 extern SocketHPACK_Table_T
 SocketHPACK_Encoder_get_table (SocketHPACK_Encoder_T encoder);
 
-/**
- * @brief HPACK decoder (opaque type).
- */
 typedef struct SocketHPACK_Decoder *SocketHPACK_Decoder_T;
 
-/**
- * @brief Decoder configuration (security limits, decompression bomb
- * prevention).
- */
 typedef struct
 {
-  size_t max_table_size;       /**< Maximum dynamic table size */
-  size_t max_header_size;      /**< Maximum individual header size */
-  size_t max_header_list_size; /**< Maximum total decoded size */
-  double max_expansion_ratio;  /**< Max decoded/encoded ratio to prevent
-                                  decompression bombs (default: 10.0) */
-
+  size_t max_table_size;
+  size_t max_header_size;
+  size_t max_header_list_size;
+  double max_expansion_ratio;
 } SocketHPACK_DecoderConfig;
 
-/**
- * @brief Initialize decoder config with defaults.
- * @param config Configuration structure.
- * @threadsafe Yes
- */
 extern void
 SocketHPACK_decoder_config_defaults (SocketHPACK_DecoderConfig *config);
 
-/**
- * @brief Create decoder instance.
- * @param config Configuration (NULL for defaults).
- * @param arena Memory arena.
- * @return New decoder.
- * @throws SocketHPACK_Error on allocation failure.
- * @threadsafe Yes (arena must be thread-safe or thread-local).
- */
 extern SocketHPACK_Decoder_T
 SocketHPACK_Decoder_new (const SocketHPACK_DecoderConfig *config,
                          Arena_T arena);
 
-/**
- * @brief Free decoder.
- * @param decoder Pointer to decoder (set to NULL).
- * @threadsafe No
- */
 extern void SocketHPACK_Decoder_free (SocketHPACK_Decoder_T *decoder);
 
-/**
- * @brief Decode HPACK header block (RFC 7541 Section 6).
- *
- * Single-pass decompression with validation against config limits. Supports
- * indexed headers, literals (with/without indexing), and table updates.
- * Strings are null-terminated and arena-allocated.
- *
- * @param decoder Decoder with security configuration.
- * @param input Encoded HPACK block.
- * @param input_len Input size.
- * @param headers Pre-allocated output array.
- * @param max_headers Array capacity.
- * @param header_count Number of decoded headers written.
- * @param arena Arena for string allocations.
- * @return HPACK_OK on success, HPACK_INCOMPLETE for partial input,
- * HPACK_ERROR_* on failure.
- * @throws SocketHPACK_Error On validation failures or limit violations.
- * @throws Arena_Failed If allocations exceed capacity.
- * @threadsafe No (modifies decoder state).
- * @see https://tools.ietf.org/html/rfc7541#section-6
- */
+/** Decode HPACK header block (RFC 7541 Section 6). */
 extern SocketHPACK_Result
 SocketHPACK_Decoder_decode (SocketHPACK_Decoder_T decoder,
                             const unsigned char *input, size_t input_len,
                             SocketHPACK_Header *headers, size_t max_headers,
                             size_t *header_count, Arena_T arena);
 
-/**
- * @brief Handle SETTINGS table size update.
- * @param decoder Decoder.
- * @param max_size New maximum size from SETTINGS frame.
- * @threadsafe No
- */
 extern void SocketHPACK_Decoder_set_table_size (SocketHPACK_Decoder_T decoder,
                                                 size_t max_size);
 
-/**
- * @brief Get decoder's dynamic table.
- * @param decoder Decoder.
- * @return Dynamic table.
- * @threadsafe No
- */
 extern SocketHPACK_Table_T
 SocketHPACK_Decoder_get_table (SocketHPACK_Decoder_T decoder);
 
-/**
- * @brief Huffman encode string (RFC 7541 Appendix B).
- * @param input Input string.
- * @param input_len Input length.
- * @param output Output buffer.
- * @param output_size Buffer size.
- * @return Encoded length, or -1 on error.
- * @threadsafe Yes
- */
+/** Huffman encode string (RFC 7541 Appendix B). Returns -1 on error. */
 extern ssize_t SocketHPACK_huffman_encode (const unsigned char *input,
                                            size_t input_len,
                                            unsigned char *output,
                                            size_t output_size);
 
-/**
- * @brief Huffman decode string (DFA-based, validates padding).
- * @param input Encoded input.
- * @param input_len Input length.
- * @param output Output buffer.
- * @param output_size Buffer size.
- * @return Decoded length, or -1 on error.
- * @threadsafe Yes
- */
+/** Huffman decode string. Returns -1 on error. */
 extern ssize_t SocketHPACK_huffman_decode (const unsigned char *input,
                                            size_t input_len,
                                            unsigned char *output,
                                            size_t output_size);
 
-/**
- * @brief Calculate Huffman encoded size.
- * @param input Input string.
- * @param input_len Input length.
- * @return Encoded size in bytes.
- * @threadsafe Yes
- */
 extern size_t SocketHPACK_huffman_encoded_size (const unsigned char *input,
                                                 size_t input_len);
 
-/**
- * @brief Encode integer with prefix (RFC 7541 Section 5.1).
- * @param value Integer value.
- * @param prefix_bits Prefix bits (1-8).
- * @param output Output buffer.
- * @param output_size Buffer size.
- * @return Bytes written.
- * @threadsafe Yes
- */
+/** Encode integer with prefix (RFC 7541 Section 5.1). */
 extern size_t SocketHPACK_int_encode (uint64_t value, int prefix_bits,
                                       unsigned char *output,
                                       size_t output_size);
 
-/**
- * @brief Decode integer with prefix (RFC 7541 Section 5.1).
- * @param input Input buffer.
- * @param input_len Input length.
- * @param prefix_bits Prefix bits (1-8).
- * @param value Output value.
- * @param consumed Bytes consumed.
- * @return Result code.
- * @threadsafe Yes
- */
+/** Decode integer with prefix (RFC 7541 Section 5.1). */
 extern SocketHPACK_Result
 SocketHPACK_int_decode (const unsigned char *input, size_t input_len,
                         int prefix_bits, uint64_t *value, size_t *consumed);
 
-/**
- * @brief Get entry from static table by index (1-61).
- * @param index Entry index.
- * @param header Output header.
- * @return HPACK_OK on success, HPACK_ERROR_INVALID_INDEX if out of range.
- * @threadsafe Yes
- */
+/** Get entry from static table by index (1-61). */
 extern SocketHPACK_Result SocketHPACK_static_get (size_t index,
                                                   SocketHPACK_Header *header);
 
-/**
- * @brief Find entry in static table.
- * @param name Header name.
- * @param name_len Name length.
- * @param value Header value (NULL to match name only).
- * @param value_len Value length.
- * @return Index (1-61) on exact match, negative if name-only match, 0 if not
- * found.
- * @threadsafe Yes
- */
+/** Find entry in static table. Returns index or 0 if not found. */
 extern int SocketHPACK_static_find (const char *name, size_t name_len,
                                     const char *value, size_t value_len);
 
-/**
- * @brief Get error description for result code.
- * @param result Result code.
- * @return Static string.
- * @threadsafe Yes
- */
 extern const char *SocketHPACK_result_string (SocketHPACK_Result result);
 
 /** @} */

--- a/include/http/SocketHTTP-private.h
+++ b/include/http/SocketHTTP-private.h
@@ -19,61 +19,32 @@
 
 #include "core/SocketUtil.h"
 #include "http/SocketHTTP.h"
-#include <string.h> /* for strncasecmp */
+#include <string.h>
 
-/**
- * @brief Hash table bucket count for header collections.
- * @internal
- *
- * Fixed prime (31) for good distribution with typical HTTP header counts
- * (10-30).
- */
 #define SOCKETHTTP_HEADER_BUCKETS 31
 
-/**
- * @brief Individual HTTP header entry (name-value pair).
- * @internal
- *
- * Node for hash table collision chains and insertion-order linked list.
- * Names are case-preserved but looked up case-insensitively.
- */
 typedef struct HeaderEntry
 {
-  char *name;       /**< Header name (case-preserved, arena-allocated) */
-  size_t name_len;  /**< Length of name excluding null */
-  char *value;      /**< Header value (arena-allocated) */
-  size_t value_len; /**< Length of value excluding null */
-  unsigned hash;    /**< Cached hash bucket index */
-
-  struct HeaderEntry *hash_next; /**< Next in hash bucket chain */
-  struct HeaderEntry *list_next; /**< Next in insertion order */
-  struct HeaderEntry *list_prev; /**< Previous in insertion order */
+  char *name;
+  size_t name_len;
+  char *value;
+  size_t value_len;
+  unsigned hash;
+  struct HeaderEntry *hash_next;
+  struct HeaderEntry *list_next;
+  struct HeaderEntry *list_prev;
 } HeaderEntry;
 
-/**
- * @brief Internal implementation of SocketHTTP_Headers_T header collection.
- * @internal
- *
- * Case-insensitive header lookup via hash table (separate chaining) and
- * ordered iteration via doubly-linked list. All allocations from arena.
- * Not thread-safe.
- */
 struct SocketHTTP_Headers
 {
-  Arena_T arena;                                    /**< Arena for allocations */
-  HeaderEntry *buckets[SOCKETHTTP_HEADER_BUCKETS]; /**< Hash table buckets */
-  HeaderEntry *first; /**< Head of insertion-order list */
-  HeaderEntry *last;  /**< Tail of insertion-order list */
-  size_t count;       /**< Number of headers stored */
-  size_t total_size;  /**< Total size of names + values (bytes) */
+  Arena_T arena;
+  HeaderEntry *buckets[SOCKETHTTP_HEADER_BUCKETS];
+  HeaderEntry *first;
+  HeaderEntry *last;
+  size_t count;
+  size_t total_size;
 };
 
-/**
- * @brief Case-insensitive comparison of HTTP header names.
- * @internal
- *
- * RFC 9110 §5.2 compliant. Returns 1 if equal, 0 otherwise.
- */
 static inline int
 sockethttp_name_equal (const char *a, size_t a_len, const char *b,
                        size_t b_len)
@@ -83,13 +54,6 @@ sockethttp_name_equal (const char *a, size_t a_len, const char *b,
   return strncasecmp (a, b, a_len) == 0;
 }
 
-/**
- * @brief Internal states for DFA-based URI parser (RFC 3986).
- * @internal
- *
- * Parses scheme://[userinfo@]host[:port]/path?query#fragment including IPv6
- * literals and percent-encoding.
- */
 typedef enum
 {
   URI_STATE_START,
@@ -105,57 +69,16 @@ typedef enum
   URI_STATE_FRAGMENT
 } URIParserState;
 
-/**
- * @brief Lookup table for valid HTTP token characters (tchar) per RFC 9110
- * §5.6.
- * @internal
- *
- * tchar ::= "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
- *           "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
- */
 extern const unsigned char sockethttp_tchar_table[256];
-
-/**
- * @brief Check if character is valid HTTP token character (RFC 9110 §5.6).
- * @internal
- */
 #define SOCKETHTTP_IS_TCHAR(c) (sockethttp_tchar_table[(unsigned char)(c)])
 
-/**
- * @brief Lookup table for URI unreserved characters per RFC 3986 §2.3.
- * @internal
- *
- * Characters not requiring percent-encoding: ALPHA / DIGIT / "-" / "." / "_" /
- * "~"
- */
 extern const unsigned char sockethttp_uri_unreserved[256];
-
-/**
- * @brief Test if character is URI unreserved (RFC 3986 §2.3).
- * @internal
- */
 #define SOCKETHTTP_IS_UNRESERVED(c)                                           \
   (sockethttp_uri_unreserved[(unsigned char)(c)])
 
-/**
- * @brief Hexadecimal digit value lookup table.
- * @internal
- *
- * Maps '0'-'9', 'a'-'f', 'A'-'F' to 0-15, invalid chars to 255.
- * Used for percent-decoding and chunked encoding.
- */
 extern const unsigned char sockethttp_hex_value[256];
-
-/**
- * @brief Extract hex digit value (0-15) or 255 if invalid.
- * @internal
- */
 #define SOCKETHTTP_HEX_VALUE(c) (sockethttp_hex_value[(unsigned char)(c)])
 
-/**
- * @brief Skip whitespace (space/tab) for OWS handling.
- * @internal
- */
 static inline const char *
 sockethttp_skip_whitespace (const char *p)
 {
@@ -164,10 +87,6 @@ sockethttp_skip_whitespace (const char *p)
   return p;
 }
 
-/**
- * @brief Skip delimiters (space/tab/comma) for list parsing.
- * @internal
- */
 static inline const char *
 sockethttp_skip_delimiters (const char *p)
 {
@@ -176,10 +95,6 @@ sockethttp_skip_delimiters (const char *p)
   return p;
 }
 
-/**
- * @brief Check if character is token boundary (NUL/comma/space/tab).
- * @internal
- */
 static inline int
 sockethttp_is_token_boundary (char c)
 {

--- a/include/http/SocketHTTP1-private.h
+++ b/include/http/SocketHTTP1-private.h
@@ -26,101 +26,83 @@
 #define HTTP1_HEADER_SEP_LEN 2
 #define HTTP1_HEX_RADIX 16
 
-/* Character classification for table-driven DFA (following SocketUTF8 pattern) */
 typedef enum
 {
-  HTTP1_CC_CTL = 0, /**< Control chars (0x00-0x1F except HTAB) - invalid */
-  HTTP1_CC_SP,      /**< Space (0x20) */
-  HTTP1_CC_HTAB,    /**< Horizontal tab (0x09) - OWS */
-  HTTP1_CC_CR,      /**< Carriage return (0x0D) */
-  HTTP1_CC_LF,      /**< Line feed (0x0A) */
-  HTTP1_CC_COLON,   /**< Colon ':' - header separator */
-  HTTP1_CC_SLASH,   /**< Slash '/' - version separator */
-  HTTP1_CC_DOT,     /**< Dot '.' - version separator */
-  HTTP1_CC_DIGIT,   /**< 0-9 */
-  HTTP1_CC_HEX,     /**< a-f, A-F (hex only, not digit) */
-  HTTP1_CC_ALPHA,   /**< A-Za-z (not H, T, P) */
-  HTTP1_CC_H,       /**< 'H' - HTTP version start */
-  HTTP1_CC_T,       /**< 'T' - HTTP version */
-  HTTP1_CC_P,       /**< 'P' - HTTP version */
-  HTTP1_CC_TCHAR,   /**< Other token chars: !#$%&'*+-.^_`|~ */
-  HTTP1_CC_VCHAR,   /**< Other visible chars (0x21-0x7E not above) */
-  HTTP1_CC_OBS,     /**< obs-text (0x80-0xFF) */
-  HTTP1_CC_INVALID, /**< Invalid (NUL, DEL, etc.) */
-  HTTP1_NUM_CLASSES /**< Number of character classes */
+  HTTP1_CC_CTL = 0,
+  HTTP1_CC_SP,
+  HTTP1_CC_HTAB,
+  HTTP1_CC_CR,
+  HTTP1_CC_LF,
+  HTTP1_CC_COLON,
+  HTTP1_CC_SLASH,
+  HTTP1_CC_DOT,
+  HTTP1_CC_DIGIT,
+  HTTP1_CC_HEX,
+  HTTP1_CC_ALPHA,
+  HTTP1_CC_H,
+  HTTP1_CC_T,
+  HTTP1_CC_P,
+  HTTP1_CC_TCHAR,
+  HTTP1_CC_VCHAR,
+  HTTP1_CC_OBS,
+  HTTP1_CC_INVALID,
+  HTTP1_NUM_CLASSES
 } HTTP1_CharClass;
 typedef enum
 {
-  HTTP1_ACT_NONE = 0,     /**< Just transition, no side effect */
-  HTTP1_ACT_STORE_METHOD, /**< Store byte in method buffer */
-  HTTP1_ACT_STORE_URI,    /**< Store byte in URI buffer */
-  HTTP1_ACT_STORE_REASON, /**< Store byte in reason buffer */
-  HTTP1_ACT_STORE_NAME,   /**< Store byte in header name buffer */
-  HTTP1_ACT_STORE_VALUE,  /**< Store byte in header value buffer */
-  HTTP1_ACT_METHOD_END,   /**< Complete method token */
-  HTTP1_ACT_URI_END,      /**< Complete URI */
-  HTTP1_ACT_VERSION_MAJ,  /**< Store major version digit */
-  HTTP1_ACT_VERSION_MIN,  /**< Store minor version digit */
-  HTTP1_ACT_STATUS_DIGIT, /**< Store status code digit */
-  HTTP1_ACT_REASON_END,   /**< Complete reason phrase */
-  HTTP1_ACT_HEADER_END,   /**< Complete current header */
-  HTTP1_ACT_HEADERS_DONE, /**< All headers complete */
-  HTTP1_ACT_ERROR         /**< Transition to error state */
+  HTTP1_ACT_NONE = 0,
+  HTTP1_ACT_STORE_METHOD,
+  HTTP1_ACT_STORE_URI,
+  HTTP1_ACT_STORE_REASON,
+  HTTP1_ACT_STORE_NAME,
+  HTTP1_ACT_STORE_VALUE,
+  HTTP1_ACT_METHOD_END,
+  HTTP1_ACT_URI_END,
+  HTTP1_ACT_VERSION_MAJ,
+  HTTP1_ACT_VERSION_MIN,
+  HTTP1_ACT_STATUS_DIGIT,
+  HTTP1_ACT_REASON_END,
+  HTTP1_ACT_HEADER_END,
+  HTTP1_ACT_HEADERS_DONE,
+  HTTP1_ACT_ERROR
 } HTTP1_Action;
 typedef enum
 {
-  /* Initial state */
   HTTP1_PS_START = 0,
-
-  /* Request line states */
-  HTTP1_PS_METHOD,          /* Parsing method token */
-  HTTP1_PS_SP_AFTER_METHOD, /* Single space after method */
-  HTTP1_PS_URI,             /* Parsing request target */
-  HTTP1_PS_SP_AFTER_URI,    /* Single space after URI */
-
-  /* Status line states (response only) */
-  HTTP1_PS_STATUS_CODE,     /* 3 digits */
-  HTTP1_PS_SP_AFTER_STATUS, /* Space after status */
-  HTTP1_PS_REASON,          /* Reason phrase (optional) */
-
-  /* Version states (shared) */
-  HTTP1_PS_VERSION_H,     /* Expecting 'H' */
-  HTTP1_PS_VERSION_T1,    /* Expecting first 'T' */
-  HTTP1_PS_VERSION_T2,    /* Expecting second 'T' */
-  HTTP1_PS_VERSION_P,     /* Expecting 'P' */
-  HTTP1_PS_VERSION_SLASH, /* Expecting '/' */
-  HTTP1_PS_VERSION_MAJOR, /* Major version digit */
-  HTTP1_PS_VERSION_DOT,   /* Expecting '.' */
-  HTTP1_PS_VERSION_MINOR, /* Minor version digit */
-
-  /* Line ending states */
-  HTTP1_PS_LINE_CR, /* Expecting CR after request/status line */
-  HTTP1_PS_LINE_LF, /* Expecting LF after CR */
-
-  /* Header states */
-  HTTP1_PS_HEADER_START,     /* Start of header or empty line */
-  HTTP1_PS_HEADER_NAME,      /* Parsing header name */
-  HTTP1_PS_HEADER_COLON,     /* After colon, skip OWS */
-  HTTP1_PS_HEADER_VALUE,     /* Parsing header value */
-  HTTP1_PS_HEADER_VALUE_OWS, /* Trailing OWS in value */
-  HTTP1_PS_HEADER_CR,        /* CR after header value */
-  HTTP1_PS_HEADER_LF,        /* LF after header CR */
-  HTTP1_PS_HEADERS_END_LF,   /* Final LF (empty line) */
-
-  /* Body states */
-  HTTP1_PS_BODY_IDENTITY,    /* Reading fixed-length body */
-  HTTP1_PS_BODY_UNTIL_CLOSE, /* Reading until EOF */
-
-  /* Chunked encoding states */
-  HTTP1_PS_CHUNK_SIZE,     /* Hex digits */
-  HTTP1_PS_CHUNK_SIZE_EXT, /* Chunk extension (skip) */
-  HTTP1_PS_CHUNK_SIZE_CR,  /* CR after size */
-  HTTP1_PS_CHUNK_SIZE_LF,  /* LF after CR */
-  HTTP1_PS_CHUNK_DATA,     /* Reading chunk data */
-  HTTP1_PS_CHUNK_DATA_CR,  /* CR after chunk data */
-  HTTP1_PS_CHUNK_DATA_LF,  /* LF after chunk CR */
-
-  /* Trailer states (reuse header logic) */
+  HTTP1_PS_METHOD,
+  HTTP1_PS_SP_AFTER_METHOD,
+  HTTP1_PS_URI,
+  HTTP1_PS_SP_AFTER_URI,
+  HTTP1_PS_STATUS_CODE,
+  HTTP1_PS_SP_AFTER_STATUS,
+  HTTP1_PS_REASON,
+  HTTP1_PS_VERSION_H,
+  HTTP1_PS_VERSION_T1,
+  HTTP1_PS_VERSION_T2,
+  HTTP1_PS_VERSION_P,
+  HTTP1_PS_VERSION_SLASH,
+  HTTP1_PS_VERSION_MAJOR,
+  HTTP1_PS_VERSION_DOT,
+  HTTP1_PS_VERSION_MINOR,
+  HTTP1_PS_LINE_CR,
+  HTTP1_PS_LINE_LF,
+  HTTP1_PS_HEADER_START,
+  HTTP1_PS_HEADER_NAME,
+  HTTP1_PS_HEADER_COLON,
+  HTTP1_PS_HEADER_VALUE,
+  HTTP1_PS_HEADER_VALUE_OWS,
+  HTTP1_PS_HEADER_CR,
+  HTTP1_PS_HEADER_LF,
+  HTTP1_PS_HEADERS_END_LF,
+  HTTP1_PS_BODY_IDENTITY,
+  HTTP1_PS_BODY_UNTIL_CLOSE,
+  HTTP1_PS_CHUNK_SIZE,
+  HTTP1_PS_CHUNK_SIZE_EXT,
+  HTTP1_PS_CHUNK_SIZE_CR,
+  HTTP1_PS_CHUNK_SIZE_LF,
+  HTTP1_PS_CHUNK_DATA,
+  HTTP1_PS_CHUNK_DATA_CR,
+  HTTP1_PS_CHUNK_DATA_LF,
   HTTP1_PS_TRAILER_START,
   HTTP1_PS_TRAILER_NAME,
   HTTP1_PS_TRAILER_COLON,
@@ -128,11 +110,8 @@ typedef enum
   HTTP1_PS_TRAILER_CR,
   HTTP1_PS_TRAILER_LF,
   HTTP1_PS_TRAILERS_END_LF,
-
-  /* Terminal states */
-  HTTP1_PS_COMPLETE, /* Message complete */
-  HTTP1_PS_ERROR,    /* Parse error */
-
+  HTTP1_PS_COMPLETE,
+  HTTP1_PS_ERROR,
   HTTP1_NUM_STATES
 } HTTP1_InternalState;
 
@@ -149,70 +128,43 @@ typedef struct
 } HTTP1_TokenBuf;
 struct SocketHTTP1_Parser
 {
-  /* Configuration */
   SocketHTTP1_ParseMode mode;
   SocketHTTP1_Config config;
   Arena_T arena;
-
-  /* High-level state */
   SocketHTTP1_State state;
   SocketHTTP1_Result error;
-
-  /* Low-level DFA state */
   HTTP1_InternalState internal_state;
-
-  /* Request/response data */
   union
   {
     SocketHTTP_Request request;
     SocketHTTP_Response response;
   } message;
-
-  /* Headers being built */
   SocketHTTP_Headers_T headers;
   SocketHTTP_Headers_T trailers;
-
-  /* Token accumulators */
-  HTTP1_TokenBuf method_buf; /* Method token */
-  HTTP1_TokenBuf uri_buf;    /* Request target */
-  HTTP1_TokenBuf reason_buf; /* Reason phrase */
-  HTTP1_TokenBuf name_buf;   /* Current header name */
-  HTTP1_TokenBuf value_buf;  /* Current header value */
-
-  /* Parsing counters */
-  size_t header_count;       /* Number of headers parsed */
-  size_t total_header_size;  /* Total header bytes */
-  size_t line_length;        /* Current line length */
-  size_t header_line_length; /* Current header line length */
-
-  /* Trailer parsing counters */
-  size_t trailer_count;      /* Number of trailer headers parsed */
-  size_t total_trailer_size; /* Total trailer bytes parsed */
-
-  /* Body handling */
+  HTTP1_TokenBuf method_buf;
+  HTTP1_TokenBuf uri_buf;
+  HTTP1_TokenBuf reason_buf;
+  HTTP1_TokenBuf name_buf;
+  HTTP1_TokenBuf value_buf;
+  size_t header_count;
+  size_t total_header_size;
+  size_t line_length;
+  size_t header_line_length;
+  size_t trailer_count;
+  size_t total_trailer_size;
   SocketHTTP1_BodyMode body_mode;
-  int64_t content_length; /* From header, or -1 */
-  int64_t body_remaining; /* Bytes remaining */
-  int body_complete;      /* Body fully received */
-  uint64_t body_read;       /**< Total body bytes processed */
-
-  /* Chunked encoding */
-  size_t chunk_size;      /* Current chunk size */
-  size_t chunk_remaining; /* Bytes remaining in chunk */
-
-  /* Version parsing */
+  int64_t content_length;
+  int64_t body_remaining;
+  int body_complete;
+  uint64_t body_read;
+  size_t chunk_size;
+  size_t chunk_remaining;
   int version_major;
   int version_minor;
-
-  /* Status code parsing */
   int status_code;
-
-  /* Connection flags */
-  int keepalive;  /* Keep-alive determined */
-  int is_upgrade; /* Upgrade requested */
+  int keepalive;
+  int is_upgrade;
   const char *upgrade_protocol;
-
-  /* 100-continue */
   int expects_continue;
 };
 static inline int
@@ -227,14 +179,12 @@ http1_tokenbuf_init (HTTP1_TokenBuf *buf, Arena_T arena,
   return 0;
 }
 
-/* Reset token buffer to empty */
 static inline void
 http1_tokenbuf_reset (HTTP1_TokenBuf *buf)
 {
   buf->len = 0;
 }
 
-/* Append character to buffer, growing if needed */
 static inline int
 http1_tokenbuf_append (HTTP1_TokenBuf *buf, Arena_T arena, char c,
                        size_t max_size)
@@ -244,7 +194,6 @@ http1_tokenbuf_append (HTTP1_TokenBuf *buf, Arena_T arena, char c,
 
   if (buf->len >= buf->capacity)
     {
-      /* Double capacity */
       size_t new_capacity = buf->capacity * 2;
       if (new_capacity > max_size)
         new_capacity = max_size;
@@ -262,13 +211,11 @@ http1_tokenbuf_append (HTTP1_TokenBuf *buf, Arena_T arena, char c,
   return 0;
 }
 
-/* Null-terminate buffer and return string pointer */
 static inline char *
 http1_tokenbuf_terminate (HTTP1_TokenBuf *buf, Arena_T arena, size_t max_size)
 {
   if (buf->len >= buf->capacity)
     {
-      /* Need space for null terminator */
       size_t new_capacity = buf->len + 1;
       if (new_capacity > max_size + 1)
         return NULL;

--- a/include/http/SocketHTTP2-private.h
+++ b/include/http/SocketHTTP2-private.h
@@ -51,281 +51,196 @@ static const unsigned char HTTP2_CLIENT_PREFACE[HTTP2_PREFACE_SIZE]
 #define HTTP2_RST_STREAM_PAYLOAD_SIZE 4
 typedef enum
 {
-  HTTP2_CONN_STATE_INIT = 0,      /**< Initial state */
-  HTTP2_CONN_STATE_PREFACE_SENT,  /**< Client preface sent */
-  HTTP2_CONN_STATE_PREFACE_RECV,  /**< Server preface received */
-  HTTP2_CONN_STATE_SETTINGS_SENT, /**< SETTINGS sent */
-  HTTP2_CONN_STATE_SETTINGS_RECV, /**< SETTINGS received */
-  HTTP2_CONN_STATE_READY,         /**< Connection ready */
-  HTTP2_CONN_STATE_GOAWAY_SENT,   /**< GOAWAY sent */
-  HTTP2_CONN_STATE_GOAWAY_RECV,   /**< GOAWAY received */
+  HTTP2_CONN_STATE_INIT = 0,
+  HTTP2_CONN_STATE_PREFACE_SENT,
+  HTTP2_CONN_STATE_PREFACE_RECV,
+  HTTP2_CONN_STATE_SETTINGS_SENT,
+  HTTP2_CONN_STATE_SETTINGS_RECV,
+  HTTP2_CONN_STATE_READY,
+  HTTP2_CONN_STATE_GOAWAY_SENT,
+  HTTP2_CONN_STATE_GOAWAY_RECV,
   HTTP2_CONN_STATE_CLOSED
 } SocketHTTP2_ConnState;
 struct SocketHTTP2_Stream
 {
-  uint32_t id;                   /**< Stream identifier */
-  SocketHTTP2_StreamState state; /**< Current state */
-  SocketHTTP2_Conn_T conn;       /**< Parent connection */
-
-  /* Flow control */
-  int32_t send_window; /**< Send window size */
-  int32_t recv_window; /**< Receive window size */
-
-  /* Received data buffer */
-  SocketBuf_T recv_buf; /**< Received DATA frames */
-
-  /* Content-Length validation */
-  int64_t expected_content_length; /**< Expected Content-Length from headers (-1 if not set) */
-  size_t total_data_received;      /**< Total DATA payload bytes received */
-
-  /* Header state */
-  int headers_received;    /**< Headers have been received */
-  int end_stream_received; /**< END_STREAM flag received */
-  int end_stream_sent;     /**< END_STREAM flag sent */
-  int pending_end_stream;  /**< Pending END_STREAM flag from initial frame in
-                              split headers */
-  int is_push_stream;    /**< 1 if this is a server push stream, 0 otherwise */
-  int trailers_received; /**< Trailers received */
-  int rst_received;      /**< RST_STREAM received (prevents sending RST_STREAM in response) */
-
-  /* RFC 8441 Extended CONNECT support */
-  int is_extended_connect; /**< 1 if RFC 8441 Extended CONNECT request */
-  char protocol[32];       /**< :protocol value (e.g., "websocket") for Extended CONNECT */
-
-  /* Decoded headers storage */
-  SocketHPACK_Header
-      headers[SOCKETHTTP2_MAX_DECODED_HEADERS]; /**< Decoded initial headers */
-  size_t header_count;  /**< Number of initial headers */
-  int headers_consumed; /**< Headers already consumed by user */
-
-  SocketHPACK_Header
-      trailers[SOCKETHTTP2_MAX_DECODED_HEADERS]; /**< Decoded trailers */
-  size_t trailer_count;                          /**< Number of trailers */
-  int trailers_consumed; /**< Trailers already consumed by user */
-
-  /* Pending headers (accumulated from CONTINUATION) */
-  unsigned char *header_block;  /**< Accumulated header block */
-  size_t header_block_len;      /**< Current length */
-  size_t header_block_capacity; /**< Allocated capacity */
-
-  /* User data */
+  uint32_t id;
+  SocketHTTP2_StreamState state;
+  SocketHTTP2_Conn_T conn;
+  int32_t send_window;
+  int32_t recv_window;
+  SocketBuf_T recv_buf;
+  int64_t expected_content_length;
+  size_t total_data_received;
+  int headers_received;
+  int end_stream_received;
+  int end_stream_sent;
+  int pending_end_stream;
+  int is_push_stream;
+  int trailers_received;
+  int rst_received;
+  int is_extended_connect;
+  char protocol[32];
+  SocketHPACK_Header headers[SOCKETHTTP2_MAX_DECODED_HEADERS];
+  size_t header_count;
+  int headers_consumed;
+  SocketHPACK_Header trailers[SOCKETHTTP2_MAX_DECODED_HEADERS];
+  size_t trailer_count;
+  int trailers_consumed;
+  unsigned char *header_block;
+  size_t header_block_len;
+  size_t header_block_capacity;
   void *userdata;
-  bool is_local_initiated; /**< True if locally initiated (for limit
-                              enforcement) */
-
-  /* Hash table chaining */
+  bool is_local_initiated;
   struct SocketHTTP2_Stream *hash_next;
 };
 struct SocketHTTP2_Conn
 {
-  Socket_T socket;             /**< Underlying transport */
-  Arena_T arena;               /**< Memory arena */
-  SocketHTTP2_Role role;       /**< Client or server */
-  SocketHTTP2_ConnState state; /**< Connection state */
-
-  /* HPACK compressor/decompressor */
-  SocketHPACK_Encoder_T encoder; /**< Header encoder */
-  SocketHPACK_Decoder_T decoder; /**< Header decoder */
-
-  /* I/O buffers */
-  SocketBuf_T recv_buf; /**< Receive buffer */
-  SocketBuf_T send_buf; /**< Send buffer */
-
-  /* Settings */
-  uint32_t local_settings[HTTP2_SETTINGS_COUNT]; /**< Our settings */
-  uint32_t peer_settings[HTTP2_SETTINGS_COUNT];  /**< Peer's settings */
-  int settings_ack_pending; /**< Waiting for SETTINGS ACK */
-
-  /* Flow control */
-  int32_t send_window;         /**< Connection send window */
-  int32_t recv_window;         /**< Connection receive window */
-  int32_t initial_send_window; /**< Initial stream send window */
-  int32_t initial_recv_window; /**< Initial stream recv window */
-
-  /* Stream management */
-  struct SocketHTTP2_Stream **streams; /**< Hash table */
-  size_t
-      stream_count; /**< Active stream count (total for legacy, deprecate) */
-  uint32_t client_initiated_count; /**< Count of client-initiated streams */
-  uint32_t server_initiated_count; /**< Count of server-initiated streams (incl
-                                      push) */
-  SocketRateLimit_T
-      stream_open_rate_limit; /**< Rate limit for stream creations */
-  SocketRateLimit_T
-      stream_close_rate_limit; /**< Rate limit for stream closes/RST */
-  uint32_t hash_seed; /**< Random seed for stream hash randomization */
-
-  uint32_t next_stream_id;      /**< Next stream ID to use */
-  uint32_t last_peer_stream_id; /**< Last peer stream ID processed */
-  uint32_t max_peer_stream_id;  /**< Max stream ID from GOAWAY */
-
-  /* CONTINUATION frame state */
-  uint32_t continuation_stream_id;   /**< Stream expecting CONTINUATION */
-  int expecting_continuation;        /**< Expecting CONTINUATION frame */
-  uint32_t continuation_frame_count; /**< Current CONTINUATION count for header
-                                        block */
-
-  /* GOAWAY state */
-  int goaway_sent;                         /**< GOAWAY frame sent */
-  int goaway_received;                     /**< GOAWAY frame received */
-  SocketHTTP2_ErrorCode goaway_error_code; /**< GOAWAY error code */
-
-  /* PING state */
-  unsigned char ping_opaque[8]; /**< Last PING opaque data */
-  int ping_pending;             /**< Waiting for PING ACK */
-
-  /* Callbacks */
+  Socket_T socket;
+  Arena_T arena;
+  SocketHTTP2_Role role;
+  SocketHTTP2_ConnState state;
+  SocketHPACK_Encoder_T encoder;
+  SocketHPACK_Decoder_T decoder;
+  SocketBuf_T recv_buf;
+  SocketBuf_T send_buf;
+  uint32_t local_settings[HTTP2_SETTINGS_COUNT];
+  uint32_t peer_settings[HTTP2_SETTINGS_COUNT];
+  int settings_ack_pending;
+  int32_t send_window;
+  int32_t recv_window;
+  int32_t initial_send_window;
+  int32_t initial_recv_window;
+  struct SocketHTTP2_Stream **streams;
+  size_t stream_count;
+  uint32_t client_initiated_count;
+  uint32_t server_initiated_count;
+  SocketRateLimit_T stream_open_rate_limit;
+  SocketRateLimit_T stream_close_rate_limit;
+  uint32_t hash_seed;
+  uint32_t next_stream_id;
+  uint32_t last_peer_stream_id;
+  uint32_t max_peer_stream_id;
+  uint32_t continuation_stream_id;
+  int expecting_continuation;
+  uint32_t continuation_frame_count;
+  int goaway_sent;
+  int goaway_received;
+  SocketHTTP2_ErrorCode goaway_error_code;
+  unsigned char ping_opaque[8];
+  int ping_pending;
   SocketHTTP2_StreamCallback stream_callback;
   SocketHTTP2_ConnCallback conn_callback;
   void *stream_callback_data;
   void *conn_callback_data;
-
-  /* Timeouts (milliseconds) */
   int settings_timeout_ms;
   int ping_timeout_ms;
-  int idle_timeout_ms;  /**< Idle connection timeout in ms (0 = disabled) */
-
-  /** Monotonic time (ms) when last SETTINGS frame sent, expecting ACK */
+  int idle_timeout_ms;
   int64_t settings_sent_time;
-
-  /** Monotonic time (ms) when PING frame sent, expecting ACK */
   int64_t ping_sent_time;
-
-  /** Monotonic time (ms) of last frame recv or send activity */
   int64_t last_activity_time;
-
-  /* Frame rate limiting using TimeWindow module (sliding window counters) */
-  TimeWindow_T rst_window;       /**< RST_STREAM rate limiter (CVE-2023-44487) */
-  TimeWindow_T ping_window;      /**< PING frame rate limiter */
-  TimeWindow_T settings_window;  /**< SETTINGS frame rate limiter */
+  TimeWindow_T rst_window;
+  TimeWindow_T ping_window;
+  TimeWindow_T settings_window;
 };
-/* Validate frame header against protocol rules */
 extern SocketHTTP2_ErrorCode
 http2_frame_validate (SocketHTTP2_Conn_T conn,
                       const SocketHTTP2_FrameHeader *header);
 
-/* Adjust flow control window by signed delta */
 extern int http2_flow_adjust_window (int32_t *window, int32_t delta);
 
-/* Serialize frame and queue in send buffer */
 extern int http2_frame_send (SocketHTTP2_Conn_T conn,
                              const SocketHTTP2_FrameHeader *header,
                              const void *payload, size_t payload_len);
 
-/* Retrieve stream from connection by ID */
 extern SocketHTTP2_Stream_T http2_stream_lookup (const SocketHTTP2_Conn_T conn,
                                                  uint32_t stream_id);
 
-/* Create and initialize new stream */
 extern SocketHTTP2_Stream_T http2_stream_create (SocketHTTP2_Conn_T conn,
                                                  uint32_t stream_id,
                                                  int is_local_initiated);
 
-/* Deallocate stream resources and remove from connection */
 extern void http2_stream_destroy (SocketHTTP2_Stream_T stream);
 
-/* Validate and apply stream state transition */
 extern SocketHTTP2_ErrorCode
 http2_stream_transition (SocketHTTP2_Stream_T stream, uint8_t frame_type,
                          uint8_t flags, int is_send);
 
-/* Deduct bytes from receive flow control windows */
 extern int http2_flow_consume_recv (SocketHTTP2_Conn_T conn,
                                     SocketHTTP2_Stream_T stream, size_t bytes);
 
-/* Deduct bytes from send flow control windows */
 extern int http2_flow_consume_send (SocketHTTP2_Conn_T conn,
                                     SocketHTTP2_Stream_T stream, size_t bytes);
 
-/* Increase receive flow control window */
 extern int http2_flow_update_recv (SocketHTTP2_Conn_T conn,
                                    SocketHTTP2_Stream_T stream,
                                    uint32_t increment);
 
-/* Update send flow control windows from peer WINDOW_UPDATE */
 extern int http2_flow_update_send (SocketHTTP2_Conn_T conn,
                                    SocketHTTP2_Stream_T stream,
                                    uint32_t increment);
 
-/* Get available send window */
 extern int32_t http2_flow_available_send (const SocketHTTP2_Conn_T conn,
                                           const SocketHTTP2_Stream_T stream);
 
-/* Process received HTTP/2 frame */
 extern int http2_process_frame (SocketHTTP2_Conn_T conn,
                                 const SocketHTTP2_FrameHeader *header,
                                 const unsigned char *payload);
 
-/* Handle incoming DATA frame */
 extern int http2_process_data (SocketHTTP2_Conn_T conn,
                                const SocketHTTP2_FrameHeader *header,
                                const unsigned char *payload);
 
-/* Process HEADERS frame with HPACK decoding */
 extern int http2_process_headers (SocketHTTP2_Conn_T conn,
                                   const SocketHTTP2_FrameHeader *header,
                                   const unsigned char *payload);
 
-/* Process RST_STREAM frame to abort stream */
 extern int http2_process_rst_stream (SocketHTTP2_Conn_T conn,
                                      const SocketHTTP2_FrameHeader *header,
                                      const unsigned char *payload);
 
-/* Process SETTINGS frame for parameter negotiation */
 extern int http2_process_settings (SocketHTTP2_Conn_T conn,
                                    const SocketHTTP2_FrameHeader *header,
                                    const unsigned char *payload);
 
-/* Process PUSH_PROMISE frame for server push */
 extern int http2_process_push_promise (SocketHTTP2_Conn_T conn,
                                        const SocketHTTP2_FrameHeader *header,
                                        const unsigned char *payload);
 
-/* Process PING frame for liveness checks */
 extern int http2_process_ping (SocketHTTP2_Conn_T conn,
                                const SocketHTTP2_FrameHeader *header,
                                const unsigned char *payload);
 
-/* Process GOAWAY frame for connection shutdown */
 extern int http2_process_goaway (SocketHTTP2_Conn_T conn,
                                  const SocketHTTP2_FrameHeader *header,
                                  const unsigned char *payload);
 
-/* Process WINDOW_UPDATE frame to replenish flow control */
 extern int http2_process_window_update (SocketHTTP2_Conn_T conn,
                                         const SocketHTTP2_FrameHeader *header,
                                         const unsigned char *payload);
 
-/* Process CONTINUATION frame for oversized header blocks */
 extern int http2_process_continuation (SocketHTTP2_Conn_T conn,
                                        const SocketHTTP2_FrameHeader *header,
                                        const unsigned char *payload);
 
-/* Decode HPACK-compressed header block */
 extern int http2_decode_headers (SocketHTTP2_Conn_T conn,
                                  SocketHTTP2_Stream_T stream,
                                  const unsigned char *block, size_t len);
 
-/* Encode headers into HPACK-compressed block */
 extern ssize_t http2_encode_headers (SocketHTTP2_Conn_T conn,
                                      const SocketHPACK_Header *headers,
                                      size_t count, unsigned char *output,
                                      size_t output_size);
 
-/* Send GOAWAY frame and shutdown connection */
 extern void http2_send_connection_error (SocketHTTP2_Conn_T conn,
                                          SocketHTTP2_ErrorCode error_code);
 
-/* Send RST_STREAM frame to terminate stream */
 extern void http2_send_stream_error (SocketHTTP2_Conn_T conn,
                                      uint32_t stream_id,
                                      SocketHTTP2_ErrorCode error_code);
 
-/* Invoke stream event callback */
 extern void http2_emit_stream_event (SocketHTTP2_Conn_T conn,
                                      SocketHTTP2_Stream_T stream, int event);
 
-/* Invoke connection event callback */
 extern void http2_emit_conn_event (SocketHTTP2_Conn_T conn, int event);
 static inline void
 write_u16_be (unsigned char *buf, uint16_t value)
@@ -372,7 +287,6 @@ read_u31_be (const unsigned char *buf)
          | ((uint32_t)buf[2] << 8) | buf[3];
 }
 
-/* Header validation (RFC 9113 Section 8) */
 extern int http2_is_connection_header_forbidden (const SocketHPACK_Header *header);
 extern int http2_field_has_uppercase (const char *name, size_t len);
 extern int http2_field_has_prohibited_chars (const char *data, size_t len);

--- a/include/http/SocketHTTPClient-config.h
+++ b/include/http/SocketHTTPClient-config.h
@@ -20,347 +20,226 @@
 #ifndef SOCKETHTTPCLIENT_CONFIG_INCLUDED
 #define SOCKETHTTPCLIENT_CONFIG_INCLUDED
 
-/* ============================================================================
- * Error Buffer Configuration
- * ============================================================================
- */
-
-/** @brief Size of error message buffer for SocketHTTPClient_error_format(). */
 #ifndef HTTPCLIENT_ERROR_BUFSIZE
 #define HTTPCLIENT_ERROR_BUFSIZE 256
 #endif
 
-/* ============================================================================
- * Connection Pool Configuration
- * ============================================================================
- */
-
-/** @brief Initial hash table size for connection pool (prime for distribution). */
 #ifndef HTTPCLIENT_POOL_HASH_SIZE
 #define HTTPCLIENT_POOL_HASH_SIZE 127
 #endif
 
-/** @brief Larger hash table size when pool exceeds LARGE_THRESHOLD connections. */
 #ifndef HTTPCLIENT_POOL_LARGE_HASH_SIZE
 #define HTTPCLIENT_POOL_LARGE_HASH_SIZE 251
 #endif
 
-/** @brief Connection count triggering resize to larger hash table. */
 #ifndef HTTPCLIENT_POOL_LARGE_THRESHOLD
 #define HTTPCLIENT_POOL_LARGE_THRESHOLD 100
 #endif
 
-/** @brief I/O buffer size per pooled connection. */
 #ifndef HTTPCLIENT_IO_BUFFER_SIZE
 #define HTTPCLIENT_IO_BUFFER_SIZE 8192
 #endif
 
-/* ============================================================================
- * Default Timeouts (milliseconds)
- * ============================================================================
- */
-
-/** @brief Connection establishment timeout (TCP + TLS + proxy). */
 #ifndef HTTPCLIENT_DEFAULT_CONNECT_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_CONNECT_TIMEOUT_MS 30000
 #endif
 
-/** @brief Full request completion timeout (DNS + connect + send + receive). */
 #ifndef HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_REQUEST_TIMEOUT_MS 60000
 #endif
 
-/** @brief DNS resolution timeout. */
 #ifndef HTTPCLIENT_DEFAULT_DNS_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_DNS_TIMEOUT_MS 10000
 #endif
 
-/** @brief Idle timeout for pooled connections before cleanup. */
 #ifndef HTTPCLIENT_DEFAULT_IDLE_TIMEOUT_MS
 #define HTTPCLIENT_DEFAULT_IDLE_TIMEOUT_MS 60000
 #endif
 
-/* ============================================================================
- * Connection Limits
- * ============================================================================
- */
-
-/** @brief Maximum redirect hops (raises SocketHTTPClient_TooManyRedirects). */
 #ifndef HTTPCLIENT_DEFAULT_MAX_REDIRECTS
 #define HTTPCLIENT_DEFAULT_MAX_REDIRECTS 10
 #endif
 
-/** @brief Maximum concurrent connections per host. */
 #ifndef HTTPCLIENT_DEFAULT_MAX_CONNS_PER_HOST
 #define HTTPCLIENT_DEFAULT_MAX_CONNS_PER_HOST 6
 #endif
 
-/** @brief Total maximum connections across all hosts. */
 #ifndef HTTPCLIENT_DEFAULT_MAX_TOTAL_CONNS
 #define HTTPCLIENT_DEFAULT_MAX_TOTAL_CONNS 100
 #endif
 
-/** @brief Maximum authentication retries on 401 responses. */
 #ifndef HTTPCLIENT_MAX_AUTH_RETRIES
 #define HTTPCLIENT_MAX_AUTH_RETRIES 2
 #endif
 
-/* ============================================================================
- * Retry Configuration
- * ============================================================================
- */
-
-/** @brief Enable automatic retry on transient failures (0=disabled). */
 #ifndef HTTPCLIENT_DEFAULT_ENABLE_RETRY
 #define HTTPCLIENT_DEFAULT_ENABLE_RETRY 0
 #endif
 
-/** @brief Maximum retry attempts for retryable errors. */
 #ifndef HTTPCLIENT_DEFAULT_MAX_RETRIES
 #define HTTPCLIENT_DEFAULT_MAX_RETRIES 3
 #endif
 
-/** @brief Initial backoff delay before first retry (ms). */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS
 #define HTTPCLIENT_DEFAULT_RETRY_INITIAL_DELAY_MS 100
 #endif
 
-/** @brief Maximum backoff delay cap (ms). */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS
 #define HTTPCLIENT_DEFAULT_RETRY_MAX_DELAY_MS 10000
 #endif
 
-/** @brief Retry on connection errors (ECONNREFUSED, ETIMEDOUT). */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_ON_CONNECT
 #define HTTPCLIENT_DEFAULT_RETRY_ON_CONNECT 1
 #endif
 
-/** @brief Retry on request timeouts. */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_ON_TIMEOUT
 #define HTTPCLIENT_DEFAULT_RETRY_ON_TIMEOUT 1
 #endif
 
-/**
- * @brief Retry on 5xx server errors (0=disabled).
- * @warning Only enable for idempotent requests (GET, HEAD, PUT, DELETE).
- */
+/* Only enable for idempotent requests (GET, HEAD, PUT, DELETE) */
 #ifndef HTTPCLIENT_DEFAULT_RETRY_ON_5XX
 #define HTTPCLIENT_DEFAULT_RETRY_ON_5XX 0
 #endif
 
-/** @brief Exponential backoff multiplier (delay doubles each attempt). */
 #ifndef HTTPCLIENT_RETRY_MULTIPLIER
 #define HTTPCLIENT_RETRY_MULTIPLIER 2.0
 #endif
 
-/** @brief Jitter factor to prevent thundering herd (+/-25% variation). */
 #ifndef HTTPCLIENT_RETRY_JITTER_FACTOR
 #define HTTPCLIENT_RETRY_JITTER_FACTOR 0.25
 #endif
 
-/** @brief Minimum delay on invalid retry input (ms). */
 #ifndef HTTPCLIENT_MIN_DELAY_MS
 #define HTTPCLIENT_MIN_DELAY_MS 1
 #endif
 
-/* ============================================================================
- * Cookie Configuration
- * ============================================================================
- */
-
-/** @brief Enforce SameSite cookie attribute for CSRF protection. */
 #ifndef HTTPCLIENT_DEFAULT_ENFORCE_SAMESITE
 #define HTTPCLIENT_DEFAULT_ENFORCE_SAMESITE 1
 #endif
 
-/** @brief Maximum cookies in a single jar (DoS protection). */
 #ifndef HTTPCLIENT_MAX_COOKIES
 #define HTTPCLIENT_MAX_COOKIES 10000
 #endif
 
-/** @brief Hash table size for cookie jar (prime for distribution). */
 #ifndef HTTPCLIENT_COOKIE_HASH_SIZE
 #define HTTPCLIENT_COOKIE_HASH_SIZE 127
 #endif
 
-/** @brief Maximum cookie name length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_NAME_LEN
 #define HTTPCLIENT_COOKIE_MAX_NAME_LEN 256
 #endif
 
-/** @brief Maximum cookie value length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_VALUE_LEN
 #define HTTPCLIENT_COOKIE_MAX_VALUE_LEN 4096
 #endif
 
-/** @brief Maximum cookie domain attribute length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_DOMAIN_LEN
 #define HTTPCLIENT_COOKIE_MAX_DOMAIN_LEN 256
 #endif
 
-/** @brief Maximum cookie path attribute length. */
 #ifndef HTTPCLIENT_COOKIE_MAX_PATH_LEN
 #define HTTPCLIENT_COOKIE_MAX_PATH_LEN 1024
 #endif
 
-/** @brief Line buffer size for Netscape cookie file parsing. */
 #ifndef HTTPCLIENT_COOKIE_FILE_LINE_SIZE
 #define HTTPCLIENT_COOKIE_FILE_LINE_SIZE 4096
 #endif
 
-/** @brief Buffer for parsing Max-Age attribute. */
 #ifndef HTTPCLIENT_COOKIE_MAX_AGE_SIZE
 #define HTTPCLIENT_COOKIE_MAX_AGE_SIZE 32
 #endif
 
-/** @brief Buffer for parsing SameSite attribute. */
 #ifndef HTTPCLIENT_COOKIE_SAMESITE_SIZE
 #define HTTPCLIENT_COOKIE_SAMESITE_SIZE 16
 #endif
 
-/** @brief Maximum cookie lifetime (10 years). */
 #ifndef HTTPCLIENT_MAX_COOKIE_AGE_SEC
 #define HTTPCLIENT_MAX_COOKIE_AGE_SEC (365LL * 24 * 3600 * 10)
 #endif
 
-/** @brief Maximum hash chain length before eviction (DoS protection). */
 #ifndef HTTPCLIENT_COOKIE_MAX_CHAIN_LEN
 #define HTTPCLIENT_COOKIE_MAX_CHAIN_LEN 100
 #endif
 
-/* ============================================================================
- * Response Limits
- * ============================================================================
- */
-
-/**
- * @brief Default maximum response body size (10MB).
- * Set to 0 in config for unlimited. Raises SocketHTTPClient_ResponseTooLarge.
- */
 #ifndef HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE
 #define HTTPCLIENT_DEFAULT_MAX_RESPONSE_SIZE (10ULL * 1024 * 1024)
 #endif
 
-/* ============================================================================
- * Authentication Buffers
- * ============================================================================
- */
-
-/** @brief Buffer for Basic auth credentials (username:password). */
 #ifndef HTTPCLIENT_AUTH_CREDENTIALS_SIZE
 #define HTTPCLIENT_AUTH_CREDENTIALS_SIZE 512
 #endif
 
-/** @brief Buffer for Digest auth A1/A2 intermediate hashes. */
 #ifndef HTTPCLIENT_DIGEST_A_BUFFER_SIZE
 #define HTTPCLIENT_DIGEST_A_BUFFER_SIZE 512
 #endif
 
-/** @brief Buffer for Digest auth response value. */
 #ifndef HTTPCLIENT_DIGEST_RESPONSE_SIZE
 #define HTTPCLIENT_DIGEST_RESPONSE_SIZE 256
 #endif
 
-/** @brief Client nonce size for Digest auth (16 bytes = 128 bits entropy). */
 #ifndef HTTPCLIENT_DIGEST_CNONCE_SIZE
 #define HTTPCLIENT_DIGEST_CNONCE_SIZE 16
 #endif
 
-/** @brief Hex-encoded cnonce buffer (32 hex chars + null). */
 #ifndef HTTPCLIENT_DIGEST_CNONCE_HEX_SIZE
 #define HTTPCLIENT_DIGEST_CNONCE_HEX_SIZE 33
 #endif
 
-/** @brief Buffer for nonce-count hex string (8 hex digits). */
 #ifndef HTTPCLIENT_DIGEST_NC_SIZE
 #define HTTPCLIENT_DIGEST_NC_SIZE 16
 #endif
 
-/* ============================================================================
- * Request/Response Buffers
- * ============================================================================
- */
-
-/** @brief Buffer for serializing request line and headers. */
 #ifndef HTTPCLIENT_REQUEST_BUFFER_SIZE
 #define HTTPCLIENT_REQUEST_BUFFER_SIZE 8192
 #endif
 
-/** @brief Chunk size for incremental response body reads. */
 #ifndef HTTPCLIENT_BODY_CHUNK_SIZE
 #define HTTPCLIENT_BODY_CHUNK_SIZE 4096
 #endif
 
-/** @brief Initial HTTP/2 response body buffer (grows dynamically). */
 #ifndef HTTPCLIENT_H2_BODY_INITIAL_CAPACITY
 #define HTTPCLIENT_H2_BODY_INITIAL_CAPACITY (64 * 1024)
 #endif
 
-/** @brief Buffer for Host header construction. */
 #ifndef HTTPCLIENT_HOST_HEADER_SIZE
 #define HTTPCLIENT_HOST_HEADER_SIZE 256
 #endif
 
-/** @brief Buffer for Cookie header serialization. */
 #ifndef HTTPCLIENT_COOKIE_HEADER_SIZE
 #define HTTPCLIENT_COOKIE_HEADER_SIZE 4096
 #endif
 
-/** @brief Standard Authorization header buffer. */
 #ifndef HTTPCLIENT_AUTH_HEADER_SIZE
 #define HTTPCLIENT_AUTH_HEADER_SIZE 512
 #endif
 
-/** @brief Extended Authorization buffer for complex Digest params. */
 #ifndef HTTPCLIENT_AUTH_HEADER_LARGE_SIZE
 #define HTTPCLIENT_AUTH_HEADER_LARGE_SIZE 1024
 #endif
 
-/** @brief Buffer for URI in Digest auth calculations. */
 #ifndef HTTPCLIENT_URI_BUFFER_SIZE
 #define HTTPCLIENT_URI_BUFFER_SIZE 512
 #endif
 
-/** @brief Maximum Set-Cookie headers processed per response. */
 #ifndef HTTPCLIENT_MAX_SET_COOKIES
 #define HTTPCLIENT_MAX_SET_COOKIES 16
 #endif
 
-/** @brief Buffer for Accept-Encoding header construction. */
 #ifndef HTTPCLIENT_ACCEPT_ENCODING_SIZE
 #define HTTPCLIENT_ACCEPT_ENCODING_SIZE 64
 #endif
 
-/** @brief Buffer for Content-Length header value. */
 #ifndef HTTPCLIENT_CONTENT_LENGTH_SIZE
 #define HTTPCLIENT_CONTENT_LENGTH_SIZE 32
 #endif
 
-/* ============================================================================
- * Default User-Agent
- * ============================================================================
- */
-
-/** @brief Default User-Agent header (override via config.user_agent). */
 #ifndef HTTPCLIENT_DEFAULT_USER_AGENT
 #define HTTPCLIENT_DEFAULT_USER_AGENT "SocketHTTPClient/1.0"
 #endif
 
-/* ============================================================================
- * Content-Encoding Flags
- * ============================================================================
- */
-
-/** @brief Identity (no compression) encoding. */
 #define HTTPCLIENT_ENCODING_IDENTITY 0x00
-
-/** @brief GZIP compression (RFC 9110). */
 #define HTTPCLIENT_ENCODING_GZIP 0x01
-
-/** @brief DEFLATE compression (RFC 9110). */
 #define HTTPCLIENT_ENCODING_DEFLATE 0x02
-
-/** @brief Brotli compression (RFC 7932). */
 #define HTTPCLIENT_ENCODING_BR 0x04
 
 #endif /* SOCKETHTTPCLIENT_CONFIG_INCLUDED */

--- a/include/http/SocketHTTPClient-private.h
+++ b/include/http/SocketHTTPClient-private.h
@@ -27,7 +27,6 @@
 #include <pthread.h>
 #include <time.h>
 
-/* Exception handling - uses centralized infrastructure from SocketUtil.h */
 #undef SOCKET_LOG_COMPONENT
 #define SOCKET_LOG_COMPONENT "HTTPClient"
 
@@ -41,14 +40,13 @@
  */
 typedef struct HTTPPoolEntry
 {
-  char *host;    /**< Target hostname (owned, null-terminated) */
-  int port;      /**< Target port */
-  int is_secure; /**< Using TLS */
-  char sni_hostname[256];  /**< Hostname used for TLS SNI verification */
+  char *host;
+  int port;
+  int is_secure;
+  char sni_hostname[256];
 
-  SocketHTTP_Version version; /**< Negotiated protocol version */
+  SocketHTTP_Version version;
 
-  /* Protocol-specific state */
   union
   {
     struct
@@ -57,24 +55,23 @@ typedef struct HTTPPoolEntry
       SocketHTTP1_Parser_T parser;
       SocketBuf_T inbuf;
       SocketBuf_T outbuf;
-      Arena_T
-          conn_arena; /**< Arena for connection resources (parser, buffers) */
+      Arena_T conn_arena;
     } h1;
     struct
     {
       SocketHTTP2_Conn_T conn;
-      int active_streams; /**< Count of active streams */
+      int active_streams;
     } h2;
   } proto;
 
-  time_t created_at; /**< Connection creation time */
-  time_t last_used;  /**< Last activity time */
-  int in_use;        /**< For H1.1: currently handling request */
-  int closed;        /**< Connection closed by peer */
+  time_t created_at;
+  time_t last_used;
+  int in_use;
+  int closed;
 
-  struct HTTPPoolEntry *hash_next; /**< Hash chain for host:port */
-  struct HTTPPoolEntry *next;      /**< Free list / all connections list */
-  struct HTTPPoolEntry *prev;      /**< Doubly linked for removal */
+  struct HTTPPoolEntry *hash_next;
+  struct HTTPPoolEntry *next;
+  struct HTTPPoolEntry *prev;
 } HTTPPoolEntry;
 
 /**
@@ -83,21 +80,20 @@ typedef struct HTTPPoolEntry
  */
 typedef struct HTTPPool
 {
-  HTTPPoolEntry **hash_table; /**< Hash table for host:port lookup */
-  size_t hash_size;           /**< Hash table size */
+  HTTPPoolEntry **hash_table;
+  size_t hash_size;
 
-  HTTPPoolEntry *all_conns;    /**< All connections (for cleanup) */
-  HTTPPoolEntry *free_entries; /**< Free entry pool */
+  HTTPPoolEntry *all_conns;
+  HTTPPoolEntry *free_entries;
 
-  size_t max_per_host;  /**< Max connections per host */
-  size_t max_total;     /**< Max total connections */
-  size_t current_count; /**< Current connection count */
-  int idle_timeout_ms;  /**< Idle connection timeout */
+  size_t max_per_host;
+  size_t max_total;
+  size_t current_count;
+  int idle_timeout_ms;
 
-  Arena_T arena;         /**< Memory arena */
-  pthread_mutex_t mutex; /**< Thread safety */
+  Arena_T arena;
+  pthread_mutex_t mutex;
 
-  /* Statistics */
   size_t total_requests;
   size_t reused_connections;
   size_t connections_failed;
@@ -109,29 +105,22 @@ typedef struct HTTPPool
  */
 struct SocketHTTPClient
 {
-  SocketHTTPClient_Config config; /**< Configuration copy */
+  SocketHTTPClient_Config config;
 
-  HTTPPool *pool; /**< Connection pool */
+  HTTPPool *pool;
 
-  /* Authentication */
-  SocketHTTPClient_Auth *default_auth; /**< Default auth (owned) */
+  SocketHTTPClient_Auth *default_auth;
 
-  /* Cookies */
-  SocketHTTPClient_CookieJar_T cookie_jar; /**< Associated cookie jar */
+  SocketHTTPClient_CookieJar_T cookie_jar;
 
 #if SOCKET_HAS_TLS
-  /* TLS */
-  SocketTLSContext_T default_tls_ctx; /**< Default TLS context (owned) */
+  SocketTLSContext_T default_tls_ctx;
 #endif
 
-  /* Last error */
   SocketHTTPClient_Error last_error;
 
-  /* Thread safety */
-  pthread_mutex_t
-      mutex; /**< Protects shared client state (auth, cookies, pool access) */
+  pthread_mutex_t mutex;
 
-  /* Memory */
   Arena_T arena;
 };
 
@@ -141,24 +130,21 @@ struct SocketHTTPClient
  */
 struct SocketHTTPClient_Request
 {
-  SocketHTTPClient_T client; /**< Parent client */
+  SocketHTTPClient_T client;
 
   SocketHTTP_Method method;
   SocketHTTP_URI uri;
 
-  SocketHTTP_Headers_T headers; /**< Request headers */
+  SocketHTTP_Headers_T headers;
 
-  /* Body */
   void *body;
   size_t body_len;
   ssize_t (*body_stream_cb) (void *buf, size_t len, void *userdata);
   void *body_stream_userdata;
 
-  /* Per-request overrides */
-  int timeout_ms;              /**< -1 = use client default */
-  SocketHTTPClient_Auth *auth; /**< NULL = use client default */
+  int timeout_ms;
+  SocketHTTPClient_Auth *auth;
 
-  /* Memory */
   Arena_T arena;
 };
 
@@ -190,16 +176,13 @@ struct SocketHTTPClient_AsyncRequest
   HTTPAsyncState state;
   SocketHTTPClient_Error error;
 
-  HTTPPoolEntry *conn; /**< Connection being used */
+  HTTPPoolEntry *conn;
 
-  /* Response accumulation */
   SocketHTTPClient_Response response;
 
-  /* Callback */
   SocketHTTPClient_Callback callback;
   void *userdata;
 
-  /* Linked list for pending requests */
   struct SocketHTTPClient_AsyncRequest *next;
 };
 
@@ -209,9 +192,9 @@ struct SocketHTTPClient_AsyncRequest
  */
 typedef struct CookieEntry
 {
-  SocketHTTPClient_Cookie cookie; /**< Cookie data (strings owned) */
-  time_t created;                 /**< Creation timestamp for eviction */
-  struct CookieEntry *next;       /**< Hash chain */
+  SocketHTTPClient_Cookie cookie;
+  time_t created;
+  struct CookieEntry *next;
 } CookieEntry;
 
 /**
@@ -224,47 +207,27 @@ struct SocketHTTPClient_CookieJar
   size_t hash_size;
   size_t count;
   size_t max_cookies;
-  unsigned hash_seed; /**< Random seed for hash collision resistance */
+  unsigned hash_seed;
   Arena_T arena;
   pthread_mutex_t mutex;
 };
 
-/* Pool operations */
-
-/** Create and initialize a new HTTP connection pool. */
 extern HTTPPool *httpclient_pool_new (Arena_T arena,
                                       const SocketHTTPClient_Config *config);
-/** Dispose of HTTP connection pool and close all connections. */
 extern void httpclient_pool_free (HTTPPool *pool);
-/** Get or create a pool entry for host:port. */
 extern HTTPPoolEntry *httpclient_pool_get (HTTPPool *pool, const char *host,
                                            int port, int is_secure);
-
-/** Release a pool entry back to available state. */
 extern void httpclient_pool_release (HTTPPool *pool, HTTPPoolEntry *entry);
-
-/** Close and remove a pool entry. */
 extern void httpclient_pool_close (HTTPPool *pool, HTTPPoolEntry *entry);
-
-/** Clean up idle connections that exceeded timeout. */
 extern void httpclient_pool_cleanup_idle (HTTPPool *pool);
 
-/* Connection management */
-
-/** Establish connection to target URI, handling proxy and TLS. */
 extern HTTPPoolEntry *httpclient_connect (SocketHTTPClient_T client,
                                           const SocketHTTP_URI *uri);
-
-/** Send HTTP request over the connection entry. */
 extern int httpclient_send_request (HTTPPoolEntry *conn,
                                     SocketHTTPClient_Request_T req);
-
-/** Receive and parse HTTP response from connection. */
 extern int httpclient_receive_response (HTTPPoolEntry *conn,
                                         SocketHTTPClient_Response *response,
                                         Arena_T arena);
-
-/* Authentication constants */
 #define HTTPCLIENT_DIGEST_REALM_MAX_LEN 128
 #define HTTPCLIENT_DIGEST_NONCE_MAX_LEN 128
 #define HTTPCLIENT_DIGEST_OPAQUE_MAX_LEN 128
@@ -273,7 +236,6 @@ extern int httpclient_receive_response (HTTPPoolEntry *conn,
 #define HTTPCLIENT_DIGEST_PARAM_NAME_MAX_LEN 32
 #define HTTPCLIENT_DIGEST_VALUE_MAX_LEN 256
 
-/* Digest token constants */
 #define HTTPCLIENT_DIGEST_TOKEN_AUTH "auth"
 #define HTTPCLIENT_DIGEST_TOKEN_AUTH_LEN 4
 #define HTTPCLIENT_DIGEST_TOKEN_TRUE "true"
@@ -281,7 +243,6 @@ extern int httpclient_receive_response (HTTPPoolEntry *conn,
 #define HTTPCLIENT_DIGEST_TOKEN_STALE "stale"
 #define HTTPCLIENT_DIGEST_TOKEN_STALE_LEN 5
 
-/* Auth prefixes and lengths */
 #define HTTPCLIENT_DIGEST_PREFIX "Digest "
 #define HTTPCLIENT_DIGEST_PREFIX_LEN 7
 #define HTTPCLIENT_BASIC_PREFIX "Basic "
@@ -289,62 +250,39 @@ extern int httpclient_receive_response (HTTPPoolEntry *conn,
 #define HTTPCLIENT_BEARER_PREFIX "Bearer "
 #define HTTPCLIENT_BEARER_PREFIX_LEN 7
 
-/* Legacy alias for backward compatibility */
 #define HTTPCLIENT_DIGEST_BASIC_PREFIX HTTPCLIENT_BASIC_PREFIX
 #define HTTPCLIENT_DIGEST_BASIC_PREFIX_LEN HTTPCLIENT_BASIC_PREFIX_LEN
 
-/* Hex digest size (max of MD5/SHA256) */
 #define HTTPCLIENT_DIGEST_HEX_SIZE (SOCKET_CRYPTO_SHA256_SIZE * 2 + 1)
 
-/* Basic auth credentials buffer size defined in SocketHTTPClient-config.h */
-
-/* Client nonce sizes */
 #define HTTPCLIENT_DIGEST_CNONCE_SIZE 16
 
-/* Temporary buffers for hash computations */
 #define HTTPCLIENT_DIGEST_A_BUFFER_SIZE 512
 
-/* Authentication helpers */
-
-/** Generate Basic auth header ("Basic base64(user:pass)"). */
 extern int httpclient_auth_basic_header (const char *username,
                                          const char *password, char *output,
                                          size_t output_size);
-
-/** Compute Digest auth response (RFC 2617, MD5 or SHA-256). */
 extern int httpclient_auth_digest_response (
     const char *username, const char *password, const char *realm,
     const char *nonce, const char *uri, const char *method, const char *qop,
     const char *nc, const char *cnonce, int use_sha256, char *output,
     size_t output_size);
-
-/** Handle Digest auth challenge and generate Authorization header. */
 extern int httpclient_auth_digest_challenge (
     const char *www_authenticate, const char *username, const char *password,
     const char *method, const char *uri, const char *nc_value, char *output,
     size_t output_size);
-
-/** Generate Bearer token header (RFC 6750). */
 extern int httpclient_auth_bearer_header (const char *token, char *output,
                                           size_t output_size);
-
-/** Check if Digest challenge indicates stale nonce. */
 extern int httpclient_auth_is_stale_nonce (const char *www_authenticate);
 
-/* Cookie helpers */
-
-/** Generate Cookie header from jar for URI. */
 extern int httpclient_cookies_for_request (
     SocketHTTPClient_CookieJar_T jar, const SocketHTTP_URI *uri, char *output,
     size_t output_size, int enforce_samesite);
-
-/** Parse Set-Cookie header into cookie structure (RFC 6265). */
 extern int httpclient_parse_set_cookie (const char *value, size_t len,
                                         const SocketHTTP_URI *request_uri,
                                         SocketHTTPClient_Cookie *cookie,
                                         Arena_T arena);
 
-/** Hash host:port for pool lookup. */
 static inline unsigned
 httpclient_host_hash (const char *host, int port, size_t table_size)
 {
@@ -356,33 +294,18 @@ httpclient_host_hash (const char *host, int port, size_t table_size)
   return socket_util_hash_uint (combined, table_size);
 }
 
-/* Retry helpers */
-
-/** Check if error is retryable per client policy. */
 extern int httpclient_should_retry_error (const SocketHTTPClient_T client,
                                           SocketHTTPClient_Error error);
-
-/** Check if status code warrants retry. */
 extern int httpclient_should_retry_status (const SocketHTTPClient_T client,
                                            int status);
-
-/** Check if status warrants retry with idempotency check. */
 extern int httpclient_should_retry_status_with_method (
     const SocketHTTPClient_T client, int status, SocketHTTP_Method method);
-
-/** Calculate exponential backoff delay with jitter. */
 extern int httpclient_calculate_retry_delay (const SocketHTTPClient_T client,
                                              int attempt);
-
-/** Sleep for retry backoff. */
 extern void httpclient_retry_sleep_ms (int ms);
-
-/** Grow arena-allocated body buffer. */
 extern int httpclient_grow_body_buffer (Arena_T arena, char **buf,
                                         size_t *capacity, size_t *total,
                                         size_t needed, size_t max_size);
-
-/** Clear response for retry. */
 extern void
 httpclient_clear_response_for_retry (SocketHTTPClient_Response *response);
 

--- a/include/http/SocketHTTPClient.h
+++ b/include/http/SocketHTTPClient.h
@@ -44,41 +44,15 @@
 typedef struct SocketTLSContext_T *SocketTLSContext_T;
 #endif
 
-/* ============================================================================
- * Exception Types
- * ============================================================================
- */
-
-/** General client failure. Retryable: depends on cause. */
 extern const Except_T SocketHTTPClient_Failed;
-
-/** DNS resolution failure. Retryable: YES. */
 extern const Except_T SocketHTTPClient_DNSFailed;
-
-/** TCP connection failure. Retryable: YES. */
 extern const Except_T SocketHTTPClient_ConnectFailed;
-
-/** TLS/SSL handshake failure. Retryable: NO (config issue). */
 extern const Except_T SocketHTTPClient_TLSFailed;
-
-/** Request timeout exceeded. Retryable: YES. */
 extern const Except_T SocketHTTPClient_Timeout;
-
-/** HTTP protocol error. Retryable: NO (malformed response). */
 extern const Except_T SocketHTTPClient_ProtocolError;
-
-/** Redirect limit exceeded. Retryable: NO (redirect loop). */
 extern const Except_T SocketHTTPClient_TooManyRedirects;
-
-/** Response body exceeds limit. Retryable: NO. */
 extern const Except_T SocketHTTPClient_ResponseTooLarge;
 
-/* ============================================================================
- * Error Codes
- * ============================================================================
- */
-
-/** Error codes for HTTP client operations. */
 typedef enum
 {
   HTTPCLIENT_OK = 0,
@@ -94,23 +68,8 @@ typedef enum
   HTTPCLIENT_ERROR_LIMIT_EXCEEDED
 } SocketHTTPClient_Error;
 
-/**
- * @brief Check if error code is retryable.
- * @param error Error code
- * @return 1 if retryable, 0 if fatal
- */
 extern int SocketHTTPClient_error_is_retryable (SocketHTTPClient_Error error);
 
-/* ============================================================================
- * Authentication Types
- * ============================================================================
- */
-
-/**
- * @brief Authentication scheme types.
- *
- * Supported: Basic (RFC 7617), Digest (RFC 7616), Bearer (RFC 6750).
- */
 typedef enum
 {
   HTTP_AUTH_NONE = 0,
@@ -119,37 +78,22 @@ typedef enum
   HTTP_AUTH_BEARER
 } SocketHTTPClient_AuthType;
 
-/** Authentication credentials. */
 typedef struct
 {
   SocketHTTPClient_AuthType type;
-  const char *username; /**< For Basic, Digest */
-  const char *password; /**< For Basic, Digest */
-  const char *token;    /**< For Bearer */
-  const char *realm;    /**< Optional realm filter */
+  const char *username;
+  const char *password;
+  const char *token;
+  const char *realm;
 } SocketHTTPClient_Auth;
 
-/* ============================================================================
- * Proxy Configuration
- * ============================================================================
- */
-
-/** Proxy configuration (opaque). See include/socket/SocketProxy.h. */
 typedef struct SocketProxy_Config SocketProxy_Config;
 
-/* ============================================================================
- * Client Configuration
- * ============================================================================
- */
-
-/** HTTP client configuration. */
 typedef struct
 {
-  /* Protocol */
   SocketHTTP_Version max_version;
   int allow_http2_cleartext;
 
-  /* Connection pooling */
   int enable_connection_pool;
   size_t max_connections_per_host;
   size_t max_total_connections;
@@ -157,33 +101,25 @@ typedef struct
   int max_connection_age_ms;
   int acquire_timeout_ms;
 
-  /* Timeouts */
   int connect_timeout_ms;
   int request_timeout_ms;
   int dns_timeout_ms;
 
-  /* Redirects */
   int follow_redirects;
   int redirect_on_post;
 
-  /* Compression */
-  int accept_encoding; /**< Bitmask: GZIP | DEFLATE | BR */
+  int accept_encoding;
   int auto_decompress;
 
-  /* TLS */
   SocketTLSContext_T tls_context;
   int verify_ssl;
 
-  /* Proxy */
   SocketProxy_Config *proxy;
 
-  /* User agent */
   const char *user_agent;
 
-  /* Limits */
   size_t max_response_size;
 
-  /* Retry configuration */
   int enable_retry;
   int max_retries;
   int retry_initial_delay_ms;
@@ -192,26 +128,14 @@ typedef struct
   int retry_on_timeout;
   int retry_on_5xx;
 
-  /* Security */
   int enforce_samesite;
 } SocketHTTPClient_Config;
-
-/* ============================================================================
- * Opaque Types
- * ============================================================================
- */
 
 typedef struct SocketHTTPClient *SocketHTTPClient_T;
 typedef struct SocketHTTPClient_Request *SocketHTTPClient_Request_T;
 typedef struct SocketHTTPClient_AsyncRequest *SocketHTTPClient_AsyncRequest_T;
 typedef struct SocketHTTPClient_CookieJar *SocketHTTPClient_CookieJar_T;
 
-/* ============================================================================
- * Response Structure
- * ============================================================================
- */
-
-/** HTTP response. Caller must call SocketHTTPClient_Response_free(). */
 typedef struct
 {
   int status_code;
@@ -222,232 +146,71 @@ typedef struct
   Arena_T arena;
 } SocketHTTPClient_Response;
 
-/* ============================================================================
- * Client Lifecycle
- * ============================================================================
- */
-
-/**
- * @brief Initialize config with production-safe defaults.
- * @param config Config structure to initialize
- */
 extern void SocketHTTPClient_config_defaults (SocketHTTPClient_Config *config);
-
-/**
- * @brief Create new HTTP client instance.
- * @param config Configuration (NULL uses defaults)
- * @return Client handle or NULL on failure
- */
 extern SocketHTTPClient_T
 SocketHTTPClient_new (const SocketHTTPClient_Config *config);
-
-/**
- * @brief Destroy HTTP client and release resources.
- * @param client Pointer to client handle (set to NULL)
- */
 extern void SocketHTTPClient_free (SocketHTTPClient_T *client);
 
-/* ============================================================================
- * Simple Synchronous API
- * ============================================================================
- */
-
-/**
- * @brief Perform synchronous GET request.
- * @param client Client instance
- * @param url Full URL (http:// or https://)
- * @param response Output response (caller must free)
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_get (SocketHTTPClient_T client, const char *url,
                                  SocketHTTPClient_Response *response);
-
-/**
- * @brief Perform synchronous HEAD request.
- * @param client Client instance
- * @param url Full URL
- * @param response Output response (caller must free)
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_head (SocketHTTPClient_T client, const char *url,
                                   SocketHTTPClient_Response *response);
-
-/**
- * @brief Perform synchronous POST request.
- * @param client Client instance
- * @param url Full URL
- * @param content_type Content-Type header
- * @param body Request body data
- * @param body_len Body length
- * @param response Output response (caller must free)
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_post (SocketHTTPClient_T client, const char *url,
                                   const char *content_type, const void *body,
                                   size_t body_len,
                                   SocketHTTPClient_Response *response);
-
-/**
- * @brief Perform synchronous PUT request.
- * @param client Client instance
- * @param url Full URL
- * @param content_type Content-Type header
- * @param body Request body data
- * @param body_len Body length
- * @param response Output response (caller must free)
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_put (SocketHTTPClient_T client, const char *url,
                                  const char *content_type, const void *body,
                                  size_t body_len,
                                  SocketHTTPClient_Response *response);
-
-/**
- * @brief Perform synchronous DELETE request.
- * @param client Client instance
- * @param url Full URL
- * @param response Output response (caller must free)
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_delete (SocketHTTPClient_T client, const char *url,
                                     SocketHTTPClient_Response *response);
-
-/**
- * @brief Free response resources.
- * @param response Response to free
- */
 extern void
 SocketHTTPClient_Response_free (SocketHTTPClient_Response *response);
 
-/* ============================================================================
- * Custom Request API
- * ============================================================================
- */
-
-/**
- * @brief Create request builder.
- * @param client Client instance
- * @param method HTTP method
- * @param url Full URL
- * @return Request builder
- */
 extern SocketHTTPClient_Request_T
 SocketHTTPClient_Request_new (SocketHTTPClient_T client,
                               SocketHTTP_Method method, const char *url);
-
-/**
- * @brief Free request builder.
- * @param req Pointer to request handle (set to NULL)
- */
 extern void SocketHTTPClient_Request_free (SocketHTTPClient_Request_T *req);
-
-/**
- * @brief Add header to request.
- * @param req Request
- * @param name Header name
- * @param value Header value
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_Request_header (SocketHTTPClient_Request_T req,
                                             const char *name,
                                             const char *value);
-
-/**
- * @brief Set request body.
- * @param req Request
- * @param data Body data
- * @param len Data length
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_Request_body (SocketHTTPClient_Request_T req,
                                           const void *data, size_t len);
-
-/**
- * @brief Set streaming body.
- * @param req Request
- * @param read_cb Callback to read body data
- * @param userdata User data for callback
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPClient_Request_body_stream (
     SocketHTTPClient_Request_T req,
     ssize_t (*read_cb) (void *buf, size_t len, void *userdata),
     void *userdata);
-
-/**
- * @brief Set per-request timeout.
- * @param req Request
- * @param ms Timeout in milliseconds
- */
 extern void SocketHTTPClient_Request_timeout (SocketHTTPClient_Request_T req,
                                               int ms);
-
-/**
- * @brief Set per-request authentication.
- * @param req Request
- * @param auth Authentication credentials
- */
 extern void SocketHTTPClient_Request_auth (SocketHTTPClient_Request_T req,
                                            const SocketHTTPClient_Auth *auth);
-
-/**
- * @brief Execute request.
- * @param req Request
- * @param response Output response
- * @return 0 on success, -1 on error
- */
 extern int
 SocketHTTPClient_Request_execute (SocketHTTPClient_Request_T req,
                                   SocketHTTPClient_Response *response);
 
-/* ============================================================================
- * Asynchronous API
- * ============================================================================
- */
-
-/** Async completion callback. */
 typedef void (*SocketHTTPClient_Callback) (SocketHTTPClient_AsyncRequest_T req,
                                            SocketHTTPClient_Response *response,
                                            SocketHTTPClient_Error error,
                                            void *userdata);
 
-/** Start async GET. */
 extern SocketHTTPClient_AsyncRequest_T
 SocketHTTPClient_get_async (SocketHTTPClient_T client, const char *url,
                             SocketHTTPClient_Callback callback,
                             void *userdata);
-
-/** Start async POST. */
 extern SocketHTTPClient_AsyncRequest_T SocketHTTPClient_post_async (
     SocketHTTPClient_T client, const char *url, const char *content_type,
     const void *body, size_t body_len, SocketHTTPClient_Callback callback,
     void *userdata);
-
-/** Start async custom request. */
 extern SocketHTTPClient_AsyncRequest_T
 SocketHTTPClient_Request_async (SocketHTTPClient_Request_T req,
                                 SocketHTTPClient_Callback callback,
                                 void *userdata);
-
-/** Cancel async request. */
 extern void
 SocketHTTPClient_AsyncRequest_cancel (SocketHTTPClient_AsyncRequest_T req);
-
-/**
- * @brief Process async requests.
- * @param client Client
- * @param timeout_ms Poll timeout
- * @return Number of completed requests
- */
 extern int SocketHTTPClient_process (SocketHTTPClient_T client,
                                      int timeout_ms);
 
-/* ============================================================================
- * Cookie Jar (RFC 6265)
- * ============================================================================
- */
-
-/** Cookie SameSite attribute (RFC 6265bis). */
 typedef enum
 {
   COOKIE_SAMESITE_NONE = 0,
@@ -455,7 +218,6 @@ typedef enum
   COOKIE_SAMESITE_STRICT = 2
 } SocketHTTPClient_SameSite;
 
-/** Cookie attributes (RFC 6265). */
 typedef struct
 {
   const char *name;
@@ -468,67 +230,32 @@ typedef struct
   SocketHTTPClient_SameSite same_site;
 } SocketHTTPClient_Cookie;
 
-/** Create cookie jar. */
 extern SocketHTTPClient_CookieJar_T SocketHTTPClient_CookieJar_new (void);
-
-/** Free cookie jar. */
 extern void
 SocketHTTPClient_CookieJar_free (SocketHTTPClient_CookieJar_T *jar);
-
-/** Associate jar with client. */
 extern void SocketHTTPClient_set_cookie_jar (SocketHTTPClient_T client,
                                              SocketHTTPClient_CookieJar_T jar);
-
-/** Get associated cookie jar. */
 extern SocketHTTPClient_CookieJar_T
 SocketHTTPClient_get_cookie_jar (SocketHTTPClient_T client);
-
-/** Set cookie. */
 extern int
 SocketHTTPClient_CookieJar_set (SocketHTTPClient_CookieJar_T jar,
                                 const SocketHTTPClient_Cookie *cookie);
-
-/** Get cookie by name. */
 extern const SocketHTTPClient_Cookie *
 SocketHTTPClient_CookieJar_get (SocketHTTPClient_CookieJar_T jar,
                                 const char *domain, const char *path,
                                 const char *name);
-
-/** Clear all cookies. */
 extern void
 SocketHTTPClient_CookieJar_clear (SocketHTTPClient_CookieJar_T jar);
-
-/** Clear expired cookies. */
 extern void
 SocketHTTPClient_CookieJar_clear_expired (SocketHTTPClient_CookieJar_T jar);
-
-/** Load cookies from file. */
 extern int SocketHTTPClient_CookieJar_load (SocketHTTPClient_CookieJar_T jar,
                                             const char *filename);
-
-/** Save cookies to file. */
 extern int SocketHTTPClient_CookieJar_save (SocketHTTPClient_CookieJar_T jar,
                                             const char *filename);
 
-/* ============================================================================
- * Client Authentication
- * ============================================================================
- */
-
-/**
- * @brief Set default authentication for all requests.
- * @param client Client instance
- * @param auth Authentication config (NULL to disable)
- */
 extern void SocketHTTPClient_set_auth (SocketHTTPClient_T client,
                                        const SocketHTTPClient_Auth *auth);
 
-/* ============================================================================
- * Connection Pool Management
- * ============================================================================
- */
-
-/** Connection pool statistics. */
 typedef struct
 {
   size_t active_connections;
@@ -542,71 +269,21 @@ typedef struct
   size_t pool_exhausted_waits;
 } SocketHTTPClient_PoolStats;
 
-/** Get pool statistics. */
 extern void SocketHTTPClient_pool_stats (SocketHTTPClient_T client,
                                          SocketHTTPClient_PoolStats *stats);
-
-/** Close all pooled connections. */
 extern void SocketHTTPClient_pool_clear (SocketHTTPClient_T client);
 
-/* ============================================================================
- * Error Handling
- * ============================================================================
- */
-
-/** Get last error code. */
 extern SocketHTTPClient_Error
 SocketHTTPClient_last_error (SocketHTTPClient_T client);
-
-/** Get error description (static string). */
 extern const char *
 SocketHTTPClient_error_string (SocketHTTPClient_Error error);
 
-/* ============================================================================
- * Convenience Functions
- * ============================================================================
- */
-
-/**
- * @brief Download URL content to file.
- * @param client HTTP client
- * @param url URL to download
- * @param filepath Destination path
- * @return 0 on success, -1 on HTTP error, -2 on file error
- */
 extern int SocketHTTPClient_download (SocketHTTPClient_T client, const char *url,
                                       const char *filepath);
-
-/**
- * @brief Upload file to URL.
- * @param client HTTP client
- * @param url Destination URL
- * @param filepath Source file path
- * @return HTTP status code on success, -1 on HTTP error, -2 on file error
- */
 extern int SocketHTTPClient_upload (SocketHTTPClient_T client, const char *url,
                                     const char *filepath);
-
-/**
- * @brief GET with JSON response.
- * @param client HTTP client
- * @param url URL to fetch
- * @param json_out Output JSON string (caller must free)
- * @param json_len Output JSON length
- * @return HTTP status on success, -1 on HTTP error, -2 on content-type mismatch
- */
 extern int SocketHTTPClient_json_get (SocketHTTPClient_T client, const char *url,
                                       char **json_out, size_t *json_len);
-
-/**
- * @brief POST JSON and receive JSON response.
- * @param client HTTP client
- * @param url Destination URL
- * @param json_body JSON to send
- * @param json_out Output JSON response (caller must free)
- * @param json_len Output JSON length
- * @return HTTP status on success, -1 on HTTP error, -2 on content-type mismatch
- */
 extern int SocketHTTPClient_json_post (SocketHTTPClient_T client,
                                        const char *url, const char *json_body,
                                        char **json_out, size_t *json_len);

--- a/include/http/SocketHTTPServer.h
+++ b/include/http/SocketHTTPServer.h
@@ -47,36 +47,6 @@ typedef struct SocketTLSContext_T *SocketTLSContext_T;
 
 #include "socket/SocketWS.h"
 
-/* ============================================================================
- * Configuration Constants
- * ============================================================================
- *
- * All limits can be overridden at compile time with -D flags or at runtime
- * via SocketHTTPServer_Config fields.
- *
- * RESOURCE LIMITS:
- *   HTTPSERVER_DEFAULT_MAX_HEADER_SIZE  - 64KB   - Max total header size
- *   HTTPSERVER_DEFAULT_MAX_BODY_SIZE    - 10MB   - Max request body size
- *   HTTPSERVER_DEFAULT_MAX_CONNECTIONS  - 1000   - Max concurrent connections
- *   HTTPSERVER_DEFAULT_MAX_CONNECTIONS_PER_CLIENT - 100 - Per-IP limit
- *   HTTPSERVER_DEFAULT_MAX_REQUESTS_PER_CONN - 1000 - Max requests per connection
- *   HTTPSERVER_DEFAULT_MAX_CONCURRENT_REQUESTS - 100 - HTTP/2 streams
- *
- * TIMEOUT LIMITS:
- *   HTTPSERVER_DEFAULT_REQUEST_TIMEOUT_MS - 30s - Idle timeout
- *   HTTPSERVER_DEFAULT_KEEPALIVE_TIMEOUT_MS - 60s - Keep-alive timeout
- *   HTTPSERVER_DEFAULT_REQUEST_READ_TIMEOUT_MS - 30s - Full request read
- *   HTTPSERVER_DEFAULT_RESPONSE_WRITE_TIMEOUT_MS - 60s - Full response write
- *   HTTPSERVER_DEFAULT_TLS_HANDSHAKE_TIMEOUT_MS - 10s - TLS handshake timeout
- *   HTTPSERVER_DEFAULT_MAX_CONNECTION_LIFETIME_MS - 300s - Max connection lifetime
- *
- * ENFORCEMENT:
- *   - max_header_size: Enforced by HTTP/1.1 parser (returns error)
- *   - max_body_size: Enforced before body allocation (returns 413)
- *   - max_connections: Enforced in accept loop (rejects new clients)
- *   - max_connections_per_client: Enforced via SocketIPTracker
- */
-
 #ifndef HTTPSERVER_DEFAULT_BACKLOG
 #define HTTPSERVER_DEFAULT_BACKLOG 128
 #endif
@@ -121,18 +91,10 @@ typedef struct SocketTLSContext_T *SocketTLSContext_T;
 #define HTTPSERVER_DEFAULT_KEEPALIVE_TIMEOUT_MS 60000
 #endif
 
-/**
- * Default maximum header size (64KB).
- * Enforced by HTTP/1.1 parser during parsing.
- */
 #ifndef HTTPSERVER_DEFAULT_MAX_HEADER_SIZE
 #define HTTPSERVER_DEFAULT_MAX_HEADER_SIZE (64 * 1024)
 #endif
 
-/**
- * Default maximum body size (10MB).
- * Returns 413 Payload Too Large when exceeded.
- */
 #ifndef HTTPSERVER_DEFAULT_MAX_BODY_SIZE
 #define HTTPSERVER_DEFAULT_MAX_BODY_SIZE (10 * 1024 * 1024)
 #endif
@@ -149,12 +111,10 @@ typedef struct SocketTLSContext_T *SocketTLSContext_T;
 #define HTTPSERVER_DEFAULT_RESPONSE_WRITE_TIMEOUT_MS 60000
 #endif
 
-/** TLS handshake timeout (ms) - prevents slowloris attacks. */
 #ifndef HTTPSERVER_DEFAULT_TLS_HANDSHAKE_TIMEOUT_MS
 #define HTTPSERVER_DEFAULT_TLS_HANDSHAKE_TIMEOUT_MS 10000
 #endif
 
-/** Max connection lifetime (ms) - defense-in-depth timeout. */
 #ifndef HTTPSERVER_DEFAULT_MAX_CONNECTION_LIFETIME_MS
 #define HTTPSERVER_DEFAULT_MAX_CONNECTION_LIFETIME_MS 300000
 #endif
@@ -195,10 +155,6 @@ typedef struct SocketTLSContext_T *SocketTLSContext_T;
 #define HTTPSERVER_CHUNK_BUFFER_SIZE 16384
 #endif
 
-/**
- * Initial buffer for chunked request bodies.
- * Grows dynamically up to max_body_size.
- */
 #ifndef HTTPSERVER_CHUNKED_BODY_INITIAL_SIZE
 #define HTTPSERVER_CHUNKED_BODY_INITIAL_SIZE 8192
 #endif
@@ -211,625 +167,206 @@ typedef struct SocketTLSContext_T *SocketTLSContext_T;
 #define HTTPSERVER_LATENCY_SAMPLES 1000
 #endif
 
-/* ============================================================================
- * Exception Types
- * ============================================================================ */
-
-/** General server failures (allocation errors, internal state corruption). */
 extern const Except_T SocketHTTPServer_Failed;
-
-/** Binding to address/port failed (EADDRINUSE, etc.). */
 extern const Except_T SocketHTTPServer_BindFailed;
-
-/** HTTP protocol violations or parsing errors. */
 extern const Except_T SocketHTTPServer_ProtocolError;
 
-/* ============================================================================
- * Server State
- * ============================================================================ */
-
-/** Server lifecycle states. */
 typedef enum
 {
-  HTTPSERVER_STATE_RUNNING,  /**< Normal operation */
-  HTTPSERVER_STATE_DRAINING, /**< Finishing existing requests */
-  HTTPSERVER_STATE_STOPPED   /**< All requests complete */
+  HTTPSERVER_STATE_RUNNING,
+  HTTPSERVER_STATE_DRAINING,
+  HTTPSERVER_STATE_STOPPED
 } SocketHTTPServer_State;
 
-/* ============================================================================
- * Server Configuration
- * ============================================================================ */
-
-/**
- * HTTP server configuration.
- * Use SocketHTTPServer_config_defaults() to initialize, then customize.
- */
 typedef struct
 {
-  /* Listener */
-  int port;                 /**< Listen port (default: 8080) */
-  const char *bind_address; /**< Bind address (default: "0.0.0.0") */
-  int backlog;              /**< Listen backlog (default: 128) */
+  int port;
+  const char *bind_address;
+  int backlog;
 
-  /* TLS */
-  SocketTLSContext_T tls_context; /**< TLS context for HTTPS (NULL = HTTP) */
+  SocketTLSContext_T tls_context;
 
-  /* Protocol */
-  SocketHTTP_Version max_version; /**< Max HTTP version (default: HTTP/2) */
-  int enable_h2c_upgrade; /**< Enable HTTP/2 upgrade over cleartext (default: 0) */
+  SocketHTTP_Version max_version;
+  int enable_h2c_upgrade;
 
-  /* Size Limits */
-  size_t max_header_size; /**< Max header size in bytes (default: 64KB) */
-  size_t max_body_size;   /**< Max body size in bytes (default: 10MB) */
+  size_t max_header_size;
+  size_t max_body_size;
 
-  /* Timeouts (ms) */
-  int request_timeout_ms;       /**< Idle timeout between requests (default: 30s) */
-  int keepalive_timeout_ms;     /**< Keep-alive timeout (default: 60s) */
-  int request_read_timeout_ms;  /**< Time to read complete request (default: 30s) */
-  int response_write_timeout_ms; /**< Time to send complete response (default: 60s) */
-  int tls_handshake_timeout_ms; /**< TLS handshake timeout (default: 10s) */
-  int max_connection_lifetime_ms; /**< Max connection lifetime (default: 5min) */
+  int request_timeout_ms;
+  int keepalive_timeout_ms;
+  int request_read_timeout_ms;
+  int response_write_timeout_ms;
+  int tls_handshake_timeout_ms;
+  int max_connection_lifetime_ms;
 
-  /* Connection Limits */
-  size_t max_connections;           /**< Max concurrent connections (default: 1000) */
-  size_t max_requests_per_connection; /**< Max requests per connection (default: 1000) */
-  int max_connections_per_client;   /**< Max connections per IP (default: 100) */
-  size_t max_concurrent_requests;   /**< Max concurrent streams (default: 100) */
+  size_t max_connections;
+  size_t max_requests_per_connection;
+  int max_connections_per_client;
+  size_t max_concurrent_requests;
 
-  /* WebSocket */
-  SocketWS_Config ws_config; /**< WebSocket upgrade configuration */
+  SocketWS_Config ws_config;
 
-  /* Metrics */
-  int per_server_metrics; /**< Enable per-server metrics (default: 0) */
+  int per_server_metrics;
 } SocketHTTPServer_Config;
 
-/* ============================================================================
- * Opaque Types
- * ============================================================================ */
-
-/**
- * Opaque HTTP server instance.
- * Manages connections, parsing, and response handling.
- */
 typedef struct SocketHTTPServer *SocketHTTPServer_T;
-
-/**
- * Opaque request context for handling individual HTTP requests.
- * Valid only during handler callback execution.
- */
 typedef struct SocketHTTPServer_Request *SocketHTTPServer_Request_T;
 
-/* ============================================================================
- * Callback Types
- * ============================================================================ */
-
-/**
- * Request handler callback invoked for each incoming HTTP request.
- *
- * Handler responsibilities:
- * 1. Inspect request via accessors (method, path, headers, body)
- * 2. Set response status and headers
- * 3. Provide body (static or streaming)
- * 4. Finalize with finish() or end_stream()
- *
- * The request context is valid only during callback execution.
- *
- * @param req      Request context
- * @param userdata User data from set_handler()
- */
 typedef void (*SocketHTTPServer_Handler) (SocketHTTPServer_Request_T req,
                                           void *userdata);
-
-/**
- * Callback for streaming request body data incrementally.
- *
- * Enables memory-efficient handling of large uploads by processing chunks
- * as received without buffering the entire body.
- *
- * @param req       Request context
- * @param chunk     Body data chunk (valid only during callback)
- * @param len       Chunk length in bytes
- * @param is_final  Non-zero if this is the final chunk
- * @param userdata  User data from body_stream()
- * @return 0 to continue, non-zero to abort (sends 400)
- */
 typedef int (*SocketHTTPServer_BodyCallback) (SocketHTTPServer_Request_T req,
                                               const void *chunk, size_t len,
                                               int is_final, void *userdata);
-
-/**
- * Middleware validator callback for request validation/authentication.
- *
- * Executed after header parsing, before body read/handler. Can short-circuit
- * invalid requests early.
- *
- * @param req           Request context (headers available, no body)
- * @param reject_status Output: HTTP status for rejection (if returning 0)
- * @param userdata      User data from set_validator()
- * @return Non-zero to proceed to handler, 0 to reject with *reject_status
- */
 typedef int (*SocketHTTPServer_Validator) (SocketHTTPServer_Request_T req,
                                            int *reject_status, void *userdata);
-
-/**
- * Callback for graceful drain completion.
- *
- * @param server    Server entering STOPPED state
- * @param timed_out Non-zero if drain timed out (connections force-closed)
- * @param userdata  User data from set_drain_callback()
- */
 typedef void (*SocketHTTPServer_DrainCallback) (SocketHTTPServer_T server,
                                                 int timed_out, void *userdata);
 
-/* ============================================================================
- * Server Lifecycle
- * ============================================================================ */
-
-/**
- * Initialize config with production-ready defaults.
- * @param config Config structure to initialize
- */
 extern void SocketHTTPServer_config_defaults (SocketHTTPServer_Config *config);
-
-/**
- * Allocate and initialize a new HTTP server.
- *
- * Does not start listening; call start() after configuring handler.
- *
- * @param config Configuration (copied internally)
- * @return Server instance (caller owns; free with free())
- * @throws SocketHTTPServer_Failed on allocation failure
- */
 extern SocketHTTPServer_T
 SocketHTTPServer_new (const SocketHTTPServer_Config *config);
-
-/**
- * Dispose of server instance and release all resources.
- *
- * Aborts ongoing requests. For clean shutdown, call drain() first.
- * Sets *server to NULL. Idempotent.
- *
- * @param server Pointer to server instance
- */
 extern void SocketHTTPServer_free (SocketHTTPServer_T *server);
-
-/**
- * Bind and start listening for connections.
- *
- * Non-blocking; use process() to handle events.
- *
- * @param server Initialized server instance
- * @return 0 on success, -1 on error
- * @throws SocketHTTPServer_BindFailed on bind/listen errors
- */
 extern int SocketHTTPServer_start (SocketHTTPServer_T server);
-
-/**
- * Stop accepting new connections; existing ones complete normally.
- * Idempotent.
- * @param server Running server instance
- */
 extern void SocketHTTPServer_stop (SocketHTTPServer_T server);
-
-/**
- * Register the request handler callback.
- *
- * @param server   Server instance
- * @param handler  Callback (NULL disables handling)
- * @param userdata Passed to handler on each request
- */
 extern void SocketHTTPServer_set_handler (SocketHTTPServer_T server,
                                           SocketHTTPServer_Handler handler,
                                           void *userdata);
 
-/* ============================================================================
- * Event Loop Integration
- * ============================================================================ */
-
-/**
- * Get listening socket fd for external poll integration.
- * @param server Server instance
- * @return fd >= 0 if listening, -1 otherwise
- */
 extern int SocketHTTPServer_fd (SocketHTTPServer_T server);
-
-/**
- * Main event loop step: poll, accept, parse, handle requests.
- *
- * @param server     Running server
- * @param timeout_ms Max wait time (-1 = infinite)
- * @return Number of requests processed, -1 on fatal error
- */
 extern int SocketHTTPServer_process (SocketHTTPServer_T server,
                                      int timeout_ms);
-
-/**
- * Access internal SocketPoll_T for custom event handling.
- * Do not free the returned poll (server-owned).
- * @param server Server instance
- * @return Internal poll, or NULL if invalid
- */
 extern SocketPoll_T SocketHTTPServer_poll (SocketHTTPServer_T server);
 
-/* ============================================================================
- * Request Accessors
- * ============================================================================ */
-
-/** Get HTTP method. */
 extern SocketHTTP_Method
 SocketHTTPServer_Request_method (SocketHTTPServer_Request_T req);
-
-/** Get request path (decoded, no query string). */
 extern const char *
 SocketHTTPServer_Request_path (SocketHTTPServer_Request_T req);
-
-/** Get query string (raw, NULL if none). */
 extern const char *
 SocketHTTPServer_Request_query (SocketHTTPServer_Request_T req);
-
-/** Get request headers (server-owned, do not free). */
 extern SocketHTTP_Headers_T
 SocketHTTPServer_Request_headers (SocketHTTPServer_Request_T req);
-
-/** Get trailer headers (HTTP/2 only, NULL otherwise). */
 extern SocketHTTP_Headers_T
 SocketHTTPServer_Request_trailers (SocketHTTPServer_Request_T req);
-
-/** Get HTTP/2 :protocol pseudo-header (RFC 8441), NULL if not present. */
 extern const char *
 SocketHTTPServer_Request_h2_protocol (SocketHTTPServer_Request_T req);
-
-/** Get buffered request body (NULL if streaming or no body). */
 extern const void *
 SocketHTTPServer_Request_body (SocketHTTPServer_Request_T req);
-
-/** Get request body length. */
 extern size_t
 SocketHTTPServer_Request_body_len (SocketHTTPServer_Request_T req);
-
-/** Get client IP address as string (format: "IP:port"). */
 extern const char *
 SocketHTTPServer_Request_client_addr (SocketHTTPServer_Request_T req);
-
-/** Get HTTP version. */
 extern SocketHTTP_Version
 SocketHTTPServer_Request_version (SocketHTTPServer_Request_T req);
-
-/** Get per-request arena for temporary allocations. */
 extern Arena_T SocketHTTPServer_Request_arena (SocketHTTPServer_Request_T req);
-
-/** Get approximate memory usage for this connection. */
 extern size_t
 SocketHTTPServer_Request_memory_used (SocketHTTPServer_Request_T req);
 
-/* ============================================================================
- * Response Building
- * ============================================================================ */
-
-/**
- * Set HTTP status code for response.
- * Must be called before headers/body. Defaults to 200.
- */
 extern void SocketHTTPServer_Request_status (SocketHTTPServer_Request_T req,
                                              int code);
-
-/** Add response header. */
 extern void SocketHTTPServer_Request_header (SocketHTTPServer_Request_T req,
                                              const char *name,
                                              const char *value);
-
-/**
- * Add response trailer (HTTP/2 only).
- * @return 0 on success, -1 if unsupported or pseudo-header provided
- */
 extern int SocketHTTPServer_Request_trailer (SocketHTTPServer_Request_T req,
                                              const char *name,
                                              const char *value);
-
-/** Set response body from buffer (sets Content-Length). */
 extern void SocketHTTPServer_Request_body_data (SocketHTTPServer_Request_T req,
                                                 const void *data, size_t len);
-
-/** Set response body from null-terminated string. */
 extern void
 SocketHTTPServer_Request_body_string (SocketHTTPServer_Request_T req,
                                       const char *str);
-
-/**
- * Finalize and send response.
- * Request context invalidated after this call.
- */
 extern void SocketHTTPServer_Request_finish (SocketHTTPServer_Request_T req);
 
-/* ============================================================================
- * Request Body Streaming
- * ============================================================================ */
-
-/**
- * Enable streaming for request body.
- * When enabled, body() returns NULL and chunks arrive via callback.
- */
 extern void
 SocketHTTPServer_Request_body_stream (SocketHTTPServer_Request_T req,
                                       SocketHTTPServer_BodyCallback callback,
                                       void *userdata);
-
-/**
- * Get expected body length from Content-Length.
- * @return Expected bytes, or -1 if chunked/unknown
- */
 extern int64_t
 SocketHTTPServer_Request_body_expected (SocketHTTPServer_Request_T req);
-
-/** Check if request uses chunked transfer encoding. */
 extern int
 SocketHTTPServer_Request_is_chunked (SocketHTTPServer_Request_T req);
 
-/* ============================================================================
- * Response Body Streaming
- * ============================================================================ */
-
-/**
- * Start streaming response (chunked transfer encoding).
- * Call send_chunk() to emit body, then end_stream() to finalize.
- * @return 0 on success, -1 on failure
- */
 extern int
 SocketHTTPServer_Request_begin_stream (SocketHTTPServer_Request_T req);
-
-/**
- * Send a chunk of response body.
- * Requires begin_stream() first.
- * @return 0 on success, -1 on error
- */
 extern int SocketHTTPServer_Request_send_chunk (SocketHTTPServer_Request_T req,
                                                 const void *data, size_t len);
-
-/**
- * End streaming response.
- * @return 0 on success, -1 on error
- */
 extern int
 SocketHTTPServer_Request_end_stream (SocketHTTPServer_Request_T req);
 
-/* ============================================================================
- * HTTP/2 Server Push
- * ============================================================================ */
-
-/**
- * Initiate HTTP/2 server push.
- *
- * @param req     Request context (must be HTTP/2)
- * @param path    Resource path to push
- * @param headers Optional headers for pushed request
- * @return 0 on success, -1 if not HTTP/2 or push disabled
- */
 extern int SocketHTTPServer_Request_push (SocketHTTPServer_Request_T req,
                                           const char *path,
                                           SocketHTTP_Headers_T headers);
-
-/** Check if connection uses HTTP/2. */
 extern int SocketHTTPServer_Request_is_http2 (SocketHTTPServer_Request_T req);
 
-/* ============================================================================
- * WebSocket Upgrade
- * ============================================================================ */
-
-/** Check if request is a WebSocket upgrade attempt. */
 extern int
 SocketHTTPServer_Request_is_websocket (SocketHTTPServer_Request_T req);
-
-/**
- * Accept WebSocket upgrade.
- * Sends 101 Switching Protocols and returns WebSocket handle.
- * HTTP functions invalid after upgrade.
- * @return SocketWS_T on success, NULL on failure
- */
 extern SocketWS_T
 SocketHTTPServer_Request_upgrade_websocket (SocketHTTPServer_Request_T req);
-
-/**
- * Accept WebSocket-over-HTTP/2 (RFC 8441 Extended CONNECT).
- *
- * @param req       HTTP/2 request with :protocol=websocket
- * @param callback  Callback for received DATA
- * @param userdata  Passed to callback
- * @return HTTP/2 stream on success, NULL on failure
- */
 extern SocketHTTP2_Stream_T
 SocketHTTPServer_Request_accept_websocket_h2 (SocketHTTPServer_Request_T req,
                                               SocketHTTPServer_BodyCallback callback,
                                               void *userdata);
 
-/* ============================================================================
- * Rate Limiting
- * ============================================================================ */
-
-/**
- * Register rate limiter for endpoints.
- *
- * Requests matching path_prefix are checked against limiter.
- * NULL prefix = global, NULL limiter = disable for prefix.
- *
- * @param server      Server instance
- * @param path_prefix Path prefix to match (case-sensitive)
- * @param limiter     Rate limiter (caller-owned; server references only)
- */
 extern void SocketHTTPServer_set_rate_limit (SocketHTTPServer_T server,
                                              const char *path_prefix,
                                              SocketRateLimit_T limiter);
 
-/* ============================================================================
- * Request Validation Middleware
- * ============================================================================ */
-
-/**
- * Install middleware validator for incoming requests.
- * Runs after header parsing, before body read/handler.
- *
- * @param server    Server instance
- * @param validator Callback (NULL disables)
- * @param userdata  Passed to validator
- */
 extern void
 SocketHTTPServer_set_validator (SocketHTTPServer_T server,
                                 SocketHTTPServer_Validator validator,
                                 void *userdata);
 
-/* ============================================================================
- * Graceful Shutdown
- * ============================================================================ */
-
-/**
- * Initiate graceful shutdown.
- *
- * Stops accepting new connections, waits for in-flight requests.
- *
- * @param server     Server instance
- * @param timeout_ms Max wait time (-1=infinite, 0=immediate force)
- * @return 0 if started, -1 if already stopped/draining
- */
 extern int SocketHTTPServer_drain (SocketHTTPServer_T server, int timeout_ms);
-
-/**
- * Non-blocking drain progress check.
- * @return >0 connections remaining, 0 fully drained, -1 timed out
- */
 extern int SocketHTTPServer_drain_poll (SocketHTTPServer_T server);
-
-/**
- * Block until drain completes.
- * @param timeout_ms Additional wait time (-1=use drain timeout)
- * @return 0 if drained gracefully, -1 if timed out
- */
 extern int SocketHTTPServer_drain_wait (SocketHTTPServer_T server,
                                         int timeout_ms);
-
-/** Get milliseconds remaining before drain timeout. */
 extern int64_t SocketHTTPServer_drain_remaining_ms (SocketHTTPServer_T server);
-
-/**
- * Register drain completion callback.
- *
- * @param server   Server instance
- * @param callback Completion handler (NULL disables)
- * @param userdata Passed to callback
- */
 extern void
 SocketHTTPServer_set_drain_callback (SocketHTTPServer_T server,
                                      SocketHTTPServer_DrainCallback callback,
                                      void *userdata);
-
-/** Get current server state. */
 extern SocketHTTPServer_State
 SocketHTTPServer_state (SocketHTTPServer_T server);
 
-/* ============================================================================
- * Server Statistics
- * ============================================================================ */
-
-/** Server statistics for monitoring. */
 typedef struct
 {
-  /* Connection stats */
-  size_t active_connections;   /**< Current active connections */
-  size_t total_connections;    /**< Cumulative connections accepted */
-  size_t connections_rejected; /**< Connections rejected (limits) */
+  size_t active_connections;
+  size_t total_connections;
+  size_t connections_rejected;
 
-  /* Request stats */
-  size_t total_requests;      /**< Total requests processed */
-  size_t requests_per_second; /**< Recent RPS */
+  size_t total_requests;
+  size_t requests_per_second;
 
-  /* Byte counters */
-  size_t total_bytes_sent;     /**< Total response bytes */
-  size_t total_bytes_received; /**< Total request bytes */
+  size_t total_bytes_sent;
+  size_t total_bytes_received;
 
-  /* Error stats */
-  size_t errors_4xx;   /**< 4xx client errors */
-  size_t errors_5xx;   /**< 5xx server errors */
-  size_t timeouts;     /**< Timeout closures */
-  size_t rate_limited; /**< Rate-limited requests (429) */
+  size_t errors_4xx;
+  size_t errors_5xx;
+  size_t timeouts;
+  size_t rate_limited;
 
-  /* Latency stats (microseconds) */
-  int64_t avg_request_time_us; /**< Mean request time */
-  int64_t max_request_time_us; /**< Maximum request time */
-  int64_t p50_request_time_us; /**< 50th percentile */
-  int64_t p95_request_time_us; /**< 95th percentile */
-  int64_t p99_request_time_us; /**< 99th percentile */
+  int64_t avg_request_time_us;
+  int64_t max_request_time_us;
+  int64_t p50_request_time_us;
+  int64_t p95_request_time_us;
+  int64_t p99_request_time_us;
 } SocketHTTPServer_Stats;
 
-/** Get server statistics snapshot. */
 extern void SocketHTTPServer_stats (SocketHTTPServer_T server,
                                     SocketHTTPServer_Stats *stats);
-
-/** Reset cumulative statistics counters. */
 extern void SocketHTTPServer_stats_reset (SocketHTTPServer_T server);
 
-/* ============================================================================
- * Static File Serving
- * ============================================================================ */
-
-/**
- * Add static file serving for a directory.
- *
- * Serves files from directory for requests matching prefix.
- * Supports conditional requests and range requests.
- * Path traversal attacks prevented.
- *
- * @param server    Server instance
- * @param prefix    URL prefix (e.g., "/static")
- * @param directory Filesystem directory
- * @return 0 on success, -1 if directory not accessible
- */
 extern int SocketHTTPServer_add_static_dir (SocketHTTPServer_T server,
                                             const char *prefix,
                                             const char *directory);
 
-/* ============================================================================
- * Middleware
- * ============================================================================ */
-
-/**
- * Middleware callback.
- *
- * @param req      Request context
- * @param userdata Middleware-specific data
- * @return 0 to continue, non-zero to stop (request handled)
- */
 typedef int (*SocketHTTPServer_Middleware) (SocketHTTPServer_Request_T req,
                                             void *userdata);
-
-/**
- * Add request middleware.
- *
- * Middleware executes in order before the main handler.
- *
- * @param server     Server instance
- * @param middleware Callback
- * @param userdata   Passed to callback
- * @return 0 on success, -1 if too many middleware
- */
 extern int SocketHTTPServer_add_middleware (SocketHTTPServer_T server,
                                             SocketHTTPServer_Middleware middleware,
                                             void *userdata);
 
-/**
- * Error handler callback for custom error pages.
- *
- * @param req         Request context (status already set)
- * @param status_code HTTP status (400-599)
- * @param userdata    Handler-specific data
- */
 typedef void (*SocketHTTPServer_ErrorHandler) (SocketHTTPServer_Request_T req,
                                                int status_code, void *userdata);
-
-/**
- * Set custom error page handler.
- *
- * @param server  Server instance
- * @param handler Error handler (NULL resets to default)
- * @param userdata Passed to handler
- */
 extern void SocketHTTPServer_set_error_handler (SocketHTTPServer_T server,
                                                 SocketHTTPServer_ErrorHandler handler,
                                                 void *userdata);


### PR DESCRIPTION
## Summary
- Remove redundant inline comments from struct fields in private headers
- Remove section dividers (`/* ===== */`) from all HTTP headers  
- Simplify verbose doxygen blocks to concise declarations
- Remove `@brief` tags on self-explanatory defines/constants

Files modified (10):
- SocketHTTPClient-private.h
- SocketHTTPClient-config.h
- SocketHTTPClient.h
- SocketHTTPServer-private.h
- SocketHTTPServer.h
- SocketHPACK-private.h
- SocketHPACK.h
- SocketHTTP-private.h
- SocketHTTP1-private.h
- SocketHTTP2-private.h

Net reduction: 1,552 lines (1,884 deletions, 332 additions)

Fixes #73

## Test plan
- [x] Build succeeds
- [x] All 70 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)