### PR TITLE
feat: enforce TLS 1.2+ and cipher restrictions for HTTP/2 (RFC 9113 §9.2)

### DIFF
--- a/include/http/SocketHTTP2.h
+++ b/include/http/SocketHTTP2.h
@@ -548,6 +548,52 @@ extern void
 SocketHTTP2_frame_header_serialize (const SocketHTTP2_FrameHeader *header,
                                     unsigned char *data);
 
+/* TLS Validation (RFC 9113 Section 9.2) */
+
+/**
+ * @brief TLS validation result codes for HTTP/2 connections.
+ *
+ * RFC 9113 Section 9.2 specifies TLS requirements for HTTP/2:
+ * - TLS version 1.2 or higher
+ * - ALPN protocol "h2" must be negotiated
+ * - Certain cipher suites are forbidden (Appendix A)
+ */
+typedef enum
+{
+  HTTP2_TLS_OK = 0,               /**< TLS requirements satisfied */
+  HTTP2_TLS_NOT_ENABLED = -1,     /**< Socket has no TLS enabled */
+  HTTP2_TLS_VERSION_TOO_LOW = -2, /**< TLS version < 1.2 */
+  HTTP2_TLS_CIPHER_FORBIDDEN = -3, /**< Cipher suite is on forbidden list */
+  HTTP2_TLS_ALPN_MISMATCH = -4    /**< ALPN is not "h2" */
+} SocketHTTP2_TLSResult;
+
+/**
+ * @brief Validate TLS connection meets HTTP/2 requirements (RFC 9113 §9.2).
+ *
+ * Checks that the TLS connection satisfies RFC 9113 security requirements:
+ * 1. TLS version is 1.2 or higher
+ * 2. ALPN protocol "h2" was negotiated (for TLS connections)
+ * 3. Cipher suite is not on the forbidden list (Appendix A)
+ *
+ * This function should be called after the TLS handshake completes but
+ * before creating HTTP/2 streams.
+ *
+ * @param socket The socket to validate (may or may not have TLS)
+ * @return HTTP2_TLS_OK if requirements met, negative error code otherwise
+ *
+ * @note For cleartext HTTP/2 (h2c), TLS is not required and this returns
+ *       HTTP2_TLS_NOT_ENABLED which callers can treat as acceptable.
+ */
+extern SocketHTTP2_TLSResult SocketHTTP2_validate_tls (Socket_T socket);
+
+/**
+ * @brief Get human-readable string for TLS validation result.
+ *
+ * @param result The TLS validation result code
+ * @return Static string describing the result
+ */
+extern const char *SocketHTTP2_tls_result_string (SocketHTTP2_TLSResult result);
+
 /** @} */
 
 #endif /* SOCKETHTTP2_INCLUDED */

