### PR TITLE
refactor: use socket_util_safe_strncpy for string copy safety

### DIFF
--- a/src/core/SocketIPTracker.c
+++ b/src/core/SocketIPTracker.c
@@ -189,7 +189,7 @@ alloc_and_init_entry (const T tracker, const char *ip, int initial_count)
   if (entry == NULL)
     return NULL;
 
-  snprintf (entry->ip, sizeof (entry->ip), "%s", ip);
+  socket_util_safe_copy_ip (entry->ip, ip, sizeof (entry->ip));
   entry->count = initial_count;
   entry->next = NULL;
 

--- a/src/core/SocketUtil.c
+++ b/src/core/SocketUtil.c
@@ -299,8 +299,7 @@ socketlog_format_timestamp (char *buf, size_t bufsize)
   if (!time_ok
       || strftime (buf, bufsize, SOCKET_LOG_TIMESTAMP_FORMAT, &tm_buf) == 0)
     {
-      strncpy (buf, SOCKET_LOG_DEFAULT_TIMESTAMP, bufsize);
-      buf[bufsize - 1] = '\0';
+      socket_util_safe_strncpy (buf, SOCKET_LOG_DEFAULT_TIMESTAMP, bufsize);
     }
 
   return buf;


### PR DESCRIPTION
## Summary

- Replace `snprintf(dest, size, "%s", src)` with `socket_util_safe_copy_ip()` for IP address copying in SocketIPTracker.c
- Replace manual `strncpy + null-termination` pattern with `socket_util_safe_strncpy()` in SocketUtil.c

Both changes improve code consistency by using the purpose-built safe string utilities added in commit 9fef12f4.

Fixes #96

## Test plan

- [x] Build passes with sanitizers enabled (ASan + UBSan)
- [x] All 72 tests pass with sanitizers
- [x] No memory safety issues detected