### PR TITLE
docs: add comprehensive fuzzing references

### DIFF
--- a/.claude/references/README.md
+++ b/.claude/references/README.md
@@ -156,6 +156,62 @@ C Interfaces and Implementations patterns and GNU C style guidelines.
 
 **Use when**: Writing new code, refactoring existing code, or ensuring style compliance.
 
+### 7. fuzzing-patterns.md
+Implementation patterns for libFuzzer harnesses.
+
+**Contents**:
+- File structure template (license, docstring, includes, entry point)
+- Operation enum pattern (multi-operation fuzzers)
+- Byte extraction helpers (read_u16, read_u32, get_op)
+- Input format documentation
+- Arena memory pattern (lifecycle management)
+- Exception handling pattern (catching all module exceptions)
+- Volatile variables for exception safety
+- GCC clobbered warning suppression
+- SIGPIPE handling for network fuzzers
+- Conditional compilation for optional features
+- Accessor coverage pattern (exercising all getters)
+- Incremental parsing pattern (variable chunk sizes)
+- Known input testing pattern (valid/invalid baselines)
+- Security attack vector pattern (explicit attack tests)
+- Configuration variation pattern (strict/lenient modes)
+- Fuzzed configuration pattern (fuzz-driven config)
+- Error/result string coverage
+- Multi-test organization (section headers)
+- Limits and bounds (fuzzing-specific constants)
+- Parser reset and reuse
+- Body reading pattern
+- Build commands (cmake, libFuzzer options)
+
+**Use when**: Creating new fuzzers, improving fuzzing coverage, or understanding fuzzer patterns.
+
+### 8. fuzzing-harnesses.md
+Complete harness templates for different fuzzer types.
+
+**Contents**:
+- Parser fuzzer template (HTTP, HPACK, WebSocket parsers)
+- Buffer fuzzer template (SocketBuf, circular buffers)
+- State machine fuzzer template (TLS handshake, connection lifecycle)
+- Codec fuzzer template (HPACK, UTF-8, Base64 encoding/decoding)
+- Security attack fuzzer template (HTTP smuggling, injection)
+- Frame parsing fuzzer template (WebSocket, HTTP/2 frames)
+- Validation fuzzer template (UTF-8, DNS, IP, URL validation)
+
+**Use when**: Creating new fuzzers from scratch, need a starting template for a specific fuzzer category.
+
+### 9. fuzzing-coverage.md
+Fuzzer coverage mapping and attack vector documentation.
+
+**Contents**:
+- Fuzzer index (all 95+ fuzzers with target modules and categories)
+- Coverage by module (detailed breakdown per module)
+- Attack vector coverage (buffer attacks, injection, smuggling, DoS, protocol, encoding)
+- Running fuzzers (quick start, recommended parameters)
+- Adding new fuzzers (checklist, CMakeLists.txt entry, initial corpus)
+- Fuzzer dependencies (required features, conditional compilation)
+
+**Use when**: Understanding what fuzzers exist, what they test, identifying coverage gaps, adding new fuzzers.
+
 ## Usage in Commands
 
 Command files can now reference these shared materials instead of duplicating content:
@@ -168,6 +224,9 @@ For protocol implementation patterns, see `.claude/references/protocol-patterns.
 For security limits, see `.claude/references/security-limits.md`
 For security patterns, see `.claude/references/security-patterns.md`
 For style guidelines, see `.claude/references/style-guide.md`
+For fuzzing patterns, see `.claude/references/fuzzing-patterns.md`
+For fuzzing harness templates, see `.claude/references/fuzzing-harnesses.md`
+For fuzzing coverage map, see `.claude/references/fuzzing-coverage.md`
 ```
 
 ## Benefits
@@ -195,5 +254,8 @@ When updating shared content:
 - `security-limits.md`: ~9.5KB (limits and constants)
 - `security-patterns.md`: ~16KB (security best practices)
 - `style-guide.md`: ~14KB (coding standards)
+- `fuzzing-patterns.md`: ~18KB (fuzzer implementation patterns)
+- `fuzzing-harnesses.md`: ~28KB (complete harness templates)
+- `fuzzing-coverage.md`: ~16KB (coverage mapping and attack vectors)
 
-Total: ~96KB of shared reference material extracted from commands
+Total: ~158KB of shared reference material

