### PR TITLE
fix: prevent use-after-free in HTTP client request cleanup

### DIFF
--- a/src/http/SocketHTTPClient.c
+++ b/src/http/SocketHTTPClient.c
@@ -1674,12 +1674,18 @@ SocketHTTPClient_Request_free (SocketHTTPClient_Request_T *req)
 
   SocketHTTPClient_Request_T r = *req;
 
-  if (r->arena != NULL)
-    {
-      Arena_dispose (&r->arena);
-    }
+  /* Save arena pointer before freeing.
+   * The request struct is allocated from its own arena, so after
+   * Arena_dispose frees the chunks, r becomes invalid. We must not
+   * access r->arena after the dispose. */
+  Arena_T arena = r->arena;
 
   *req = NULL;
+
+  if (arena != NULL)
+    {
+      Arena_dispose (&arena);
+    }
 }
 
 int


### PR DESCRIPTION
## Summary
- Fix use-after-free bug in `SocketHTTPClient_Request_free` that caused memory corruption with high request counts
- The request struct is allocated from its own arena, so after `Arena_dispose` frees the chunks, the request becomes invalid
- Save arena pointer to local variable before calling `Arena_dispose` to avoid writing to freed memory

Fixes #119

## Test plan
- [x] All 73 tests pass with AddressSanitizer enabled
- [x] HTTP client tests pass with sanitizers
- [x] No memory corruption detected by ASan