### PR TITLE
docs: add socket_util_safe_strncpy to references

### DIFF
--- a/.claude/references/README.md
+++ b/.claude/references/README.md
@@ -118,6 +118,7 @@ Security-focused implementation patterns and validation utilities.
 - Safe allocation patterns (Arena with overflow protection, buffer size validation)
 - Overflow-safe arithmetic (addition, multiplication with checks)
 - Input validation macros (port, buffer size)
+- Safe string copy patterns (socket_util_safe_strncpy instead of strncpy)
 - Cryptographic security patterns (constant-time comparison, secure clearing, CSPRNG)
 - Thread-safe error handling (thread-local exceptions, error buffers)
 - Safe system call patterns (SAFE_CLOSE, thread-safe strerror)

--- a/.claude/references/module-apis.md
+++ b/.claude/references/module-apis.md
@@ -411,6 +411,10 @@ Logging, metrics, and events (from `include/core/SocketUtil.h`):
 - `SocketEvents_emit(event_type, event_data)` - Emit event
 - `SocketEvents_set_callback(callback, userdata)` - Set custom event callback
 
+### Safe String Utilities:
+- `socket_util_safe_strncpy(dest, src, max_len)` - Safe string copy with guaranteed null-termination (use instead of strncpy)
+- `socket_util_safe_copy_ip(dest, src, max_len)` - Safe IP address string copy (use with SOCKET_IP_MAX_LEN)
+
 ### Hash Utilities:
 - `socket_util_hash_fd(fd, table_size)` - Hash file descriptor (golden ratio)
 - `socket_util_hash_ptr(ptr, table_size)` - Hash pointer

--- a/.claude/references/security-patterns.md
+++ b/.claude/references/security-patterns.md
@@ -113,6 +113,33 @@ if (!SOCKET_VALID_BUFFER_SIZE(buffer_size)) {
 }
 ```
 
+## Safe String Copy Patterns
+
+### Use socket_util_safe_strncpy Instead of strncpy:
+```c
+/* NEVER use strncpy() directly - may not null-terminate */
+
+/* WRONG - strncpy does NOT guarantee null-termination */
+char buf[256];
+strncpy(buf, user_input, sizeof(buf));  /* BUG: may not be null-terminated! */
+
+/* CORRECT - socket_util_safe_strncpy always null-terminates */
+char buf[256];
+socket_util_safe_strncpy(buf, user_input, sizeof(buf));  /* Always safe */
+```
+
+### Safe IP Address Copy:
+```c
+/* Use socket_util_safe_copy_ip for IP address strings */
+char ip_buf[SOCKET_IP_MAX_LEN];
+socket_util_safe_copy_ip(ip_buf, client_ip, sizeof(ip_buf));
+```
+
+### Why strncpy is Dangerous:
+- `strncpy(dest, src, n)` does NOT null-terminate if `strlen(src) >= n`
+- This leads to buffer overread vulnerabilities when the string is used
+- `socket_util_safe_strncpy` always null-terminates by copying at most `max_len-1` chars
+
 ## Cryptographic Security Patterns
 
 ### Constant-Time Comparison (Timing Attack Prevention):


### PR DESCRIPTION
## Summary

Document the safe string copy utilities added in #94:
- Add `socket_util_safe_strncpy()` and `socket_util_safe_copy_ip()` to module-apis.md under SocketUtil Functions
- Add "Safe String Copy Patterns" section to security-patterns.md explaining why strncpy is dangerous
- Update README.md to include safe string patterns in contents list

### Changes to module-apis.md

Added new "Safe String Utilities" section:
```
- socket_util_safe_strncpy(dest, src, max_len) - Safe string copy with guaranteed null-termination (use instead of strncpy)
- socket_util_safe_copy_ip(dest, src, max_len) - Safe IP address string copy (use with SOCKET_IP_MAX_LEN)
```

### Changes to security-patterns.md

Added "Safe String Copy Patterns" section with:
- Example of WRONG (strncpy) vs CORRECT (socket_util_safe_strncpy) usage
- Safe IP address copy pattern
- Explanation of why strncpy is dangerous

## Test plan

- [x] Verify documentation matches the actual function signatures in SocketUtil.h
- [x] Verify code examples are correct and follow library patterns