--- a/include/tls/SocketTLS.h
+++ b/include/tls/SocketTLS.h
@@ -1119,6 +1119,30 @@ extern const char *SocketTLS_get_cipher (Socket_T socket);
 extern const char *SocketTLS_get_version (Socket_T socket);
 
 /**
+ * @brief Get negotiated TLS protocol version as numeric value
+ * @ingroup security
+ * @param socket The socket instance with completed handshake
+ *
+ * Returns the TLS protocol version as a numeric value suitable for
+ * comparison. This is useful for validating minimum TLS version requirements
+ * (e.g., HTTP/2 requires TLS 1.2+).
+ *
+ * Common version values (from OpenSSL):
+ * - TLS1_VERSION   (0x0301) - TLS 1.0
+ * - TLS1_1_VERSION (0x0302) - TLS 1.1
+ * - TLS1_2_VERSION (0x0303) - TLS 1.2
+ * - TLS1_3_VERSION (0x0304) - TLS 1.3
+ *
+ * @return Protocol version number, or 0 if unavailable
+ * @throws None
+ * @threadsafe Yes - reads immutable post-handshake state
+ *
+ * @see SocketTLS_get_version() for human-readable version string.
+ * @see SocketTLSContext_set_min_protocol() for minimum version config.
+ */
+extern int SocketTLS_get_protocol_version (Socket_T socket);
+
+/**
  * @brief Get peer certificate verification result
  * @ingroup security
  * @param socket The socket instance with completed handshake

--- a/src/http/SocketHTTP2-connection.c
+++ b/src/http/SocketHTTP2-connection.c
@@ -276,6 +276,16 @@ SocketHTTP2_Conn_new (Socket_T socket, const SocketHTTP2_Config *config,
   assert (socket);
   assert (arena);
 
+  /* RFC 9113 §9.2: Validate TLS requirements for HTTP/2 over TLS */
+  SocketHTTP2_TLSResult tls_result = SocketHTTP2_validate_tls (socket);
+  if (tls_result != HTTP2_TLS_OK && tls_result != HTTP2_TLS_NOT_ENABLED)
+    {
+      /* TLS is enabled but doesn't meet HTTP/2 requirements */
+      SOCKET_RAISE_MSG (SocketHTTP2, SocketHTTP2_ProtocolError,
+                        "HTTP/2 TLS validation failed: %s",
+                        SocketHTTP2_tls_result_string (tls_result));
+    }
+
   /* Use default config if none provided */
   if (config == NULL)
     {

--- a/src/test/test_http2.c
+++ b/src/test/test_http2.c
@@ -775,6 +775,62 @@ test_validate_regular_header_rfc9113 (void)
 }
 
 /* ============================================================================
+ * TLS Validation Tests (RFC 9113 §9.2)
+ * ============================================================================
+ */
+
+static int
+test_tls_result_strings (void)
+{
+  TEST_BEGIN (tls_result_strings);
+
+  /* Test that all result codes have meaningful strings */
+  const char *str;
+
+  str = SocketHTTP2_tls_result_string (HTTP2_TLS_OK);
+  TEST_ASSERT (str != NULL, "HTTP2_TLS_OK should have a string");
+  TEST_ASSERT (strlen (str) > 0, "String should not be empty");
+
+  str = SocketHTTP2_tls_result_string (HTTP2_TLS_NOT_ENABLED);
+  TEST_ASSERT (str != NULL, "HTTP2_TLS_NOT_ENABLED should have a string");
+  TEST_ASSERT (strstr (str, "cleartext") != NULL || strstr (str, "not enabled") != NULL,
+               "Should mention cleartext or not enabled");
+
+  str = SocketHTTP2_tls_result_string (HTTP2_TLS_VERSION_TOO_LOW);
+  TEST_ASSERT (str != NULL, "HTTP2_TLS_VERSION_TOO_LOW should have a string");
+  TEST_ASSERT (strstr (str, "1.2") != NULL, "Should mention TLS 1.2");
+
+  str = SocketHTTP2_tls_result_string (HTTP2_TLS_CIPHER_FORBIDDEN);
+  TEST_ASSERT (str != NULL, "HTTP2_TLS_CIPHER_FORBIDDEN should have a string");
+  TEST_ASSERT (strstr (str, "cipher") != NULL || strstr (str, "Cipher") != NULL,
+               "Should mention cipher");
+
+  str = SocketHTTP2_tls_result_string (HTTP2_TLS_ALPN_MISMATCH);
+  TEST_ASSERT (str != NULL, "HTTP2_TLS_ALPN_MISMATCH should have a string");
+  TEST_ASSERT (strstr (str, "ALPN") != NULL || strstr (str, "h2") != NULL,
+               "Should mention ALPN or h2");
+
+  /* Unknown code should still return a valid string */
+  str = SocketHTTP2_tls_result_string ((SocketHTTP2_TLSResult)-99);
+  TEST_ASSERT (str != NULL, "Unknown code should have a string");
+
+  TEST_PASS ();
+}
+
+static int
+test_tls_validate_null_socket (void)
+{
+  TEST_BEGIN (tls_validate_null_socket);
+
+  /* NULL socket should return NOT_ENABLED */
+  SocketHTTP2_TLSResult result = SocketHTTP2_validate_tls (NULL);
+  TEST_ASSERT (result == HTTP2_TLS_NOT_ENABLED,
+               "NULL socket should return NOT_ENABLED");
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
  * Main Test Runner
  * ============================================================================
  */
@@ -832,6 +888,12 @@ main (void)
   test_field_name_colon ();
   test_field_name_valid ();
   test_validate_regular_header_rfc9113 ();
+  printf ("\n");
+
+  /* TLS validation tests (RFC 9113 §9.2) */
+  printf ("TLS Validation Tests (RFC 9113 §9.2):\n");
+  test_tls_result_strings ();
+  test_tls_validate_null_socket ();
   printf ("\n");
 
   /* Summary */

--- a/src/tls/SocketTLS.c
+++ b/src/tls/SocketTLS.c
@@ -1274,6 +1274,21 @@ SocketTLS_get_version (Socket_T socket)
   return ssl ? SSL_get_version (ssl) : NULL;
 }
 
+int
+SocketTLS_get_protocol_version (Socket_T socket)
+{
+  assert (socket);
+
+  SSL *ssl = tls_socket_get_ssl (socket);
+  if (!ssl)
+    return 0;
+
+  /* SSL_version() returns the protocol version:
+   * TLS1_VERSION (0x0301), TLS1_1_VERSION (0x0302),
+   * TLS1_2_VERSION (0x0303), TLS1_3_VERSION (0x0304) */
+  return SSL_version (ssl);
+}
+
 long
 SocketTLS_get_verify_result (Socket_T socket)
 {


### PR DESCRIPTION
## Summary

Implements RFC 9113 Section 9.2 TLS requirements for HTTP/2 connections:

- **TLS Version Check**: Require TLS 1.2 or higher for HTTP/2 over TLS
- **ALPN Validation**: Verify ALPN protocol is "h2" for TLS connections
- **Cipher Suite Blocklist**: Block weak/forbidden ciphers per RFC 9113 Appendix A:
  - NULL ciphers (no encryption)
  - EXPORT ciphers (weak export-grade)
  - RC4 ciphers (broken)
  - 3DES/DES-CBC3 ciphers (Sweet32)
  - Anonymous ciphers (ADH, AECDH, aNULL)
  - Single DES ciphers
  - MD5 MAC ciphers

### Changes

- `include/tls/SocketTLS.h`: Add `SocketTLS_get_protocol_version()` for numeric TLS version
- `include/http/SocketHTTP2.h`: Add `SocketHTTP2_TLSResult` enum and validation API
- `src/tls/SocketTLS.c`: Implement protocol version getter
- `src/http/SocketHTTP2-validate.c`: Implement TLS validation with cipher blocklist
- `src/http/SocketHTTP2-connection.c`: Integrate validation into `SocketHTTP2_Conn_new()`
- `src/test/test_http2.c`: Add unit tests for TLS validation

Fixes #113

## Test plan

- [x] All existing tests pass (73/73)
- [x] Tests pass with AddressSanitizer enabled
- [x] Tests pass with UndefinedBehaviorSanitizer enabled
- [x] New unit tests for TLS validation result strings
- [x] New unit tests for NULL socket handling

## References

- [RFC 9113 §9.2 - Use of TLS Features](https://www.rfc-editor.org/rfc/rfc9113#section-9.2)
- [RFC 9113 Appendix A - TLS 1.2 Cipher Suites](https://www.rfc-editor.org/rfc/rfc9113#appendix-A)