--- a/.claude/references/fuzzing-coverage.md
+++ b/.claude/references/fuzzing-coverage.md
@@ -1,0 +1,551 @@
+# Fuzzing Coverage Reference
+
+This document maps all fuzzers to their target modules, attack vectors, and coverage goals.
+
+## Fuzzer Index
+
+| Fuzzer | Target Module | Category | Max Input Size |
+|--------|---------------|----------|----------------|
+| `fuzz_address_parse` | SocketCommon | Validation | 4096 |
+| `fuzz_arena` | Arena | Memory | 4096 |
+| `fuzz_async` | SocketAsync | I/O | 4096 |
+| `fuzz_base64_decode` | SocketCrypto | Codec | 4096 |
+| `fuzz_cert_pinning` | SocketTLS | TLS | 4096 |
+| `fuzz_certificate_parsing` | SocketTLS | TLS | 4096 |
+| `fuzz_cidr_parse` | SocketCommon | Validation | 4096 |
+| `fuzz_connect` | Socket | Core | 4096 |
+| `fuzz_dns_inj` | SocketDNS | Security | 4096 |
+| `fuzz_dns_validate` | SocketDNS | Validation | 4096 |
+| `fuzz_dtls_config` | SocketDTLS | TLS | 4096 |
+| `fuzz_dtls_context` | SocketDTLS | TLS | 4096 |
+| `fuzz_dtls_cookie` | SocketDTLS | TLS | 4096 |
+| `fuzz_dtls_enable_config` | SocketDTLS | TLS | 4096 |
+| `fuzz_dtls_handshake` | SocketDTLS | TLS | 4096 |
+| `fuzz_dtls_io` | SocketDTLS | TLS | 4096 |
+| `fuzz_exception` | Except | Core | 4096 |
+| `fuzz_happy_eyeballs` | SocketHappyEyeballs | Connection | 4096 |
+| `fuzz_hex_decode` | SocketCrypto | Codec | 4096 |
+| `fuzz_hpack` | SocketHPACK | HTTP/2 | 32768 |
+| `fuzz_hpack_decode` | SocketHPACK | HTTP/2 | 32768 |
+| `fuzz_hpack_encode` | SocketHPACK | HTTP/2 | 32768 |
+| `fuzz_hpack_huffman` | SocketHPACK | HTTP/2 | 4096 |
+| `fuzz_hpack_integer` | SocketHPACK | HTTP/2 | 4096 |
+| `fuzz_http1_chunked` | SocketHTTP1 | HTTP | 65536 |
+| `fuzz_http1_compression` | SocketHTTP1 | HTTP | 65536 |
+| `fuzz_http1_headers` | SocketHTTP1 | HTTP | 65536 |
+| `fuzz_http1_request` | SocketHTTP1 | HTTP | 65536 |
+| `fuzz_http1_response` | SocketHTTP1 | HTTP | 65536 |
+| `fuzz_http1_serialize` | SocketHTTP1 | HTTP | 65536 |
+| `fuzz_http2_connection` | SocketHTTP2 | HTTP/2 | 65536 |
+| `fuzz_http2_frames` | SocketHTTP2 | HTTP/2 | 65536 |
+| `fuzz_http2_frames_full` | SocketHTTP2 | HTTP/2 | 65536 |
+| `fuzz_http2_headers` | SocketHTTP2 | HTTP/2 | 65536 |
+| `fuzz_http2_settings` | SocketHTTP2 | HTTP/2 | 65536 |
+| `fuzz_http_auth` | SocketHTTPClient | HTTP | 32768 |
+| `fuzz_http_client` | SocketHTTPClient | HTTP | 65536 |
+| `fuzz_http_content_type` | SocketHTTP | HTTP | 32768 |
+| `fuzz_http_cookies` | SocketHTTP | HTTP | 32768 |
+| `fuzz_http_cookies_simple` | SocketSimple | HTTP | 32768 |
+| `fuzz_http_core` | SocketHTTP | HTTP | 32768 |
+| `fuzz_http_date` | SocketHTTP | HTTP | 4096 |
+| `fuzz_http_headers_collection` | SocketHTTP | HTTP | 32768 |
+| `fuzz_http_server` | SocketHTTPServer | HTTP | 65536 |
+| `fuzz_http_smuggling` | SocketHTTP1 | Security | 65536 |
+| `fuzz_ip_parse` | SocketCommon | Validation | 4096 |
+| `fuzz_iptracker` | SocketIPTracker | Security | 4096 |
+| `fuzz_metrics` | SocketMetrics | Util | 4096 |
+| `fuzz_new_features` | Various | Mixed | 65536 |
+| `fuzz_pin_hex_parsing` | SocketTLS | TLS | 4096 |
+| `fuzz_pool_dos` | SocketPool | Security | 4096 |
+| `fuzz_proxy_http` | SocketProxy | Proxy | 4096 |
+| `fuzz_proxy_socks4` | SocketProxy | Proxy | 4096 |
+| `fuzz_proxy_socks5` | SocketProxy | Proxy | 4096 |
+| `fuzz_proxy_url` | SocketProxy | Proxy | 4096 |
+| `fuzz_ratelimit` | SocketRateLimit | Security | 4096 |
+| `fuzz_reconnect` | SocketReconnect | Connection | 4096 |
+| `fuzz_security` | Various | Security | 65536 |
+| `fuzz_socketbuf` | SocketBuf | Buffer | 4096 |
+| `fuzz_socketbuf_stress` | SocketBuf | Buffer | 4096 |
+| `fuzz_socketdgram` | SocketDgram | UDP | 65536 |
+| `fuzz_socketio` | SocketIO | I/O | 4096 |
+| `fuzz_socketpoll` | SocketPoll | Event | 4096 |
+| `fuzz_socketpool` | SocketPool | Pool | 4096 |
+| `fuzz_ssl_path_validation` | SocketTLS | TLS | 4096 |
+| `fuzz_synprotect` | SocketSYNProtect | Security | 4096 |
+| `fuzz_timer` | SocketTimer | Util | 4096 |
+| `fuzz_tls_alpn` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_buffer_pool` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_cert_lookup` | SocketTLSContext | TLS | 4096 |
+| `fuzz_tls_certs` | SocketTLSContext | TLS | 4096 |
+| `fuzz_tls_cipher` | SocketTLSContext | TLS | 4096 |
+| `fuzz_tls_config` | SocketTLSContext | TLS | 4096 |
+| `fuzz_tls_context` | SocketTLSContext | TLS | 4096 |
+| `fuzz_tls_crl` | SocketTLSContext | TLS | 4096 |
+| `fuzz_tls_ct` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_error` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_handshake` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_io` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_key_update` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_ktls` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_ocsp` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_protocol_version` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_records` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_session` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_shutdown` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_sni` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_verify` | SocketTLS | TLS | 4096 |
+| `fuzz_tls_verify_callback` | SocketTLS | TLS | 4096 |
+| `fuzz_unix_path` | SocketUnix | Validation | 4096 |
+| `fuzz_uri_parse` | SocketHTTP | Validation | 4096 |
+| `fuzz_utf8` | SocketUTF8 | Validation | 4096 |
+| `fuzz_utf8_incremental` | SocketUTF8 | Validation | 4096 |
+| `fuzz_utf8_validate` | SocketUTF8 | Validation | 4096 |
+| `fuzz_websocket_handshake` | SocketWS | WebSocket | 4096 |
+| `fuzz_ws_deflate` | SocketWS | WebSocket | 4096 |
+| `fuzz_ws_frame` | SocketWS | WebSocket | 4096 |
+| `fuzz_ws_frames` | SocketWS | WebSocket | 65536 |
+| `fuzz_ws_handshake` | SocketWS | WebSocket | 4096 |
+
+## Coverage by Module
+
+### Core Modules
+
+**Arena** (`fuzz_arena`):
+- Arena creation with various sizes
+- Allocation patterns
+- Deallocation and reset
+- Overflow protection
+- Memory exhaustion
+
+**Except** (`fuzz_exception`):
+- Exception raising
+- TRY/EXCEPT/FINALLY blocks
+- Nested exception handling
+- RERAISE functionality
+- Thread-local exception state
+
+### Socket Core
+
+**Socket** (`fuzz_connect`):
+- Socket creation
+- Connection operations
+- Timeout handling
+- Error conditions
+
+**SocketBuf** (`fuzz_socketbuf`, `fuzz_socketbuf_stress`):
+- Buffer creation
+- Write/read operations
+- Peek/consume
+- Wraparound handling
+- Dynamic resizing
+- Secure clear
+- Mixed operations stress test
+
+**SocketDgram** (`fuzz_socketdgram`):
+- UDP socket operations
+- Multicast
+- Broadcast
+- Message boundaries
+
+**SocketIO** (`fuzz_socketio`):
+- Vectored I/O
+- Partial reads/writes
+- Scatter/gather operations
+
+### HTTP/1.1 Parsing
+
+**SocketHTTP1 Request** (`fuzz_http1_request`):
+- Request line parsing (method, URI, version)
+- Header parsing
+- Body mode detection
+- Incremental parsing
+- Parser state transitions
+- Configuration variations
+- Resource limits
+- Keep-alive detection
+- 100-continue handling
+- Malformed request rejection
+
+**SocketHTTP1 Response** (`fuzz_http1_response`):
+- Status line parsing
+- Response header parsing
+- Body handling
+- Chunked encoding
+- Connection close detection
+
+**SocketHTTP1 Chunked** (`fuzz_http1_chunked`):
+- Chunk size parsing
+- Chunk extension handling
+- Trailer headers
+- Malformed chunks
+- Chunk overflow
+
+**SocketHTTP1 Headers** (`fuzz_http1_headers`):
+- Header name validation
+- Header value validation
+- Obs-fold handling
+- Header injection prevention
+- Multiple headers
+
+**SocketHTTP1 Serialize** (`fuzz_http1_serialize`):
+- Request serialization
+- Response serialization
+- Header serialization
+- Body encoding
+
+### HTTP/2 and HPACK
+
+**SocketHPACK** (`fuzz_hpack`, `fuzz_hpack_decode`, `fuzz_hpack_encode`):
+- HPACK decoding
+- HPACK encoding
+- Dynamic table manipulation
+- Table size changes
+- Integer encoding/decoding
+- Huffman encoding/decoding
+- HPACK bomb prevention
+
+**SocketHPACK Huffman** (`fuzz_hpack_huffman`):
+- Huffman decoding
+- Padding validation
+- Truncated sequences
+- EOS symbol
+
+**SocketHPACK Integer** (`fuzz_hpack_integer`):
+- Integer prefix decoding
+- Overflow handling
+- Multi-byte integers
+
+**SocketHTTP2 Frames** (`fuzz_http2_frames`, `fuzz_http2_frames_full`):
+- Frame type parsing
+- Frame header validation
+- Payload length validation
+- Stream ID handling
+- Flag interpretation
+
+**SocketHTTP2 Connection** (`fuzz_http2_connection`):
+- Connection preface
+- SETTINGS frames
+- Flow control
+- Stream management
+- GOAWAY handling
+
+**SocketHTTP2 Settings** (`fuzz_http2_settings`):
+- SETTINGS payload parsing
+- Setting value validation
+- ACK handling
+
+**SocketHTTP2 Headers** (`fuzz_http2_headers`):
+- HEADERS frame parsing
+- CONTINUATION handling
+- Priority information
+- Pseudo-headers
+
+### WebSocket
+
+**SocketWS Frames** (`fuzz_ws_frames`, `fuzz_ws_frame`):
+- Frame header parsing
+- Opcode validation
+- Masking/unmasking
+- Payload length (7/16/64-bit)
+- Control frame limits
+- RSV bits
+- Fragment handling
+
+**SocketWS Handshake** (`fuzz_websocket_handshake`, `fuzz_ws_handshake`):
+- Upgrade request parsing
+- Sec-WebSocket-Key handling
+- Protocol negotiation
+- Extension negotiation
+
+**SocketWS Deflate** (`fuzz_ws_deflate`):
+- Permessage-deflate
+- Compression parameters
+- Decompression
+
+### TLS/DTLS
+
+**SocketTLS Handshake** (`fuzz_tls_handshake`):
+- Handshake state machine
+- Non-blocking handshake
+- Timeout handling
+- State queries
+
+**SocketTLS Context** (`fuzz_tls_context`, `fuzz_tls_config`):
+- Context creation
+- Configuration options
+- Protocol version selection
+- Cipher suite selection
+
+**SocketTLS Certificates** (`fuzz_tls_certs`, `fuzz_certificate_parsing`):
+- Certificate loading
+- Certificate chain validation
+- Certificate pinning
+
+**SocketTLS Pinning** (`fuzz_cert_pinning`, `fuzz_pin_hex_parsing`):
+- Pin parsing
+- Pin validation
+- Backup pins
+
+**SocketTLS ALPN** (`fuzz_tls_alpn`):
+- Protocol list parsing
+- Protocol negotiation
+- Callback handling
+
+**SocketTLS Session** (`fuzz_tls_session`):
+- Session caching
+- Session resumption
+- Session tickets
+
+**SocketTLS CRL** (`fuzz_tls_crl`):
+- CRL loading
+- CRL checking
+- Revocation handling
+
+**SocketTLS OCSP** (`fuzz_tls_ocsp`):
+- OCSP stapling
+- OCSP response parsing
+- Status checking
+
+**SocketDTLS** (`fuzz_dtls_*`):
+- Cookie exchange
+- Retransmission
+- MTU handling
+- DoS protection
+
+### Proxy
+
+**SocketProxy HTTP** (`fuzz_proxy_http`):
+- HTTP CONNECT parsing
+- Authentication
+- Response handling
+
+**SocketProxy SOCKS** (`fuzz_proxy_socks4`, `fuzz_proxy_socks5`):
+- SOCKS4/4a parsing
+- SOCKS5 authentication
+- Address types (IPv4, IPv6, domain)
+
+**SocketProxy URL** (`fuzz_proxy_url`):
+- Proxy URL parsing
+- Credential extraction
+- Scheme detection
+
+### Validation
+
+**SocketUTF8** (`fuzz_utf8`, `fuzz_utf8_incremental`, `fuzz_utf8_validate`):
+- UTF-8 validation
+- Overlong sequence detection
+- Surrogate rejection
+- Invalid code point detection
+- Incremental validation
+
+**IP Parsing** (`fuzz_ip_parse`, `fuzz_cidr_parse`, `fuzz_address_parse`):
+- IPv4 parsing
+- IPv6 parsing
+- CIDR notation
+- Address validation
+
+**URI Parsing** (`fuzz_uri_parse`):
+- URI component parsing
+- Scheme detection
+- Authority parsing
+- Path normalization
+
+**Unix Path** (`fuzz_unix_path`):
+- Unix socket path validation
+- Abstract socket names
+- Path length limits
+
+### Security Features
+
+**HTTP Smuggling** (`fuzz_http_smuggling`):
+- CL.TE attacks
+- TE.CL attacks
+- TE.TE obfuscation
+- Duplicate headers
+- Header injection
+- Chunk attacks
+
+**Rate Limiting** (`fuzz_ratelimit`):
+- Token bucket algorithm
+- Rate calculations
+- Burst handling
+
+**IP Tracking** (`fuzz_iptracker`):
+- Per-IP connection tracking
+- Limit enforcement
+- Hash collisions
+
+**SYN Protection** (`fuzz_synprotect`):
+- Reputation system
+- Challenge generation
+- Action decisions
+
+**Pool DoS** (`fuzz_pool_dos`):
+- Resource exhaustion
+- Connection limits
+- Drain handling
+
+### Utility Modules
+
+**SocketTimer** (`fuzz_timer`):
+- Timer creation
+- Expiration handling
+- Cancellation
+
+**SocketMetrics** (`fuzz_metrics`):
+- Metric recording
+- Counter operations
+- Gauge operations
+
+## Attack Vector Coverage
+
+### Buffer Attacks
+| Attack | Fuzzer(s) |
+|--------|-----------|
+| Buffer overflow | All buffer/parser fuzzers |
+| Integer overflow in length | `fuzz_http1_*`, `fuzz_http2_*`, `fuzz_hpack_*` |
+| Stack buffer overflow | All fuzzers (assert-based) |
+| Heap buffer overflow | All fuzzers with Arena |
+
+### Injection Attacks
+| Attack | Fuzzer(s) |
+|--------|-----------|
+| Header injection | `fuzz_http1_*`, `fuzz_http_smuggling` |
+| CRLF injection | `fuzz_http1_*`, `fuzz_http_smuggling` |
+| Null byte injection | `fuzz_http1_*`, `fuzz_dns_inj` |
+| Command injection | `fuzz_proxy_*` |
+
+### Smuggling Attacks
+| Attack | Fuzzer(s) |
+|--------|-----------|
+| CL.TE | `fuzz_http_smuggling` |
+| TE.CL | `fuzz_http_smuggling` |
+| TE.TE obfuscation | `fuzz_http_smuggling` |
+| Duplicate CL | `fuzz_http_smuggling`, `fuzz_http1_request` |
+| Obs-fold | `fuzz_http_smuggling`, `fuzz_http1_headers` |
+
+### DoS Attacks
+| Attack | Fuzzer(s) |
+|--------|-----------|
+| HPACK bomb | `fuzz_hpack`, `fuzz_hpack_decode` |
+| Huge allocations | All fuzzers with size parameters |
+| Resource exhaustion | `fuzz_pool_dos`, `fuzz_socketpool` |
+| Slowloris | `fuzz_http1_*` (incremental parsing) |
+| Hash collision | `fuzz_iptracker` |
+| Fragment bomb | `fuzz_ws_frames` |
+
+### Protocol Attacks
+| Attack | Fuzzer(s) |
+|--------|-----------|
+| State machine corruption | All state machine fuzzers |
+| Invalid state transitions | `fuzz_tls_handshake`, `fuzz_ws_frames` |
+| Protocol downgrade | `fuzz_tls_protocol_version` |
+| Renegotiation attack | `fuzz_tls_*` |
+
+### Encoding Attacks
+| Attack | Fuzzer(s) |
+|--------|-----------|
+| Overlong UTF-8 | `fuzz_utf8*` |
+| Surrogate pairs | `fuzz_utf8*` |
+| Invalid Huffman | `fuzz_hpack_huffman` |
+| Base64 malformed | `fuzz_base64_decode` |
+| Hex decode malformed | `fuzz_hex_decode` |
+
+## Running Fuzzers
+
+### Quick Start
+```bash
+# Build all fuzzers
+CC=clang cmake -S . -B build -DENABLE_FUZZING=ON
+cmake --build build -j
+
+# Run single fuzzer
+cd build && ./fuzz_http1_request corpus/http1_request/ -fork=16 -max_len=65536
+```
+
+### Recommended Parameters by Category
+
+**Parser Fuzzers** (HTTP, HPACK, WebSocket):
+```bash
+./fuzz_parser corpus/ -fork=16 -max_len=65536 -rss_limit_mb=2048
+```
+
+**Buffer Fuzzers**:
+```bash
+./fuzz_buffer corpus/ -fork=8 -max_len=4096 -rss_limit_mb=512
+```
+
+**TLS Fuzzers**:
+```bash
+./fuzz_tls corpus/ -fork=8 -max_len=4096 -timeout=60
+```
+
+**Security Fuzzers**:
+```bash
+./fuzz_security corpus/ -fork=16 -max_len=65536 -rss_limit_mb=4096
+```
+
+### Continuous Fuzzing
+```bash
+# Run for 24 hours
+./fuzz_target corpus/ -fork=16 -max_total_time=86400
+
+# Run until N new crashes
+./fuzz_target corpus/ -fork=16 -max_crashes=10
+
+# Minimize corpus
+./fuzz_target -merge=1 corpus_minimal/ corpus/
+```
+
+## Adding New Fuzzers
+
+### Checklist
+1. [ ] Follow file structure template from `fuzzing-patterns.md`
+2. [ ] Use appropriate harness template from `fuzzing-harnesses.md`
+3. [ ] Add to CMakeLists.txt fuzzer list
+4. [ ] Create initial corpus directory
+5. [ ] Document in this coverage file
+6. [ ] Test with sanitizers enabled
+
+### CMakeLists.txt Entry
+```cmake
+if(ENABLE_FUZZING)
+    add_executable(fuzz_new_module src/fuzz/fuzz_new_module.c)
+    target_link_libraries(fuzz_new_module PRIVATE socket_lib)
+    target_compile_options(fuzz_new_module PRIVATE -fsanitize=fuzzer,address,undefined)
+    target_link_options(fuzz_new_module PRIVATE -fsanitize=fuzzer,address,undefined)
+endif()
+```
+
+### Initial Corpus
+```bash
+# Create corpus directory
+mkdir -p corpus/new_module
+
+# Add seed files
+echo "minimal valid input" > corpus/new_module/seed_valid
+echo -e "\x00\x01\x02" > corpus/new_module/seed_binary
+```
+
+## Fuzzer Dependencies
+
+### Required Features
+| Fuzzer | Required Feature |
+|--------|------------------|
+| `fuzz_tls_*` | `SOCKET_HAS_TLS` |
+| `fuzz_dtls_*` | `SOCKET_HAS_TLS` |
+| `fuzz_http1_compression` | `ENABLE_HTTP_COMPRESSION` |
+| `fuzz_ws_deflate` | `ENABLE_HTTP_COMPRESSION` |
+| `fuzz_async` | Platform-specific async I/O |
+
+### Conditional Compilation
+```c
+#if SOCKET_HAS_TLS
+/* TLS fuzzer implementation */
+#else
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    (void)data; (void)size;
+    return 0;
+}
+#endif
+```

