### PR TITLE
feat: HTTP client benchmark suite comparing tetsuo-socket vs libcurl

### DIFF
--- a/run_http_benchmarks.sh
+++ b/run_http_benchmarks.sh
@@ -24,8 +24,10 @@ echo "=========================================="
 echo ""
 
 # Parse arguments
+# Note: Keep total requests low (<2000) until issue #119 (HTTP client memory
+# corruption) is fixed
 REBUILD_FLAG=""
-REQS=10000
+REQS=100
 THREADS=4
 HTTP_VERSION="both"
 NGINX_PORT=8080

--- a/src/test/benchmark_http_common.h
+++ b/src/test/benchmark_http_common.h
@@ -23,10 +23,13 @@
 #include <string.h>
 #include <time.h>
 
-/* Benchmark configuration defaults */
-#define BENCH_HTTP_DEFAULT_REQUESTS 10000
+/* Benchmark configuration defaults
+ * Note: Keep total requests low until issue #119 (HTTP client memory corruption)
+ * is fixed. With high request counts (>2000 total), the HTTP client crashes.
+ */
+#define BENCH_HTTP_DEFAULT_REQUESTS 100
 #define BENCH_HTTP_DEFAULT_THREADS 4
-#define BENCH_HTTP_DEFAULT_WARMUP 1000
+#define BENCH_HTTP_DEFAULT_WARMUP 10
 #define BENCH_HTTP_DEFAULT_PORT 8080
 #define BENCH_HTTP_DEFAULT_TLS_PORT 8443
 

--- a/src/test/benchmark_http_curl.c
+++ b/src/test/benchmark_http_curl.c
@@ -41,6 +41,7 @@ handle_signal (int sig)
 static size_t
 write_callback (void *contents, size_t size, size_t nmemb, void *userp)
 {
+  (void)contents; /* Data is discarded, only tracking size */
   size_t *bytes_received = (size_t *)userp;
   size_t total = size * nmemb;
   *bytes_received += total;


### PR DESCRIPTION
## Summary
- Add HTTP client benchmark infrastructure comparing tetsuo-socket vs libcurl
- Support both HTTP/1.1 and HTTP/2 protocols
- Measure requests/sec, latency percentiles (p50/p90/p99/p999), connection reuse
- Use nginx as reference server for fair comparison

Fixes #114

## Files Added
- `src/test/benchmark_http_common.h` - Shared types and utilities
- `src/test/benchmark_http_tetsuo.c` - tetsuo-socket HTTP client benchmark
- `src/test/benchmark_http_curl.c` - libcurl HTTP client benchmark
- `run_http_benchmarks.sh` - Orchestration script

## Usage
```bash
cmake -B build -DBUILD_HTTP_BENCHMARKS=ON
cmake --build build
./run_http_benchmarks.sh
```

## Known Limitations
- Request counts are currently limited due to issue #119 (HTTP client memory corruption with high request counts)
- Full benchmark capability will be available once #119 is resolved

## Test plan
- [x] Builds with and without libcurl installed
- [x] Runs successfully with nginx test server
- [x] Produces valid JSON output
- [ ] Full stress testing blocked by #119