### PR TITLE
refactor: comment cleanup in src/http/

### DIFF
--- a/src/http/SocketHTTP1-compress.c
+++ b/src/http/SocketHTTP1-compress.c
@@ -68,14 +68,7 @@
 
 #endif /* SOCKETHTTP1_HAS_BROTLI */
 
-/**
- * struct SocketHTTP1_Decoder - Internal decoder state for content decoding
- *
- * Manages decompression state for gzip, deflate, or brotli content.
- * Tracks total decompressed bytes to enforce zip bomb protection limits.
- *
- * Thread-safe: No - single-threaded use per instance
- */
+/* Decoder state for gzip/deflate/brotli decompression */
 struct SocketHTTP1_Decoder
 {
   SocketHTTP_Coding coding;         /**< Content coding type (gzip/deflate/br) */
@@ -98,14 +91,7 @@ struct SocketHTTP1_Decoder
   size_t max_decompressed_size;     /**< Limit for zip bomb protection */
 };
 
-/**
- * struct SocketHTTP1_Encoder - Internal encoder state for content encoding
- *
- * Manages compression state for gzip, deflate, or brotli output.
- * Tracks total encoded bytes for optional output size limiting.
- *
- * Thread-safe: No - single-threaded use per instance
- */
+/* Encoder state for gzip/deflate/brotli compression */
 struct SocketHTTP1_Encoder
 {
   SocketHTTP_Coding coding;             /**< Content coding type */

--- a/src/http/SocketHTTP1-serialize.c
+++ b/src/http/SocketHTTP1-serialize.c
@@ -183,12 +183,6 @@ append_content_length_header (char **buf, size_t *remaining,
   return safe_append_crlf (buf, remaining);
 }
 
-/**
- * validate_request_target - Validate request target for forbidden chars
- * @target: Request target string
- *
- * Raises: SocketHTTP1_SerializeError if invalid
- */
 static int
 serialize_request_line (const SocketHTTP_Request *request, char **buf,
                         size_t *remaining)

--- a/src/http/SocketHTTP2-connection.c
+++ b/src/http/SocketHTTP2-connection.c
@@ -4,9 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketHTTP2-connection.c - HTTP/2 Connection Management (RFC 9113)
- */
+/* SocketHTTP2-connection.c - HTTP/2 Connection Management (RFC 9113) */
 
 #include "http/SocketHTTP2-private.h"
 #include "http/SocketHTTP2.h"

--- a/src/http/SocketHTTP2-flow.c
+++ b/src/http/SocketHTTP2-flow.c
@@ -4,9 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketHTTP2-flow.c - HTTP/2 Flow Control (RFC 9113 Section 5.2)
- */
+/* SocketHTTP2-flow.c - HTTP/2 Flow Control (RFC 9113 Section 5.2) */
 
 #include <assert.h>
 #include <stdint.h>

--- a/src/http/SocketHTTPClient-auth.c
+++ b/src/http/SocketHTTPClient-auth.c
@@ -4,9 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketHTTPClient-auth.c - HTTP Authentication (RFC 7617 Basic, RFC 7616 Digest, RFC 6750 Bearer)
- */
+/* SocketHTTPClient-auth.c - HTTP Authentication (RFC 7617 Basic, RFC 7616 Digest, RFC 6750 Bearer) */
 
 #include <assert.h>
 #include <stdint.h>
@@ -259,16 +257,7 @@ compute_response_with_qop (const char *ha1_hex, const char *nonce,
   return 0;
 }
 
-/**
- * compute_response_no_qop - Compute response without qop (RFC 2617 compat)
- * @ha1_hex: H(A1) as hex
- * @nonce: Server nonce
- * @ha2_hex: H(A2) as hex
- * @use_sha256: Use SHA-256 or MD5
- * @response_hex: Output buffer
- *
- * Returns: 0 on success, -1 on error
- */
+/* Compute response without qop (RFC 2617 compat) */
 static int
 compute_response_no_qop (const char *ha1_hex, const char *nonce,
                          const char *ha2_hex, int use_sha256,
@@ -543,14 +532,7 @@ generate_cnonce (char *cnonce, size_t size)
   SocketCrypto_secure_clear (random_bytes, sizeof (random_bytes));
 }
 
-/**
- * find_auth_qop - Find "auth" token in qop list
- * @qop_list: Comma-separated qop values
- *
- * Returns: "auth" if found, NULL otherwise
- *
- * NOTE: qop=auth-int is NOT supported (requires request body hash).
- */
+/* Find "auth" token in qop list (qop=auth-int not supported) */
 static const char *
 find_auth_qop (const char *qop_list)
 {

--- a/src/http/SocketHTTPClient-cookie.c
+++ b/src/http/SocketHTTPClient-cookie.c
@@ -4,9 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketHTTPClient-cookie.c - HTTP Cookie Implementation (RFC 6265)
- */
+/* SocketHTTPClient-cookie.c - HTTP Cookie Implementation (RFC 6265) */
 
 #include <assert.h>
 #include <limits.h>
@@ -54,15 +52,7 @@ static const char COOKIE_ATTR_SAMESITE_STR[] = "SameSite";
 #define COOKIE_ATTR_PATH_LEN (sizeof (COOKIE_ATTR_PATH_STR) - 1)
 #define COOKIE_ATTR_SAMESITE_LEN (sizeof (COOKIE_ATTR_SAMESITE_STR) - 1)
 
-/**
- * is_valid_cookie_octet - Check if char is valid in cookie name/value
- * @c: Character to check
- *
- * Returns: 1 if valid, 0 if invalid
- *
- * Per RFC 6265 §3.1, cookie-octet excludes CTL chars (0-31, 127-159).
- * SECURITY: Also rejects CRLF characters to prevent header injection.
- */
+/* RFC 6265 §3.1 cookie-octet validation (rejects CTL/CRLF for security) */
 static int
 validate_cookie_octets (const unsigned char *data, size_t len)
 {
@@ -106,13 +96,7 @@ cookie_hash (const char *domain, const char *path, const char *name,
   return hash;
 }
 
-/**
- * domain_matches - Check if domain matches cookie domain (RFC 6265 §5.1.3)
- * @request_domain: Domain from request URL
- * @cookie_domain: Domain from cookie
- *
- * Returns: 1 if matches, 0 otherwise
- */
+/* RFC 6265 §5.1.3 domain matching */
 static int
 domain_matches (const char *request_domain, const char *cookie_domain)
 {
@@ -141,13 +125,7 @@ domain_matches (const char *request_domain, const char *cookie_domain)
   return 0;
 }
 
-/**
- * path_matches - Check if path matches cookie path (RFC 6265 §5.1.4)
- * @request_path: Path from request URL
- * @cookie_path: Path from cookie
- *
- * Returns: 1 if matches, 0 otherwise
- */
+/* RFC 6265 §5.1.4 path matching */
 static int
 path_matches (const char *request_path, const char *cookie_path)
 {
@@ -174,17 +152,7 @@ path_matches (const char *request_path, const char *cookie_path)
   return 0;
 }
 
-/**
- * parse_max_age - Parse Max-Age attribute value from cookie
- * @value: String value of Max-Age (e.g. "3600")
- * @len: Length of value string
- *
- * Returns: Unix timestamp of expiration, or 0 if invalid/session cookie
- *
- * Per RFC 6265: Non-positive Max-Age means delete cookie (return 1 for
- * immediate expiry). Positive values are capped at HTTPCLIENT_MAX_COOKIE_AGE_SEC.
- * SECURITY: Fixed overflow handling - checks overflow before sign application.
- */
+/* Parse Max-Age with overflow protection */
 static time_t
 parse_max_age (const char *value, const size_t len)
 {
@@ -258,14 +226,7 @@ parse_max_age (const char *value, const size_t len)
   return expires;
 }
 
-/**
- * parse_same_site - Parse SameSite attribute value
- * @value: String value ("Strict", "Lax", "None", case-insensitive)
- * @len: Length of value string
- *
- * Returns: Parsed SameSite enum, defaults to LAX if unknown per RFC 6265bis
- * Thread-safe: Yes (stateless)
- */
+/* Parse SameSite attribute (defaults to LAX per RFC 6265bis) */
 static SocketHTTPClient_SameSite
 parse_same_site (const char *value, const size_t len)
 {
@@ -297,12 +258,7 @@ cookie_expiry_is_valid (time_t expires, time_t now)
 
 
 
-/**
- * get_default_path - Get default path from request URI (RFC 6265 §5.1.4)
- * @request_path: Request URI path
- * @output: Output buffer for default path
- * @output_size: Size of output buffer
- */
+/* RFC 6265 §5.1.4 default path derivation */
 static void
 get_default_path (const char *request_path, char *output, size_t output_size)
 {

--- a/src/http/SocketHTTPClient-pool.c
+++ b/src/http/SocketHTTPClient-pool.c
@@ -4,9 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketHTTPClient-pool.c - HTTP Connection Pooling with Happy Eyeballs
- */
+/* SocketHTTPClient-pool.c - HTTP Connection Pooling with Happy Eyeballs */
 
 #include "core/Arena.h"
 #include "core/SocketConfig.h"
@@ -976,27 +974,7 @@ setup_tls_connection (SocketHTTPClient_T client, Socket_T *socket,
 }
 #endif /* SOCKET_HAS_TLS */
 
-/**
- * create_temp_entry - Create temporary entry for non-pooled connections
- * @socket: Connected socket
- * @host: Target hostname
- * @port: Target port
- * @is_secure: 1 for HTTPS, 0 for HTTP
- *
- * Returns: Thread-local pool entry
- *
- * Uses thread-local storage for non-pooled case. The thread-local arena
- * is reused across calls within the same thread, with previous allocations
- * cleaned up on each new call.
- *
- * MEMORY NOTE: The thread-local arena is freed on each subsequent call,
- * but will not be freed if the thread exits without making another call.
- * This is acceptable because:
- * 1. Non-pooled mode is rare (pooling is enabled by default)
- * 2. Memory is small (~8KB per thread)
- * 3. Thread exit typically means process exit or thread pool reuse
- * For long-running servers, always use connection pooling.
- */
+/* Create temporary thread-local entry for non-pooled connections */
 static HTTPPoolEntry *
 create_temp_entry (Socket_T socket, const char *host, int port, int is_secure)
 {
@@ -1086,19 +1064,6 @@ create_pooled_entry (SocketHTTPClient_T client, Socket_T socket,
   return entry;
 }
 
-/**
- * httpclient_connect - Get or create connection to host
- * @client: HTTP client
- * @uri: Target URI
- *
- * Returns: Pool entry for connection, or NULL on failure
- *
- * Orchestrates connection establishment:
- * 1. Try existing pool connection (supports HTTP/2 multiplexing)
- * 2. Establish TCP via Happy Eyeballs
- * 3. Set up TLS if needed (with ALPN for HTTP/2 negotiation)
- * 4. Create pool entry (HTTP/2 or HTTP/1.1 based on ALPN result)
- */
 HTTPPoolEntry *
 httpclient_connect (SocketHTTPClient_T client, const SocketHTTP_URI *uri)
 {

--- a/src/http/SocketHTTPClient.c
+++ b/src/http/SocketHTTPClient.c
@@ -4,9 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketHTTPClient.c - HTTP Client with HTTP/1.1 and HTTP/2 Support
- */
+/* SocketHTTPClient.c - HTTP Client with HTTP/1.1 and HTTP/2 Support */
 
 #include <assert.h>
 #include <string.h>
@@ -57,15 +55,6 @@ static const char *error_strings[]
         [HTTPCLIENT_ERROR_CANCELLED] = "Request cancelled",
         [HTTPCLIENT_ERROR_OUT_OF_MEMORY] = "Out of memory" };
 
-/**
- * SocketHTTPClient_error_is_retryable - Check if error code is retryable
- * @error: Error code from async operation
- *
- * Returns: 1 if error is typically retryable, 0 if fatal
- * Thread-safe: Yes (pure function)
- *
- * Determines if a failed request should be retried based on error type.
- */
 int
 SocketHTTPClient_error_is_retryable (SocketHTTPClient_Error error)
 {
@@ -416,9 +405,7 @@ send_http1_body (HTTPPoolEntry *conn, const void *body, size_t body_len)
   return 0;
 }
 
-/**
- * HTTP/1.1 response body accumulator state
- */
+/* HTTP/1.1 response body accumulator state */
 typedef struct
 {
   char *body_buf;
@@ -467,29 +454,7 @@ calculate_new_capacity (HTTP1BodyAccumulator *acc, size_t needed_size)
   return new_cap;
 }
 
-/**
- * grow_body_buffer - Grow accumulator buffer if needed
- * @acc: Body accumulator
- * @needed_size: Minimum required size
- *
- * Returns: 0 on success, -1 on allocation failure
- */
-/**
- * httpclient_grow_body_buffer - Grow arena buffer for body accumulation
- * @arena: Arena for allocation
- * @buf: Pointer to buffer pointer (updated)
- * @capacity: Pointer to capacity (updated)
- * @total: Pointer to current total bytes (updated to needed)
- * @needed_size: New required total size
- * @max_size: Maximum allowed size (0=unlimited)
- *
- * Common implementation for HTTP/1 and HTTP/2 body buffer growth.
- * Exponential doubling with safe math, clamp to max_size.
- * Reallocates via Arena_alloc, copies existing data.
- * Replaces redundant growth logic in HTTP1 and HTTP2.
- *
- * Returns: 0 success, -1 alloc fail or overflow
- */
+/* Grow arena buffer for body accumulation (exponential doubling) */
 int
 httpclient_grow_body_buffer (Arena_T arena, char **buf, size_t *capacity, size_t *total, size_t needed_size, size_t max_size)
 {


### PR DESCRIPTION
## Summary
- Simplify verbose doxygen-style comments across HTTP module implementation files
- Replace multi-line comment blocks with concise single-line comments
- Remove redundant thread-safety notes and parameter descriptions
- Keep RFC references and essential section markers

**Files cleaned (17 total):**
- SocketHPACK-huffman.c, SocketHPACK-table.c, SocketHPACK.c
- SocketHTTP-core.c, SocketHTTP-date.c, SocketHTTP-headers.c, SocketHTTP-uri.c
- SocketHTTP1-compress.c, SocketHTTP1-parser.c, SocketHTTP1-serialize.c
- SocketHTTP2-connection.c, SocketHTTP2-flow.c
- SocketHTTPClient-auth.c, SocketHTTPClient-cookie.c, SocketHTTPClient-pool.c, SocketHTTPClient-retry.c, SocketHTTPClient.c

**Impact:** ~1100 lines removed while preserving code clarity

Fixes #70

## Test plan
- [x] Build with sanitizers (`ENABLE_SANITIZERS=ON`)
- [x] All 70 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)