--- a/.claude/references/fuzzing-harnesses.md
+++ b/.claude/references/fuzzing-harnesses.md
@@ -1,0 +1,1363 @@
+# Fuzzing Harness Templates
+
+This document contains complete harness templates for different types of fuzzers in the socket library.
+
+## Parser Fuzzer Template
+
+For protocol parsers (HTTP/1.1, HTTP/2, HPACK, WebSocket):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_protocol_parser.c - Protocol Parser Fuzzer
+ *
+ * Targets:
+ * - Message parsing (headers, body)
+ * - State machine transitions
+ * - Incremental parsing with arbitrary boundaries
+ * - Configuration variations
+ * - Resource limits enforcement
+ * - Error handling paths
+ *
+ * Security focus:
+ * - Injection prevention
+ * - Buffer overflow prevention
+ * - Integer overflow in lengths
+ * - Resource exhaustion protection
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_protocol_parser
+ * ./fuzz_protocol_parser corpus/protocol/ -fork=16 -max_len=65536
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "protocol/SocketProtocol.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * Exercise all parser accessor functions
+ */
+static void
+exercise_parser_accessors(Parser_T parser)
+{
+    State state = Parser_state(parser);
+    (void)state;
+
+    /* Query all available state */
+    int64_t length = Parser_content_length(parser);
+    (void)length;
+
+    int complete = Parser_is_complete(parser);
+    (void)complete;
+
+    /* Access parsed structures if available */
+    if (state >= STATE_COMPLETE) {
+        const ParsedData *data = Parser_get_data(parser);
+        if (data) {
+            (void)data->field1;
+            (void)data->field2;
+        }
+    }
+}
+
+/**
+ * Test incremental parsing with variable chunk sizes
+ */
+static void
+test_incremental_parsing(Parser_T parser, const uint8_t *data,
+                         size_t size, size_t chunk_size)
+{
+    size_t offset = 0;
+    size_t consumed;
+    Result result = RESULT_INCOMPLETE;
+
+    while (offset < size && result == RESULT_INCOMPLETE) {
+        size_t remaining = size - offset;
+        size_t to_parse = (remaining < chunk_size) ? remaining : chunk_size;
+
+        result = Parser_execute(parser, (const char *)data + offset,
+                                to_parse, &consumed);
+        offset += consumed;
+
+        if (consumed == 0 && result == RESULT_INCOMPLETE)
+            offset++;
+    }
+
+    exercise_parser_accessors(parser);
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Arena_T arena = NULL;
+    Parser_T parser = NULL;
+    size_t consumed;
+    Result result;
+
+    if (size == 0)
+        return 0;
+
+    arena = Arena_new();
+    if (!arena)
+        return 0;
+
+    TRY {
+        /* ====================================================================
+         * Test 1: Default configuration
+         * ==================================================================== */
+        {
+            parser = Parser_new(NULL, arena);
+            if (parser) {
+                result = Parser_execute(parser, (const char *)data, size, &consumed);
+                exercise_parser_accessors(parser);
+
+                /* Test reset and reparse */
+                Parser_reset(parser);
+                Parser_execute(parser, (const char *)data, size, &consumed);
+
+                Parser_free(&parser);
+            }
+        }
+
+        /* ====================================================================
+         * Test 2: Strict mode
+         * ==================================================================== */
+        {
+            Config strict_cfg;
+            config_defaults(&strict_cfg);
+            strict_cfg.strict_mode = 1;
+
+            parser = Parser_new(&strict_cfg, arena);
+            if (parser) {
+                Parser_execute(parser, (const char *)data, size, &consumed);
+                exercise_parser_accessors(parser);
+                Parser_free(&parser);
+            }
+        }
+
+        /* ====================================================================
+         * Test 3: Restrictive limits
+         * ==================================================================== */
+        {
+            Config restrictive_cfg;
+            config_defaults(&restrictive_cfg);
+            restrictive_cfg.max_size = 1024;
+            restrictive_cfg.max_count = 10;
+
+            parser = Parser_new(&restrictive_cfg, arena);
+            if (parser) {
+                Parser_execute(parser, (const char *)data, size, &consumed);
+                Parser_free(&parser);
+            }
+        }
+
+        /* ====================================================================
+         * Test 4: Incremental parsing
+         * ==================================================================== */
+        {
+            size_t chunk_sizes[] = { 1, 2, 7, 13, 64, 256, 1024 };
+
+            for (size_t i = 0; i < sizeof(chunk_sizes) / sizeof(chunk_sizes[0]); i++) {
+                parser = Parser_new(NULL, arena);
+                if (parser) {
+                    test_incremental_parsing(parser, data, size, chunk_sizes[i]);
+                    Parser_free(&parser);
+                }
+            }
+        }
+
+        /* ====================================================================
+         * Test 5: Known valid inputs
+         * ==================================================================== */
+        {
+            const char *valid_inputs[] = {
+                "VALID INPUT 1",
+                "VALID INPUT 2",
+                "VALID INPUT 3",
+            };
+
+            for (size_t i = 0; i < sizeof(valid_inputs) / sizeof(valid_inputs[0]); i++) {
+                parser = Parser_new(NULL, arena);
+                if (parser) {
+                    Parser_execute(parser, valid_inputs[i], strlen(valid_inputs[i]), &consumed);
+                    exercise_parser_accessors(parser);
+                    Parser_free(&parser);
+                }
+            }
+        }
+
+        /* ====================================================================
+         * Test 6: Security attack vectors
+         * ==================================================================== */
+        {
+            const char *attack_vectors[] = {
+                "ATTACK VECTOR 1 - injection",
+                "ATTACK VECTOR 2 - overflow",
+                "ATTACK VECTOR 3 - smuggling",
+            };
+
+            Config strict_cfg;
+            config_defaults(&strict_cfg);
+            strict_cfg.strict_mode = 1;
+
+            for (size_t i = 0; i < sizeof(attack_vectors) / sizeof(attack_vectors[0]); i++) {
+                parser = Parser_new(&strict_cfg, arena);
+                if (parser) {
+                    Parser_execute(parser, attack_vectors[i], strlen(attack_vectors[i]), &consumed);
+                    Parser_free(&parser);
+                }
+            }
+        }
+    }
+    EXCEPT(Parser_Error) {
+        /* Expected on malformed input */
+    }
+    EXCEPT(Arena_Failed) {
+        /* Expected on memory exhaustion */
+    }
+    END_TRY;
+
+    Arena_dispose(&arena);
+
+    return 0;
+}
+```
+
+## Buffer Fuzzer Template
+
+For buffer operations (SocketBuf, circular buffers):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_buffer.c - Buffer Operations Fuzzer
+ *
+ * Targets:
+ * - Buffer creation with various capacities
+ * - Write/read/peek operations
+ * - Wraparound edge cases
+ * - Dynamic resizing
+ * - Zero-copy pointer access
+ * - Secure memory clearing
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_buffer
+ * ./fuzz_buffer corpus/buffer/ -fork=16 -max_len=4096
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "buffer/Buffer.h"
+
+/* Operation codes */
+enum BufOp {
+    OP_CREATE = 0,
+    OP_WRITE_READ,
+    OP_PEEK_CONSUME,
+    OP_RESERVE_GROW,
+    OP_ZERO_COPY,
+    OP_WRAPAROUND,
+    OP_SECURE_CLEAR,
+    OP_MIXED_OPS,
+    OP_COUNT
+};
+
+/* Limits */
+#define MAX_FUZZ_CAPACITY 4096
+#define MIN_FUZZ_CAPACITY 64
+
+static uint16_t
+read_u16(const uint8_t *p)
+{
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Arena_T arena = NULL;
+    Buffer_T buf = NULL;
+    char read_buffer[MAX_FUZZ_CAPACITY];
+
+    if (size < 5)
+        return 0;
+
+    uint8_t op = data[0];
+    uint16_t capacity_raw = read_u16(data + 1);
+    size_t capacity = (capacity_raw % (MAX_FUZZ_CAPACITY - MIN_FUZZ_CAPACITY))
+                      + MIN_FUZZ_CAPACITY;
+    uint16_t len_param = read_u16(data + 3);
+    size_t data_offset = 5;
+    size_t data_len = size > data_offset ? size - data_offset : 0;
+
+    TRY {
+        arena = Arena_new();
+        if (!arena)
+            return 0;
+
+        switch (op % OP_COUNT) {
+            case OP_CREATE:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    assert(Buffer_available(buf) == 0);
+                    assert(Buffer_space(buf) == capacity);
+                    assert(Buffer_empty(buf));
+                }
+                break;
+
+            case OP_WRITE_READ:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    size_t to_write = data_len > capacity ? capacity : data_len;
+                    size_t written = 0;
+
+                    if (to_write > 0)
+                        written = Buffer_write(buf, data + data_offset, to_write);
+
+                    assert(Buffer_available(buf) == written);
+
+                    size_t bytes_read = Buffer_read(buf, read_buffer, written);
+                    assert(bytes_read == written);
+                    assert(Buffer_empty(buf));
+
+                    if (written > 0)
+                        assert(memcmp(read_buffer, data + data_offset, written) == 0);
+                }
+                break;
+
+            case OP_PEEK_CONSUME:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    size_t to_write = data_len > capacity ? capacity : data_len;
+                    size_t written = 0;
+
+                    if (to_write > 0)
+                        written = Buffer_write(buf, data + data_offset, to_write);
+
+                    size_t peeked = Buffer_peek(buf, read_buffer, written);
+                    assert(peeked == written);
+                    assert(Buffer_available(buf) == written);
+
+                    size_t consume_amt = len_param % (written + 1);
+                    if (consume_amt > 0 && consume_amt <= written) {
+                        Buffer_consume(buf, consume_amt);
+                        assert(Buffer_available(buf) == written - consume_amt);
+                    }
+
+                    Buffer_clear(buf);
+                    assert(Buffer_empty(buf));
+                }
+                break;
+
+            case OP_RESERVE_GROW:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    size_t initial = data_len > capacity / 2 ? capacity / 2 : data_len;
+
+                    if (initial > 0)
+                        Buffer_write(buf, data + data_offset, initial);
+
+                    size_t reserve_amt = len_param % MAX_FUZZ_CAPACITY;
+                    if (reserve_amt > 0) {
+                        TRY {
+                            Buffer_reserve(buf, reserve_amt);
+                            assert(Buffer_space(buf) >= reserve_amt);
+                        }
+                        EXCEPT(Buffer_Failed) {
+                            /* Expected for overflow */
+                        }
+                        END_TRY;
+                    }
+                }
+                break;
+
+            case OP_ZERO_COPY:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    size_t write_space = 0;
+                    void *write_ptr = Buffer_writeptr(buf, &write_space);
+
+                    if (write_ptr && write_space > 0) {
+                        size_t direct_write = data_len > write_space ? write_space : data_len;
+                        if (direct_write > 0) {
+                            memcpy(write_ptr, data + data_offset, direct_write);
+                            Buffer_written(buf, direct_write);
+                            assert(Buffer_available(buf) == direct_write);
+                        }
+                    }
+
+                    size_t read_avail = 0;
+                    const void *read_ptr = Buffer_readptr(buf, &read_avail);
+                    (void)read_ptr;
+                }
+                break;
+
+            case OP_WRAPAROUND:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    size_t first_write = capacity / 2;
+                    if (first_write > data_len)
+                        first_write = data_len;
+
+                    if (first_write > 0) {
+                        Buffer_write(buf, data + data_offset, first_write);
+                        size_t to_read = first_write / 2;
+                        Buffer_read(buf, read_buffer, to_read);
+
+                        size_t space = Buffer_space(buf);
+                        size_t remaining = data_len > first_write ? data_len - first_write : 0;
+                        size_t second_write = remaining > space ? space : remaining;
+
+                        if (second_write > 0) {
+                            size_t offset = data_offset + first_write;
+                            if (offset < size)
+                                Buffer_write(buf, data + offset, second_write);
+                        }
+
+                        size_t total = Buffer_available(buf);
+                        Buffer_read(buf, read_buffer, total);
+                    }
+                }
+                break;
+
+            case OP_SECURE_CLEAR:
+                {
+                    buf = Buffer_new(arena, capacity);
+                    size_t to_write = data_len > capacity ? capacity : data_len;
+
+                    if (to_write > 0)
+                        Buffer_write(buf, data + data_offset, to_write);
+
+                    Buffer_secureclear(buf);
+                    assert(Buffer_empty(buf));
+
+                    if (to_write > 0) {
+                        size_t written = Buffer_write(buf, data + data_offset, to_write);
+                        assert(written == to_write);
+                    }
+                }
+                break;
+
+            case OP_MIXED_OPS:
+                {
+                    buf = Buffer_new(arena, capacity);
+
+                    for (size_t i = data_offset; i < size && i < data_offset + 20; i++) {
+                        uint8_t sub_op = data[i] % 6;
+
+                        switch (sub_op) {
+                            case 0: /* Write */
+                                {
+                                    size_t space = Buffer_space(buf);
+                                    size_t amt = (data[i] % 64) + 1;
+                                    if (amt > space) amt = space;
+                                    if (amt > 0 && i + amt < size)
+                                        Buffer_write(buf, data + i, amt);
+                                }
+                                break;
+
+                            case 1: /* Read */
+                                {
+                                    size_t avail = Buffer_available(buf);
+                                    size_t amt = (data[i] % 64) + 1;
+                                    if (amt > avail) amt = avail;
+                                    if (amt > 0)
+                                        Buffer_read(buf, read_buffer, amt);
+                                }
+                                break;
+
+                            case 2: /* Peek */
+                                {
+                                    size_t avail = Buffer_available(buf);
+                                    if (avail > 0)
+                                        Buffer_peek(buf, read_buffer, avail);
+                                }
+                                break;
+
+                            case 3: /* Consume */
+                                {
+                                    size_t avail = Buffer_available(buf);
+                                    size_t amt = data[i] % (avail + 1);
+                                    if (amt > 0)
+                                        Buffer_consume(buf, amt);
+                                }
+                                break;
+
+                            case 4: /* Clear */
+                                Buffer_clear(buf);
+                                break;
+
+                            case 5: /* State check */
+                                {
+                                    (void)Buffer_available(buf);
+                                    (void)Buffer_space(buf);
+                                    (void)Buffer_empty(buf);
+                                    (void)Buffer_full(buf);
+                                }
+                                break;
+                        }
+                    }
+                }
+                break;
+        }
+    }
+    EXCEPT(Buffer_Failed) { /* Expected */ }
+    EXCEPT(Arena_Failed) { /* Expected */ }
+    FINALLY {
+        if (buf)
+            Buffer_release(&buf);
+        if (arena)
+            Arena_dispose(&arena);
+    }
+    END_TRY;
+
+    return 0;
+}
+```
+
+## State Machine Fuzzer Template
+
+For protocol state machines (TLS handshake, connection lifecycle):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_state_machine.c - State Machine Fuzzer
+ *
+ * Targets:
+ * - State transitions
+ * - Timeout handling
+ * - Non-blocking operations
+ * - Multiple operation steps
+ * - State queries
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_state_machine
+ * ./fuzz_state_machine corpus/state/ -fork=16 -max_len=4096
+ */
+
+#if FEATURE_ENABLED
+
+#include <signal.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "core/Except.h"
+#include "module/StateMachine.h"
+
+/* Suppress GCC clobbered warnings */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wclobbered"
+#endif
+
+/* Ignore SIGPIPE */
+__attribute__((constructor)) static void
+ignore_sigpipe(void)
+{
+    signal(SIGPIPE, SIG_IGN);
+}
+
+typedef enum {
+    OP_STEP_SINGLE = 0,
+    OP_LOOP_ZERO_TIMEOUT,
+    OP_LOOP_FUZZED_TIMEOUT,
+    OP_LOOP_EXTENDED,
+    OP_AUTO,
+    OP_STATE_QUERY,
+    OP_MULTIPLE_STEPS,
+    OP_COUNT
+} Operation;
+
+static uint8_t
+get_op(const uint8_t *data, size_t size)
+{
+    return size > 0 ? data[0] % OP_COUNT : 0;
+}
+
+static uint16_t
+get_timeout(const uint8_t *data, size_t size)
+{
+    if (size < 3)
+        return 0;
+    return (uint16_t)data[1] | ((uint16_t)data[2] << 8);
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 3)
+        return 0;
+
+    volatile uint8_t op = get_op(data, size);
+    uint16_t timeout_ms = get_timeout(data, size) % 100;  /* Cap timeout */
+    StateMachine_T sm = NULL;
+    Context_T ctx = NULL;
+
+    TRY {
+        sm = StateMachine_new();
+        if (!sm)
+            return 0;
+
+        ctx = Context_new(NULL);
+        if (!ctx) {
+            StateMachine_free(&sm);
+            return 0;
+        }
+
+        StateMachine_init(sm, ctx);
+
+        switch (op) {
+            case OP_STEP_SINGLE:
+                {
+                    State state = StateMachine_step(sm);
+                    (void)state;
+                }
+                break;
+
+            case OP_LOOP_ZERO_TIMEOUT:
+                {
+                    State state = StateMachine_loop(sm, 0);
+                    (void)state;
+                }
+                break;
+
+            case OP_LOOP_FUZZED_TIMEOUT:
+                {
+                    State state = StateMachine_loop(sm, (int)timeout_ms);
+                    (void)state;
+                }
+                break;
+
+            case OP_LOOP_EXTENDED:
+                {
+                    int poll_interval = (size > 3) ? (data[3] % 50) : 10;
+                    State state = StateMachine_loop_ex(sm, (int)timeout_ms, poll_interval);
+                    (void)state;
+                }
+                break;
+
+            case OP_AUTO:
+                {
+                    State state = StateMachine_auto(sm);
+                    (void)state;
+                }
+                break;
+
+            case OP_STATE_QUERY:
+                {
+                    StateMachine_step(sm);
+                    (void)StateMachine_get_info(sm);
+                    (void)StateMachine_get_status(sm);
+                    (void)StateMachine_is_complete(sm);
+                }
+                break;
+
+            case OP_MULTIPLE_STEPS:
+                {
+                    int steps = (size > 3) ? (data[3] % 5 + 1) : 2;
+                    for (int i = 0; i < steps; i++) {
+                        State state = StateMachine_step(sm);
+                        if (state == STATE_COMPLETE || state == STATE_ERROR)
+                            break;
+                    }
+                }
+                break;
+        }
+    }
+    EXCEPT(StateMachine_Failed) {}
+    EXCEPT(Context_Failed) {}
+    ELSE {}
+    END_TRY;
+
+    if (sm)
+        StateMachine_free(&sm);
+    if (ctx)
+        Context_free(&ctx);
+
+    return 0;
+}
+
+#else /* !FEATURE_ENABLED */
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    (void)data;
+    (void)size;
+    return 0;
+}
+
+#endif
+```
+
+## Codec Fuzzer Template
+
+For encoding/decoding (HPACK, UTF-8, Base64):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_codec.c - Codec Fuzzer
+ *
+ * Targets:
+ * - Decoding malformed input
+ * - Encoding roundtrip
+ * - Table/state manipulation
+ * - Integer overflow in sizes
+ * - Limit enforcement
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_codec
+ * ./fuzz_codec corpus/codec/ -fork=16 -max_len=32768
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "codec/Codec.h"
+
+#define MAX_DECODED_ITEMS 64
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 1)
+        return 0;
+
+    Arena_T arena_instance = Arena_new();
+    if (!arena_instance)
+        return 0;
+    volatile Arena_T arena = arena_instance;
+    (void)arena;
+
+    TRY {
+        /* Create decoder with default config */
+        Codec_Config cfg;
+        Codec_config_defaults(&cfg);
+        Codec_Decoder_T decoder = Codec_Decoder_new(&cfg, arena_instance);
+
+        /* Decode fuzzed data */
+        Codec_Item items[MAX_DECODED_ITEMS];
+        size_t item_count = 0;
+        Codec_Result res = Codec_Decoder_decode(
+            decoder, data, size, items, MAX_DECODED_ITEMS,
+            &item_count, arena_instance);
+
+        /* Access decoded items */
+        (void)res;
+        for (size_t i = 0; i < item_count; i++) {
+            (void)items[i].field1;
+            (void)items[i].field2;
+        }
+
+        /* Fuzz configuration change */
+        if (size > 4) {
+            uint32_t new_size = *(uint32_t *)data % CODEC_MAX_SIZE;
+            Codec_Decoder_set_size(decoder, new_size);
+        }
+
+        /* Test encode if data decoded successfully */
+        if (res == CODEC_OK && item_count > 0) {
+            uint8_t encode_buf[4096];
+            size_t encoded_len = 0;
+
+            Codec_Encoder_T encoder = Codec_Encoder_new(&cfg, arena_instance);
+            for (size_t i = 0; i < item_count && i < 10; i++) {
+                Codec_Encoder_encode(encoder, &items[i],
+                                     encode_buf, sizeof(encode_buf),
+                                     &encoded_len);
+            }
+            Codec_Encoder_free(&encoder);
+        }
+
+        Codec_Decoder_free(&decoder);
+    }
+    EXCEPT(Codec_Error) {
+        /* Expected on malformed input */
+    }
+    EXCEPT(Arena_Failed) {
+        /* Expected on memory exhaustion */
+    }
+    END_TRY;
+
+    Arena_dispose(&arena_instance);
+
+    return 0;
+}
+```
+
+## Security Attack Fuzzer Template
+
+For security-focused testing (HTTP smuggling, injection):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_security_attack.c - Security Attack Vector Fuzzer
+ *
+ * Comprehensive fuzzing targeting specific attack categories:
+ *
+ * Attack Categories:
+ * 1. Injection attacks (header, command, etc.)
+ * 2. Smuggling attacks (CL.TE, TE.CL, TE.TE)
+ * 3. Parsing ambiguity attacks
+ * 4. Obfuscation attacks
+ * 5. Duplicate header attacks
+ * 6. Length manipulation attacks
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_security_attack
+ * ./fuzz_security_attack corpus/security/ -fork=16 -max_len=65536
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "protocol/Protocol.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void
+test_detection(Arena_T arena, const char *input, size_t len, int strict)
+{
+    Parser_T parser = NULL;
+    Config cfg;
+    size_t consumed;
+
+    config_defaults(&cfg);
+    cfg.strict_mode = strict;
+
+    parser = Parser_new(&cfg, arena);
+    if (!parser)
+        return;
+
+    Result result = Parser_execute(parser, input, len, &consumed);
+
+    if (result == RESULT_OK) {
+        const ParsedData *data = Parser_get_data(parser);
+        if (data && data->headers) {
+            /* Check for conflicting indicators */
+            const char *indicator1 = Headers_get(data->headers, "Header1");
+            const char *indicator2 = Headers_get(data->headers, "Header2");
+
+            if (indicator1 && indicator2) {
+                /* Potential attack detected */
+                (void)indicator1;
+                (void)indicator2;
+            }
+
+            /* Check for multiple values */
+            const char *values[10];
+            size_t count = Headers_get_all(data->headers, "Header1", values, 10);
+            if (count > 1) {
+                /* Multiple values - potential attack */
+                (void)count;
+            }
+        }
+    }
+
+    Parser_free(&parser);
+}
+
+static void
+test_incremental(Arena_T arena, const char *input, size_t len)
+{
+    Parser_T parser = NULL;
+    Config cfg;
+
+    config_defaults(&cfg);
+    cfg.strict_mode = 1;
+
+    parser = Parser_new(&cfg, arena);
+    if (!parser)
+        return;
+
+    /* Byte-by-byte parsing for state corruption */
+    size_t offset = 0;
+    size_t consumed;
+    Result result = RESULT_INCOMPLETE;
+
+    while (offset < len && result == RESULT_INCOMPLETE) {
+        result = Parser_execute(parser, input + offset, 1, &consumed);
+        offset += consumed;
+        if (consumed == 0 && result == RESULT_INCOMPLETE)
+            offset++;
+    }
+
+    Parser_free(&parser);
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Arena_T arena = NULL;
+
+    if (size < 16)
+        return 0;
+
+    arena = Arena_new();
+    if (!arena)
+        return 0;
+
+    TRY {
+        /* Direct fuzzed input */
+        test_detection(arena, (const char *)data, size, 0);
+        test_detection(arena, (const char *)data, size, 1);
+
+        /* Byte-by-byte parsing */
+        test_incremental(arena, (const char *)data, size);
+
+        /* Attack Category 1: Type A attacks */
+        {
+            const char *type_a_attacks[] = {
+                "ATTACK VARIANT 1",
+                "ATTACK VARIANT 2",
+                "ATTACK VARIANT 3",
+            };
+
+            for (size_t i = 0; i < sizeof(type_a_attacks) / sizeof(type_a_attacks[0]); i++) {
+                test_detection(arena, type_a_attacks[i], strlen(type_a_attacks[i]), 0);
+                test_detection(arena, type_a_attacks[i], strlen(type_a_attacks[i]), 1);
+            }
+        }
+
+        /* Attack Category 2: Type B attacks */
+        {
+            const char *type_b_attacks[] = {
+                "ATTACK VARIANT 1",
+                "ATTACK VARIANT 2",
+            };
+
+            for (size_t i = 0; i < sizeof(type_b_attacks) / sizeof(type_b_attacks[0]); i++) {
+                test_detection(arena, type_b_attacks[i], strlen(type_b_attacks[i]), 0);
+                test_detection(arena, type_b_attacks[i], strlen(type_b_attacks[i]), 1);
+            }
+        }
+
+        /* Attack Category 3: Edge cases */
+        {
+            const char *edge_cases[] = {
+                "EDGE CASE 1 - negative value",
+                "EDGE CASE 2 - zero value",
+                "EDGE CASE 3 - max value",
+                "EDGE CASE 4 - overflow",
+            };
+
+            for (size_t i = 0; i < sizeof(edge_cases) / sizeof(edge_cases[0]); i++) {
+                test_detection(arena, edge_cases[i], strlen(edge_cases[i]), 0);
+                test_detection(arena, edge_cases[i], strlen(edge_cases[i]), 1);
+            }
+        }
+
+        /* Build attack with fuzzed payload */
+        if (size > 50) {
+            char attack_buf[8192];
+            int len;
+            size_t payload_len = size > 100 ? 100 : size;
+
+            len = snprintf(attack_buf, sizeof(attack_buf),
+                           "PREFIX %zu CONTENT\r\n\r\n",
+                           payload_len + 7);
+
+            if (len > 0 && (size_t)len + payload_len < sizeof(attack_buf)) {
+                memcpy(attack_buf + len, data, payload_len);
+                test_detection(arena, attack_buf, len + payload_len, 0);
+                test_detection(arena, attack_buf, len + payload_len, 1);
+            }
+        }
+    }
+    EXCEPT(Parser_Error) {
+        /* Expected */
+    }
+    EXCEPT(Arena_Failed) {
+        /* Expected */
+    }
+    END_TRY;
+
+    Arena_dispose(&arena);
+
+    return 0;
+}
+```
+
+## Frame Parsing Fuzzer Template
+
+For frame-based protocols (WebSocket, HTTP/2):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_frames.c - Frame Parsing Fuzzer
+ *
+ * Targets:
+ * - Frame header parsing
+ * - Payload validation
+ * - Fragmentation handling
+ * - Control frame limits
+ * - State machine corruption
+ * - Length field overflow
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_frames
+ * ./fuzz_frames corpus/frames/ -fork=16 -max_len=65536
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "protocol/Frames.h"
+
+/* Suppress GCC clobbered warnings */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wclobbered"
+#endif
+
+static size_t
+calc_header_size(uint8_t len_indicator, int has_mask)
+{
+    size_t base = 2;
+    if (len_indicator == 126)
+        base += 2;
+    else if (len_indicator == 127)
+        base += 8;
+    if (has_mask)
+        base += 4;
+    return base;
+}
+
+static uint64_t
+extract_length(const uint8_t *data, size_t size, size_t *header_size)
+{
+    if (size < 2) {
+        *header_size = 0;
+        return 0;
+    }
+
+    uint8_t len_ind = data[1] & 0x7F;
+    int has_mask = (data[1] >> 7) & 1;
+    size_t hdr_size = calc_header_size(len_ind, has_mask);
+    *header_size = hdr_size;
+
+    if (size < hdr_size)
+        return 0;
+
+    if (len_ind <= 125)
+        return len_ind;
+    else if (len_ind == 126)
+        return ((uint16_t)data[2] << 8) | (uint16_t)data[3];
+    else {
+        uint64_t len = 0;
+        for (int i = 0; i < 8; i++)
+            len = (len << 8) | data[2 + i];
+        return len;
+    }
+}
+
+static void
+test_header_parsing(const uint8_t *data, size_t size)
+{
+    if (size < 2)
+        return;
+
+    uint8_t byte0 = data[0];
+    uint8_t byte1 = data[1];
+
+    int fin = (byte0 >> 7) & 1;
+    int rsv1 = (byte0 >> 6) & 1;
+    int rsv2 = (byte0 >> 5) & 1;
+    int rsv3 = (byte0 >> 4) & 1;
+    Opcode opcode = (Opcode)(byte0 & 0x0F);
+    int masked = (byte1 >> 7) & 1;
+    uint8_t len_ind = byte1 & 0x7F;
+
+    (void)fin;
+    (void)rsv1;
+    (void)rsv2;
+    (void)rsv3;
+    (void)masked;
+    (void)len_ind;
+
+    int is_control = (opcode >= OPCODE_CONTROL_START);
+    if (is_control && !fin) {
+        /* Protocol violation */
+    }
+    if (is_control && len_ind > 125) {
+        /* Protocol violation */
+    }
+
+    (void)is_control;
+}
+
+static void
+test_fragmentation(const uint8_t *data, size_t size)
+{
+    if (size < 10)
+        return;
+
+    size_t offset = 0;
+    int in_message = 0;
+    Opcode message_type = OPCODE_CONTINUATION;
+    int fragment_count = 0;
+    const int max_fragments = 100;
+
+    while (offset + 2 <= size && fragment_count < max_fragments) {
+        uint8_t byte0 = data[offset];
+        int fin = (byte0 >> 7) & 1;
+        Opcode opcode = (Opcode)(byte0 & 0x0F);
+
+        int is_control = (opcode >= OPCODE_CONTROL_START);
+
+        if (is_control) {
+            size_t header_size;
+            uint64_t payload_len = extract_length(data + offset, size - offset, &header_size);
+            if (header_size == 0)
+                break;
+
+            size_t frame_size = header_size + (size_t)payload_len;
+            if (offset + frame_size > size)
+                break;
+
+            offset += frame_size;
+            fragment_count++;
+            continue;
+        }
+
+        if (!in_message) {
+            if (opcode == OPCODE_CONTINUATION)
+                break;
+            message_type = opcode;
+            in_message = 1;
+        } else {
+            if (opcode != OPCODE_CONTINUATION)
+                break;
+        }
+
+        size_t header_size;
+        uint64_t payload_len = extract_length(data + offset, size - offset, &header_size);
+        if (header_size == 0)
+            break;
+
+        size_t frame_size = header_size + (size_t)payload_len;
+        if (offset + frame_size > size)
+            break;
+
+        offset += frame_size;
+        fragment_count++;
+
+        if (fin)
+            in_message = 0;
+    }
+
+    (void)message_type;
+}
+
+static void
+test_config_validation(const uint8_t *data, size_t size)
+{
+    if (size < 16)
+        return;
+
+    Config config;
+    config_defaults(&config);
+
+    config.max_frame_size = ((size_t)data[0] << 24) | ((size_t)data[1] << 16) |
+                            ((size_t)data[2] << 8) | data[3];
+    config.max_message_size = ((size_t)data[4] << 24) | ((size_t)data[5] << 16) |
+                              ((size_t)data[6] << 8) | data[7];
+    config.max_fragments = ((size_t)data[8] << 8) | data[9];
+    config.validate = data[10] & 1;
+    config.strict = data[11] & 1;
+
+    if (config.max_frame_size > 0 && config.max_message_size > 0 &&
+        config.max_fragments > 0) {
+        if (config.max_frame_size <= SIZE_MAX / config.max_fragments) {
+            /* Safe */
+        }
+    }
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 2)
+        return 0;
+
+    Arena_T arena_instance = Arena_new();
+    if (!arena_instance)
+        return 0;
+    volatile Arena_T arena = arena_instance;
+
+    TRY {
+        test_header_parsing(data, size);
+        test_fragmentation(data, size);
+        test_config_validation(data, size);
+
+        size_t header_size;
+        uint64_t payload_len = extract_length(data, size, &header_size);
+        (void)payload_len;
+
+        Arena_clear(arena_instance);
+    }
+    EXCEPT(Frame_Failed) { /* Expected */ }
+    EXCEPT(Frame_ProtocolError) { /* Expected */ }
+    EXCEPT(Arena_Failed) { /* Expected */ }
+    END_TRY;
+
+    arena_instance = arena;
+    Arena_dispose(&arena_instance);
+
+    return 0;
+}
+```
+
+## Validation Fuzzer Template
+
+For input validation (UTF-8, DNS, IP, URL):
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_validation.c - Input Validation Fuzzer
+ *
+ * Targets:
+ * - Valid input acceptance
+ * - Invalid input rejection
+ * - Boundary conditions
+ * - Overlong sequences
+ * - Edge cases
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_validation
+ * ./fuzz_validation corpus/validation/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "validation/Validator.h"
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 1)
+        return 0;
+
+    Arena_T arena = Arena_new();
+    if (!arena)
+        return 0;
+
+    TRY {
+        /* One-shot validation */
+        Result result = Validator_validate(data, size);
+        (void)result;
+
+        /* Incremental validation */
+        Validator_State state;
+        Validator_init(&state);
+        result = Validator_update(&state, data, size);
+
+        if (result == RESULT_VALID || result == RESULT_INCOMPLETE) {
+            Validator_finish(&state);
+        }
+
+        /* Chunk-based validation */
+        Validator_init(&state);
+        size_t chunk_size = 7;
+        for (size_t offset = 0; offset < size; offset += chunk_size) {
+            size_t remaining = size - offset;
+            size_t to_check = (remaining < chunk_size) ? remaining : chunk_size;
+            result = Validator_update(&state, data + offset, to_check);
+            if (result != RESULT_VALID && result != RESULT_INCOMPLETE)
+                break;
+        }
+        if (result == RESULT_VALID || result == RESULT_INCOMPLETE) {
+            Validator_finish(&state);
+        }
+
+        /* Known valid inputs */
+        const char *valid_inputs[] = {
+            "valid1",
+            "valid2",
+            "valid3",
+        };
+        for (size_t i = 0; i < sizeof(valid_inputs) / sizeof(valid_inputs[0]); i++) {
+            result = Validator_validate((const uint8_t *)valid_inputs[i],
+                                        strlen(valid_inputs[i]));
+            (void)result;
+        }
+
+        /* Known invalid inputs */
+        const uint8_t *invalid_inputs[] = {
+            (const uint8_t *)"invalid1",
+            (const uint8_t *)"\xFF\xFE",
+            (const uint8_t *)"\x00",
+        };
+        size_t invalid_lens[] = { 8, 2, 1 };
+        for (size_t i = 0; i < sizeof(invalid_inputs) / sizeof(invalid_inputs[0]); i++) {
+            result = Validator_validate(invalid_inputs[i], invalid_lens[i]);
+            (void)result;
+        }
+    }
+    EXCEPT(Validator_Failed) {
+        /* Expected */
+    }
+    EXCEPT(Arena_Failed) {
+        /* Expected */
+    }
+    END_TRY;
+
+    Arena_dispose(&arena);
+
+    return 0;
+}
+```

--- a/.claude/references/fuzzing-patterns.md
+++ b/.claude/references/fuzzing-patterns.md
@@ -1,0 +1,678 @@
+# Fuzzing Patterns Reference
+
+This document contains implementation patterns for libFuzzer harnesses in the socket library.
+
+## File Structure Template
+
+Every fuzzer follows this structure:
+
+```c
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_module_name.c - Brief description of fuzzer purpose
+ *
+ * Part of the Socket Library Fuzzing Suite
+ *
+ * Targets:
+ * - Target 1 (e.g., "Buffer creation with various capacities")
+ * - Target 2 (e.g., "Circular buffer wraparound edge cases")
+ * - Target 3 (e.g., "Memory safety under stress")
+ *
+ * Security focus:
+ * - Attack vector 1 (e.g., "Buffer overflow prevention")
+ * - Attack vector 2 (e.g., "Integer overflow in lengths")
+ *
+ * Build: CC=clang cmake .. -DENABLE_FUZZING=ON && make fuzz_module_name
+ * Run:   ./fuzz_module_name corpus/module_name/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Project headers */
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "module/SocketModule.h"
+
+/* Static helpers before main function */
+static void
+helper_function(const uint8_t *data, size_t size)
+{
+    /* Implementation */
+}
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    /* Implementation */
+    return 0;
+}
+```
+
+## Operation Enum Pattern
+
+For fuzzers testing multiple operations, use an enum to dispatch:
+
+```c
+/* Operation codes */
+enum ModuleOp {
+    OP_CREATE = 0,
+    OP_WRITE_READ,
+    OP_EDGE_CASE,
+    OP_STRESS_TEST,
+    OP_COUNT
+};
+
+/* In LLVMFuzzerTestOneInput: */
+uint8_t op = data[0];
+switch (op % OP_COUNT) {
+    case OP_CREATE:
+        /* Test creation */
+        break;
+    case OP_WRITE_READ:
+        /* Test read/write */
+        break;
+    /* ... */
+}
+```
+
+## Byte Extraction Helpers
+
+Standard helpers for reading multi-byte values from fuzz input:
+
+```c
+/**
+ * read_u16 - Read 16-bit value from byte stream (little-endian)
+ */
+static uint16_t
+read_u16(const uint8_t *p)
+{
+    return (uint16_t)p[0] | ((uint16_t)p[1] << 8);
+}
+
+/**
+ * read_u32 - Read 32-bit value from byte stream (little-endian)
+ */
+static uint32_t
+read_u32(const uint8_t *p)
+{
+    return (uint32_t)p[0] | ((uint32_t)p[1] << 8) |
+           ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+/**
+ * get_op - Extract operation selector
+ */
+static uint8_t
+get_op(const uint8_t *data, size_t size)
+{
+    return size > 0 ? data[0] % OP_COUNT : 0;
+}
+```
+
+## Input Format Documentation
+
+Document the expected input format in the function header:
+
+```c
+/**
+ * LLVMFuzzerTestOneInput - libFuzzer entry point
+ *
+ * Input format:
+ * - Byte 0: Operation selector
+ * - Bytes 1-2: Capacity parameter
+ * - Bytes 3-4: Length parameter
+ * - Remaining: Data payload
+ */
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 5)
+        return 0;  /* Minimum input size */
+
+    uint8_t op = data[0];
+    uint16_t capacity = read_u16(data + 1);
+    uint16_t length = read_u16(data + 3);
+    const uint8_t *payload = data + 5;
+    size_t payload_len = size - 5;
+    /* ... */
+}
+```
+
+## Arena Memory Pattern
+
+Always use Arena for memory management in fuzzers:
+
+```c
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Arena_T arena = NULL;
+    ModuleType_T instance = NULL;
+
+    if (size < MINIMUM_SIZE)
+        return 0;
+
+    TRY {
+        arena = Arena_new();
+        if (!arena)
+            return 0;
+
+        instance = Module_new(arena, ...);
+        /* Test operations */
+    }
+    EXCEPT(Module_Failed) {
+        /* Expected for invalid inputs */
+    }
+    EXCEPT(Arena_Failed) {
+        /* Memory allocation failure */
+    }
+    FINALLY {
+        if (instance)
+            Module_release(&instance);
+        if (arena)
+            Arena_dispose(&arena);
+    }
+    END_TRY;
+
+    return 0;
+}
+```
+
+## Exception Handling Pattern
+
+Catch all relevant exceptions - never let them propagate:
+
+```c
+TRY {
+    /* Fuzzing operations */
+}
+EXCEPT(SocketHTTP1_ParseError) {
+    /* Expected on malformed HTTP input */
+}
+EXCEPT(SocketHPACK_Error) {
+    /* Expected on malformed HPACK input */
+}
+EXCEPT(SocketWS_ProtocolError) {
+    /* Expected on WebSocket protocol violations */
+}
+EXCEPT(SocketTLS_Failed) {
+    /* Expected on TLS errors */
+}
+EXCEPT(Arena_Failed) {
+    /* Memory exhaustion */
+}
+ELSE {
+    /* Catch any other exceptions */
+}
+END_TRY;
+```
+
+## Volatile Variables for Exception Safety
+
+Variables modified in TRY and read after EXCEPT must be volatile:
+
+```c
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    Arena_T arena_instance = Arena_new();
+    if (!arena_instance)
+        return 0;
+    volatile Arena_T arena = arena_instance;  /* Volatile for exception safety */
+
+    TRY {
+        /* Operations using arena_instance */
+    }
+    EXCEPT(Module_Failed) {
+        /* arena still valid */
+    }
+    END_TRY;
+
+    arena_instance = arena;  /* Restore for cleanup */
+    Arena_dispose(&arena_instance);
+    return 0;
+}
+```
+
+## GCC Clobbered Warning Suppression
+
+Suppress false-positive warnings for TRY/EXCEPT:
+
+```c
+/* Suppress GCC clobbered warnings for TRY/EXCEPT */
+#if defined(__GNUC__) && !defined(__clang__)
+#pragma GCC diagnostic ignored "-Wclobbered"
+#endif
+```
+
+## SIGPIPE Handling
+
+For network-related fuzzers, ignore SIGPIPE:
+
+```c
+#include <signal.h>
+
+/* Ignore SIGPIPE for socket operations */
+__attribute__((constructor)) static void
+ignore_sigpipe(void)
+{
+    signal(SIGPIPE, SIG_IGN);
+}
+```
+
+## Conditional Compilation for Optional Features
+
+Handle optional features like TLS:
+
+```c
+#if SOCKET_HAS_TLS
+
+/* TLS-specific fuzzer code */
+
+#else /* !SOCKET_HAS_TLS */
+
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    (void)data;
+    (void)size;
+    return 0;
+}
+
+#endif /* SOCKET_HAS_TLS */
+```
+
+## Accessor Coverage Pattern
+
+Exercise all getter functions to ensure complete coverage:
+
+```c
+static void
+exercise_parser_accessors(Parser_T parser)
+{
+    /* State queries */
+    State state = Parser_state(parser);
+    (void)state;
+
+    BodyMode mode = Parser_body_mode(parser);
+    (void)mode;
+
+    /* Content info */
+    int64_t content_length = Parser_content_length(parser);
+    (void)content_length;
+
+    int body_complete = Parser_body_complete(parser);
+    (void)body_complete;
+
+    /* Connection info */
+    int keepalive = Parser_should_keepalive(parser);
+    (void)keepalive;
+
+    /* Header iteration if available */
+    if (state >= STATE_HEADERS_COMPLETE) {
+        const Headers *headers = Parser_get_headers(parser);
+        if (headers) {
+            size_t count = Headers_count(headers);
+            for (size_t i = 0; i < count && i < 50; i++) {
+                const Header *h = Headers_at(headers, i);
+                if (h) {
+                    (void)h->name;
+                    (void)h->value;
+                }
+            }
+        }
+    }
+}
+```
+
+## Incremental Parsing Pattern
+
+Test parsers with variable chunk sizes:
+
+```c
+static void
+test_incremental_parsing(Parser_T parser, const uint8_t *data,
+                         size_t size, size_t chunk_size)
+{
+    size_t offset = 0;
+    size_t consumed;
+    Result result = INCOMPLETE;
+
+    while (offset < size && result == INCOMPLETE) {
+        size_t remaining = size - offset;
+        size_t to_parse = (remaining < chunk_size) ? remaining : chunk_size;
+
+        result = Parser_execute(parser, (const char *)data + offset,
+                                to_parse, &consumed);
+        offset += consumed;
+
+        /* Prevent infinite loop if no progress */
+        if (consumed == 0 && result == INCOMPLETE)
+            offset++;
+    }
+}
+
+/* In main fuzzer: */
+size_t chunk_sizes[] = { 1, 2, 7, 13, 64, 256, 1024 };
+for (size_t i = 0; i < sizeof(chunk_sizes) / sizeof(chunk_sizes[0]); i++) {
+    parser = Parser_new(...);
+    if (parser) {
+        test_incremental_parsing(parser, data, size, chunk_sizes[i]);
+        Parser_free(&parser);
+    }
+}
+```
+
+## Known Input Testing Pattern
+
+Test with known valid/invalid inputs modified by fuzz data:
+
+```c
+/* Known valid requests */
+const char *valid_requests[] = {
+    "GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
+    "POST /data HTTP/1.1\r\nHost: test.com\r\nContent-Length: 5\r\n\r\nhello",
+    "PUT /resource HTTP/1.1\r\nHost: api.com\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+};
+
+for (size_t i = 0; i < sizeof(valid_requests) / sizeof(valid_requests[0]); i++) {
+    parser = Parser_new(...);
+    if (parser) {
+        Parser_execute(parser, valid_requests[i], strlen(valid_requests[i]), &consumed);
+        exercise_parser_accessors(parser);
+        Parser_free(&parser);
+    }
+}
+```
+
+## Security Attack Vector Pattern
+
+Explicitly test known attack vectors:
+
+```c
+/* Malformed requests (security edge cases) */
+const char *malformed_requests[] = {
+    /* No CRLF */
+    "GET / HTTP/1.1 Host: test.com",
+    /* Header injection attempt */
+    "GET / HTTP/1.1\r\nHost: test.com\r\nX-Inject: value\r\nEvil: header\r\n\r\n",
+    /* Duplicate Content-Length (smuggling) */
+    "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: 5\r\nContent-Length: 10\r\n\r\nhello",
+    /* CL + TE (smuggling) */
+    "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: 5\r\nTransfer-Encoding: chunked\r\n\r\n5\r\nhello\r\n0\r\n\r\n",
+    /* Null byte in header */
+    "GET / HTTP/1.1\r\nHost: test\x00.com\r\n\r\n",
+    /* Negative content length */
+    "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: -1\r\n\r\n",
+    /* Huge content length (DoS) */
+    "POST / HTTP/1.1\r\nHost: test.com\r\nContent-Length: 99999999999999999999\r\n\r\n",
+};
+
+Config strict_cfg;
+config_defaults(&strict_cfg);
+strict_cfg.strict_mode = 1;
+
+for (size_t i = 0; i < sizeof(malformed_requests) / sizeof(malformed_requests[0]); i++) {
+    parser = Parser_new(PARSE_REQUEST, &strict_cfg, arena);
+    if (parser) {
+        Parser_execute(parser, malformed_requests[i],
+                       strlen(malformed_requests[i]), &consumed);
+        Parser_free(&parser);
+    }
+}
+```
+
+## Configuration Variation Pattern
+
+Test with different configuration combinations:
+
+```c
+/* Test 1: Default configuration */
+{
+    parser = Parser_new(PARSE_REQUEST, NULL, arena);
+    /* ... test ... */
+}
+
+/* Test 2: Strict mode */
+{
+    Config strict_cfg;
+    config_defaults(&strict_cfg);
+    strict_cfg.strict_mode = 1;
+    parser = Parser_new(PARSE_REQUEST, &strict_cfg, arena);
+    /* ... test ... */
+}
+
+/* Test 3: Lenient with larger limits */
+{
+    Config lenient_cfg;
+    config_defaults(&lenient_cfg);
+    lenient_cfg.strict_mode = 0;
+    lenient_cfg.max_header_size = 32768;
+    lenient_cfg.max_headers = 200;
+    parser = Parser_new(PARSE_REQUEST, &lenient_cfg, arena);
+    /* ... test ... */
+}
+
+/* Test 4: Restrictive limits for DoS testing */
+{
+    Config restrictive_cfg;
+    config_defaults(&restrictive_cfg);
+    restrictive_cfg.max_header_size = 1024;
+    restrictive_cfg.max_headers = 10;
+    restrictive_cfg.max_request_line = 256;
+    parser = Parser_new(PARSE_REQUEST, &restrictive_cfg, arena);
+    /* ... test ... */
+}
+```
+
+## Fuzzed Configuration Pattern
+
+Use fuzz data to drive configuration:
+
+```c
+static void
+test_fuzzed_config(const uint8_t *data, size_t size)
+{
+    if (size < 16)
+        return;
+
+    Config config;
+    config_defaults(&config);
+
+    /* Fuzz configuration values */
+    config.max_frame_size = ((size_t)data[0] << 24) | ((size_t)data[1] << 16) |
+                            ((size_t)data[2] << 8) | data[3];
+    config.max_message_size = ((size_t)data[4] << 24) | ((size_t)data[5] << 16) |
+                              ((size_t)data[6] << 8) | data[7];
+    config.validate_utf8 = data[10] & 1;
+    config.strict_mode = data[11] & 1;
+    config.timeout_ms = ((int)data[14] << 8) | data[15];
+
+    /* Use config in tests */
+}
+```
+
+## Error/Result String Coverage
+
+Test all error code string conversions:
+
+```c
+{
+    Result results[] = {
+        RESULT_OK,
+        RESULT_INCOMPLETE,
+        RESULT_ERROR,
+        RESULT_ERROR_OVERFLOW,
+        RESULT_ERROR_INVALID_INPUT,
+        /* ... all result codes ... */
+    };
+
+    for (size_t i = 0; i < sizeof(results) / sizeof(results[0]); i++) {
+        const char *str = result_string(results[i]);
+        (void)str;
+    }
+
+    /* Also test with fuzzed values */
+    if (size >= 1) {
+        result_string((Result)data[0]);
+    }
+}
+```
+
+## Multi-Test Organization
+
+Organize multiple test cases with clear section headers:
+
+```c
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    /* ... setup ... */
+
+    TRY {
+        /* ====================================================================
+         * Test 1: Default configuration parsing
+         * ==================================================================== */
+        {
+            /* ... test code ... */
+        }
+
+        /* ====================================================================
+         * Test 2: Strict mode configuration
+         * ==================================================================== */
+        {
+            /* ... test code ... */
+        }
+
+        /* ====================================================================
+         * Test 3: Incremental parsing
+         * ==================================================================== */
+        {
+            /* ... test code ... */
+        }
+
+        /* ====================================================================
+         * Test 4: Known attack vectors
+         * ==================================================================== */
+        {
+            /* ... test code ... */
+        }
+    }
+    EXCEPT(...) {}
+    END_TRY;
+
+    /* ... cleanup ... */
+    return 0;
+}
+```
+
+## Limits and Bounds
+
+Define fuzzing-specific limits:
+
+```c
+/* Limits for fuzzing */
+#define MAX_FUZZ_CAPACITY 4096
+#define MIN_FUZZ_CAPACITY 64
+#define MAX_FUZZ_HEADERS 64
+#define MAX_FUZZ_FRAGMENTS 100
+#define MAX_FUZZ_ITERATIONS 20
+
+/* Bound parameters to limits */
+size_t capacity = (capacity_raw % (MAX_FUZZ_CAPACITY - MIN_FUZZ_CAPACITY))
+                  + MIN_FUZZ_CAPACITY;
+
+/* Limit iteration counts */
+for (size_t i = 0; i < size && i < MAX_FUZZ_ITERATIONS; i++) {
+    /* ... */
+}
+```
+
+## Parser Reset and Reuse
+
+Test parser reset functionality:
+
+```c
+/* Parse once */
+result = Parser_execute(parser, data, size, &consumed);
+exercise_parser_accessors(parser);
+
+/* Reset and reparse */
+Parser_reset(parser);
+result = Parser_execute(parser, data, size, &consumed);
+exercise_parser_accessors(parser);
+```
+
+## Body Reading Pattern
+
+Handle body content after header parsing:
+
+```c
+if (result == RESULT_OK && Parser_state(parser) >= STATE_BODY) {
+    char body_buf[8192];
+    size_t body_consumed, body_written;
+    size_t remaining = size - consumed;
+
+    while (remaining > 0 && !Parser_body_complete(parser)) {
+        Result body_result = Parser_read_body(
+            parser, data + consumed, remaining, &body_consumed,
+            body_buf, sizeof(body_buf), &body_written);
+
+        if (body_consumed == 0)
+            break;
+
+        consumed += body_consumed;
+        remaining -= body_consumed;
+
+        if (body_result != RESULT_OK && body_result != RESULT_INCOMPLETE)
+            break;
+    }
+}
+```
+
+## Return Value
+
+Always return 0 from LLVMFuzzerTestOneInput:
+
+```c
+int
+LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    /* ... all fuzzing logic ... */
+
+    return 0;  /* Always return 0 */
+}
+```
+
+## Build Commands
+
+Standard fuzzer build and run commands:
+
+```bash
+# Build fuzzers
+CC=clang cmake -S . -B build -DENABLE_FUZZING=ON
+cmake --build build -j
+
+# Run single fuzzer
+cd build && ./fuzz_module corpus/module/ -fork=16 -max_len=4096
+
+# Run with memory limits
+./fuzz_module corpus/module/ -fork=16 -max_len=4096 -rss_limit_mb=2048
+
+# Run for specific duration
+./fuzz_module corpus/module/ -fork=16 -max_len=4096 -max_total_time=3600
+
+# Merge corpus
+./fuzz_module -merge=1 corpus/module/ corpus/module_new/
+
+# Minimize crash
+./fuzz_module -minimize_crash=1 -exact_artifact_path=minimized crash_file
+```


### PR DESCRIPTION
## Summary
- Add `fuzzing-patterns.md` (~16KB) with implementation patterns for libFuzzer harnesses
- Add `fuzzing-harnesses.md` (~38KB) with complete templates for 7 fuzzer categories
- Add `fuzzing-coverage.md` (~16KB) mapping all 95+ fuzzers to modules and attack vectors
- Update `README.md` with documentation for the new reference files

Fixes #100

## Details

### fuzzing-patterns.md
Implementation patterns extracted from analyzing existing fuzzers:
- File structure template with SPDX headers and docstrings
- Operation enum pattern for multi-case fuzzers
- Arena memory management pattern
- Exception handling with TRY/EXCEPT/FINALLY
- Volatile variables for exception safety
- Incremental parsing with variable chunk sizes
- Security attack vector testing patterns
- Configuration variation testing
- Build commands and libFuzzer options

### fuzzing-harnesses.md
Complete harness templates for different fuzzer types:
- Parser fuzzer template (HTTP, HPACK, WebSocket)
- Buffer fuzzer template (SocketBuf, circular buffers)
- State machine fuzzer template (TLS handshake)
- Codec fuzzer template (HPACK, UTF-8, Base64)
- Security attack fuzzer template (HTTP smuggling, injection)
- Frame parsing fuzzer template (WebSocket, HTTP/2)
- Validation fuzzer template (UTF-8, DNS, IP, URL)

### fuzzing-coverage.md
Comprehensive fuzzer coverage documentation:
- Index of all 95+ fuzzers with target modules and categories
- Coverage breakdown by module (Core, HTTP/1.1, HTTP/2, WebSocket, TLS, Proxy, etc.)
- Attack vector coverage matrix (buffer, injection, smuggling, DoS, protocol, encoding)
- Running commands and recommended parameters by category
- Checklist and CMakeLists.txt template for adding new fuzzers

## Test plan
- [x] Documentation only - no code changes
- [x] All markdown files render correctly
- [x] Cross-references in README.md are accurate