### PR TITLE
refactor: comment cleanup in src/socket/

### DIFF
--- a/src/socket/Socket-convenience.c
+++ b/src/socket/Socket-convenience.c
@@ -4,45 +4,6 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * @file Socket-convenience.c
- * @ingroup core_io
- * @brief High-level convenience functions for socket setup and connections
- *
- * This split implementation file provides simplified APIs for common socket
- * patterns, reducing boilerplate code while maintaining full control and safety.
- * Functions combine creation, configuration, binding, listening, connecting,
- * and timeout handling into single calls.
- *
- * ## Key Features
- *
- * - **TCP Convenience**: Quick server/client setup with reuseaddr and timeouts
- * - **Timed Operations**: Accept and connect with poll-based timeouts and EINTR retry
- * - **Non-blocking Support**: Initiate async connects, temporary mode management
- * - **Unix Domain**: Full support for filesystem and abstract sockets (Linux)
- * - **Error Handling**: Consistent exception raising with detailed messages
- * - **Mode Preservation**: Automatic restoration of original blocking/non-blocking state
- *
- * ## Module Dependencies
- *
- * - Foundation: Arena, Except for memory/error handling
- * - Core I/O: Socket base API (bind, listen, connect, accept)
- * - Utilities: SocketUtil for logging, timeouts, error categorization
- *
- * ## Usage Philosophy
- *
- * Designed for rapid prototyping and production use cases where simplicity
- * outweighs low-level customization. For advanced scenarios (e.g., custom options,
- * IPv6 dual-stack, event integration), use base Socket API directly.
- *
- * All functions are thread-safe and integrate seamlessly with SocketPoll and SocketPool.
- *
- * @see Socket.h for declarations and base API
- * @see core/SocketUtil.h for shared utilities and macros
- * @see docs/ASYNC_IO.md for integration with event systems
- * @see docs/ERROR_HANDLING.md for exception patterns
- */
-
 #include <arpa/inet.h>
 #include <assert.h>
 #include <errno.h>
@@ -65,26 +26,10 @@
 
 #define T Socket_T
 
-/* Declare module-specific exception using centralized macros */
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketConvenience);
 
-/* Macro to raise exception with detailed error message */
 #define RAISE_MODULE_ERROR(e) SOCKET_RAISE_MODULE_ERROR (SocketConvenience, e)
 
-/* ============================================================================
- * Static Helper Functions
- * ============================================================================
- */
-
-
-/**
- * get_socket_flags - Get current socket flags with error handling
- * @fd: File descriptor to query
- * @flags_out: Output parameter for flags
- *
- * Returns: 0 on success, -1 on error (raises exception)
- * Thread-safe: Yes
- */
 static int
 get_socket_flags (int fd, int *flags_out)
 {
@@ -103,14 +48,6 @@ get_socket_flags (int fd, int *flags_out)
         return 0;
 }
 
-/**
- * set_nonblocking_mode - Set socket to non-blocking mode
- * @fd: File descriptor
- * @original_flags: Current flags value
- *
- * Returns: 0 on success, -1 on error (raises exception)
- * Thread-safe: Yes
- */
 static int
 set_nonblocking_mode (int fd, int original_flags)
 {
@@ -122,16 +59,6 @@ set_nonblocking_mode (int fd, int original_flags)
         return 0;
 }
 
-/**
- * restore_blocking_mode - Restore socket to original blocking mode
- * @fd: File descriptor
- * @original_flags: Original flags to restore
- *
- * Thread-safe: Yes
- *
- * Logs warning on failure but does not raise exception, as this is
- * typically called in cleanup paths where we want to continue.
- */
 static void
 restore_blocking_mode (int fd, int original_flags)
 {
@@ -144,15 +71,6 @@ restore_blocking_mode (int fd, int original_flags)
                 }
 }
 
-/**
- * check_connect_result - Check result of non-blocking connect via SO_ERROR
- * @fd: File descriptor
- * @context_path: Path or address for error message context
- *
- * Returns: 0 on success
- * Raises: Socket_Failed on error
- * Thread-safe: Yes
- */
 static int
 check_connect_result (int fd, const char *context_path)
 {
@@ -166,16 +84,6 @@ check_connect_result (int fd, const char *context_path)
         return 0;
 }
 
-/**
- * parse_ip_address - Parse IPv4 or IPv6 address string
- * @ip_address: IP address string to parse
- * @addr: Output sockaddr_storage
- * @addrlen: Output address length
- *
- * Returns: 0 on success
- * Raises: Socket_Failed if address is invalid
- * Thread-safe: Yes
- */
 static int
 parse_ip_address (const char *ip_address, struct sockaddr_storage *addr,
                   socklen_t *addrlen, int port)
