### PR TITLE
fix: complete HTTP/2 field name character validation (RFC 9113 §8.2.1)

### DIFF
--- a/include/http/SocketHTTP2-private.h
+++ b/include/http/SocketHTTP2-private.h
@@ -298,6 +298,7 @@ read_u31_be (const unsigned char *buf)
 extern int http2_is_connection_header_forbidden (const SocketHPACK_Header *header);
 extern int http2_field_has_uppercase (const char *name, size_t len);
 extern int http2_field_has_prohibited_chars (const char *data, size_t len);
+extern int http2_field_name_has_prohibited_chars (const char *name, size_t len);
 extern int http2_field_has_boundary_whitespace (const char *value, size_t len);
 extern int http2_validate_te_header (const char *value, size_t len);
 extern int http2_validate_regular_header (const SocketHPACK_Header *header);


### PR DESCRIPTION
## Summary

- Add `http2_field_name_has_prohibited_chars()` for complete RFC 9113 §8.2.1 compliance
- The existing validation only checked for NUL/CR/LF in field names, but the RFC requires rejecting:
  - 0x00-0x20: Control characters and space
  - 0x41-0x5A: Uppercase A-Z
  - 0x7F-0xFF: DEL and extended ASCII
  - Colon ':' except as first character (pseudo-headers)
- Update `http2_validate_regular_header()` to use the new comprehensive validator
- Add comprehensive test coverage for all prohibited character classes
- Fix `socket_peek_basic` test to use a less common port and handle port-in-use gracefully

Fixes #110

## Test plan

- [x] All 73 tests pass with ASan/UBSan enabled
- [x] New field name validation tests verify all RFC 9113 §8.2.1 prohibited character ranges
- [x] Integration with existing `http2_validate_regular_header()` verified