@@ -189,7 +97,6 @@ parse_ip_address (const char *ip_address, struct sockaddr_storage *addr,
 
         memset (addr, 0, sizeof (*addr));
 
-        /* Try IPv4 first */
         addr4 = (struct sockaddr_in *)addr;
         if (inet_pton (AF_INET, ip_address, &addr4->sin_addr) == 1)
                 {
@@ -199,7 +106,6 @@ parse_ip_address (const char *ip_address, struct sockaddr_storage *addr,
                         return 0;
                 }
 
-        /* Try IPv6 */
         addr6 = (struct sockaddr_in6 *)addr;
         if (inet_pton (AF_INET6, ip_address, &addr6->sin6_addr) == 1)
                 {
@@ -209,40 +115,13 @@ parse_ip_address (const char *ip_address, struct sockaddr_storage *addr,
                         return 0;
                 }
 
-        /* Invalid address */
         SOCKET_ERROR_MSG ("Invalid IP address (not IPv4 or IPv6): %.*s",
                           SOCKET_ERROR_MAX_HOSTNAME, ip_address);
         RAISE_MODULE_ERROR (Socket_Failed);
 
-        return -1; /* Unreachable, but satisfies compiler */
+        return -1;
 }
 
-/**
- * @brief Temporarily manage socket non-blocking mode for timed operations.
- * @ingroup core_io
- *
- * Centralizes logic to set socket to non-blocking mode before timed operations
- * and restore original mode afterward. Used by convenience functions to avoid
- * code duplication.
- *
- * Call with enable=1 before TRY to setup, and enable=0 in FINALLY to cleanup.
- * If socket already non-blocking, no change is made.
- *
- * @param[in] fd File descriptor of socket
- * @param[in] enable 1=setup non-blocking, 0=restore original
- * @param[out] original_flags Stores original flags when enabling (volatile compatible)
- * @param[out] need_restore Tracks if restore was needed (volatile compatible)
- *
- * @threadsafe Yes - atomic fcntl operations, no shared state
- *
- * @note Designed for use with volatile int locals in TRY/EXCEPT contexts to prevent clobbering
- * @note Does not raise exceptions; logs warnings on restore failure (non-fatal)
- * @note Uses local copy for fcntl to avoid volatile access issues in system calls
- *
- * @see Socket_accept_timeout()
- * @see Socket_connect_unix_timeout()
- * @see .cursorrules#volatile-variables-with-tryexcept-critical
- */
 static void
 with_nonblocking_scope (int fd, int enable, volatile int *original_flags, volatile int *need_restore)
 {
@@ -251,7 +130,6 @@ with_nonblocking_scope (int fd, int enable, volatile int *original_flags, volati
         assert (need_restore != NULL);
 
         if (!enable) {
-                /* Restore original blocking mode if we changed it */
                 if (*need_restore) {
                         restore_blocking_mode (fd, (int)*original_flags);
                         *need_restore = 0;
@@ -259,7 +137,6 @@ with_nonblocking_scope (int fd, int enable, volatile int *original_flags, volati
                 return;
         }
 
-        /* Setup non-blocking if not already set - use local copy for syscalls */
         int flags_copy;
         get_socket_flags (fd, &flags_copy);
         *original_flags = flags_copy;
@@ -271,67 +148,6 @@ with_nonblocking_scope (int fd, int enable, volatile int *original_flags, volati
         }
 }
 
-/* ============================================================================
- * TCP Convenience Functions
- * ============================================================================
- */
-
-/**
- * @brief Create and configure listening TCP server socket in single call.
- * @ingroup core_io
- *
- * High-level convenience for TCP server setup: creates IPv4 TCP socket,
- * enables SO_REUSEADDR for fast restarts, binds to specified host/port,
- * and starts listening with given backlog. Ready for immediate Socket_accept() calls.
- *
- * Supports INADDR_ANY (NULL or "") for all interfaces; port 0 assigns ephemeral port.
- * Does not support IPv6 (use Socket_new(AF_INET6, ...) for dual-stack).
- *
- * @param[in] host Bind address (IPv4 or NULL/"" for 0.0.0.0)
- * @param[in] port Local port (0-65535; 0=ephemeral)
- * @param[in] backlog Listen queue depth (SOMAXCONN recommended for production)
- *
- * @return New listening Socket_T ready for accepts
- *
- * @throws Socket_Failed On socket creation failure, bind error (EADDRINUSE, EACCES),
- *                       listen failure, or invalid params (port/backlog)
- *
- * @threadsafe Yes - creates independent new socket
- *
- * ## Usage Example
- *
- * @code{.c}
- * // Simple HTTP server setup
- * Socket_T server = Socket_listen_tcp(NULL, 8080, SOMAXCONN);
- * if (server) {
- *   while (running) {
- *     Socket_T client = Socket_accept_timeout(server, 1000);  // Optional timeout
- *     if (client) {
- *       // Handle client...
- *       Socket_free(&client);
- *     }
- *   }
- *   Socket_free(&server);
- * }
- * @endcode
- *
- * ## Configuration Notes
- *
- * - SO_REUSEADDR enabled to allow bind after quick server crashes/restarts
- * - SO_REUSEPORT not set (use Socket_setreuseport() post-creation for load balancing)
- * - Backlog clamped internally if invalid (see listen(2) man page)
- * - No TLS/Proxy/DNS config; apply post-creation via SocketTLS_enable() etc.
- *
- * @note IPv4 only; for IPv6: Socket_new(AF_INET6, SOCK_STREAM, 0) + manual bind/listen
- * @warning Port <1024 requires root privileges (or setcap)
- * @note Ephemeral port: Check Socket_getlocalport(server) after bind
- * @complexity O(1)
- *
- * @see Socket_listen_unix() for Unix domain equivalent
- * @see Socket_bind() and Socket_listen() for low-level control
- * @see Socket_setreuseport() for multi-process sharing
- * @see SocketPool_accept_limited() for pooled accepts with limits
- */
 T
 Socket_listen_tcp (const char *host, int port, int backlog)
 {
@@ -342,16 +158,9 @@ Socket_listen_tcp (const char *host, int port, int backlog)
 
         TRY
         {
-                /* Create IPv4 TCP socket */
                 server = Socket_new (AF_INET, SOCK_STREAM, 0);
-
-                /* Enable address reuse for quick restart */
                 Socket_setreuseaddr (server);
-
-                /* Bind to address/port */
                 Socket_bind (server, host, port);
-
-                /* Start listening */
                 Socket_listen (server, backlog);
         }
         EXCEPT (Socket_Failed)
@@ -365,20 +174,6 @@ Socket_listen_tcp (const char *host, int port, int backlog)
         return server;
 }
 
-/**
- * Socket_connect_tcp - Create a connected TCP client socket in one call
- * @host: Remote address (IP or hostname)
- * @port: Remote port (1-65535)
- * @timeout_ms: Connection timeout in milliseconds (0 = no timeout)
- *
- * Returns: New connected socket
- * Raises: Socket_Failed on error or timeout
- * Thread-safe: Yes
- *
- * Combines Socket_new(), timeout configuration, and Socket_connect()
- * into a single convenient call. If timeout_ms > 0, the connection
- * attempt will fail with ETIMEDOUT if it takes longer than specified.
- */
 T
 Socket_connect_tcp (const char *host, int port, int timeout_ms)
 {
@@ -390,10 +185,8 @@ Socket_connect_tcp (const char *host, int port, int timeout_ms)
 
         TRY
         {
-                /* Create IPv4 TCP socket */
                 client = Socket_new (AF_INET, SOCK_STREAM, 0);
 
-                /* Set connect timeout if specified */
                 if (timeout_ms > 0)
                         {
                                 SocketTimeouts_T timeouts = { 0 };
@@ -402,7 +195,6 @@ Socket_connect_tcp (const char *host, int port, int timeout_ms)
                                 Socket_timeouts_set (client, &timeouts);
                         }
 
-                /* Connect to remote host */
                 Socket_connect (client, host, port);
         }
         EXCEPT (Socket_Failed)
@@ -416,69 +208,6 @@ Socket_connect_tcp (const char *host, int port, int timeout_ms)
         return client;
 }
 
-/**
- * @brief Accept incoming connection with configurable timeout behavior.
- * @ingroup core_io
- *
- * Performs timed or blocking accept on listening socket. Behavior varies by timeout_ms:
- *
- * - -1: Blocks indefinitely using standard blocking accept (no mode change)
- * - 0: Immediate non-blocking check (temporarily enables non-blocking if needed)
- * - >0: Polls for POLLIN up to timeout_ms, then accepts if ready
- *
- * Returns NULL on timeout for positive timeouts without raising exception.
- * Restores original socket blocking mode after finite/immediate operations.
- *
- * @param[in] socket Listening Socket_T (must be bound and listening)
- * @param[in] timeout_ms Timeout: -1=infinite block, 0=immediate, >0=ms timeout
- *
- * @return New connected Socket_T on success, NULL on timeout (positive timeout_ms)
- *
- * @throws Socket_Failed On accept failure, poll error, invalid socket/fd, or system errors (EAGAIN not considered failure)
- *
- * @threadsafe Yes - per-socket operation, thread-local error buffers and mode restoration
- *
- * ## Usage Example
- *
- * @code{.c}
- * Socket_T server = Socket_listen_tcp("127.0.0.1", 8080, 128);
- *
- * // Block forever (traditional blocking accept)
- * Socket_T client1 = Socket_accept_timeout(server, -1);
- *
- * // Wait max 5s for connection
- * Socket_T client2 = Socket_accept_timeout(server, 5000);
- * if (client2 == NULL) {
- *     SOCKET_LOG_INFO_MSG("Accept timeout - no connection");
- *     // Continue or retry
- * }
- *
- * // Non-blocking immediate check
- * Socket_T client3 = Socket_accept_timeout(server, 0);
- * if (client3 == NULL) {
- *     // No pending connection
- * }
- *
- * Socket_free(&server);
- * @endcode
- *
- * ## Edge Cases and Notes
- *
- * - If socket already non-blocking, mode not changed
- * - Compatible with event loops (SocketPoll integration via non-blocking poll)
- * - For -1, relies on socket's configured timeouts if any (SO_RCVTIMEO etc.)
- * - Poll uses EINTR retry internally for signal safety
- * - On Windows, uses WSAPoll equivalent (poll emulation)
- *
- * @warning Listening socket state not validated; ensure Socket_islistening(socket) == 1
- * @note IPv4/IPv6/Unix domain supported via underlying Socket_accept()
- * @complexity O(1) average; O(timeout_ms / poll_interval) worst for long timeouts
- *
- * @see Socket_accept() base accept without timeout
- * @see Socket_listen_tcp() for TCP server creation
- * @see SocketPoll_add() for event-driven accept
- * @see docs/ASYNC_IO.md for non-blocking patterns
- */
 T
 Socket_accept_timeout (T socket, int timeout_ms)
 {
@@ -487,7 +216,6 @@ Socket_accept_timeout (T socket, int timeout_ms)
         assert (socket);
 
         if (timeout_ms == -1) {
-                /* Infinite block: use standard blocking accept, no mode change */
                 TRY {
                         client = Socket_accept (socket);
                 } EXCEPT (Socket_Failed) {
@@ -496,7 +224,6 @@ Socket_accept_timeout (T socket, int timeout_ms)
                 return client;
         }
 
-        /* Finite timeout or immediate: enable non-blocking mode temporarily */
         int original_flags;
         volatile int need_restore = 0;
         with_nonblocking_scope (fd, 1, &original_flags, &need_restore);
@@ -508,18 +235,16 @@ Socket_accept_timeout (T socket, int timeout_ms)
                 int poll_result;
 
                 if (timeout_ms > 0) {
-                        /* Poll for readiness with timeout */
                         poll_result = socket_poll_eintr_retry (&pfd, timeout_ms);
                         if (poll_result < 0) {
                                 SOCKET_ERROR_FMT ("poll() failed in accept_timeout");
                                 RAISE_MODULE_ERROR (Socket_Failed);
                         }
                         if (poll_result == 0) {
-                                /* Timeout expired */
                                 client = NULL;
                                 do_accept = 0;
                         }
-                } /* else timeout_ms == 0: immediate non-blocking accept, do_accept=1 */
+                }
 
                 if (do_accept) {
                         client = Socket_accept (socket);
@@ -527,7 +252,6 @@ Socket_accept_timeout (T socket, int timeout_ms)
         }
         FINALLY
         {
-                /* Restore original mode */
                 with_nonblocking_scope (fd, 0, &original_flags, &need_restore);
         }
         END_TRY;
@@ -535,24 +259,6 @@ Socket_accept_timeout (T socket, int timeout_ms)
         return client;
 }
 
-/**
- * Socket_connect_nonblocking - Initiate non-blocking connect (IP only)
- * @socket: Socket (will be set to non-blocking)
- * @ip_address: Remote IP address (IPv4 or IPv6, no hostnames)
- * @port: Remote port (1-65535)
- *
- * Returns: 0 if connected immediately, 1 if connection in progress
- * Raises: Socket_Failed on invalid IP or immediate failure
- * Thread-safe: Yes
- *
- * Initiates a non-blocking connect operation. The socket is set to
- * non-blocking mode before connecting. If the connection cannot be
- * completed immediately (common for TCP), returns 1 and the caller
- * should poll for POLLOUT to determine when the connection completes.
- *
- * Note: Does not accept hostnames - use Socket_connect() for hostname
- * resolution or SocketDNS for async resolution.
- */
 int
 Socket_connect_nonblocking (T socket, const char *ip_address, int port)
 {
@@ -567,53 +273,25 @@ Socket_connect_nonblocking (T socket, const char *ip_address, int port)
 
         fd = Socket_fd (socket);
 
-        /* Parse IP address */
         parse_ip_address (ip_address, &addr, &addrlen, port);
-
-        /* Set socket to non-blocking mode */
         Socket_setnonblocking (socket);
-
-        /* Initiate connect */
         result = connect (fd, (struct sockaddr *)&addr, addrlen);
 
         if (result == 0)
                 {
-                        /* Connected immediately (rare for TCP, common for Unix domain) */
                         return 0;
                 }
 
         if (errno == EINPROGRESS || errno == EINTR)
                 {
-                        /* Connection in progress - caller should poll for POLLOUT */
                         return 1;
                 }
 
-        /* Immediate failure */
         SOCKET_ERROR_FMT ("Connect to %.*s:%d failed", SOCKET_ERROR_MAX_HOSTNAME,
                           ip_address, port);
         RAISE_MODULE_ERROR (Socket_Failed);
 }
 
-/* ============================================================================
- * Unix Domain Socket Convenience Functions
- * ============================================================================
- */
-
-/**
- * Socket_listen_unix - Create a listening Unix domain socket in one call
- * @path: Socket file path (or '@' prefix for abstract namespace on Linux)
- * @backlog: Maximum pending connections (must be > 0)
- *
- * Returns: New listening Unix domain socket
- * Raises: Socket_Failed on error
- * Thread-safe: Yes
- *
- * Combines Socket_new(), Socket_bind_unix(), and Socket_listen() into
- * a single convenient call. For filesystem paths, any existing socket
- * file is removed before binding (handled by Socket_bind_unix).
- *
- * For abstract namespace sockets (Linux only), prefix the path with '@'.
- */
 T
 Socket_listen_unix (const char *path, int backlog)
 {
@@ -624,13 +302,8 @@ Socket_listen_unix (const char *path, int backlog)
 
         TRY
         {
-                /* Create Unix domain stream socket */
                 server = Socket_new (AF_UNIX, SOCK_STREAM, 0);
-
-                /* Bind to path */
                 Socket_bind_unix (server, path);
-
-                /* Start listening */
                 Socket_listen (server, backlog);
         }
         EXCEPT (Socket_Failed)
@@ -644,72 +317,7 @@ Socket_listen_unix (const char *path, int backlog)
         return server;
 }
 
-/**
- * @brief Connect to Unix domain socket with optional timeout control.
- * @ingroup core_io
- *
- * Establishes a connection to a Unix domain server socket. Supports both blocking
- * and timed non-blocking connection attempts.
- *
- * - timeout_ms == 0: Performs blocking connect using high-level Socket_connect_unix() (no temporary mode change)
- * - timeout_ms > 0: Non-blocking connect initiation + POLLOUT poll up to timeout_ms, then verifies completion
- *
- * Supports filesystem paths and Linux abstract namespace (prefix path with '@').
- * Validates path length and builds sockaddr_un internally.
- *
- * @param[in] socket Pre-created AF_UNIX SOCK_STREAM socket
- * @param[in] path Socket file path or abstract name (e.g., "@abstract")
- * @param[in] timeout_ms 0=blocking (no timeout), >0=milliseconds timeout
- *
- * @throws Socket_Failed On immediate connect failure, poll failure, timeout expiration (ETIMEDOUT),
- *                       invalid path length (>=108 bytes), or system errors (EINPROGRESS handled internally)
- *
- * @threadsafe Yes - per-socket, thread-local errors, atomic mode changes
- *
- * ## Usage Example
- *
- * @code{.c}
- * Socket_T client = Socket_new(AF_UNIX, SOCK_STREAM, 0);
- *
- * TRY {
- *   // Blocking connect - waits indefinitely
- *   Socket_connect_unix_timeout(client, "/var/run/myserver.sock", 0);
- * } EXCEPT(Socket_Failed) {
- *   // Connect failed (e.g., no server, permission denied)
- *   Socket_free(&client);
- *   return -1;
- * }
- *
- * // Use client...
- * Socket_free(&client);
- *
- * TRY {
- *   Socket_T timed_client = Socket_new(AF_UNIX, SOCK_STREAM, 0);
- *   Socket_connect_unix_timeout(timed_client, "@abstract_server", 3000);  // 3s timeout
- * } EXCEPT(Socket_Failed) {
- *   // Timeout or error
- * }
- * @endcode
- *
- * ## Behavior Details
- *
- * - For blocking (0): Delegates to Socket_connect_unix() for consistency with library API
- * - For timed (>0): Manually constructs sockaddr_un and calls connect(); polls POLLOUT for completion
- * - Abstract sockets: '@' prefix sets sun_path[0]='\0' per Linux man pages
- * - Error checking: Uses getsockopt(SO_ERROR) post-poll to detect connect outcome
- * - Mode restoration: Always restores original blocking mode after timed operations
- * - EINTR/EAGAIN handled during poll and connect
- *
- * @note Path must be null-terminated; max length ~108 bytes (sizeof(sun_path)-1)
- * @warning Socket must be unused AF_UNIX stream; reuse raises undefined behavior
- * @note No support for -1 (infinite); use 0 for blocking
- * @complexity O(1) for blocking; O(timeout_ms) for timed polls
- *
- * @see Socket_connect_unix() for blocking connect without timeout param
- * @see Socket_listen_unix() for server-side Unix socket setup
- * @see with_nonblocking_scope() internal mode management helper
- * @see docs/SECURITY.md#unix-domain-sockets for security considerations
- */
+/* For abstract namespace sockets (Linux), '@' prefix becomes '\0' */
 void
 Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
 {
@@ -727,17 +335,14 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
         fd = Socket_fd (socket);
         path_len = strlen (path);
 
-        /* Validate path length */
         if (path_len == 0 || path_len >= sizeof (addr.sun_path)) {
                 SOCKET_ERROR_MSG ("Invalid Unix socket path length: %zu", path_len);
                 RAISE_MODULE_ERROR (Socket_Failed);
         }
 
-        /* Build address */
         memset (&addr, 0, sizeof (addr));
         addr.sun_family = AF_UNIX;
 
-        /* Handle abstract sockets (Linux: '@' prefix becomes '\0') */
         if (path[0] == '@') {
                 addr.sun_path[0] = '\0';
                 memcpy (addr.sun_path + 1, path + 1, path_len - 1);
@@ -746,7 +351,6 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
         }
 
         if (timeout_ms == 0) {
-                /* Blocking connect: delegate to high-level API, no mode change */
                 TRY {
                         Socket_connect_unix (socket, path);
                 } EXCEPT (Socket_Failed) {
@@ -755,26 +359,22 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
                 return;
         }
 
-        /* Timed connect: enable non-blocking temporarily */
         with_nonblocking_scope (fd, 1, &original_flags, &need_restore);
 
         result = connect (fd, (struct sockaddr *)&addr, sizeof (addr));
 
         if (result == 0 || errno == EISCONN) {
-                /* Immediate success - restore flags and return */
                 with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
                 return;
         }
 
         if (errno != EINPROGRESS && errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
-                /* Immediate failure - restore flags before raising */
                 with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
                 SOCKET_ERROR_FMT ("Unix connect to %.*s failed",
                                   SOCKET_ERROR_MAX_HOSTNAME, path);
                 RAISE_MODULE_ERROR (Socket_Failed);
         }
 
-        /* In progress: poll for completion */
         TRY {
                 struct pollfd pfd = { .fd = fd, .events = POLLOUT, .revents = 0 };
                 int poll_result = socket_poll_eintr_retry (&pfd, timeout_ms);
@@ -791,11 +391,9 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
                         RAISE_MODULE_ERROR (Socket_Failed);
                 }
 
-                /* Verify connect outcome */
                 check_connect_result (fd, path);
         }
         FINALLY {
-                /* Restore original mode */
                 with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
         }
         END_TRY;

--- a/src/socket/SocketAsync.c
+++ b/src/socket/SocketAsync.c
@@ -4,36 +4,6 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketAsync.c - Asynchronous I/O core
- *
- * Core asynchronous I/O context management and request tracking for socket
- * operations. Provides the foundation for platform-specific async backends
- * with thread-safe request management and completion handling.
- *
- * Features:
- * - Async context lifecycle management (new/free)
- * - Request ID generation and tracking via hash table
- * - O(1) average-case request lookup and cancellation
- * - Completion callback handling with partial transfer support
- * - Thread-safe operations via mutex protection
- * - Memory management using Arena allocation
- * - Automatic backend detection (io_uring, kqueue, fallback)
- * - Batch submission support for reduced syscall overhead
- *
- * Backend Support:
- * - Linux (kernel 5.1+): io_uring with eventfd notification
- * - BSD/macOS: kqueue with edge-triggered events
- * - Other POSIX: Fallback mode with manual I/O
- *
- * Thread Safety:
- * - All public APIs are thread-safe via internal mutex
- * - Callbacks invoked from the thread calling process_completions()
- * - Request state protected during concurrent access
- *
- * Part of the Socket Library
- * Following C Interfaces and Implementations patterns
- */
 
 #include <assert.h>
 #include <errno.h>
@@ -70,16 +40,11 @@
 
 #define T SocketAsync_T
 
-/* Test ring entries for io_uring availability check */
 #ifndef SOCKET_IO_URING_TEST_ENTRIES
 #define SOCKET_IO_URING_TEST_ENTRIES 32
 #endif
 
-/* Request structures defined in SocketAsync-private.h */
-
-/* Async context structure defined in SocketAsync-private.h
- *
- * Key fields for partial completion and timeout support:
+/* Key fields for partial completion and timeout support:
  * - size_t completed in AsyncRequest - tracks bytes transferred so far
  * - int64_t submitted_at in AsyncRequest - submission timestamp for timeout
  * - int64_t deadline_ms in AsyncRequest - per-request deadline (0 = use global)
@@ -89,40 +54,19 @@
  * See SocketAsync_set_timeout(), SocketAsync_expire_stale() for timeout handling.
  */
 
-/* Exception */
 const Except_T SocketAsync_Failed
     = { &SocketAsync_Failed, "SocketAsync operation failed" };
 
-/* Thread-local exception for detailed error messages */
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketAsync);
 
 #define RAISE_MODULE_ERROR(e) SOCKET_RAISE_MODULE_ERROR (SocketAsync, e)
-
-/* ==================== Static Helper Functions ==================== */
-
-/**
- * request_hash - Hash function for request IDs
- * @request_id: Request ID to hash
- *
- * Returns: Hash value in range [0, SOCKET_HASH_TABLE_SIZE)
- * Thread-safe: Yes - pure function with no side effects
- *
- * Uses socket_util_hash_uint() for golden ratio multiplicative hashing.
- */
 static inline unsigned
 request_hash (const unsigned request_id)
 {
   return socket_util_hash_uint (request_id, SOCKET_HASH_TABLE_SIZE);
 }
 
-/**
- * generate_request_id_unlocked - Generate unique request ID
- * @async: Async context
- *
- * Returns: Unique request ID (> 0)
- * Thread-safe: No - caller must hold async->mutex
- *
- * Note: Request ID 0 is reserved as invalid. When unsigned wraps from
+/* Request ID 0 is reserved as invalid. When unsigned wraps from
  * UINT_MAX to 0, we skip to 1.
  */
 static unsigned
@@ -133,7 +77,7 @@ generate_request_id_unlocked (T async)
   assert (async);
 
   id = async->next_request_id++;
-  /* LCOV_EXCL_START - Wrap from UINT_MAX to 0 is rare */
+  /* LCOV_EXCL_START */
   if (id == 0)
     id = async->next_request_id++;
   /* LCOV_EXCL_STOP */
@@ -141,13 +85,6 @@ generate_request_id_unlocked (T async)
   return id;
 }
 
-/**
- * socket_async_allocate_request - Allocate async request structure
- * @async: Async context
- *
- * Returns: Allocated and zeroed request
- * Raises: SocketAsync_Failed on allocation failure
- */
 static struct AsyncRequest *
 socket_async_allocate_request (T async)
 {
@@ -168,16 +105,9 @@ socket_async_allocate_request (T async)
   return (struct AsyncRequest *)req;
 }
 
-/**
- * socket_async_free_request - Clear async request structure
- * @async: Async context (unused, arena manages memory)
- * @req: Request to clear
- *
- * Note: Request is allocated from arena, so no explicit free needed.
+/* Note: Request is allocated from arena, so no explicit free needed.
  * We clear it securely to prevent use-after-free bugs and ensure
  * sensitive callback data doesn't persist in memory.
- *
- * Thread-safe: No - caller must ensure exclusive access
  */
 static void
 socket_async_free_request (T async, struct AsyncRequest *req)
@@ -185,8 +115,6 @@ socket_async_free_request (T async, struct AsyncRequest *req)
   (void)async;
   if (req)
     {
-      /* Use secure clear to prevent compiler optimization and ensure
-       * sensitive data (user_data pointers, callback addresses) is zeroed */
       volatile unsigned char *p = (volatile unsigned char *)req;
       size_t n = sizeof (*req);
       while (n--)
@@ -203,17 +131,6 @@ static int find_and_remove_request (T async, unsigned request_id,
 static void remove_known_request (T async, struct AsyncRequest *req);
 
 static int check_and_expire_stale_requests (T async);
-
-/**
- * accumulate_transfer_progress - Update request progress for partial transfers
- * @req: Request to update
- * @result: Bytes transferred in this operation (must be > 0)
- *
- * Accumulates transferred bytes for partial transfer tracking.
- * Caps at request length to prevent overflow.
- *
- * Thread-safe: No - caller must ensure exclusive access to req
- */
 static inline void
 accumulate_transfer_progress (struct AsyncRequest *req, ssize_t result)
 {
@@ -225,20 +142,10 @@ accumulate_transfer_progress (struct AsyncRequest *req, ssize_t result)
   transferred = (size_t)result;
   req->completed += transferred;
 
-  /* Cap at requested length to prevent overflow */
   if (req->completed > req->len)
     req->completed = req->len;
 }
 
-/**
- * handle_completion - Handle async operation completion
- * @async: Async context
- * @request_id: Request ID that completed
- * @result: Result (bytes transferred, or negative on error)
- * @err: Error code (0 on success)
- *
- * Thread-safe: Yes - delegates to find_and_remove_request for mutex handling
- */
 static void
 process_request_completion (T async, struct AsyncRequest *req, ssize_t result, int err)
 {
@@ -263,22 +170,6 @@ handle_completion (T async, unsigned request_id, ssize_t result, int err)
   process_request_completion (async, req, result, err);
 }
 #endif /* SOCKET_HAS_IO_URING */
-
-/**
- * setup_async_request - Initialize async request structure
- * @async: Async context
- * @socket: Socket for operation
- * @cb: Completion callback
- * @user_data: User data for callback
- * @type: Request type (REQ_SEND or REQ_RECV)
- * @send_buf: Buffer for send operations (NULL for recv)
- * @recv_buf: Buffer for recv operations (NULL for send)
- * @len: Buffer length
- * @flags: Operation flags
- *
- * Returns: Initialized request (never NULL - raises on failure)
- * Raises: SocketAsync_Failed on allocation failure
- */
 static struct AsyncRequest *
 setup_async_request (T async, Socket_T socket, SocketAsync_Callback cb,
                      void *user_data, enum AsyncRequestType type,
@@ -295,22 +186,12 @@ setup_async_request (T async, Socket_T socket, SocketAsync_Callback cb,
   req->recv_buf = recv_buf;
   req->len = len;
   req->flags = flags;
-  req->deadline_ms = 0; /* Use global timeout; caller may override */
+  req->deadline_ms = 0;
 
   return req;
 }
 
-/**
- * cleanup_failed_request - Clean up failed request submission
- * @async: Async context
- * @req: Request that failed
- *
- * Thread-safe: Yes - delegates to remove_known_request
- *
- * Note: Only reachable when submit_async_operation() returns < 0,
- * which requires async->available = 1 (io_uring/kqueue backend).
- */
-/* LCOV_EXCL_START - Only reachable with io_uring/kqueue backend */
+/* LCOV_EXCL_START */
 static void
 cleanup_failed_request (T async, struct AsyncRequest *req)
 {
@@ -318,18 +199,6 @@ cleanup_failed_request (T async, struct AsyncRequest *req)
   socket_async_free_request (async, req);
 }
 /* LCOV_EXCL_STOP */
-
-/**
- * find_request_unlocked - Find request by ID without removing
- * @async: Async context (must hold mutex)
- * @request_id: ID of request to find
- *
- * Returns: Pointer to request if found, NULL otherwise
- * Thread-safe: No - caller must hold async->mutex
- *
- * Used for progress queries and continuation where we need to inspect
- * request state before deciding whether to remove it.
- */
 static struct AsyncRequest *
 find_request_unlocked (T async, unsigned request_id)
 {
@@ -347,15 +216,6 @@ find_request_unlocked (T async, unsigned request_id)
   return req;
 }
 
-/**
- * remove_request_unlocked - Remove specific request from hash table
- * @async: Async context (must hold mutex)
- * @req: Request to remove
- *
- * Thread-safe: No - caller must hold async->mutex
- *
- * Unlinks request from hash chain. Safe if req not in table (no-op).
- */
 static void
 remove_request_unlocked (T async, struct AsyncRequest *req)
 {
@@ -375,22 +235,6 @@ remove_request_unlocked (T async, struct AsyncRequest *req)
     *pp = req->next;
 }
 
-/**
- * find_and_remove_request - Find request by ID, remove from hash table,
- * extract info
- * @async: Async context
- * @request_id: ID of request to find and remove
- * @out_req: Output: removed request pointer (always set if found)
- * @out_cb: Output: callback function (set if not NULL and found)
- * @out_socket: Output: socket (set if not NULL and found)
- * @out_user_data: Output: user data (set if not NULL and found)
- *
- * Returns: 1 if found and removed, 0 otherwise
- * Thread-safe: Yes (acquires/releases mutex)
- *
- * Extracts callback info under lock for safety, minimizes lock hold time.
- * Outputs initialized to NULL/0 if not found or param NULL.
- */
 static int
 find_and_remove_request (T async, unsigned request_id,
                          struct AsyncRequest **out_req,
@@ -438,16 +282,6 @@ find_and_remove_request (T async, unsigned request_id,
   return found;
 }
 
-/**
- * remove_known_request - Remove known request from hash table
- * @async: Async context
- * @req: Request pointer to remove (validated != NULL)
- *
- * Thread-safe: Yes (acquires/releases mutex)
- *
- * Traverses hash chain to find and unlink the specific req pointer.
- * Safe to call even if req already removed (no-op).
- */
 static void
 remove_known_request (T async, struct AsyncRequest *req)
 {
@@ -471,17 +305,7 @@ remove_known_request (T async, struct AsyncRequest *req)
   pthread_mutex_unlock (&async->mutex);
 }
 
-/* Forward declaration for backend-specific submit */
 static int submit_async_operation (T async, struct AsyncRequest *req);
-
-/**
- * submit_and_track_request - Submit request and track in hash table
- * @async: Async context
- * @req: Request to submit and track
- *
- * Returns: Request ID on success, 0 on failure
- * Thread-safe: Yes (handles mutex locking)
- */
 static unsigned
 submit_and_track_request (T async, struct AsyncRequest *req)
 {
@@ -496,7 +320,6 @@ submit_and_track_request (T async, struct AsyncRequest *req)
   req->next = async->requests[hash];
   async->requests[hash] = req;
 
-  /* Initialize progress tracking fields */
   req->completed = 0;
   req->submitted_at = Socket_get_monotonic_ms();
 
@@ -504,7 +327,7 @@ submit_and_track_request (T async, struct AsyncRequest *req)
 
   result = async->available ? submit_async_operation (async, req) : 0;
 
-  /* LCOV_EXCL_START - Only fails with io_uring/kqueue backend */
+  /* LCOV_EXCL_START */
   if (result < 0)
     {
       cleanup_failed_request (async, req);
@@ -515,19 +338,7 @@ submit_and_track_request (T async, struct AsyncRequest *req)
   return req->request_id;
 }
 
-/* ==================== io_uring Backend ==================== */
-
 #ifdef SOCKET_HAS_IO_URING
-
-/**
- * submit_io_uring_op - Submit operation via io_uring
- * @async: Async context
- * @req: Request structure
- *
- * Returns: 0 on success, -1 on failure
- *
- * Unified submission for both send and recv operations.
- */
 static int
 submit_io_uring_op (T async, struct AsyncRequest *req)
 {
@@ -545,7 +356,6 @@ submit_io_uring_op (T async, struct AsyncRequest *req)
       return -1;
     }
 
-  /* Prepare operation based on type */
   if (req->type == REQ_SEND)
     io_uring_prep_send (sqe, fd, req->send_buf, req->len, 0);
   else
@@ -563,13 +373,7 @@ submit_io_uring_op (T async, struct AsyncRequest *req)
   return 0;
 }
 
-/**
- * process_io_uring_completions - Process io_uring completion queue
- * @async: Async context
- * @max_completions: Maximum completions to process
- *
- * Returns: Number of completions processed
- */
+
 static int
 process_io_uring_completions (T async, int max_completions)
 {
@@ -599,18 +403,9 @@ process_io_uring_completions (T async, int max_completions)
 
 #endif /* SOCKET_HAS_IO_URING */
 
-/* ==================== kqueue Backend ==================== */
-
 #if defined(__APPLE__) || defined(__FreeBSD__)
 
-/**
- * submit_kqueue_aio - Submit operation via kqueue (edge-triggered mode)
- * @async: Async context
- * @req: Request structure
- *
- * Returns: 0 on success, -1 on failure
- *
- * Note: macOS/BSD don't have true AIO like io_uring. This implementation
+/* Note: macOS/BSD don't have true AIO like io_uring. This implementation
  * uses edge-triggered kqueue events. The actual I/O is performed when
  * the event fires, then the callback is invoked.
  */
@@ -633,14 +428,7 @@ submit_kqueue_aio (T async, struct AsyncRequest *req)
   return 0;
 }
 
-/**
- * kqueue_perform_io - Perform I/O operation for kqueue completion
- * @req: Request with operation details
- * @result: Output for bytes transferred
- * @err: Output for error code
- *
- * Thread-safe: Yes (operates on single socket)
- */
+
 static ssize_t
 socket_async_perform_io (Socket_T socket, enum AsyncRequestType type,
                          const void *send_buf, void *recv_buf, size_t len,
@@ -714,15 +502,7 @@ kqueue_complete_request (T async, struct AsyncRequest *req)
   process_request_completion (async, req, result, err);
 }
 
-/**
- * process_kqueue_completions - Process kqueue events and perform I/O
- * @async: Async context
- * @timeout_ms: Timeout in milliseconds
- * @max_completions: Maximum completions to process
- *
- * Returns: Number of completions processed
- * Thread-safe: Yes
- */
+
 static int
 process_kqueue_completions (T async, int timeout_ms, int max_completions)
 {
@@ -759,21 +539,13 @@ process_kqueue_completions (T async, int timeout_ms, int max_completions)
 
 #endif /* __APPLE__ || __FreeBSD__ */
 
-/* ==================== Backend Detection ==================== */
 
-/**
- * detect_async_backend - Detect and initialize platform-specific async backend
- * @async: Async context to initialize
- *
- * Returns: Non-zero if async available, 0 if fallback mode
- */
 static int
 detect_async_backend (T async)
 {
   assert (async);
 
 #ifdef SOCKET_HAS_IO_URING
-  /* Try io_uring */
   struct io_uring test_ring;
   if (io_uring_queue_init (SOCKET_IO_URING_TEST_ENTRIES, &test_ring, 0) == 0)
     {
@@ -834,16 +606,7 @@ detect_async_backend (T async)
 #endif
 }
 
-/**
- * submit_async_operation - Submit async operation to appropriate backend
- * @async: Async context
- * @req: Request to submit
- *
- * Returns: 0 on success, -1 on failure
- *
- * Note: Only called when async->available = 1 (io_uring/kqueue backend).
- */
-/* LCOV_EXCL_START - Only called with io_uring/kqueue backend */
+/* LCOV_EXCL_START */
 static int
 submit_async_operation (T async, struct AsyncRequest *req)
 {
@@ -866,16 +629,7 @@ submit_async_operation (T async, struct AsyncRequest *req)
 }
 /* LCOV_EXCL_STOP */
 
-/**
- * process_async_completions_internal - Process completions from backend
- * @async: Async context
- * @timeout_ms: Timeout in milliseconds
- *
- * Returns: Number of completions processed (including expired requests)
- *
- * Also checks for and expires stale requests when global or per-request
- * timeouts are configured.
- */
+
 static int
 process_async_completions_internal (T async,
                                     int timeout_ms __attribute__ ((unused)))
@@ -884,7 +638,6 @@ process_async_completions_internal (T async,
 
   assert (async);
 
-  /* Process backend completions if available */
   if (async->available)
     {
 #ifdef SOCKET_HAS_IO_URING
@@ -905,31 +658,13 @@ process_async_completions_internal (T async,
 #endif
     }
 
-  /* Check for stale requests when timeout is configured */
   if (async->request_timeout_ms > 0)
     completed += check_and_expire_stale_requests (async);
 
   return completed;
 }
 
-/**
- * socket_async_submit - Common submit logic for send/recv requests
- * @async: Async context
- * @socket: Target socket
- * @type: REQ_SEND or REQ_RECV
- * @send_buf: Buffer for send (NULL for recv)
- * @recv_buf: Buffer for recv (NULL for send)
- * @len: Buffer length
- * @cb: Completion callback (required)
- * @user_data: User data for callback
- * @flags: Operation flags
- *
- * Returns: Request ID on success, raises on failure
- * Thread-safe: Yes
- *
- * Validates parameters, sets up request, tracks in hash, submits to backend.
- * Used by public SocketAsync_send/recv.
- */
+
 static unsigned
 socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
                      const void *send_buf, void *recv_buf, size_t len,
@@ -939,7 +674,6 @@ socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
   struct AsyncRequest *req;
   unsigned request_id;
 
-  /* Validate parameters */
   if (!async || !socket || !cb || len == 0)
     {
       errno = EINVAL;
@@ -960,9 +694,8 @@ socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
       RAISE_MODULE_ERROR (SocketAsync_Failed);
     }
 
-  /* Ensure socket is non-blocking */
   TRY { Socket_setnonblocking (socket); }
-  EXCEPT (Socket_Failed) { /* Ignore - may already be set or error */ }
+  EXCEPT (Socket_Failed) { }
   END_TRY;
 
   req = setup_async_request (async, socket, cb, user_data, type, send_buf,
@@ -978,8 +711,6 @@ socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
 
   return request_id;
 }
-
-/* ==================== Public API ==================== */
 
 T
 SocketAsync_new (Arena_T arena)
@@ -999,7 +730,7 @@ SocketAsync_new (Arena_T arena)
   END_TRY;
 
   ((T)async)->arena = arena;
-  ((T)async)->next_request_id = 1; /* 0 = invalid */
+  ((T)async)->next_request_id = 1;
 
   if (pthread_mutex_init (&((T)async)->mutex, NULL) != 0)
     {
@@ -1020,7 +751,6 @@ SocketAsync_free (T *async)
   if (!async || !*async)
     return;
 
-  /* Cleanup pending requests to prevent leaks */
   pthread_mutex_lock (&(*async)->mutex);
   for (unsigned i = 0; i < SOCKET_HASH_TABLE_SIZE; ++i)
     {
@@ -1074,23 +804,7 @@ SocketAsync_backend_name (const T async)
   return async->backend_name;
 }
 
-/**
- * SocketAsync_send - Submit asynchronous send operation
- * @async: Async context
- * @socket: Target socket
- * @buf: Data buffer to send
- * @len: Length of data
- * @cb: Completion callback (required)
- * @user_data: User data passed to callback
- * @flags: Operation flags (e.g. ASYNC_FLAG_URGENT)
- *
- * Returns: Unique request ID on success, raises SocketAsync_Failed on error
- * Thread-safe: Yes
- *
- * Submits non-blocking send operation to backend. Callback invoked on
- * completion with bytes sent (or negative error). Use SocketAsync_cancel to
- * cancel pending. Raises if no async backend available or submit fails.
- */
+
 unsigned
 SocketAsync_send (T async, Socket_T socket, const void *buf, size_t len,
                   SocketAsync_Callback cb, void *user_data,
@@ -1100,24 +814,7 @@ SocketAsync_send (T async, Socket_T socket, const void *buf, size_t len,
                               user_data, flags);
 }
 
-/**
- * SocketAsync_recv - Submit asynchronous receive operation
- * @async: Async context
- * @socket: Target socket
- * @buf: Receive buffer
- * @len: Buffer length
- * @cb: Completion callback (required)
- * @user_data: User data passed to callback
- * @flags: Operation flags (e.g. ASYNC_FLAG_URGENT)
- *
- * Returns: Unique request ID on success, raises SocketAsync_Failed on error
- * Thread-safe: Yes
- *
- * Submits non-blocking recv operation to backend. Callback invoked on
- * completion with bytes received (0 for EOF/would block, negative error). Use
- * SocketAsync_cancel to cancel pending. Raises if no async backend available
- * or submit fails.
- */
+
 unsigned
 SocketAsync_recv (T async, Socket_T socket, void *buf, size_t len,
                   SocketAsync_Callback cb, void *user_data,
@@ -1127,17 +824,7 @@ SocketAsync_recv (T async, Socket_T socket, void *buf, size_t len,
                               user_data, flags);
 }
 
-/**
- * SocketAsync_cancel - Cancel pending async request
- * @async: Async context
- * @request_id: ID of request to cancel
- *
- * Returns: 0 on success (cancelled or not found), -1 on error
- * Thread-safe: Yes - uses find_and_remove_request
- *
- * Removes request from tracking, frees resources. Callback not invoked.
- * Safe to call on completed or non-existent requests (no-op).
- */
+
 int
 SocketAsync_cancel (T async, unsigned request_id)
 {
@@ -1158,20 +845,7 @@ SocketAsync_process_completions (T async, int timeout_ms)
   return process_async_completions_internal (async, timeout_ms);
 }
 
-/* ==================== Batch Operations ==================== */
 
-/**
- * SocketAsync_submit_batch - Submit multiple async operations
- * @async: Async context
- * @ops: Array of operation descriptors
- * @count: Number of operations
- *
- * Returns: Number of successfully submitted operations
- * Thread-safe: Yes
- *
- * Enables efficient batch submission. Each op's request_id is populated
- * on success. Stops at first failure but returns count of successful.
- */
 int
 SocketAsync_submit_batch (T async, SocketAsync_Op *ops, size_t count)
 {
@@ -1203,7 +877,6 @@ SocketAsync_submit_batch (T async, SocketAsync_Op *ops, size_t count)
       }
       EXCEPT (SocketAsync_Failed)
       {
-        /* Stop on first failure */
         break;
       }
       END_TRY;
@@ -1212,16 +885,7 @@ SocketAsync_submit_batch (T async, SocketAsync_Op *ops, size_t count)
   return (int)submitted;
 }
 
-/**
- * SocketAsync_cancel_all - Cancel all pending async operations
- * @async: Async context
- *
- * Returns: Number of operations cancelled
- * Thread-safe: Yes
- *
- * Iterates through all hash buckets and cancels every pending request.
- * Callbacks are NOT invoked.
- */
+
 int
 SocketAsync_cancel_all (T async)
 {
@@ -1232,7 +896,6 @@ SocketAsync_cancel_all (T async)
 
   pthread_mutex_lock (&async->mutex);
 
-  /* Iterate through all hash buckets */
   for (unsigned i = 0; i < SOCKET_HASH_TABLE_SIZE; i++)
     {
       struct AsyncRequest *req = async->requests[i];
@@ -1251,32 +914,21 @@ SocketAsync_cancel_all (T async)
   return cancelled;
 }
 
-/* ==================== Backend Selection ==================== */
-
-/* Thread-safe preferred backend (atomic would be cleaner but this works) */
 static pthread_mutex_t backend_pref_mutex = PTHREAD_MUTEX_INITIALIZER;
 static SocketAsync_Backend preferred_backend = ASYNC_BACKEND_AUTO;
 
-/**
- * SocketAsync_backend_available - Check if backend is available
- * @backend: Backend type to check
- *
- * Returns: 1 if available, 0 otherwise
- * Thread-safe: Yes
- */
+
 int
 SocketAsync_backend_available (SocketAsync_Backend backend)
 {
   switch (backend)
     {
     case ASYNC_BACKEND_AUTO:
-      /* Auto is always "available" */
       return 1;
 
     case ASYNC_BACKEND_IO_URING:
 #ifdef SOCKET_HAS_IO_URING
       {
-        /* Probe kernel support */
         struct io_uring test_ring;
         if (io_uring_queue_init (SOCKET_IO_URING_TEST_ENTRIES, &test_ring, 0)
             == 0)
@@ -1302,11 +954,9 @@ SocketAsync_backend_available (SocketAsync_Backend backend)
       return 0;
 
     case ASYNC_BACKEND_POLL:
-      /* Poll fallback is always available on POSIX */
       return 1;
 
     case ASYNC_BACKEND_NONE:
-      /* "None" is always available (sync mode) */
       return 1;
 
     default:
@@ -1314,17 +964,10 @@ SocketAsync_backend_available (SocketAsync_Backend backend)
     }
 }
 
-/**
- * SocketAsync_set_backend - Set preferred backend for new contexts
- * @backend: Desired backend
- *
- * Returns: 0 on success, -1 if backend unavailable
- * Thread-safe: Yes
- */
+
 int
 SocketAsync_set_backend (SocketAsync_Backend backend)
 {
-  /* Check availability first */
   if (!SocketAsync_backend_available (backend))
     return -1;
 
@@ -1335,21 +978,7 @@ SocketAsync_set_backend (SocketAsync_Backend backend)
   return 0;
 }
 
-/* ==================== Progress and Continuation API ==================== */
 
-/**
- * SocketAsync_get_progress - Query progress of a pending async request
- * @async: Async context
- * @request_id: ID of request to query
- * @completed: Output: bytes completed so far (set to 0 if not found)
- * @total: Output: total bytes requested (set to 0 if not found)
- *
- * Returns: 1 if request found, 0 if not found or already completed
- * Thread-safe: Yes
- *
- * Allows applications to check progress of in-flight operations before
- * deciding whether to continue or cancel them.
- */
 int
 SocketAsync_get_progress (T async, unsigned request_id, size_t *completed,
                           size_t *total)
@@ -1380,18 +1009,7 @@ SocketAsync_get_progress (T async, unsigned request_id, size_t *completed,
   return found;
 }
 
-/**
- * socket_async_continue_request - Internal helper for continuation
- * @async: Async context
- * @request_id: Original request ID
- * @expected_type: Expected request type (REQ_SEND or REQ_RECV)
- *
- * Returns: New request ID on success, 0 on failure
- * Thread-safe: Yes
- *
- * Finds original request, validates type, extracts remaining transfer info,
- * removes original, creates new request with remaining data.
- */
+
 static unsigned
 socket_async_continue_request (T async, unsigned request_id,
                                enum AsyncRequestType expected_type)
@@ -1419,21 +1037,18 @@ socket_async_continue_request (T async, unsigned request_id,
       return 0;
     }
 
-  /* Validate type matches */
   if (orig_req->type != expected_type)
     {
       pthread_mutex_unlock (&async->mutex);
       return 0;
     }
 
-  /* Check if anything remains */
   if (orig_req->completed >= orig_req->len)
     {
       pthread_mutex_unlock (&async->mutex);
       return 0;
     }
 
-  /* Extract info from original request */
   socket = orig_req->socket;
   cb = orig_req->cb;
   user_data = orig_req->user_data;
@@ -1445,15 +1060,12 @@ socket_async_continue_request (T async, unsigned request_id,
   else
     recv_buf = (char *)orig_req->recv_buf + orig_req->completed;
 
-  /* Remove original from hash table */
   remove_request_unlocked (async, orig_req);
 
   pthread_mutex_unlock (&async->mutex);
 
-  /* Free original request */
   socket_async_free_request (async, orig_req);
 
-  /* Create and submit new request with remaining data */
   new_req = setup_async_request (async, socket, cb, user_data, expected_type,
                                  send_buf, recv_buf, remaining_len, flags);
 
@@ -1464,51 +1076,21 @@ socket_async_continue_request (T async, unsigned request_id,
   return new_id;
 }
 
-/**
- * SocketAsync_send_continue - Continue a partially completed send operation
- * @async: Async context
- * @request_id: ID of the original request to continue
- *
- * Returns: New request ID (>0) on success, 0 if original not found or complete
- * Thread-safe: Yes
- *
- * Looks up the original request, calculates remaining buffer (buf + completed,
- * len - completed), and resubmits with the same callback/user_data. Original
- * request is removed and freed.
- */
+
 unsigned
 SocketAsync_send_continue (T async, unsigned request_id)
 {
   return socket_async_continue_request (async, request_id, REQ_SEND);
 }
 
-/**
- * SocketAsync_recv_continue - Continue a partially completed receive operation
- * @async: Async context
- * @request_id: ID of the original request to continue
- *
- * Returns: New request ID (>0) on success, 0 if original not found or complete
- * Thread-safe: Yes
- */
+
 unsigned
 SocketAsync_recv_continue (T async, unsigned request_id)
 {
   return socket_async_continue_request (async, request_id, REQ_RECV);
 }
 
-/* ==================== Timeout Configuration API ==================== */
 
-/**
- * SocketAsync_set_timeout - Set global request timeout for async context
- * @async: Async context
- * @timeout_ms: Timeout in milliseconds (0 = disable timeout)
- *
- * Thread-safe: Yes
- *
- * Requests older than this timeout will be cancelled with ETIMEDOUT during
- * SocketAsync_process_completions() or SocketAsync_expire_stale().
- * Per-request deadlines (set via send_timeout/recv_timeout) override this.
- */
 void
 SocketAsync_set_timeout (T async, int64_t timeout_ms)
 {
@@ -1520,13 +1102,7 @@ SocketAsync_set_timeout (T async, int64_t timeout_ms)
   pthread_mutex_unlock (&async->mutex);
 }
 
-/**
- * SocketAsync_get_timeout - Get current global request timeout
- * @async: Async context
- *
- * Returns: Timeout in milliseconds (0 = disabled)
- * Thread-safe: Yes
- */
+
 int64_t
 SocketAsync_get_timeout (T async)
 {
@@ -1542,16 +1118,7 @@ SocketAsync_get_timeout (T async)
   return timeout;
 }
 
-/**
- * check_and_expire_stale_requests - Check all requests for timeout expiration
- * @async: Async context
- *
- * Returns: Number of requests expired
- * Thread-safe: Yes
- *
- * Iterates all hash buckets, finds stale requests based on their deadline
- * or global timeout, invokes callbacks with ETIMEDOUT, removes from tracking.
- */
+
 static int
 check_and_expire_stale_requests (T async)
 {
@@ -1569,7 +1136,6 @@ check_and_expire_stale_requests (T async)
   pthread_mutex_lock (&async->mutex);
   global_timeout = async->request_timeout_ms;
 
-  /* Collect expired requests under lock */
   for (unsigned i = 0; i < SOCKET_HASH_TABLE_SIZE; i++)
     {
       struct AsyncRequest **pp = &async->requests[i];
@@ -1579,30 +1145,24 @@ check_and_expire_stale_requests (T async)
           struct AsyncRequest *req = *pp;
           int64_t deadline;
 
-          /* Determine effective deadline */
           if (req->deadline_ms > 0)
             {
-              /* Per-request deadline takes precedence */
               deadline = req->deadline_ms;
             }
           else if (global_timeout > 0 && req->submitted_at > 0)
             {
-              /* Use global timeout from submission time */
               deadline = req->submitted_at + global_timeout;
             }
           else
             {
-              /* No timeout configured */
               pp = &req->next;
               continue;
             }
 
           if (now_ms >= deadline)
             {
-              /* Unlink from hash chain */
               *pp = req->next;
 
-              /* Add to expired list */
               req->next = NULL;
               if (expired_tail)
                 expired_tail->next = req;
@@ -1620,7 +1180,6 @@ check_and_expire_stale_requests (T async)
 
   pthread_mutex_unlock (&async->mutex);
 
-  /* Invoke callbacks outside lock */
   while (expired_list)
     {
       struct AsyncRequest *req = expired_list;
@@ -1635,41 +1194,14 @@ check_and_expire_stale_requests (T async)
   return expired_count;
 }
 
-/**
- * SocketAsync_expire_stale - Manually check and cancel stale (timed-out) requests
- * @async: Async context
- *
- * Returns: Number of requests cancelled due to timeout
- * Thread-safe: Yes
- *
- * Called automatically from SocketAsync_process_completions() when timeout is
- * configured. Can also be called manually for finer control over when stale
- * request cleanup occurs.
- */
+
 int
 SocketAsync_expire_stale (T async)
 {
   return check_and_expire_stale_requests (async);
 }
 
-/* ==================== Timeout-Aware Send/Recv API ==================== */
 
-/**
- * socket_async_submit_with_timeout - Common submit logic with per-request timeout
- * @async: Async context
- * @socket: Target socket
- * @type: REQ_SEND or REQ_RECV
- * @send_buf: Buffer for send (NULL for recv)
- * @recv_buf: Buffer for recv (NULL for send)
- * @len: Buffer length
- * @cb: Completion callback (required)
- * @user_data: User data for callback
- * @flags: Operation flags
- * @timeout_ms: Per-request timeout in milliseconds (0 = use global)
- *
- * Returns: Request ID on success, raises on failure
- * Thread-safe: Yes
- */
 static unsigned
 socket_async_submit_with_timeout (T async, Socket_T socket,
                                   enum AsyncRequestType type,
@@ -1681,7 +1213,6 @@ socket_async_submit_with_timeout (T async, Socket_T socket,
   struct AsyncRequest *req;
   unsigned request_id;
 
-  /* Validate parameters */
   if (!async || !socket || !cb || len == 0)
     {
       errno = EINVAL;
@@ -1702,15 +1233,13 @@ socket_async_submit_with_timeout (T async, Socket_T socket,
       RAISE_MODULE_ERROR (SocketAsync_Failed);
     }
 
-  /* Ensure socket is non-blocking */
   TRY { Socket_setnonblocking (socket); }
-  EXCEPT (Socket_Failed) { /* Ignore - may already be set or error */ }
+  EXCEPT (Socket_Failed) { }
   END_TRY;
 
   req = setup_async_request (async, socket, cb, user_data, type, send_buf,
                              recv_buf, len, flags);
 
-  /* Set per-request deadline if specified */
   if (timeout_ms > 0)
     req->deadline_ms = Socket_get_monotonic_ms () + timeout_ms;
 
@@ -1725,23 +1254,7 @@ socket_async_submit_with_timeout (T async, Socket_T socket,
   return request_id;
 }
 
-/**
- * SocketAsync_send_timeout - Submit async send with per-request timeout
- * @async: Async context
- * @socket: Target socket
- * @buf: Data buffer to send
- * @len: Length of data
- * @cb: Completion callback (required)
- * @user_data: User data passed to callback
- * @flags: Operation flags
- * @timeout_ms: Per-request timeout in milliseconds (0 = use global timeout)
- *
- * Returns: Unique request ID on success, raises SocketAsync_Failed on error
- * Thread-safe: Yes
- *
- * Like SocketAsync_send() but with explicit per-request timeout. The request
- * will be cancelled with ETIMEDOUT if not completed within timeout_ms.
- */
+
 unsigned
 SocketAsync_send_timeout (T async, Socket_T socket, const void *buf, size_t len,
                           SocketAsync_Callback cb, void *user_data,
@@ -1752,20 +1265,7 @@ SocketAsync_send_timeout (T async, Socket_T socket, const void *buf, size_t len,
                                            timeout_ms);
 }
 
-/**
- * SocketAsync_recv_timeout - Submit async recv with per-request timeout
- * @async: Async context
- * @socket: Target socket
- * @buf: Receive buffer
- * @len: Buffer length
- * @cb: Completion callback (required)
- * @user_data: User data passed to callback
- * @flags: Operation flags
- * @timeout_ms: Per-request timeout in milliseconds (0 = use global timeout)
- *
- * Returns: Unique request ID on success, raises SocketAsync_Failed on error
- * Thread-safe: Yes
- */
+
 unsigned
 SocketAsync_recv_timeout (T async, Socket_T socket, void *buf, size_t len,
                           SocketAsync_Callback cb, void *user_data,

--- a/src/socket/SocketBuf.c
+++ b/src/socket/SocketBuf.c
@@ -4,19 +4,6 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketBuf.c - Circular buffer for socket I/O
- *
- * Implements a circular buffer for efficient socket I/O operations.
- *
- * Features:
- * - Circular buffer implementation
- * - Read/write/peek operations
- * - Dynamic buffer resizing
- * - Zero-copy pointer access
- * - Secure memory clearing
- */
-
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -37,15 +24,12 @@
 const Except_T SocketBuf_Failed
     = { &SocketBuf_Failed, "SocketBuf operation failed" };
 
-/* Declare module-specific exception using centralized macros */
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketBuf);
 
-/* Module-local convenience macros for error handling */
 #define RAISE_MODULE_ERROR(e) SOCKET_RAISE_MODULE_ERROR (SocketBuf, e)
 #define RAISE_MSG(e, fmt, ...)                                                \
   SOCKET_RAISE_MSG (SocketBuf, e, fmt, ##__VA_ARGS__)
 
-/* Validation macros for defensive programming */
 #define VALIDATE_BUF(buf)                                                     \
   do                                                                          \
     {                                                                         \
@@ -88,13 +72,7 @@ struct T
   Arena_T arena;
 };
 
-/**
- * SocketBuf_check_invariants - Validate buffer invariants
- * @buf: Buffer to check (read-only)
- *
- * Returns: true if all invariants hold, false otherwise
- * Thread-safe: No (caller must ensure exclusive access)
- */
+
 bool
 SocketBuf_check_invariants (const T buf)
 {
@@ -107,12 +85,7 @@ SocketBuf_check_invariants (const T buf)
   return true;
 }
 
-/**
- * new_validate_capacity - Validate capacity for new buffer
- * @capacity: Requested capacity
- *
- * Raises: SocketBuf_Failed if capacity exceeds SOCKETBUF_MAX_CAPACITY
- */
+
 static void
 new_validate_capacity (size_t capacity)
 {
@@ -124,11 +97,7 @@ new_validate_capacity (size_t capacity)
                SOCKET_MAX_BUFFER_SIZE);
 }
 
-/**
- * new_alloc_struct - Allocate buffer structure
- * @arena: Memory arena
- * Returns: Allocated buffer or raises on failure
- */
+
 static T
 new_alloc_struct (Arena_T arena)
 {
@@ -139,12 +108,7 @@ new_alloc_struct (Arena_T arena)
   return buf;
 }
 
-/**
- * new_alloc_data - Allocate buffer data
- * @arena: Memory arena
- * @capacity: Buffer capacity
- * Returns: Allocated data or raises on failure
- */
+
 static char *
 new_alloc_data (Arena_T arena, size_t capacity)
 {
@@ -155,13 +119,7 @@ new_alloc_data (Arena_T arena, size_t capacity)
   return data;
 }
 
-/**
- * SocketBuf_new - Create new circular buffer
- * @arena: Memory arena for allocations
- * @capacity: Buffer capacity in bytes
- * Returns: New buffer instance
- * Raises: SocketBuf_Failed on allocation failure or invalid capacity
- */
+
 T
 SocketBuf_new (Arena_T arena, size_t capacity)
 {
@@ -181,15 +139,7 @@ SocketBuf_new (Arena_T arena, size_t capacity)
   return buf;
 }
 
-/**
- * SocketBuf_release - Release buffer handle (invalidate pointer)
- * @bufp: Pointer to buffer pointer (set to NULL)
- *
- * Nullifies the buffer pointer to prevent use-after-free. Does not
- * free memory (arena-managed). Idempotent if *bufp is already NULL.
- *
- * Thread-safe: Yes (no shared state modified)
- */
+
 void
 SocketBuf_release (T *bufp)
 {
@@ -201,13 +151,7 @@ SocketBuf_release (T *bufp)
   *bufp = NULL;
 }
 
-/**
- * circular_calc_chunk - Calculate chunk size for circular buffer transfer
- * @capacity: Buffer capacity
- * @pos: Current position in buffer
- * @remaining: Remaining bytes to transfer
- * Returns: Chunk size for this iteration
- */
+
 static size_t
 circular_calc_chunk (size_t capacity, size_t pos, size_t remaining)
 {
@@ -215,13 +159,7 @@ circular_calc_chunk (size_t capacity, size_t pos, size_t remaining)
   return chunk > remaining ? remaining : chunk;
 }
 
-/**
- * circular_copy_to_buffer - Copy data to circular buffer at position
- * @buf: Target buffer
- * @src: Source data
- * @pos: Position in buffer
- * @len: Length to copy
- */
+
 static void
 circular_copy_to_buffer (T buf, const char *src, size_t pos, size_t len)
 {
@@ -229,13 +167,7 @@ circular_copy_to_buffer (T buf, const char *src, size_t pos, size_t len)
   memcpy (buf->data + pos, src, len);
 }
 
-/**
- * SocketBuf_write - Write data to circular buffer
- * @buf: Buffer to write to
- * @data: Source data
- * @len: Maximum bytes to write
- * Returns: Bytes actually written
- */
+
 size_t
 SocketBuf_write (T buf, const void *data, size_t len)
 {
@@ -267,13 +199,7 @@ SocketBuf_write (T buf, const void *data, size_t len)
   return written;
 }
 
-/**
- * circular_copy_from_buffer - Copy data from circular buffer at position
- * @buf: Source buffer (read-only)
- * @dst: Destination data
- * @pos: Position in buffer
- * @len: Length to copy
- */
+
 static void
 circular_copy_from_buffer (const T buf, char *dst, size_t pos, size_t len)
 {
@@ -281,13 +207,7 @@ circular_copy_from_buffer (const T buf, char *dst, size_t pos, size_t len)
   memcpy (dst, buf->data + pos, len);
 }
 
-/**
- * SocketBuf_read - Read data from circular buffer (destructive)
- * @buf: Buffer to read from
- * @data: Destination buffer
- * @len: Maximum bytes to read
- * Returns: Bytes actually read
- */
+
 size_t
 SocketBuf_read (T buf, void *data, size_t len)
 {
@@ -318,13 +238,7 @@ SocketBuf_read (T buf, void *data, size_t len)
   return bytes_read;
 }
 
-/**
- * SocketBuf_peek - Peek data from circular buffer (non-destructive)
- * @buf: Buffer to peek from
- * @data: Destination buffer
- * @len: Maximum bytes to peek
- * Returns: Bytes actually peeked
- */
+
 size_t
 SocketBuf_peek (T buf, void *data, size_t len)
 {
@@ -407,11 +321,7 @@ SocketBuf_clear (T buf)
   buf->size = 0;
 }
 
-/**
- * SocketBuf_secureclear - Securely clear buffer (for sensitive data)
- * @buf: Buffer to clear
- *
- * Zeros memory contents before resetting pointers. Uses SocketCrypto
+/* Zeros memory contents before resetting pointers. Uses SocketCrypto
  * secure clear to prevent compiler optimization removal. Use for
  * sensitive data (passwords, keys, tokens).
  */
@@ -427,16 +337,7 @@ SocketBuf_secureclear (T buf)
   buf->size = 0;
 }
 
-/* ==================== Reserve Operations ==================== */
 
-/**
- * reserve_calc_new_capacity - Calculate new capacity for reserve
- * @current_cap: Current capacity
- * @total_needed: Total capacity needed (current size + min_space)
- *
- * Returns: New capacity or 0 on overflow/invalid
- * Thread-safe: Yes (pure function)
- */
 static size_t
 reserve_calc_new_capacity (size_t current_cap, size_t total_needed)
 {
@@ -463,15 +364,7 @@ reserve_calc_new_capacity (size_t current_cap, size_t total_needed)
   return new_cap;
 }
 
-/**
- * reserve_migrate_data - Migrate data to new buffer and cleanup old
- * @buf: Buffer to update
- * @new_data: New buffer data pointer
- * @new_cap: New buffer capacity
- *
- * Thread-safe: No (modifies buffer)
- *
- * Note: Uses memmove instead of memcpy because arena allocation may place
+/* Note: Uses memmove instead of memcpy because arena allocation may place
  * new_data adjacent to old_data in the same chunk, causing memory regions
  * to overlap when old_data + head extends into new_data's region.
  *
@@ -486,17 +379,14 @@ reserve_migrate_data (T buf, char *new_data, size_t new_cap)
 
   if (buf->size > 0)
     {
-      /* Calculate contiguous bytes from head to end of buffer */
       size_t first_part = old_cap - buf->head;
 
       if (first_part >= buf->size)
         {
-          /* No wrap - all data is contiguous from head */
           memmove (new_data, old_data + buf->head, buf->size);
         }
       else
         {
-          /* Data wraps around - copy in two parts */
           memmove (new_data, old_data + buf->head, first_part);
           memmove (new_data + first_part, old_data, buf->size - first_part);
         }
@@ -511,15 +401,7 @@ reserve_migrate_data (T buf, char *new_data, size_t new_cap)
   buf->tail = buf->size;
 }
 
-/**
- * SocketBuf_reserve - Resize buffer to ensure min_space available
- * @buf: Buffer to resize
- * @min_space: Minimum additional space required
- *
- * Raises: SocketBuf_Failed on overflow or allocation failure
- * Thread-safe: No (modifies buffer)
- *
- * Memory note: This function allocates a new buffer from the arena and
+/* Memory note: This function allocates a new buffer from the arena and
  * abandons the old buffer. Since arenas don't support individual frees,
  * the old allocation remains until Arena_dispose(). This is acceptable
  * because:
@@ -555,8 +437,6 @@ SocketBuf_reserve (T buf, size_t min_space)
     RAISE_MSG (SocketBuf_Failed, "SocketBuf reserve: new capacity invalid "
                                  "(overflow or exceeds limits)");
 
-  /* Arena allocation - old buffer remains allocated until arena disposal.
-   * See function doc for rationale on this acceptable memory behavior. */
   char *new_data = Arena_calloc (buf->arena, 1, new_cap, __FILE__, __LINE__);
   if (!new_data)
     RAISE_MSG (SocketBuf_Failed, SOCKET_ENOMEM ": Failed to calloc SocketBuf");
@@ -564,8 +444,6 @@ SocketBuf_reserve (T buf, size_t min_space)
   reserve_migrate_data (buf, new_data, new_cap);
   SOCKETBUF_INVARIANTS (buf);
 }
-
-/* ==================== Zero-Copy Pointer Access ==================== */
 
 const void *
 SocketBuf_readptr (T buf, size_t *len)
@@ -651,16 +529,7 @@ SocketBuf_written (T buf, size_t len)
   SOCKETBUF_INVARIANTS (buf);
 }
 
-/* ==================== Buffer Management Operations ==================== */
-
-/**
- * compact_rotate_in_place - Rotate buffer data in place using reversal
- * @data: Buffer data pointer
- * @capacity: Buffer capacity
- * @head: Current head position
- * @size: Current data size
- *
- * Uses the "three reversals" algorithm to rotate data in place:
+/* Uses the "three reversals" algorithm to rotate data in place:
  * 1. Reverse [head, capacity)
  * 2. Reverse [0, head)
  * 3. Reverse [0, size)
@@ -670,7 +539,6 @@ SocketBuf_written (T buf, size_t len)
 static void
 compact_rotate_in_place (char *data, size_t capacity, size_t head, size_t size)
 {
-  /* Helper macro to swap bytes */
 #define SWAP_BYTES(a, b)                                                      \
   do                                                                          \
     {                                                                         \
@@ -680,19 +548,15 @@ compact_rotate_in_place (char *data, size_t capacity, size_t head, size_t size)
     }                                                                         \
   while (0)
 
-  /* Reverse function for a range [start, end) */
   size_t first_part = capacity - head;
   size_t second_part = size - first_part;
 
-  /* Reverse [head, capacity) */
   for (size_t i = 0; i < first_part / 2; i++)
     SWAP_BYTES (data[head + i], data[capacity - 1 - i]);
 
-  /* Reverse [0, second_part) */
   for (size_t i = 0; i < second_part / 2; i++)
     SWAP_BYTES (data[i], data[second_part - 1 - i]);
 
-  /* Reverse [0, size) */
   for (size_t i = 0; i < size / 2; i++)
     SWAP_BYTES (data[i], data[size - 1 - i]);
 
@@ -704,44 +568,35 @@ SocketBuf_compact (T buf)
 {
   VALIDATE_BUF (buf);
 
-  /* Nothing to do if empty or already compacted */
   if (buf->size == 0 || buf->head == 0)
     return;
 
-  /* Calculate contiguous bytes from head to end of buffer */
   size_t first_part = buf->capacity - buf->head;
 
   if (first_part >= buf->size)
     {
-      /* No wrap - all data is contiguous, just memmove */
       memmove (buf->data, buf->data + buf->head, buf->size);
     }
   else
     {
-      /* Data wraps around - need temporary or two-part move */
       size_t second_part = buf->size - first_part;
 
-      /* If there's room at the end, shift first part up temporarily */
       if (first_part <= buf->head)
         {
-          /* Can move directly: second part fits before first moves */
           memmove (buf->data + first_part, buf->data, second_part);
           memmove (buf->data, buf->data + buf->head, first_part);
         }
       else
         {
-          /* Need to be careful - use arena temp buffer */
           char *temp = Arena_alloc (buf->arena, buf->size, __FILE__, __LINE__);
           if (temp)
             {
               memmove (temp, buf->data + buf->head, first_part);
               memmove (temp + first_part, buf->data, second_part);
               memmove (buf->data, temp, buf->size);
-              /* Arena temp will be freed with arena */
             }
           else
             {
-              /* Fall back to in-place rotation using reversal algorithm */
               compact_rotate_in_place (buf->data, buf->capacity, buf->head,
                                        buf->size);
             }
@@ -759,18 +614,14 @@ SocketBuf_ensure (T buf, size_t min_space)
 {
   VALIDATE_BUF (buf);
 
-  /* Check if already have enough space */
   if (SocketBuf_space (buf) >= min_space)
     return 1;
 
-  /* Try compacting first - might free up contiguous space */
   SocketBuf_compact (buf);
 
-  /* Check again after compacting */
   if (SocketBuf_space (buf) >= min_space)
     return 1;
 
-  /* Need to resize */
   TRY { SocketBuf_reserve (buf, min_space); }
   EXCEPT (SocketBuf_Failed) { return 0; }
   END_TRY;
@@ -778,28 +629,14 @@ SocketBuf_ensure (T buf, size_t min_space)
   return 1;
 }
 
-/**
- * get_byte_at_offset - Get byte at offset from head (handles wraparound)
- * @buf: Buffer to read from
- * @offset: Offset from head
- * Returns: Byte value at offset
- */
+
 static unsigned char
 get_byte_at_offset (const T buf, size_t offset)
 {
   return (unsigned char)buf->data[(buf->head + offset) % buf->capacity];
 }
 
-/**
- * match_pattern_at_offset - Check if pattern matches at given offset
- * @buf: Buffer to search in
- * @offset: Offset from head to start matching
- * @pattern: Pattern bytes to match
- * @pattern_len: Length of pattern
- *
- * Returns: 1 if pattern matches at offset, 0 otherwise
- * Thread-safe: No (caller must ensure exclusive access)
- */
+
 static int
 match_pattern_at_offset (const T buf, size_t offset,
                          const unsigned char *pattern, size_t pattern_len)
@@ -834,7 +671,6 @@ SocketBuf_find (T buf, const void *needle, size_t needle_len)
   const unsigned char *pattern = needle;
   size_t search_limit = buf->size - needle_len + 1;
 
-  /* Simple search - handles circular buffer transparently */
   for (size_t i = 0; i < search_limit; i++)
     {
       if (match_pattern_at_offset (buf, i, pattern, needle_len))
@@ -844,15 +680,7 @@ SocketBuf_find (T buf, const void *needle, size_t needle_len)
   return -1;
 }
 
-/**
- * readline_copy_and_strip - Copy line data and strip CR/LF endings
- * @src: Source buffer containing line data
- * @src_len: Length of source data
- * @dst: Destination buffer
- * @newline_pos: Position of newline in source, or -1 if not found
- *
- * Returns: Number of bytes written to dst (excluding null terminator)
- */
+
 static size_t
 readline_copy_and_strip (const char *src, size_t src_len, char *dst,
                          ssize_t newline_pos)
@@ -864,7 +692,6 @@ readline_copy_and_strip (const char *src, size_t src_len, char *dst,
   else
     line_bytes = src_len;
 
-  /* Strip trailing \r if present (handle \r\n line endings) */
   if (line_bytes > 0 && src[line_bytes - 1] == '\r')
     line_bytes--;
 
@@ -889,31 +716,25 @@ SocketBuf_readline (T buf, char *line, size_t max_len)
   if (max_len == 0)
     return -1;
 
-  /* Check if there's a complete line by trying to find newline */
   ssize_t nl_pos = SocketBuf_find (buf, "\n", 1);
   if (nl_pos < 0)
-    return -1; /* No complete line yet */
+    return -1;
 
-  /* Calculate line length excluding newline */
   size_t line_len = (size_t)nl_pos;
 
-  /* Limit to max_len - 1 (reserve space for null) */
   if (line_len > max_len - 1)
     line_len = max_len - 1;
 
-  /* Read the line data and newline together */
-  size_t total_to_read = line_len + 1; /* Include newline */
+  size_t total_to_read = line_len + 1;
   if (total_to_read > max_len)
     total_to_read = max_len;
 
-  /* Use fixed-size buffer to avoid VLA security issues */
   char temp[SOCKETBUF_MAX_LINE_LENGTH + 1];
   if (total_to_read > SOCKETBUF_MAX_LINE_LENGTH)
     total_to_read = SOCKETBUF_MAX_LINE_LENGTH;
 
   size_t bytes_read = SocketBuf_read (buf, temp, total_to_read);
 
-  /* Find newline in what we read */
   char *nl_ptr = memchr (temp, '\n', bytes_read);
   ssize_t newline_offset = nl_ptr ? (nl_ptr - temp) : -1;
 
@@ -922,8 +743,6 @@ SocketBuf_readline (T buf, char *line, size_t max_len)
 
   return (ssize_t)line_bytes;
 }
-
-/* ==================== Scatter-Gather I/O ==================== */
 
 #include <sys/uio.h>
 
@@ -955,7 +774,6 @@ SocketBuf_readv (T buf, const struct iovec *iov, int iovcnt)
       size_t n = SocketBuf_read (buf, iov[i].iov_base, iov[i].iov_len);
       total_read += n;
 
-      /* If we read less than requested, buffer is empty */
       if (n < iov[i].iov_len)
         break;
     }
@@ -991,7 +809,6 @@ SocketBuf_writev (T buf, const struct iovec *iov, int iovcnt)
       size_t n = SocketBuf_write (buf, iov[i].iov_base, iov[i].iov_len);
       total_written += n;
 
-      /* If we wrote less than requested, buffer is full */
       if (n < iov[i].iov_len)
         break;
     }

--- a/src/socket/SocketIO.c
+++ b/src/socket/SocketIO.c
@@ -4,21 +4,6 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketIO.c - Internal I/O abstraction layer
- *
- * Implements the internal I/O operations for sockets, handling both
- * standard system calls (send/recv) and TLS operations (SSL_write/SSL_read).
- * This abstraction allows the upper layers to be agnostic of the underlying
- * transport security.
- *
- * Features:
- * - Transparent TLS support
- * - Scatter/gather I/O emulation for TLS
- * - Consistent error handling via exceptions
- * - Thread-safe operation
- */
-
 /* System headers first (GNU C style) */
 #include <assert.h>
 #include <errno.h>
@@ -77,16 +62,6 @@ static ssize_t socket_recvv_tls (T socket, struct iovec *iov, int iovcnt);
  * - socketio_is_connection_closed_recv()
  */
 
-/**
- * socket_send_raw - Raw socket send operation
- * @socket: Socket instance
- * @buf: Data to send
- * @len: Length of data
- * @flags: Send flags
- *
- * Returns: Bytes sent or 0 if would block
- * Raises: Socket_Failed, Socket_Closed
- */
 static ssize_t
 socket_send_raw (T socket, const void *buf, size_t len, int flags)
 {
@@ -104,16 +79,6 @@ socket_send_raw (T socket, const void *buf, size_t len, int flags)
   return result;
 }
 
-/**
- * socket_recv_raw - Raw socket receive operation
- * @socket: Socket instance
- * @buf: Buffer for received data
- * @len: Buffer size
- * @flags: Receive flags
- *
- * Returns: Bytes received or 0 if would block
- * Raises: Socket_Failed, Socket_Closed
- */
 static ssize_t
 socket_recv_raw (T socket, void *buf, size_t len, int flags)
 {
@@ -135,15 +100,6 @@ socket_recv_raw (T socket, void *buf, size_t len, int flags)
   return result;
 }
 
-/**
- * socket_send_internal - Internal send operation
- * @socket: Socket instance
- * @buf: Data to send
- * @len: Length of data
- * @flags: Send flags
- *
- * Returns: Bytes sent or 0 if would block
- */
 ssize_t
 socket_send_internal (T socket, const void *buf, size_t len, int flags)
 {
@@ -175,15 +131,6 @@ socket_send_internal (T socket, const void *buf, size_t len, int flags)
   return result;
 }
 
-/**
- * socket_recv_internal - Internal receive operation
- * @socket: Socket instance
- * @buf: Buffer for received data
- * @len: Buffer size
- * @flags: Receive flags
- *
- * Returns: Bytes received or 0 if would block
- */
 ssize_t
 socket_recv_internal (T socket, void *buf, size_t len, int flags)
 {
@@ -215,18 +162,6 @@ socket_recv_internal (T socket, void *buf, size_t len, int flags)
   return result;
 }
 
-/**
- * socket_sendv_raw - Raw scatter/gather send implementation
- * @socket: Socket instance
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- * @flags: Send flags (MSG_NOSIGNAL automatically added)
- * Returns: Total bytes sent or 0 if would block
- * Raises: Socket_Failed
- *
- * Uses sendmsg() instead of writev() to support MSG_NOSIGNAL for
- * SIGPIPE suppression. The flags parameter is OR'd with MSG_NOSIGNAL.
- */
 static ssize_t
 socket_sendv_raw (T socket, const struct iovec *iov, int iovcnt, int flags)
 {
@@ -251,15 +186,6 @@ socket_sendv_raw (T socket, const struct iovec *iov, int iovcnt, int flags)
   return result;
 }
 
-/**
- * socket_recvv_raw - Raw scatter/gather receive implementation
- * @socket: Socket instance
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- * @flags: Receive flags
- * Returns: Total bytes received or 0 if would block
- * Raises: Socket_Failed or Socket_Closed
- */
 static ssize_t
 socket_recvv_raw (T socket, struct iovec *iov, int iovcnt, int flags)
 {
@@ -282,15 +208,6 @@ socket_recvv_raw (T socket, struct iovec *iov, int iovcnt, int flags)
   return result;
 }
 
-/**
- * socket_sendv_internal - Internal scatter/gather send
- * @socket: Socket instance
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- * @flags: Send flags
- *
- * Returns: Total bytes sent or 0 if would block
- */
 ssize_t
 socket_sendv_internal (T socket, const struct iovec *iov, int iovcnt,
                        int flags)
@@ -312,15 +229,6 @@ socket_sendv_internal (T socket, const struct iovec *iov, int iovcnt,
   return socket_sendv_raw (socket, iov, iovcnt, flags);
 }
 
-/**
- * socket_recvv_internal - Internal scatter/gather receive
- * @socket: Socket instance
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- * @flags: Receive flags
- *
- * Returns: Total bytes received or 0 if would block
- */
 ssize_t
 socket_recvv_internal (T socket, struct iovec *iov, int iovcnt, int flags)
 {
@@ -341,12 +249,6 @@ socket_recvv_internal (T socket, struct iovec *iov, int iovcnt, int flags)
   return socket_recvv_raw (socket, iov, iovcnt, flags);
 }
 
-/**
- * socket_is_tls_enabled - Check if TLS is enabled
- * @socket: Socket instance (read-only)
- *
- * Returns: 1 if enabled, 0 otherwise
- */
 int
 socket_is_tls_enabled (const T socket)
 {
@@ -359,11 +261,6 @@ socket_is_tls_enabled (const T socket)
 #endif
 }
 
-/**
- * socket_tls_want_read - Check if TLS wants read
- * @socket: Socket instance (read-only)
- * Returns: 1 if want read, 0 otherwise
- */
 int
 socket_tls_want_read (const T socket)
 {
@@ -381,11 +278,6 @@ socket_tls_want_read (const T socket)
 #endif
 }
 
-/**
- * socket_tls_want_write - Check if TLS wants write
- * @socket: Socket instance (read-only)
- * Returns: 1 if want write, 0 otherwise
- */
 int
 socket_tls_want_write (const T socket)
 {
@@ -402,17 +294,10 @@ socket_tls_want_write (const T socket)
 #endif
 }
 
-/* ==================== TLS I/O Operations ==================== */
 /* Merged from SocketIO-tls.c and SocketIO-tls-iov.c */
 
 #if SOCKET_HAS_TLS
 
-/**
- * socket_get_ssl - Helper to get SSL object from socket
- * @socket: Socket instance
- *
- * Returns: SSL object or NULL if not available
- */
 SSL *
 socket_get_ssl (T socket)
 {
@@ -423,15 +308,6 @@ socket_get_ssl (T socket)
 
 /* socket_is_recoverable_io_error removed - use socketio_is_wouldblock() */
 
-/* ==================== SSL Error Mapping ==================== */
-
-/**
- * SSLErrorMapping - Mapping from SSL error code to errno and state
- *
- * Provides data-driven error handling for SSL operations. Each entry
- * maps an SSL_ERROR_* code to the corresponding errno value and
- * indicates whether the error clears the handshake completion flag.
- */
 typedef struct
 {
   int ssl_error;        /**< SSL_ERROR_* constant */
@@ -439,13 +315,6 @@ typedef struct
   int clears_handshake; /**< 1 if this error resets handshake_done */
 } SSLErrorMapping;
 
-/**
- * SSL error mapping table - data-driven error classification
- *
- * This table maps SSL error codes to errno values. Using a table instead
- * of a switch statement makes it easier to add new error codes and
- * ensures consistent handling across all TLS operations.
- */
 static const SSLErrorMapping ssl_error_map[] = {
   { SSL_ERROR_NONE, 0, 0 },
   { SSL_ERROR_SSL, EPROTO, 0 },
@@ -463,12 +332,6 @@ static const SSLErrorMapping ssl_error_map[] = {
 
 #define SSL_ERROR_MAP_SIZE (sizeof (ssl_error_map) / sizeof (ssl_error_map[0]))
 
-/**
- * ssl_lookup_error - Find mapping for SSL error code
- * @ssl_error: SSL_ERROR_* constant to look up
- *
- * Returns: Pointer to mapping entry, or NULL if not found
- */
 static const SSLErrorMapping *
 ssl_lookup_error (int ssl_error)
 {
@@ -480,14 +343,6 @@ ssl_lookup_error (int ssl_error)
   return NULL;
 }
 
-/**
- * ssl_handle_syscall_error - Handle SSL_ERROR_SYSCALL specially
- *
- * Returns: -1 (always an error)
- *
- * SSL_ERROR_SYSCALL requires special handling: if errno is 0,
- * the connection was closed (EOF). Otherwise, keep the existing errno.
- */
 static int
 ssl_handle_syscall_error (void)
 {
@@ -496,19 +351,6 @@ ssl_handle_syscall_error (void)
   return -1;
 }
 
-/**
- * socket_handle_ssl_error - Map SSL error codes to errno values
- * @socket: Socket instance
- * @ssl: SSL object
- * @ssl_result: Result from SSL operation
- *
- * Returns: 0 on SSL_ERROR_NONE, -1 on error (sets errno)
- * Thread-safe: Yes (operates on single socket)
- *
- * Uses data-driven mapping table to convert SSL error codes to
- * appropriate errno values. Updates socket handshake state when
- * SSL indicates the handshake needs to continue.
- */
 int
 socket_handle_ssl_error (T socket, SSL *ssl, int ssl_result)
 {
@@ -536,13 +378,6 @@ socket_handle_ssl_error (T socket, SSL *ssl, int ssl_result)
   return -1;
 }
 
-/**
- * socket_validate_tls_ready - Validate TLS is ready for I/O
- * @socket: Socket instance
- *
- * Returns: SSL pointer if ready, raises exception otherwise
- * Thread-safe: Yes (operates on single socket)
- */
 SSL *
 socket_validate_tls_ready (T socket)
 {
@@ -554,16 +389,6 @@ socket_validate_tls_ready (T socket)
   return ssl;
 }
 
-/**
- * socket_send_tls - TLS send operation
- * @socket: Socket instance with TLS enabled
- * @buf: Data to send
- * @len: Length of data
- *
- * Returns: Bytes sent or 0 if would block
- * Raises: SocketTLS_Failed on error
- * Thread-safe: Yes (operates on single socket)
- */
 static ssize_t
 socket_send_tls (T socket, const void *buf, size_t len)
 {
@@ -586,16 +411,6 @@ socket_send_tls (T socket, const void *buf, size_t len)
   return (ssize_t)ssl_result;
 }
 
-/**
- * socket_recv_tls - TLS receive operation
- * @socket: Socket instance with TLS enabled
- * @buf: Buffer for received data
- * @len: Buffer size
- *
- * Returns: Bytes received or 0 if would block
- * Raises: SocketTLS_Failed on error, Socket_Closed on disconnect
- * Thread-safe: Yes (operates on single socket)
- */
 static ssize_t
 socket_recv_tls (T socket, void *buf, size_t len)
 {
@@ -620,25 +435,8 @@ socket_recv_tls (T socket, void *buf, size_t len)
   return (ssize_t)ssl_result;
 }
 
-/* ==================== TLS Scatter/Gather I/O ==================== */
 /* Merged from SocketIO-tls-iov.c */
 
-/**
- * copy_iov_to_buffer - Copy iovec array to contiguous buffer
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- * @buffer: Destination buffer
- * @buffer_size: Size of destination buffer
- *
- * Returns: Total bytes copied
- * Raises: Socket_Failed if buffer too small or overflow detected
- * Thread-safe: Yes (operates on local data)
- *
- * Security: Pre-validates total iovec size using
- * SocketCommon_calculate_total_iov_len which performs overflow-safe summation.
- * This prevents integer overflow attacks that could bypass the per-iteration
- * buffer bounds check.
- */
 static size_t
 copy_iov_to_buffer (const struct iovec *iov, int iovcnt, void *buffer,
                     size_t buffer_size)
@@ -674,16 +472,6 @@ copy_iov_to_buffer (const struct iovec *iov, int iovcnt, void *buffer,
   return offset;
 }
 
-/**
- * distribute_buffer_to_iov - Distribute buffer data across iovec array
- * @buffer: Source buffer
- * @buffer_len: Length of data in buffer
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- *
- * Returns: Total bytes distributed
- * Thread-safe: Yes (operates on local data)
- */
 static size_t
 distribute_buffer_to_iov (const void *buffer, size_t buffer_len,
                           struct iovec *iov, int iovcnt)
@@ -724,16 +512,6 @@ distribute_buffer_to_iov (const void *buffer, size_t buffer_len,
   return buffer_len - remaining;
 }
 
-/**
- * socket_sendv_tls - TLS scatter/gather send implementation
- * @socket: Socket instance
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- *
- * Returns: Total bytes sent or 0 if would block
- * Raises: Socket_Failed or SocketTLS_Failed
- * Thread-safe: Yes (operates on single socket)
- */
 static ssize_t
 socket_sendv_tls (T socket, const struct iovec *iov, int iovcnt)
 {
@@ -769,16 +547,6 @@ socket_sendv_tls (T socket, const struct iovec *iov, int iovcnt)
   return (ssize_t)ssl_result;
 }
 
-/**
- * socket_recvv_tls - TLS scatter/gather receive implementation
- * @socket: Socket instance
- * @iov: Array of iovec structures
- * @iovcnt: Number of iovec structures
- *
- * Returns: Total bytes received or 0 if would block
- * Raises: Socket_Failed, SocketTLS_Failed, or Socket_Closed
- * Thread-safe: Yes (operates on single socket)
- */
 static ssize_t
 socket_recvv_tls (T socket, struct iovec *iov, int iovcnt)
 {

--- a/src/socket/SocketWS-handshake.c
+++ b/src/socket/SocketWS-handshake.c
@@ -4,11 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketWS-handshake.c - WebSocket Handshake (RFC 6455 Section 4)
- *
- * Part of the Socket Library
- * Following C Interfaces and Implementations patterns
+/* SocketWS-handshake.c - WebSocket Handshake (RFC 6455 Section 4)
  *
  * HTTP upgrade handshake for WebSocket connections.
  *
@@ -46,20 +42,6 @@
 #include "socket/SocketBuf.h"
 #include "socket/SocketWS-private.h"
 
-/* ============================================================================
- * Safe snprintf Helper
- * ============================================================================
- */
-
-/**
- * ws_snprintf_checked - Write formatted string with overflow check
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset (updated on success)
- * @fmt: Format string
- *
- * Returns: 0 on success, -1 if buffer overflow would occur
- */
 static int ws_snprintf_checked (char *buf, size_t size, size_t *offset,
                                 const char *fmt, ...)
     __attribute__ ((format (printf, 4, 5)));
@@ -89,17 +71,6 @@ ws_snprintf_checked (char *buf, size_t size, size_t *offset, const char *fmt,
   return 0;
 }
 
-/* ============================================================================
- * Client Request Building - Helper Functions
- * ============================================================================
- */
-
-/**
- * ws_generate_handshake_keys - Generate client key and expected accept
- * @ws: WebSocket context
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_generate_handshake_keys (SocketWS_T ws)
 {
@@ -124,15 +95,6 @@ ws_generate_handshake_keys (SocketWS_T ws)
   return 0;
 }
 
-/**
- * ws_write_request_line - Write HTTP GET request line
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @path: Request path
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_request_line (char *buf, size_t size, size_t *offset,
                        const char *path)
@@ -141,16 +103,6 @@ ws_write_request_line (char *buf, size_t size, size_t *offset,
                               path ? path : "/");
 }
 
-/**
- * ws_write_host_header - Write Host header with optional port
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @host: Hostname
- * @port: Port number
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_host_header (char *buf, size_t size, size_t *offset, const char *host,
                       int port)
@@ -170,15 +122,6 @@ ws_write_host_header (char *buf, size_t size, size_t *offset, const char *host,
                               port);
 }
 
-/**
- * ws_write_websocket_headers - Write required WebSocket upgrade headers
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @client_key: Generated Sec-WebSocket-Key
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_websocket_headers (char *buf, size_t size, size_t *offset,
                             const char *client_key)
@@ -193,15 +136,6 @@ ws_write_websocket_headers (char *buf, size_t size, size_t *offset,
                               SOCKETWS_PROTOCOL_VERSION);
 }
 
-/**
- * ws_write_subprotocol_header - Write Sec-WebSocket-Protocol header
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @subprotocols: NULL-terminated array of subprotocols
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_subprotocol_header (char *buf, size_t size, size_t *offset,
                              const char *const *subprotocols)
@@ -229,15 +163,6 @@ ws_write_subprotocol_header (char *buf, size_t size, size_t *offset,
   return ws_snprintf_checked (buf, size, offset, "\r\n");
 }
 
-/**
- * ws_write_compression_header - Write permessage-deflate extension header
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @config: WebSocket configuration
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_compression_header (char *buf, size_t size, size_t *offset,
                              const SocketWS_Config *config)
@@ -270,12 +195,6 @@ ws_write_compression_header (char *buf, size_t size, size_t *offset,
   return ws_snprintf_checked (buf, size, offset, "\r\n");
 }
 
-/**
- * ws_build_client_request - Build HTTP upgrade request
- * @ws: WebSocket context
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_build_client_request (SocketWS_T ws)
 {
@@ -350,18 +269,6 @@ ws_build_client_request (SocketWS_T ws)
   return 0;
 }
 
-/* ============================================================================
- * Client Response Validation - Helper Functions
- * ============================================================================
- */
-
-/**
- * ws_validate_status_101 - Validate HTTP 101 status code
- * @ws: WebSocket context
- * @response: HTTP response
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_status_101 (SocketWS_T ws, const SocketHTTP_Response *response)
 {
@@ -375,16 +282,6 @@ ws_validate_status_101 (SocketWS_T ws, const SocketHTTP_Response *response)
   return 0;
 }
 
-/**
- * ws_validate_websocket_upgrade_header - Validate Upgrade: websocket header (shared for req/res)
- * @ws: WebSocket context
- * @headers: HTTP headers from request or response
- * @include_value: If true, include actual header value in error message for debugging
- *
- * Returns: 0 on success, -1 on error. Sets error via ws_set_error.
- *
- * @note Used for both client response validation and server request validation.
- */
 static int
 ws_validate_websocket_upgrade_header (SocketWS_T ws, SocketHTTP_Headers_T headers, bool include_value)
 {
@@ -407,16 +304,6 @@ ws_validate_websocket_upgrade_header (SocketWS_T ws, SocketHTTP_Headers_T header
   return 0;
 }
 
-/**
- * ws_validate_connection_upgrade_header - Validate Connection header contains "Upgrade" (shared for req/res)
- * @ws: WebSocket context
- * @headers: HTTP headers from request or response
- * @include_value: If true, include actual header value in error message for debugging
- *
- * Returns: 0 on success, -1 on error. Sets error via ws_set_error.
- *
- * @note Used for both client response validation and server request validation.
- */
 static int
 ws_validate_connection_upgrade_header (SocketWS_T ws, SocketHTTP_Headers_T headers, bool include_value)
 {
@@ -439,23 +326,6 @@ ws_validate_connection_upgrade_header (SocketWS_T ws, SocketHTTP_Headers_T heade
   return 0;
 }
 
-/**
- * ws_validate_base64_decoding - Shared helper to validate WebSocket base64 values
- * @ws: WebSocket context
- * @b64str: Input base64 string
- * @b64_len: Length of b64str
- * @expected_decoded_len: Expected length after base64 decode
- * @field_desc: Field name for error messages (e.g., "Sec-WebSocket-Key")
- *
- * Validates base64 decoding without retaining decoded data. Uses secure clear on temp buffer.
- * Does NOT check b64_len; caller must validate length first.
- *
- * Returns: 0 on success, -1 on error (sets error via ws_set_error)
- *
- * @note Used internally for Sec-WebSocket-Key and Sec-WebSocket-Accept validation.
- * @security Clears temporary decode buffer to prevent sensitive data leaks.
- * @complexity O(n) where n is decoded length
- */
 static int
 ws_validate_base64_decoding (SocketWS_T ws, const char *b64str, size_t b64_len,
                              size_t expected_decoded_len, const char *field_desc)
@@ -481,19 +351,6 @@ ws_validate_base64_decoding (SocketWS_T ws, const char *b64str, size_t b64_len,
   return 0;
 }
 
-/**
- * ws_init_compression_if_negotiated - Initialize compression if negotiated (shared helper)
- * @ws: WebSocket context
- *
- * Initializes per-message deflate compression context if negotiated during handshake.
- * Called after successful handshake validation on both client and server sides.
- * Logs warning if init fails but continues without compression.
- *
- * @note Only effective if SOCKETWS_HAS_DEFLATE defined and compression_negotiated true.
- * @note Idempotent: safe to call multiple times.
- * @threadsafe No - assumes single-threaded handshake completion.
- * @see ws_compression_init() for low-level init
- */
 static void
 ws_init_compression_if_negotiated (SocketWS_T ws)
 {
@@ -515,13 +372,6 @@ ws_init_compression_if_negotiated (SocketWS_T ws)
 #endif
 }
 
-/**
- * ws_validate_accept_value - Validate Sec-WebSocket-Accept header
- * @ws: WebSocket context
- * @headers: HTTP headers
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_accept_value (SocketWS_T ws, SocketHTTP_Headers_T headers)
 {
@@ -563,13 +413,6 @@ ws_validate_accept_value (SocketWS_T ws, SocketHTTP_Headers_T headers)
   return 0;
 }
 
-/**
- * ws_validate_negotiated_subprotocol - Validate server-selected subprotocol
- * @ws: WebSocket context
- * @headers: HTTP headers
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_negotiated_subprotocol (SocketWS_T ws,
                                     SocketHTTP_Headers_T headers)
@@ -606,13 +449,6 @@ ws_validate_negotiated_subprotocol (SocketWS_T ws,
   return 0;
 }
 
-/**
- * ws_parse_window_bits - Parse window bits parameter from extension string
- * @extensions: Extension header value
- * @param_name: Parameter name to look for
- *
- * Returns: Parsed value (8-15), or default if not found
- */
 static int
 ws_parse_window_bits (const char *extensions, const char *param_name)
 {
@@ -640,19 +476,6 @@ ws_parse_window_bits (const char *extensions, const char *param_name)
   return value;
 }
 
-/**
- * ws_parse_permessage_deflate_params - Parse permessage-deflate extension parameters (shared)
- * @ws: WebSocket context
- * @extensions: Sec-WebSocket-Extensions header value string
- *
- * Parses permessage-deflate parameters from extensions string.
- * Sets handshake flags only if "permessage-deflate" found.
- * Used by both client (server response) and server (client request) negotiation.
- *
- * @note Does not check config.enable_permessage_deflate; caller must handle.
- * @note Window bits default to SOCKETWS_DEFAULT_DEFLATE_WINDOW_BITS if not specified.
- * @see ws_negotiate_server_compression() for server-specific overrides.
- */
 static void
 ws_parse_permessage_deflate_params (SocketWS_T ws, const char *extensions)
 {
@@ -674,11 +497,6 @@ ws_parse_permessage_deflate_params (SocketWS_T ws, const char *extensions)
       = ws_parse_window_bits (extensions, "client_max_window_bits");
 }
 
-/**
- * ws_parse_negotiated_extensions - Parse extension negotiation results
- * @ws: WebSocket context
- * @headers: HTTP headers
- */
 static void
 ws_parse_negotiated_extensions (SocketWS_T ws, SocketHTTP_Headers_T headers)
 {
@@ -691,13 +509,6 @@ ws_parse_negotiated_extensions (SocketWS_T ws, SocketHTTP_Headers_T headers)
   ws_parse_permessage_deflate_params (ws, extensions);
 }
 
-/**
- * ws_validate_upgrade_response - Validate server's upgrade response
- * @ws: WebSocket context
- * @response: Parsed HTTP response
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_upgrade_response (SocketWS_T ws,
                               const SocketHTTP_Response *response)
@@ -732,11 +543,6 @@ ws_validate_upgrade_response (SocketWS_T ws,
   return 0;
 }
 
-/* ============================================================================
- * Client Handshake - State Machine
- * ============================================================================
- */
-
 int
 ws_handshake_client_init (SocketWS_T ws)
 {
@@ -760,12 +566,6 @@ ws_handshake_client_init (SocketWS_T ws)
   return 0;
 }
 
-/**
- * ws_send_request_data - Send pending request data
- * @ws: WebSocket context
- *
- * Returns: 0 if complete, 1 if would block, -1 on error
- */
 static int
 ws_send_request_data (SocketWS_T ws)
 {
@@ -788,12 +588,6 @@ ws_send_request_data (SocketWS_T ws)
   return 0;
 }
 
-/**
- * ws_read_and_parse_response - Read and parse HTTP response
- * @ws: WebSocket context
- *
- * Returns: 0 if complete, 1 if need more data, -1 on error
- */
 static int
 ws_read_and_parse_response (SocketWS_T ws)
 {
@@ -832,14 +626,6 @@ ws_read_and_parse_response (SocketWS_T ws)
   return 0;
 }
 
-/**
- * ws_finalize_client_handshake - Finalize successful client handshake
- * @ws: WebSocket context
- *
- * Returns: 0 on success, -1 on error
- *
- * Note: Compression initialization is handled in ws_validate_upgrade_response()
- */
 static int
 ws_finalize_client_handshake (SocketWS_T ws)
 {
@@ -906,20 +692,6 @@ ws_handshake_client_process (SocketWS_T ws)
     }
 }
 
-/* ============================================================================
- * Server Response Building - Helper Functions
- * ============================================================================
- */
-
-/**
- * ws_write_101_status_line - Write HTTP 101 status and core headers
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @accept_value: Computed Sec-WebSocket-Accept value
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_101_status_line (char *buf, size_t size, size_t *offset,
                           const char *accept_value)
@@ -933,15 +705,6 @@ ws_write_101_status_line (char *buf, size_t size, size_t *offset,
                               SOCKETWS_CONNECTION_VALUE, accept_value);
 }
 
-/**
- * ws_write_negotiated_subprotocol - Write selected subprotocol header
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @subprotocol: Selected subprotocol (may be NULL)
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_write_negotiated_subprotocol (char *buf, size_t size, size_t *offset,
                                  const char *subprotocol)
@@ -953,15 +716,6 @@ ws_write_negotiated_subprotocol (char *buf, size_t size, size_t *offset,
                               "Sec-WebSocket-Protocol: %s\r\n", subprotocol);
 }
 
-/**
- * ws_write_negotiated_compression - Write compression extension header
- * @buf: Output buffer
- * @size: Buffer size
- * @offset: Current offset
- * @handshake: Handshake state with compression params
- *
- * Returns: 0 on success, -1 on error
- */
 #ifdef SOCKETWS_HAS_DEFLATE
 static int
 ws_write_negotiated_compression (char *buf, size_t size, size_t *offset,
@@ -995,13 +749,6 @@ ws_write_negotiated_compression (char *buf, size_t size, size_t *offset,
 }
 #endif
 
-/**
- * ws_build_server_response - Build HTTP 101 response
- * @ws: WebSocket context
- * @client_key: Sec-WebSocket-Key from client
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_build_server_response (SocketWS_T ws, const char *client_key)
 {
@@ -1069,23 +816,10 @@ ws_build_server_response (SocketWS_T ws, const char *client_key)
   return 0;
 }
 
-/* ============================================================================
- * Server Handshake - Validation Helper Functions
- * ============================================================================
- */
 
 
 
 
-
-/**
- * ws_validate_client_key - Validate Sec-WebSocket-Key from client
- * @ws: WebSocket context
- * @headers: HTTP headers
- * @key_out: Output - pointer to key value
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_client_key (SocketWS_T ws, SocketHTTP_Headers_T headers,
                         const char **key_out)
@@ -1115,13 +849,6 @@ ws_validate_client_key (SocketWS_T ws, SocketHTTP_Headers_T headers,
   return 0;
 }
 
-/**
- * ws_validate_client_version - Validate Sec-WebSocket-Version from client
- * @ws: WebSocket context
- * @headers: HTTP headers
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_client_version (SocketWS_T ws, SocketHTTP_Headers_T headers)
 {
@@ -1138,14 +865,6 @@ ws_validate_client_version (SocketWS_T ws, SocketHTTP_Headers_T headers)
   return 0;
 }
 
-/**
- * ws_validate_client_upgrade_request - Validate all required upgrade headers
- * @ws: WebSocket context
- * @request: HTTP request
- * @key_out: Output - pointer to client key
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_validate_client_upgrade_request (SocketWS_T ws,
                                     const SocketHTTP_Request *request,
@@ -1166,11 +885,6 @@ ws_validate_client_upgrade_request (SocketWS_T ws,
   return 0;
 }
 
-/**
- * ws_negotiate_server_subprotocol - Negotiate subprotocol with client
- * @ws: WebSocket context
- * @headers: HTTP headers
- */
 static void
 ws_negotiate_server_subprotocol (SocketWS_T ws, SocketHTTP_Headers_T headers)
 {
@@ -1204,11 +918,6 @@ ws_negotiate_server_subprotocol (SocketWS_T ws, SocketHTTP_Headers_T headers)
     }
 }
 
-/**
- * ws_negotiate_server_compression - Negotiate compression with client
- * @ws: WebSocket context
- * @headers: HTTP headers
- */
 static void
 ws_negotiate_server_compression (SocketWS_T ws, SocketHTTP_Headers_T headers)
 {
@@ -1253,10 +962,6 @@ ws_handshake_server_init (SocketWS_T ws, const SocketHTTP_Request *request)
   return 0;
 }
 
-/**
- * ws_finalize_server_handshake - Finalize successful server handshake
- * @ws: WebSocket context
- */
 static void
 ws_finalize_server_handshake (SocketWS_T ws)
 {
@@ -1310,11 +1015,6 @@ ws_handshake_validate_accept (SocketWS_T ws, const char *accept)
                                       strlen (accept));
 }
 
-/* ============================================================================
- * Helper - Copy String to Arena
- * ============================================================================
- */
-
 char *
 ws_copy_string (Arena_T arena, const char *str)
 {
@@ -1332,17 +1032,6 @@ ws_copy_string (Arena_T arena, const char *str)
   return copy;
 }
 
-/* ============================================================================
- * Public API - Check WebSocket Upgrade
- * ============================================================================
- */
-
-/**
- * SocketWS_is_upgrade - Check if HTTP request is WebSocket upgrade
- * @request: Parsed HTTP request
- *
- * Returns: 1 if WebSocket upgrade request, 0 otherwise
- */
 int
 SocketWS_is_upgrade (const SocketHTTP_Request *request)
 {
@@ -1369,13 +1058,6 @@ SocketWS_is_upgrade (const SocketHTTP_Request *request)
   return 1;
 }
 
-/**
- * ws_copy_status_phrase - Safely copy status phrase with length limit
- * @dest: Destination buffer
- * @dest_size: Size of destination buffer
- * @reason: Source string (may be NULL)
- * @default_phrase: Default phrase if reason is NULL or too long
- */
 static void
 ws_copy_status_phrase (char *dest, size_t dest_size, const char *reason,
                        const char *default_phrase)
@@ -1396,12 +1078,6 @@ ws_copy_status_phrase (char *dest, size_t dest_size, const char *reason,
   snprintf (dest, dest_size, "%s", source);
 }
 
-/**
- * SocketWS_server_reject - Reject WebSocket upgrade with HTTP response
- * @socket: TCP socket
- * @status_code: HTTP status code (e.g., 400, 403)
- * @reason: Rejection reason
- */
 void
 SocketWS_server_reject (Socket_T socket, int status_code, const char *reason)
 {

--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -4,11 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketWS.c - WebSocket Protocol Core (RFC 6455)
- *
- * Part of the Socket Library
- * Following C Interfaces and Implementations patterns
+/* SocketWS.c - WebSocket Protocol Core (RFC 6455)
  *
  * Core WebSocket lifecycle, configuration, state management, and I/O.
  * Frame parsing and handshake logic are in separate files.
@@ -50,18 +46,6 @@
 
 #define T SocketWS_T
 
-/* ============================================================================
- * Poll Event Translation
- * ============================================================================
- */
-
-/**
- * ws_translate_poll_revents - Translate poll(2) revents to library events
- * @revents: poll(2) revents bitmask
- *
- * Returns: Library POLL_* event bitmask
- * Thread-safe: Yes - pure function
- */
 static unsigned
 ws_translate_poll_revents (short revents)
 {
@@ -79,30 +63,11 @@ ws_translate_poll_revents (short revents)
   return ev;
 }
 
-/* ============================================================================
- * Module Constants
- * ============================================================================
- */
-
-/** Initial message assembly buffer capacity */
 #define SOCKETWS_INITIAL_MESSAGE_CAPACITY 4096
-
-/** Buffer growth factor for message assembly */
 #define SOCKETWS_MESSAGE_BUFFER_GROWTH_FACTOR 2
-
-/** Maximum iterations for buffer growth loop (overflow protection) */
 #define SOCKETWS_MAX_GROWTH_ITERATIONS 64
-
-/** Default zlib compression level */
 #define SOCKETWS_DEFAULT_COMPRESSION_LEVEL 6
-
-/** Default zlib window bits (maximum) */
 #define SOCKETWS_DEFAULT_WINDOW_BITS 15
-
-/* ============================================================================
- * Exception Definitions
- * ============================================================================
- */
 
 const Except_T SocketWS_Failed
     = { &SocketWS_Failed, "WebSocket operation failed" };
@@ -111,13 +76,7 @@ const Except_T SocketWS_ProtocolError
 const Except_T SocketWS_Closed
     = { &SocketWS_Closed, "WebSocket connection closed" };
 
-/* Thread-local exception for detailed error messages */
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketWS);
-
-/* ============================================================================
- * Configuration Defaults
- * ============================================================================
- */
 
 void
 SocketWS_config_defaults (SocketWS_Config *config)
@@ -139,24 +98,6 @@ SocketWS_config_defaults (SocketWS_Config *config)
   config->ping_timeout_ms = SOCKETWS_DEFAULT_PING_TIMEOUT_MS;
 }
 
-/* ============================================================================
- * Internal Helpers
- * ============================================================================
- */
-
-/**
- * ws_alloc_context - Allocate and initialize WebSocket context
- * @arena: Memory arena
- * @config: Configuration (NULL for defaults)
- *
- * Returns: Allocated context, or NULL on error
- */
-/**
- * ws_alloc_struct - Allocate and zero WebSocket structure
- * @arena: Memory arena
- *
- * Returns: Allocated structure or NULL
- */
 static SocketWS_T
 ws_alloc_struct (Arena_T arena)
 {
@@ -172,11 +113,6 @@ ws_alloc_struct (Arena_T arena)
   return ws;
 }
 
-/**
- * ws_init_config - Initialize configuration
- * @ws: WebSocket context
- * @config: Input config or NULL for defaults
- */
 static void
 ws_init_config (SocketWS_T ws, const SocketWS_Config *config)
 {
@@ -189,12 +125,6 @@ ws_init_config (SocketWS_T ws, const SocketWS_Config *config)
   ws->state = WS_STATE_CONNECTING;
 }
 
-/**
- * ws_init_buffers - Allocate receive and send buffers
- * @ws: WebSocket context
- *
- * Returns: 0 on success, -1 on failure (previous buffers freed)
- */
 static int
 ws_init_buffers (SocketWS_T ws)
 {
@@ -212,10 +142,6 @@ ws_init_buffers (SocketWS_T ws)
   return 0;
 }
 
-/**
- * ws_init_parsers - Initialize frame and message parsers
- * @ws: WebSocket context
- */
 static void
 ws_init_parsers (SocketWS_T ws)
 {
@@ -248,11 +174,6 @@ ws_alloc_context (Arena_T arena, const SocketWS_Config *config)
 /* ws_copy_string is declared in private header and defined in
  * SocketWS-handshake.c */
 
-/* ============================================================================
- * Error Handling
- * ============================================================================
- */
-
 void
 ws_set_error (SocketWS_T ws, SocketWS_Error error, const char *fmt, ...)
 {
@@ -276,14 +197,6 @@ ws_set_error (SocketWS_T ws, SocketWS_Error error, const char *fmt, ...)
     }
 }
 
-/**
- * ws_ensure_open - Ensure WebSocket is in open state for data/control frames
- * @ws: WebSocket context
- *
- * Returns: 1 if open and ready, 0 otherwise (error set)
- * Raises: None
- * Thread-safe: No
- */
 static int
 ws_ensure_open (SocketWS_T ws)
 {
@@ -295,11 +208,6 @@ ws_ensure_open (SocketWS_T ws)
   return 1;
 }
 
-/* ============================================================================
- * Frame State Management
- * ============================================================================
- */
-
 void
 ws_frame_reset (SocketWS_FrameParse *frame)
 {
@@ -309,11 +217,6 @@ ws_frame_reset (SocketWS_FrameParse *frame)
   frame->state = WS_FRAME_STATE_HEADER;
   frame->header_needed = 2; /* Minimum header size */
 }
-
-/* ============================================================================
- * Message Assembly Management
- * ============================================================================
- */
 
 void
 ws_message_reset (SocketWS_MessageAssembly *message)
@@ -328,13 +231,6 @@ ws_message_reset (SocketWS_MessageAssembly *message)
   message->utf8_initialized = 0;
 }
 
-/**
- * ws_message_check_limits - Check fragment and size limits
- * @ws: WebSocket context
- * @additional_len: Length to add
- *
- * Returns: 0 if OK, -1 if limit exceeded (sets error)
- */
 static int
 ws_message_check_limits (SocketWS_T ws, size_t additional_len)
 {
@@ -365,13 +261,6 @@ ws_message_check_limits (SocketWS_T ws, size_t additional_len)
   return 0;
 }
 
-/**
- * ws_message_grow_buffer - Grow message buffer if needed
- * @ws: WebSocket context
- * @required_len: Required total length
- *
- * Returns: 0 on success, -1 on error
- */
 static int
 ws_message_grow_buffer (SocketWS_T ws, size_t required_len)
 {
@@ -416,14 +305,6 @@ ws_message_grow_buffer (SocketWS_T ws, size_t required_len)
   return 0;
 }
 
-/**
- * ws_message_validate_utf8 - Validate UTF-8 incrementally
- * @ws: WebSocket context
- * @data: Data to validate
- * @len: Data length
- *
- * Returns: 0 if valid, -1 if invalid
- */
 static int
 ws_message_validate_utf8 (SocketWS_T ws, const unsigned char *data, size_t len)
 {
@@ -511,20 +392,6 @@ ws_message_finalize (SocketWS_T ws)
   return 0;
 }
 
-/* ============================================================================
- * Message Finalization Helpers
- * ============================================================================
- */
-
-/**
- * ws_finalize_assembled_message - Apply post-processing to an assembled message
- * @ws: WebSocket context
- *
- * Handles permessage-deflate decompression when negotiated. Leaves
- * ws->message.* populated for consumption by SocketWS_recv_message().
- *
- * Returns: 0 on success, -1 on error (ws->last_error set)
- */
 static int
 ws_finalize_assembled_message (SocketWS_T ws)
 {
@@ -559,20 +426,6 @@ ws_finalize_assembled_message (SocketWS_T ws)
   return 0;
 }
 
-/* ============================================================================
- * Transport Helpers
- * ============================================================================
- */
-
-/**
- * ws_requires_masking - Check if frames require client masking
- * @ws: WebSocket context
- *
- * Per RFC 6455, client frames over TCP must be masked.
- * Per RFC 8441, HTTP/2 WebSocket frames do not use masking.
- *
- * Returns: 1 if masking required, 0 otherwise
- */
 int
 ws_requires_masking (SocketWS_T ws)
 {
@@ -588,22 +441,6 @@ ws_requires_masking (SocketWS_T ws)
   return ws->role == WS_ROLE_CLIENT;
 }
 
-/* ============================================================================
- * I/O Helpers
- * ============================================================================
- */
-
-/**
- * ws_send_contiguous - Send contiguous data from send buffer
- * @ws: WebSocket context
- * @ptr: Data pointer
- * @available: Available length
- *
- * Uses transport abstraction if available, falls back to direct socket I/O.
- *
- * Returns: Bytes sent, 0 would block/empty, -1 error
- * Raises: None (sets ws error)
- */
 static ssize_t
 ws_send_contiguous (SocketWS_T ws, const void *ptr, size_t available)
 {
@@ -686,17 +523,6 @@ ws_flush_send_buffer (SocketWS_T ws)
   return ws_send_contiguous (ws, ptr, available);
 }
 
-/**
- * ws_recv_contiguous - Receive into contiguous buffer space
- * @ws: WebSocket context
- * @ptr: Write pointer
- * @space: Available space
- *
- * Uses transport abstraction if available, falls back to direct socket I/O.
- *
- * Returns: Bytes received, 0 EOF/would block, -1 error
- * Raises: None (sets ws error)
- */
 static ssize_t
 ws_recv_contiguous (SocketWS_T ws, void *ptr, size_t space)
 {
@@ -779,19 +605,6 @@ ws_fill_recv_buffer (SocketWS_T ws)
   return ws_recv_contiguous (ws, ptr, space);
 }
 
-/* ============================================================================
- * Control Frame Handling
- * ============================================================================
- */
-
-/**
- * ws_store_close_reason - Store close reason in context
- * @ws: WebSocket context
- * @reason: Reason string (may be NULL)
- * @reason_len: Reason length
- *
- * Truncates reason to SOCKETWS_MAX_CLOSE_REASON if needed.
- */
 static void
 ws_store_close_reason (SocketWS_T ws, const char *reason, size_t reason_len)
 {
@@ -809,16 +622,6 @@ ws_store_close_reason (SocketWS_T ws, const char *reason, size_t reason_len)
     }
 }
 
-/**
- * ws_build_close_payload - Build CLOSE frame payload
- * @payload: Output buffer
- * @payload_len: Output length
- * @code: Close code
- * @reason: Reason string or NULL
- *
- * Fills payload with code + reason (truncated if needed)
- * Returns: 0 on success
- */
 static int
 ws_build_close_payload (unsigned char *payload, size_t *payload_len,
                         SocketWS_CloseCode code, const char *reason)
@@ -850,17 +653,6 @@ ws_build_close_payload (unsigned char *payload, size_t *payload_len,
   return 0;
 }
 
-/**
- * ws_prepare_close_state - Prepare close state and info
- * @ws: WebSocket context
- * @code: Close code
- * @reason: Reason or NULL
- * @payload: Payload buffer
- * @payload_len: Payload length output
- *
- * Updates state, stores info, builds payload
- * Returns: 0 on success, -1 if invalid code/reason
- */
 static int
 ws_prepare_close_state (SocketWS_T ws, SocketWS_CloseCode code,
                         const char *reason, unsigned char *payload,
@@ -949,25 +741,6 @@ ws_send_pong (SocketWS_T ws, const unsigned char *payload, size_t len)
   return ws_send_control_frame (ws, WS_OPCODE_PONG, payload, len);
 }
 
-/**
- * ws_handle_close_frame - Handle received CLOSE frame
- * @ws: WebSocket context
- * @payload: Close frame payload
- * @len: Payload length
- *
- * Returns: 0 on success, -1 on error
- */
-/**
- * ws_parse_close_payload - Parse CLOSE frame payload
- * @payload: Input payload
- * @len: Payload length
- * @code_out: Output close code
- * @reason_out: Output reason string
- * @reason_len_out: Output reason length
- *
- * Parses code (first 2 bytes) and reason (rest).
- * Returns: 1 if parsed, 0 if invalid (<2 bytes)
- */
 static int
 ws_parse_close_payload (const unsigned char *payload, size_t len,
                         SocketWS_CloseCode *code_out, const char **reason_out,
@@ -990,15 +763,6 @@ ws_parse_close_payload (const unsigned char *payload, size_t len,
   return 1;
 }
 
-/**
- * ws_validate_and_store_close_reason - Validate and store close reason
- * @ws: WebSocket context
- * @reason: Reason string
- * @reason_len: Length
- *
- * Validates UTF-8 if enabled, truncates if too long, stores.
- * Returns: 0 on success, -1 invalid UTF-8
- */
 static int
 ws_validate_and_store_close_reason (SocketWS_T ws, const char *reason,
                                     size_t reason_len)
@@ -1105,11 +869,6 @@ ws_handle_control_frame (SocketWS_T ws, SocketWS_Opcode opcode,
     }
 }
 
-/* ============================================================================
- * Auto-Ping Timer Integration
- * ============================================================================
- */
-
 void
 ws_auto_ping_callback (void *userdata)
 {
@@ -1178,17 +937,6 @@ ws_auto_ping_stop (SocketWS_T ws)
     }
 }
 
-/* ============================================================================
- * Public API - Lifecycle
- * ============================================================================
- */
-
-/**
- * ws_prepare_config - Prepare configuration with role
- * @cfg: Output configuration
- * @config: Input configuration (may be NULL)
- * @role: Role to set
- */
 static void
 ws_prepare_config (SocketWS_Config *cfg, const SocketWS_Config *config,
                    SocketWS_Role role)
@@ -1201,13 +949,6 @@ ws_prepare_config (SocketWS_Config *cfg, const SocketWS_Config *config,
   cfg->role = role;
 }
 
-/**
- * ws_create_context - Create WebSocket context with arena
- * @config: Prepared configuration
- *
- * Returns: New WebSocket context (caller owns arena on error)
- * Raises: SocketWS_Failed on error
- */
 static SocketWS_T
 ws_create_context (const SocketWS_Config *config)
 {
@@ -1347,11 +1088,6 @@ SocketWS_free (SocketWS_T *wsp)
   *wsp = NULL;
 }
 
-/* ============================================================================
- * Public API - State Accessors
- * ============================================================================
- */
-
 SocketWS_State
 SocketWS_state (SocketWS_T ws)
 {
@@ -1438,11 +1174,6 @@ SocketWS_error_string (SocketWS_Error error)
     }
 }
 
-/* ============================================================================
- * Public API - Handshake
- * ============================================================================
- */
-
 int
 SocketWS_handshake (SocketWS_T ws)
 {
@@ -1469,11 +1200,6 @@ SocketWS_handshake (SocketWS_T ws)
 
   return result;
 }
-
-/* ============================================================================
- * Public API - Event Loop Integration
- * ============================================================================
- */
 
 int
 SocketWS_pollfd (SocketWS_T ws)
@@ -1508,17 +1234,6 @@ SocketWS_poll_events (SocketWS_T ws)
   return events;
 }
 
-/**
- * ws_process_frames - Drain receive buffer into frames/messages
- * @ws: WebSocket context
- *
- * Parses available frames, handling control frames inline and assembling data
- * frames into ws->message. Stops when a complete data message is ready or no
- * more data is available.
- *
- * Returns: 1 if a complete message became available, 0 if no complete message,
- *          -1 on error.
- */
 static int
 ws_process_frames (SocketWS_T ws)
 {
@@ -1590,11 +1305,6 @@ SocketWS_process (SocketWS_T ws, unsigned events)
 
   return 0;
 }
-
-/* ============================================================================
- * Public API - Sending
- * ============================================================================
- */
 
 int
 SocketWS_send_text (SocketWS_T ws, const char *data, size_t len)
@@ -1668,11 +1378,6 @@ SocketWS_close (SocketWS_T ws, int code, const char *reason)
 
   return ws_send_close (ws, (SocketWS_CloseCode)code, reason);
 }
-
-/* ============================================================================
- * Convenience Functions
- * ============================================================================
- */
 
 SocketWS_T
 SocketWS_connect (const char *url, const char *protocols)

--- a/src/socket/SocketWSH2.c
+++ b/src/socket/SocketWSH2.c
@@ -4,10 +4,7 @@
  * https://x.com/tetsuoai
  */
 
-/**
- * SocketWSH2.c - WebSocket over HTTP/2 (RFC 8441)
- *
- * Part of the Socket Library
+/* SocketWSH2.c - WebSocket over HTTP/2 (RFC 8441)
  *
  * Implements WebSocket connections over HTTP/2 streams using Extended CONNECT.
  *
@@ -32,39 +29,15 @@
 #include <assert.h>
 #include <string.h>
 
-/* ============================================================================
- * Module Log Component
- * ============================================================================
- */
-
 #undef SOCKET_LOG_COMPONENT
 #define SOCKET_LOG_COMPONENT "SocketWSH2"
 
 #include "core/SocketUtil.h"
 
-/* ============================================================================
- * Internal Constants
- * ============================================================================
- */
-
 /** Buffer sizes for WebSocket-over-HTTP/2 */
 #define WSH2_RECV_BUFFER_SIZE 16384
 #define WSH2_SEND_BUFFER_SIZE 16384
 
-/* ============================================================================
- * Internal Helpers
- * ============================================================================
- */
-
-/**
- * wsh2_create_ws_context - Create WebSocket context for HTTP/2 stream
- * @arena: Memory arena for allocations
- * @stream: HTTP/2 stream
- * @config: WebSocket configuration
- * @role: Client or server role
- *
- * Returns: WebSocket context or NULL on failure
- */
 static SocketWS_T
 wsh2_create_ws_context (Arena_T arena, SocketHTTP2_Stream_T stream,
                         const SocketWS_Config *config, SocketWS_Role role)
@@ -137,11 +110,6 @@ wsh2_create_ws_context (Arena_T arena, SocketHTTP2_Stream_T stream,
 
   return ws;
 }
-
-/* ============================================================================
- * Server API
- * ============================================================================
- */
 
 int
 SocketWSH2_is_websocket_request (SocketHTTP2_Stream_T stream)
@@ -221,11 +189,6 @@ SocketWSH2_server_accept (SocketHTTP2_Stream_T stream,
 
   return ws;
 }
-
-/* ============================================================================
- * Client API
- * ============================================================================
- */
 
 int
 SocketWSH2_is_supported (SocketHTTP2_Conn_T conn)
@@ -362,11 +325,6 @@ SocketWSH2_client_connect (SocketHTTP2_Conn_T conn, const char *path,
 
   return ws;
 }
-
-/* ============================================================================
- * Accessor Functions
- * ============================================================================
- */
 
 SocketHTTP2_Stream_T
 SocketWSH2_get_stream (SocketWS_T ws)


### PR DESCRIPTION
## Summary

- Remove redundant and overly verbose comments from all socket module source files
- Follow established pattern from recent cleanup PRs in `src/tls/` and `include/http/`
- Remove 5,300+ lines of redundant documentation while preserving comments that explain non-obvious logic

## Changes

**Files cleaned (17 total):**
- `Socket.c`, `Socket-connect.c`, `Socket-convenience.c`, `Socket-fd.c`
- `SocketAsync.c`, `SocketBuf.c`, `SocketDgram.c`, `SocketHappyEyeballs.c`
- `SocketIO.c`, `SocketProxy.c`, `SocketReconnect.c`
- `SocketWS.c`, `SocketWS-deflate.c`, `SocketWS-frame.c`, `SocketWS-handshake.c`, `SocketWS-transport.c`, `SocketWSH2.c`

**Types of comments removed:**
- File-level block comments duplicating header documentation
- Function doc blocks that restate obvious behavior from function names/signatures
- Section separator comments (`/* ========== Section ========== */`)
- "Thread-safe:" annotations where obvious from context
- Redundant macro/constant explanations

## Test plan

- [x] Build passes with sanitizers enabled
- [x] All 70 tests pass with ASan + UBSan