### PR TITLE
docs: add comprehensive DNS RFC references and implementation plan

### DIFF
--- a/DNS_IMPLEMENTATION_PLAN.md
+++ b/DNS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,311 @@
+# DNS Resolver Implementation Plan
+
+**23 Issues · 12 RFCs · Zero External Dependencies**
+
+## Phase 1: Wire Format Foundation
+
+Build the DNS message encoding/decoding layer.
+
+```
+#128 Header ──────┐
+                  ├──► #130 Question
+#129 Names ───────┤
+      │           │
+      │           └──► #131 RR Parsing ───┬──► #132 A/AAAA
+      │                      │            ├──► #133 CNAME
+      └──────────────────────┘            └──► #149 SOA
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 1 | #128 | DNS message header encoding/decoding (RFC 1035 §4.1.1) | (none) |
+| | | • ID, flags (QR, OPCODE, RCODE) | |
+| | | • Section counts (QD, AN, NS, AR) | |
+| | | • 12 bytes, network byte order | |
+| 2 | #129 | Domain name encoding/decoding (RFC 1035 §4.1.2, §4.1.4) | (none) |
+| | | • Label format (length + data) | |
+| | | • Compression pointers (0xC0) | |
+| | | • Max label 63, max name 255 bytes | |
+| | | • Case-insensitive comparison | |
+| 3 | #130 | Question section encoding (RFC 1035 §4.1.2) | #128, #129 |
+| | | • QNAME (domain name) | |
+| | | • QTYPE (A=1, AAAA=28, etc.) | |
+| | | • QCLASS (IN=1) | |
+| 4 | #131 | Resource record parsing (RFC 1035 §4.1.3) | #129 |
+| | | • NAME, TYPE, CLASS, TTL, RDLENGTH | |
+| | | • Generic RDATA extraction | |
+| | | • Handle compressed names | |
+| 5 | #132 | A and AAAA RDATA parsing (RFC 1035 §3.4.1, RFC 3596) | #131 |
+| | | • A: 4-byte IPv4 address | |
+| | | • AAAA: 16-byte IPv6 address | |
+| 6 | #133 | CNAME RDATA parsing (RFC 1035 §3.3.1) | #129, #131 |
+| | | • Canonical name (domain name) | |
+| | | • Chain following logic | |
+| 7 | #149 | SOA RDATA parsing (RFC 1035 §3.3.13) | #129, #131 |
+| | | • MNAME, RNAME (domain names) | |
+| | | • SERIAL, REFRESH, RETRY, EXPIRE | |
+| | | • MINIMUM (negative cache TTL) | |
+
+---
+
+## Phase 2: Transport Layer
+
+Implement UDP/TCP communication with nameservers.
+
+```
+#134 UDP ──────► #135 TCP
+   │
+   └──────────► #143 EDNS0
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 8 | #134 | UDP transport (RFC 1035 §4.2.1) | #128-#132 |
+| | | • Send query to port 53 | |
+| | | • Max 512 bytes (without EDNS0) | |
+| | | • Non-blocking I/O | |
+| | | • Detect TC (truncation) bit | |
+| 9 | #135 | TCP transport fallback (RFC 1035 §4.2.2) | #134 |
+| | | • 2-byte length prefix | |
+| | | • Used when UDP truncated | |
+| | | • Connection reuse | |
+| 10 | #143 | EDNS0 for larger UDP (RFC 6891) | #131, #134 |
+| | | • OPT pseudo-RR (TYPE=41) | |
+| | | • Advertise 4096 byte buffer | |
+| | | • Extended RCODE support | |
+| | | • Avoid TCP fallback in most cases | |
+
+---
+
+## Phase 3: Resolver Core
+
+Implement the async resolver with caching.
+
+```
+#136 resolv.conf ────┐
+                     │
+#149 SOA ──► #137 Cache ──┬──► #138 Async Resolver ──┬──► #145 Retry
+                          │           │              │
+#134 UDP ─────────────────┘           │              └──► #144 Validation
+                                      │
+                                      ▼
+                                ★ BENCHMARK ★
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 11 | #136 | /etc/resolv.conf parsing | (none) - parallel OK |
+| | | • nameserver directives | |
+| | | • search domains | |
+| | | • options (timeout, attempts, ndots) | |
+| 12 | #137 | DNS cache with TTL (RFC 1035 §7.4, RFC 2308) | #131, #149 |
+| | | • Hash table for O(1) lookup | |
+| | | • TTL-based expiration | |
+| | | • Negative caching (NXDOMAIN) | |
+| | | • LRU eviction, thread-safe | |
+| 13 | #138 | Async resolver with multiplexing (RFC 1035 §7) | #134, #136, #137 |
+| | | • Event loop integration | |
+| | | • Query ID management | |
+| | | • Multiple queries in flight | |
+| | | • CNAME chain following | |
+| 14 | #145 | Retry with exponential backoff (RFC 1035 §4.2.1, §7.2) | #138 |
+| | | • Configurable initial timeout | |
+| | | • Exponential backoff (2x) | |
+| | | • Nameserver rotation | |
+| 15 | #144 | Response validation & security | #138 |
+| | | • Query/response ID matching | |
+| | | • QNAME/QTYPE verification | |
+| | | • Bailiwick checking | |
+| | | • Source port randomization | |
+| | | • TTL capping (max 1 week) | |
+
+---
+
+## Phase 4: Integration
+
+Connect resolver to HTTP client and HappyEyeballs.
+
+```
+#138 Resolver ──► #140 IP Fast Path ──► #139 HappyEyeballs
+                                               │
+                                               ▼
+                                       ★ COMPARE TO LIBCURL ★
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 16 | #140 | Numeric IP address fast path | #138 |
+| | | • Detect IPv4/IPv6 literals | |
+| | | • Skip DNS for IP addresses | |
+| | | • inet_pton() validation | |
+| 17 | #139 | HappyEyeballs integration (RFC 8305) | #138, #140 |
+| | | • Parallel A + AAAA queries | |
+| | | • Connection racing | |
+| | | • Replace getaddrinfo() calls | |
+
+---
+
+## Phase 5: EDNS0 Security Extensions
+
+Add DNS Cookies and Extended Error reporting.
+
+```
+#143 EDNS0 ──┬──► #150 DNS Cookies
+             │
+             └──► #151 Extended DNS Errors
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 18 | #150 | DNS Cookies (RFC 7873) | #143 |
+| | | • Client cookie (8 bytes) | |
+| | | • Server cookie caching | |
+| | | • Anti-spoofing protection | |
+| | | • BADCOOKIE handling | |
+| 19 | #151 | Extended DNS Errors (RFC 8914) | #143 |
+| | | • 24 error codes | |
+| | | • DNSSEC failure details | |
+| | | • Human-readable EXTRA-TEXT | |
+| | | • Better debugging | |
+
+---
+
+## Phase 6: Encrypted DNS
+
+Add DNS-over-TLS and DNS-over-HTTPS for privacy.
+
+```
+#135 TCP ──────► #146 DNS-over-TLS (port 853)
+
+#138 Resolver ─► #147 DNS-over-HTTPS
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 20 | #146 | DNS-over-TLS (RFC 7858) | #135, #138, SocketTLS |
+| | | • TLS on port 853 | |
+| | | • Opportunistic or strict mode | |
+| | | • Connection reuse | |
+| | | • SPKI pinning support | |
+| 21 | #147 | DNS-over-HTTPS (RFC 8484) | #138, SocketHTTPClient |
+| | | • POST with application/dns-message | |
+| | | • GET with base64url encoding | |
+| | | • HTTP/2 multiplexing | |
+| | | • Cache-Control integration | |
+
+---
+
+## Phase 7: DNSSEC Validation
+
+Cryptographic verification of DNS responses.
+
+```
+#131 RR Parsing ──┐
+                  │
+#137 Cache ───────┼──► #148 DNSSEC Validation
+                  │
+#138 Resolver ────┘
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 22 | #148 | DNSSEC validation (RFC 4033, 4034, 4035, 5155) | #131, #137, #138 |
+| | | • DNSKEY, RRSIG, DS record parsing | |
+| | | • RSA/SHA-256, ECDSA verification | |
+| | | • Chain of trust from root | |
+| | | • NSEC/NSEC3 denial proofs | |
+| | | • SECURE/INSECURE/BOGUS states | |
+
+---
+
+## Phase 8: Quality Assurance
+
+Comprehensive testing and fuzzing.
+
+```
+All Issues ──────► #141 Tests and Fuzzing
+```
+
+| Order | Issue | Description | Dependencies |
+|-------|-------|-------------|--------------|
+| 23 | #141 | Comprehensive tests and fuzzing | All above |
+| | | • Unit tests per module | |
+| | | • Integration tests | |
+| | | • libFuzzer harnesses | |
+| | | • Malformed packet handling | |
+| | | • Compression bomb detection | |
+
+---
+
+## Milestones
+
+| Milestone | After Issue | Status |
+|-----------|-------------|--------|
+| Can send/receive DNS queries | #134 (UDP) | Basic functionality |
+| Working async resolver | #138 (Resolver) | **BENCHMARK vs libcurl** |
+| Full HappyEyeballs integration | #139 (HE) | **PRODUCTION READY** |
+| Privacy-enabled resolver | #147 (DoH) | Encrypted DNS |
+| Cryptographically verified DNS | #148 (DNSSEC) | **COMPLETE** |
+
+---
+
+## RFC Documents (12)
+
+| RFC | Title |
+|-----|-------|
+| rfc1035.txt | Domain Names - Implementation and Specification (Core) |
+| rfc2308.txt | Negative Caching of DNS Queries |
+| rfc3596.txt | DNS Extensions to Support IPv6 (AAAA) |
+| rfc4033.txt | DNS Security Introduction and Requirements |
+| rfc4034.txt | Resource Records for DNS Security Extensions |
+| rfc4035.txt | Protocol Modifications for DNS Security Extensions |
+| rfc5155.txt | NSEC3 Hashed Authenticated Denial of Existence |
+| rfc6891.txt | Extension Mechanisms for DNS (EDNS0) |
+| rfc7858.txt | Specification for DNS over TLS |
+| rfc7873.txt | Domain Name System (DNS) Cookies |
+| rfc8484.txt | DNS Queries over HTTPS (DoH) |
+| rfc8914.txt | Extended DNS Errors |
+
+---
+
+## Quick Reference
+
+### Issue Numbers by Phase
+
+- **Phase 1 (Wire Format):** #128, #129, #130, #131, #132, #133, #149
+- **Phase 2 (Transport):** #134, #135, #143
+- **Phase 3 (Resolver):** #136, #137, #138, #145, #144
+- **Phase 4 (Integration):** #140, #139
+- **Phase 5 (EDNS0 Ext):** #150, #151
+- **Phase 6 (Encrypted):** #146, #147
+- **Phase 7 (DNSSEC):** #148
+- **Phase 8 (Testing):** #141
+
+### Files to Create
+
+```
+include/dns/
+├── SocketDNSWire.h        # Wire format (Phase 1)
+├── SocketDNSTransport.h   # UDP/TCP (Phase 2)
+├── SocketDNSConfig.h      # resolv.conf (Phase 3)
+├── SocketDNSCache.h       # Cache (Phase 3)
+├── SocketDNSResolver.h    # Async resolver (Phase 3)
+├── SocketDNSCookie.h      # Cookies (Phase 5)
+├── SocketDNSError.h       # Extended errors (Phase 5)
+├── SocketDNSoverTLS.h     # DoT (Phase 6)
+├── SocketDNSoverHTTPS.h   # DoH (Phase 6)
+└── SocketDNSSEC.h         # DNSSEC (Phase 7)
+
+src/dns/
+├── SocketDNSWire.c
+├── SocketDNSTransport.c
+├── SocketDNSConfig.c
+├── SocketDNSCache.c
+├── SocketDNSResolver.c
+├── SocketDNSCookie.c
+├── SocketDNSError.c
+├── SocketDNSoverTLS.c
+├── SocketDNSoverHTTPS.c
+├── SocketDNSSEC.c
+└── SocketDNSSECCrypto.c
+```

--- a/rfc/dns/rfc2308.txt
+++ b/rfc/dns/rfc2308.txt
@@ -1,0 +1,1067 @@
+
+
+
+
+
+
+Network Working Group                                          M. Andrews
+Request for Comments: 2308                                          CSIRO
+Updates: 1034, 1035                                            March 1998
+Category: Standards Track
+
+
+              Negative Caching of DNS Queries (DNS NCACHE)
+
+Status of this Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+Abstract
+
+   [RFC1034] provided a description of how to cache negative responses.
+   It however had a fundamental flaw in that it did not allow a name
+   server to hand out those cached responses to other resolvers, thereby
+   greatly reducing the effect of the caching.  This document addresses
+   issues raise in the light of experience and replaces [RFC1034 Section
+   4.3.4].
+
+   Negative caching was an optional part of the DNS specification and
+   deals with the caching of the non-existence of an RRset [RFC2181] or
+   domain name.
+
+   Negative caching is useful as it reduces the response time for
+   negative answers.  It also reduces the number of messages that have
+   to be sent between resolvers and name servers hence overall network
+   traffic.  A large proportion of DNS traffic on the Internet could be
+   eliminated if all resolvers implemented negative caching.  With this
+   in mind negative caching should no longer be seen as an optional part
+   of a DNS resolver.
+
+
+
+
+
+
+
+
+
+
+
+Andrews                     Standards Track                     [Page 1]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+1 - Terminology
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED",  "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+   "Negative caching" - the storage of knowledge that something does not
+   exist.  We can store the knowledge that a record has a particular
+   value.  We can also do the reverse, that is, to store the knowledge
+   that a record does not exist.  It is the storage of knowledge that
+   something does not exist, cannot or does not give an answer that we
+   call negative caching.
+
+   "QNAME" - the name in the query section of an answer, or where this
+   resolves to a CNAME, or CNAME chain, the data field of the last
+   CNAME.  The last CNAME in this sense is that which contains a value
+   which does not resolve to another CNAME.  Implementations should note
+   that including CNAME records in responses in order, so that the first
+   has the label from the query section, and then each in sequence has
+   the label from the data section of the previous (where more than one
+   CNAME is needed) allows the sequence to be processed in one pass, and
+   considerably eases the task of the receiver.  Other relevant records
+   (such as SIG RRs [RFC2065]) can be interspersed amongst the CNAMEs.
+
+   "NXDOMAIN" - an alternate expression for the "Name Error" RCODE as
+   described in [RFC1035 Section 4.1.1] and the two terms are used
+   interchangeably in this document.
+
+   "NODATA" - a pseudo RCODE which indicates that the name is valid, for
+   the given class, but are no records of the given type.  A NODATA
+   response has to be inferred from the answer.
+
+   "FORWARDER" - a nameserver used to resolve queries instead of
+   directly using the authoritative nameserver chain.  The forwarder
+   typically either has better access to the internet, or maintains a
+   bigger cache which may be shared amongst many resolvers.  How a
+   server is identified as a FORWARDER, or knows it is a FORWARDER is
+   outside the scope of this document.  However if you are being used as
+   a forwarder the query will have the recursion desired flag set.
+
+   An understanding of [RFC1034], [RFC1035] and [RFC2065] is expected
+   when reading this document.
+
+
+
+
+
+
+
+
+
+Andrews                     Standards Track                     [Page 2]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+2 - Negative Responses
+
+   The most common negative responses indicate that a particular RRset
+   does not exist in the DNS.  The first sections of this document deal
+   with this case.  Other negative responses can indicate failures of a
+   nameserver, those are dealt with in section 7 (Other Negative
+   Responses).
+
+   A negative response is indicated by one of the following conditions:
+
+2.1 - Name Error
+
+   Name errors (NXDOMAIN) are indicated by the presence of "Name Error"
+   in the RCODE field.  In this case the domain referred to by the QNAME
+   does not exist.  Note: the answer section may have SIG and CNAME RRs
+   and the authority section may have SOA, NXT [RFC2065] and SIG RRsets.
+
+   It is possible to distinguish between a referral and a NXDOMAIN
+   response by the presense of NXDOMAIN in the RCODE regardless of the
+   presence of NS or SOA records in the authority section.
+
+   NXDOMAIN responses can be categorised into four types by the contents
+   of the authority section.  These are shown below along with a
+   referral for comparison.  Fields not mentioned are not important in
+   terms of the examples.
+
+           NXDOMAIN RESPONSE: TYPE 1.
+
+           Header:
+               RDCODE=NXDOMAIN
+           Query:
+               AN.EXAMPLE. A
+           Answer:
+               AN.EXAMPLE. CNAME TRIPPLE.XX.
+           Authority:
+               XX. SOA NS1.XX. HOSTMASTER.NS1.XX. ....
+               XX. NS NS1.XX.
+               XX. NS NS2.XX.
+           Additional:
+               NS1.XX. A 127.0.0.2
+               NS2.XX. A 127.0.0.3
+
+           NXDOMAIN RESPONSE: TYPE 2.
+
+           Header:
+               RDCODE=NXDOMAIN
+           Query:
+               AN.EXAMPLE. A
+
+
+
+Andrews                     Standards Track                     [Page 3]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+           Answer:
+               AN.EXAMPLE. CNAME TRIPPLE.XX.
+           Authority:
+               XX. SOA NS1.XX. HOSTMASTER.NS1.XX. ....
+           Additional:
+               <empty>
+
+           NXDOMAIN RESPONSE: TYPE 3.
+
+           Header:
+               RDCODE=NXDOMAIN
+           Query:
+               AN.EXAMPLE. A
+           Answer:
+               AN.EXAMPLE. CNAME TRIPPLE.XX.
+           Authority:
+               <empty>
+           Additional:
+               <empty>
+
+           NXDOMAIN RESPONSE: TYPE 4
+
+           Header:
+               RDCODE=NXDOMAIN
+           Query:
+               AN.EXAMPLE. A
+           Answer:
+               AN.EXAMPLE. CNAME TRIPPLE.XX.
+           Authority:
+               XX. NS NS1.XX.
+               XX. NS NS2.XX.
+           Additional:
+               NS1.XX. A 127.0.0.2
+               NS2.XX. A 127.0.0.3
+
+           REFERRAL RESPONSE.
+
+           Header:
+               RDCODE=NOERROR
+           Query:
+               AN.EXAMPLE. A
+           Answer:
+               AN.EXAMPLE. CNAME TRIPPLE.XX.
+           Authority:
+               XX. NS NS1.XX.
+               XX. NS NS2.XX.
+           Additional:
+               NS1.XX. A 127.0.0.2
+
+
+
+Andrews                     Standards Track                     [Page 4]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+               NS2.XX. A 127.0.0.3
+
+   Note, in the four examples of NXDOMAIN responses, it is known that
+   the name "AN.EXAMPLE." exists, and has as its value a CNAME record.
+   The NXDOMAIN refers to "TRIPPLE.XX", which is then known not to
+   exist.  On the other hand, in the referral example, it is shown that
+   "AN.EXAMPLE" exists, and has a CNAME RR as its value, but nothing is
+   known one way or the other about the existence of "TRIPPLE.XX", other
+   than that "NS1.XX" or "NS2.XX" can be consulted as the next step in
+   obtaining information about it.
+
+   Where no CNAME records appear, the NXDOMAIN response refers to the
+   name in the label of the RR in the question section.
+
+2.1.1 Special Handling of Name Error
+
+   This section deals with errors encountered when implementing negative
+   caching of NXDOMAIN responses.
+
+   There are a large number of resolvers currently in existence that
+   fail to correctly detect and process all forms of NXDOMAIN response.
+   Some resolvers treat a TYPE 1 NXDOMAIN response as a referral.  To
+   alleviate this problem it is recommended that servers that are
+   authoritative for the NXDOMAIN response only send TYPE 2 NXDOMAIN
+   responses, that is the authority section contains a SOA record and no
+   NS records.  If a non- authoritative server sends a type 1 NXDOMAIN
+   response to one of these old resolvers, the result will be an
+   unnecessary query to an authoritative server.  This is undesirable,
+   but not fatal except when the server is being used a FORWARDER.  If
+   however the resolver is using the server as a FORWARDER to such a
+   resolver it will be necessary to disable the sending of TYPE 1
+   NXDOMAIN response to it, use TYPE 2 NXDOMAIN instead.
+
+   Some resolvers incorrectly continue processing if the authoritative
+   answer flag is not set, looping until the query retry threshold is
+   exceeded and then returning SERVFAIL.  This is a problem when your
+   nameserver is listed as a FORWARDER for such resolvers.  If the
+   nameserver is used as a FORWARDER by such resolver, the authority
+   flag will have to be forced on for NXDOMAIN responses to these
+   resolvers.  In practice this causes no problems even if turned on
+   always, and has been the default behaviour in BIND from 4.9.3
+   onwards.
+
+2.2 - No Data
+
+   NODATA is indicated by an answer with the RCODE set to NOERROR and no
+   relevant answers in the answer section.  The authority section will
+   contain an SOA record, or there will be no NS records there.
+
+
+
+Andrews                     Standards Track                     [Page 5]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   NODATA responses have to be algorithmically determined from the
+   response's contents as there is no RCODE value to indicate NODATA.
+   In some cases to determine with certainty that NODATA is the correct
+   response it can be necessary to send another query.
+
+   The authority section may contain NXT and SIG RRsets in addition to
+   NS and SOA records.  CNAME and SIG records may exist in the answer
+   section.
+
+   It is possible to distinguish between a NODATA and a referral
+   response by the presence of a SOA record in the authority section or
+   the absence of NS records in the authority section.
+
+   NODATA responses can be categorised into three types by the contents
+   of the authority section.  These are shown below along with a
+   referral for comparison.  Fields not mentioned are not important in
+   terms of the examples.
+
+           NODATA RESPONSE: TYPE 1.
+
+           Header:
+               RDCODE=NOERROR
+           Query:
+               ANOTHER.EXAMPLE. A
+           Answer:
+               <empty>
+           Authority:
+               EXAMPLE. SOA NS1.XX. HOSTMASTER.NS1.XX. ....
+               EXAMPLE. NS NS1.XX.
+               EXAMPLE. NS NS2.XX.
+           Additional:
+               NS1.XX. A 127.0.0.2
+               NS2.XX. A 127.0.0.3
+
+           NO DATA RESPONSE: TYPE 2.
+
+           Header:
+               RDCODE=NOERROR
+           Query:
+               ANOTHER.EXAMPLE. A
+           Answer:
+               <empty>
+           Authority:
+               EXAMPLE. SOA NS1.XX. HOSTMASTER.NS1.XX. ....
+           Additional:
+               <empty>
+
+
+
+
+
+Andrews                     Standards Track                     [Page 6]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+           NO DATA RESPONSE: TYPE 3.
+
+           Header:
+               RDCODE=NOERROR
+           Query:
+               ANOTHER.EXAMPLE. A
+           Answer:
+               <empty>
+           Authority:
+               <empty>
+           Additional:
+               <empty>
+
+           REFERRAL RESPONSE.
+
+           Header:
+               RDCODE=NOERROR
+           Query:
+               ANOTHER.EXAMPLE. A
+           Answer:
+               <empty>
+           Authority:
+               EXAMPLE. NS NS1.XX.
+               EXAMPLE. NS NS2.XX.
+           Additional:
+               NS1.XX. A 127.0.0.2
+               NS2.XX. A 127.0.0.3
+
+
+   These examples, unlike the NXDOMAIN examples above, have no CNAME
+   records, however they could, in just the same way that the NXDOMAIN
+   examples did, in which case it would be the value of the last CNAME
+   (the QNAME) for which NODATA would be concluded.
+
+2.2.1 - Special Handling of No Data
+
+   There are a large number of resolvers currently in existence that
+   fail to correctly detect and process all forms of NODATA response.
+   Some resolvers treat a TYPE 1 NODATA response as a referral.  To
+   alleviate this problem it is recommended that servers that are
+   authoritative for the NODATA response only send TYPE 2 NODATA
+   responses, that is the authority section contains a SOA record and no
+   NS records.  Sending a TYPE 1 NODATA response from a non-
+   authoritative server to one of these resolvers will only result in an
+   unnecessary query.  If a server is listed as a FORWARDER for another
+   resolver it may also be necessary to disable the sending of TYPE 1
+   NODATA response for non-authoritative NODATA responses.
+
+
+
+
+Andrews                     Standards Track                     [Page 7]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   Some name servers fail to set the RCODE to NXDOMAIN in the presence
+   of CNAMEs in the answer section.  If a definitive NXDOMAIN / NODATA
+   answer is required in this case the resolver must query again using
+   the QNAME as the query label.
+
+3 - Negative Answers from Authoritative Servers
+
+   Name servers authoritative for a zone MUST include the SOA record of
+   the zone in the authority section of the response when reporting an
+   NXDOMAIN or indicating that no data of the requested type exists.
+   This is required so that the response may be cached.  The TTL of this
+   record is set from the minimum of the MINIMUM field of the SOA record
+   and the TTL of the SOA itself, and indicates how long a resolver may
+   cache the negative answer.  The TTL SIG record associated with the
+   SOA record should also be trimmed in line with the SOA's TTL.
+
+   If the containing zone is signed [RFC2065] the SOA and appropriate
+   NXT and SIG records MUST be added.
+
+4 - SOA Minimum Field
+
+   The SOA minimum field has been overloaded in the past to have three
+   different meanings, the minimum TTL value of all RRs in a zone, the
+   default TTL of RRs which did not contain a TTL value and the TTL of
+   negative responses.
+
+   Despite being the original defined meaning, the first of these, the
+   minimum TTL value of all RRs in a zone, has never in practice been
+   used and is hereby deprecated.
+
+   The second, the default TTL of RRs which contain no explicit TTL in
+   the master zone file, is relevant only at the primary server.  After
+   a zone transfer all RRs have explicit TTLs and it is impossible to
+   determine whether the TTL for a record was explicitly set or derived
+   from the default after a zone transfer.  Where a server does not
+   require RRs to include the TTL value explicitly, it should provide a
+   mechanism, not being the value of the MINIMUM field of the SOA
+   record, from which the missing TTL values are obtained.  How this is
+   done is implementation dependent.
+
+   The Master File format [RFC 1035 Section 5] is extended to include
+   the following directive:
+
+                           $TTL <TTL> [comment]
+
+
+
+
+
+
+
+Andrews                     Standards Track                     [Page 8]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   All resource records appearing after the directive, and which do not
+   explicitly include a TTL value, have their TTL set to the TTL given
+   in the $TTL directive.  SIG records without a explicit TTL get their
+   TTL from the "original TTL" of the SIG record [RFC 2065 Section 4.5].
+
+   The remaining of the current meanings, of being the TTL to be used
+   for negative responses, is the new defined meaning of the SOA minimum
+   field.
+
+5 - Caching Negative Answers
+
+   Like normal answers negative answers have a time to live (TTL).  As
+   there is no record in the answer section to which this TTL can be
+   applied, the TTL must be carried by another method.  This is done by
+   including the SOA record from the zone in the authority section of
+   the reply.  When the authoritative server creates this record its TTL
+   is taken from the minimum of the SOA.MINIMUM field and SOA's TTL.
+   This TTL decrements in a similar manner to a normal cached answer and
+   upon reaching zero (0) indicates the cached negative answer MUST NOT
+   be used again.
+
+   A negative answer that resulted from a name error (NXDOMAIN) should
+   be cached such that it can be retrieved and returned in response to
+   another query for the same <QNAME, QCLASS> that resulted in the
+   cached negative response.
+
+   A negative answer that resulted from a no data error (NODATA) should
+   be cached such that it can be retrieved and returned in response to
+   another query for the same <QNAME, QTYPE, QCLASS> that resulted in
+   the cached negative response.
+
+   The NXT record, if it exists in the authority section of a negative
+   answer received, MUST be stored such that it can be be located and
+   returned with SOA record in the authority section, as should any SIG
+   records in the authority section.  For NXDOMAIN answers there is no
+   "necessary" obvious relationship between the NXT records and the
+   QNAME.  The NXT record MUST have the same owner name as the query
+   name for NODATA responses.
+
+   Negative responses without SOA records SHOULD NOT be cached as there
+   is no way to prevent the negative responses looping forever between a
+   pair of servers even with a short TTL.
+
+   Despite the DNS forming a tree of servers, with various mis-
+   configurations it is possible to form a loop in the query graph, e.g.
+   two servers listing each other as forwarders, various lame server
+   configurations.  Without a TTL count down a cache negative response
+
+
+
+
+Andrews                     Standards Track                     [Page 9]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   when received by the next server would have its TTL reset.  This
+   negative indication could then live forever circulating between the
+   servers involved.
+
+   As with caching positive responses it is sensible for a resolver to
+   limit for how long it will cache a negative response as the protocol
+   supports caching for up to 68 years.  Such a limit should not be
+   greater than that applied to positive answers and preferably be
+   tunable.  Values of one to three hours have been found to work well
+   and would make sensible a default.  Values exceeding one day have
+   been found to be problematic.
+
+6 - Negative answers from the cache
+
+   When a server, in answering a query, encounters a cached negative
+   response it MUST add the cached SOA record to the authority section
+   of the response with the TTL decremented by the amount of time it was
+   stored in the cache.  This allows the NXDOMAIN / NODATA response to
+   time out correctly.
+
+   If a NXT record was cached along with SOA record it MUST be added to
+   the authority section.  If a SIG record was cached along with a NXT
+   record it SHOULD be added to the authority section.
+
+   As with all answers coming from the cache, negative answers SHOULD
+   have an implicit referral built into the answer.  This enables the
+   resolver to locate an authoritative source.  An implicit referral is
+   characterised by NS records in the authority section referring the
+   resolver towards a authoritative source.  NXDOMAIN types 1 and 4
+   responses contain implicit referrals as does NODATA type 1 response.
+
+7 - Other Negative Responses
+
+   Caching of other negative responses is not covered by any existing
+   RFC.  There is no way to indicate a desired TTL in these responses.
+   Care needs to be taken to ensure that there are not forwarding loops.
+
+7.1 Server Failure (OPTIONAL)
+
+   Server failures fall into two major classes.  The first is where a
+   server can determine that it has been misconfigured for a zone.  This
+   may be where it has been listed as a server, but not configured to be
+   a server for the zone, or where it has been configured to be a server
+   for the zone, but cannot obtain the zone data for some reason.  This
+   can occur either because the zone file does not exist or contains
+   errors, or because another server from which the zone should have
+   been available either did not respond or was unable or unwilling to
+   supply the zone.
+
+
+
+Andrews                     Standards Track                    [Page 10]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   The second class is where the server needs to obtain an answer from
+   elsewhere, but is unable to do so, due to network failures, other
+   servers that don't reply, or return server failure errors, or
+   similar.
+
+   In either case a resolver MAY cache a server failure response.  If it
+   does so it MUST NOT cache it for longer than five (5) minutes, and it
+   MUST be cached against the specific query tuple <query name, type,
+   class, server IP address>.
+
+7.2 Dead / Unreachable Server (OPTIONAL)
+
+   Dead / Unreachable servers are servers that fail to respond in any
+   way to a query or where the transport layer has provided an
+   indication that the server does not exist or is unreachable.  A
+   server may be deemed to be dead or unreachable if it has not
+   responded to an outstanding query within 120 seconds.
+
+   Examples of transport layer indications are:
+
+      ICMP error messages indicating host, net or port unreachable.
+      TCP resets
+      IP stack error messages providing similar indications to those above.
+
+   A server MAY cache a dead server indication.  If it does so it MUST
+   NOT be deemed dead for longer than five (5) minutes.  The indication
+   MUST be stored against query tuple <query name, type, class, server
+   IP address> unless there was a transport layer indication that the
+   server does not exist, in which case it applies to all queries to
+   that specific IP address.
+
+8 - Changes from RFC 1034
+
+   Negative caching in resolvers is no-longer optional, if a resolver
+   caches anything it must also cache negative answers.
+
+   Non-authoritative negative answers MAY be cached.
+
+   The SOA record from the authority section MUST be cached.  Name error
+   indications must be cached against the tuple <query name, QCLASS>.
+   No data indications must be cached against <query name, QTYPE,
+   QCLASS> tuple.
+
+   A cached SOA record must be added to the response.  This was
+   explicitly not allowed because previously the distinction between a
+   normal cached SOA record, and the SOA cached as a result of a
+   negative response was not made, and simply extracting a normal cached
+   SOA and adding that to a cached negative response causes problems.
+
+
+
+Andrews                     Standards Track                    [Page 11]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   The $TTL TTL directive was added to the master file format.
+
+9 - History of Negative Caching
+
+   This section presents a potted history of negative caching in the DNS
+   and forms no part of the technical specification of negative caching.
+
+   It is interesting to note that the same concepts were re-invented in
+   both the CHIVES and BIND servers.
+
+   The history of the early CHIVES work (Section 9.1) was supplied by
+   Rob Austein <sra@epilogue.com> and is reproduced here in the form in
+   which he supplied it [MPA].
+
+   Sometime around the spring of 1985, I mentioned to Paul Mockapetris
+   that our experience with his JEEVES DNS resolver had pointed out the
+   need for some kind of negative caching scheme.  Paul suggested that
+   we simply cache authoritative errors, using the SOA MINIMUM value for
+   the zone that would have contained the target RRs.  I'm pretty sure
+   that this conversation took place before RFC-973 was written, but it
+   was never clear to me whether this idea was something that Paul came
+   up with on the spot in response to my question or something he'd
+   already been planning to put into the document that became RFC-973.
+   In any case, neither of us was entirely sure that the SOA MINIMUM
+   value was really the right metric to use, but it was available and
+   was under the control of the administrator of the target zone, both
+   of which seemed to us at the time to be important feature.
+
+   Late in 1987, I released the initial beta-test version of CHIVES, the
+   DNS resolver I'd written to replace Paul's JEEVES resolver.  CHIVES
+   included a search path mechanism that was used pretty heavily at
+   several sites (including my own), so CHIVES also included a negative
+   caching mechanism based on SOA MINIMUM values.  The basic strategy
+   was to cache authoritative error codes keyed by the exact query
+   parameters (QNAME, QCLASS, and QTYPE), with a cache TTL equal to the
+   SOA MINIMUM value.  CHIVES did not attempt to track down SOA RRs if
+   they weren't supplied in the authoritative response, so it never
+   managed to completely eliminate the gratuitous DNS error message
+   traffic, but it did help considerably.  Keep in mind that this was
+   happening at about the same time as the near-collapse of the ARPANET
+   due to congestion caused by exponential growth and the the "old"
+   (pre-VJ) TCP retransmission algorithm, so negative caching resulted
+   in drasticly better DNS response time for our users, mailer daemons,
+   etcetera.
+
+
+
+
+
+
+
+Andrews                     Standards Track                    [Page 12]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   As far as I know, CHIVES was the first resolver to implement negative
+   caching.  CHIVES was developed during the twilight years of TOPS-20,
+   so it never ran on very many machines, but the few machines that it
+   did run on were the ones that were too critical to shut down quickly
+   no matter how much it cost to keep them running.  So what few users
+   we did have tended to drive CHIVES pretty hard.  Several interesting
+   bits of DNS technology resulted from that, but the one that's
+   relevant here is the MAXTTL configuration parameter.
+
+   Experience with JEEVES had already shown that RRs often showed up
+   with ridiculously long TTLs (99999999 was particularly popular for
+   many years, due to bugs in the code and documentation of several
+   early versions of BIND), and that robust software that blindly
+   believed such TTLs could create so many strange failures that it was
+   often necessary to reboot the resolver frequently just to clear this
+   garbage out of the cache.  So CHIVES had a configuration parameter
+   "MAXTTL", which specified the maximum "reasonable" TTL in a received
+   RR.  RRs with TTLs greater than MAXTTL would either have their TTLs
+   reduced to MAXTTL or would be discarded entirely, depending on the
+   setting of another configuration parameter.
+
+   When we started getting field experience with CHIVES's negative
+   caching code, it became clear that the SOA MINIMUM value was often
+   large enough to cause the same kinds of problems for negative caching
+   as the huge TTLs in RRs had for normal caching (again, this was in
+   part due to a bug in several early versions of BIND, where a
+   secondary server would authoritatively deny all knowledge of its
+   zones if it couldn't contact the primaries on reboot).  So we started
+   running the negative cache TTLs through the MAXTTL check too, and
+   continued to experiment.
+
+   The configuration that seemed to work best on WSMR-SIMTEL20.ARMY.MIL
+   (last of the major Internet TOPS-20 machines to be shut down, thus
+   the last major user of CHIVES, thus the place where we had the
+   longest experimental baseline) was to set MAXTTL to about three days.
+   Most of the traffic initiated by SIMTEL20 in its last years was
+   mail-related, and the mail queue timeout was set to one week, so this
+   gave a "stuck" message several tries at complete DNS resolution,
+   without bogging down the system with a lot of useless queries.  Since
+   (for reasons that now escape me) we only had the single MAXTTL
+   parameter rather than separate ones for positive and negative
+   caching, it's not clear how much effect this setting of MAXTTL had on
+   the negative caching code.
+
+   CHIVES also included a second, somewhat controversial mechanism which
+   took the place of negative caching in some cases.  The CHIVES
+   resolver daemon could be configured to load DNS master files, giving
+   it the ability to act as what today would be called a "stealth
+
+
+
+Andrews                     Standards Track                    [Page 13]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   secondary".  That is, when configured in this way, the resolver had
+   direct access to authoritative information for heavily-used zones.
+   The search path mechanisms in CHIVES reflected this: there were
+   actually two separate search paths, one of which only searched local
+   authoritative zone data, and one which could generate normal
+   iterative queries.  This cut down on the need for negative caching in
+   cases where usage was predictably heavy (e.g., the resolver on
+   XX.LCS.MIT.EDU always loaded the zone files for both LCS.MIT.EDU and
+   AI.MIT.EDU and put both of these suffixes into the "local" search
+   path, since between them the hosts in these two zones accounted for
+   the bulk of the DNS traffic).  Not all sites running CHIVES chose to
+   use this feature; C.CS.CMU.EDU, for example, chose to use the
+   "remote" search path for everything because there were too many
+   different sub-zones at CMU for zone shadowing to be practical for
+   them, so they relied pretty heavily on negative caching even for
+   local traffic.
+
+   Overall, I still think the basic design we used for negative caching
+   was pretty reasonable: the zone administrator specified how long to
+   cache negative answers, and the resolver configuration chose the
+   actual cache time from the range between zero and the period
+   specified by the zone administrator.  There are a lot of details I'd
+   do differently now (like using a new SOA field instead of overloading
+   the MINIMUM field), but after more than a decade, I'd be more worried
+   if we couldn't think of at least a few improvements.
+
+9.2 BIND
+
+   While not the first attempt to get negative caching into BIND, in
+   July 1993, BIND 4.9.2 ALPHA, Anant Kumar of ISI supplied code that
+   implemented, validation and negative caching (NCACHE).  This code had
+   a 10 minute TTL for negative caching and only cached the indication
+   that there was a negative response, NXDOMAIN or NOERROR_NODATA. This
+   is the origin of the NODATA pseudo response code mentioned above.
+
+   Mark Andrews of CSIRO added code (RETURNSOA) that stored the SOA
+   record such that it could be retrieved by a similar query.  UUnet
+   complained that they were getting old answers after loading a new
+   zone, and the option was turned off, BIND 4.9.3-alpha5, April 1994.
+   In reality this indicated that the named needed to purge the space
+   the zone would occupy.  Functionality to do this was added in BIND
+   4.9.3 BETA11 patch2, December 1994.
+
+   RETURNSOA was re-enabled by default, BIND 4.9.5-T1A, August 1996.
+
+
+
+
+
+
+
+Andrews                     Standards Track                    [Page 14]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+10 Example
+
+   The following example is based on a signed zone that is empty apart
+   from the nameservers.  We will query for WWW.XX.EXAMPLE showing
+   initial response and again 10 minutes later.  Note 1: during the
+   intervening 10 minutes the NS records for XX.EXAMPLE have expired.
+   Note 2: the TTL of the SIG records are not explicitly set in the zone
+   file and are hence the TTL of the RRset they are the signature for.
+
+        Zone File:
+
+        $TTL 86400
+        $ORIGIN XX.EXAMPLE.
+        @       IN      SOA     NS1.XX.EXAMPLE. HOSTMATER.XX.EXAMPLE. (
+                                1997102000      ; serial
+                                1800    ; refresh (30 mins)
+                                900     ; retry (15 mins)
+                                604800  ; expire (7 days)
+                                1200 ) ; minimum (20 mins)
+                IN      SIG     SOA ...
+          1200  IN      NXT     NS1.XX.EXAMPLE. A NXT SIG SOA NS KEY
+                IN      SIG     NXT ... XX.EXAMPLE. ...
+           300  IN      NS      NS1.XX.EXAMPLE.
+           300  IN      NS      NS2.XX.EXAMPLE.
+                IN      SIG     NS ... XX.EXAMPLE. ...
+                IN      KEY     0x4100 1 1 ...
+                IN      SIG     KEY ... XX.EXAMPLE. ...
+                IN      SIG     KEY ... EXAMPLE. ...
+        NS1     IN      A       10.0.0.1
+                IN      SIG     A ... XX.EXAMPLE. ...
+          1200  IN      NXT     NS2.XX.EXAMPLE. A NXT SIG
+                IN      SIG     NXT ...
+        NS2     IN      A       10.0.0.2
+                IN      SIG     A ... XX.EXAMPLE. ...
+          1200  IN      NXT     XX.EXAMPLE. A NXT SIG
+                IN      SIG     NXT ... XX.EXAMPLE. ...
+
+        Initial Response:
+
+        Header:
+            RDCODE=NXDOMAIN, AA=1, QR=1, TC=0
+        Query:
+            WWW.XX.EXAMPLE. IN A
+        Answer:
+            <empty>
+        Authority:
+            XX.EXAMPLE.      1200 IN SOA NS1.XX.EXAMPLE. ...
+            XX.EXAMPLE.      1200 IN SIG SOA ... XX.EXAMPLE. ...
+
+
+
+Andrews                     Standards Track                    [Page 15]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+            NS2.XX.EXAMPLE.  1200 IN NXT XX.EXAMPLE. NXT A NXT SIG
+            NS2.XX.EXAMPLE.  1200 IN SIG NXT ... XX.EXAMPLE. ...
+            XX.EXAMPLE.     86400 IN NS  NS1.XX.EXAMPLE.
+            XX.EXAMPLE.     86400 IN NS  NS2.XX.EXAMPLE.
+            XX.EXAMPLE.     86400 IN SIG NS ... XX.EXAMPLE. ...
+        Additional
+            XX.EXAMPLE.     86400 IN KEY 0x4100 1 1 ...
+            XX.EXAMPLE.     86400 IN SIG KEY ... EXAMPLE. ...
+            NS1.XX.EXAMPLE. 86400 IN A   10.0.0.1
+            NS1.XX.EXAMPLE. 86400 IN SIG A ... XX.EXAMPLE. ...
+            NS2.XX.EXAMPLE. 86400 IN A   10.0.0.2
+            NS3.XX.EXAMPLE. 86400 IN SIG A ... XX.EXAMPLE. ...
+
+         After 10 Minutes:
+
+         Header:
+             RDCODE=NXDOMAIN, AA=0, QR=1, TC=0
+         Query:
+             WWW.XX.EXAMPLE. IN A
+         Answer:
+             <empty>
+         Authority:
+             XX.EXAMPLE.       600 IN SOA NS1.XX.EXAMPLE. ...
+             XX.EXAMPLE.       600 IN SIG SOA ... XX.EXAMPLE. ...
+             NS2.XX.EXAMPLE.   600 IN NXT XX.EXAMPLE. NXT A NXT SIG
+             NS2.XX.EXAMPLE.   600 IN SIG NXT ... XX.EXAMPLE. ...
+             EXAMPLE.        65799 IN NS  NS1.YY.EXAMPLE.
+             EXAMPLE.        65799 IN NS  NS2.YY.EXAMPLE.
+             EXAMPLE.        65799 IN SIG NS ... XX.EXAMPLE. ...
+         Additional
+             XX.EXAMPLE.     65800 IN KEY 0x4100 1 1 ...
+             XX.EXAMPLE.     65800 IN SIG KEY ... EXAMPLE. ...
+             NS1.YY.EXAMPLE. 65799 IN A   10.100.0.1
+             NS1.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+             NS2.YY.EXAMPLE. 65799 IN A   10.100.0.2
+             NS3.YY.EXAMPLE. 65799 IN SIG A ... EXAMPLE. ...
+             EXAMPLE.        65799 IN KEY 0x4100 1 1 ...
+             EXAMPLE.        65799 IN SIG KEY ... . ...
+
+
+11 Security Considerations
+
+   It is believed that this document does not introduce any significant
+   additional security threats other that those that already exist when
+   using data from the DNS.
+
+
+
+
+
+
+Andrews                     Standards Track                    [Page 16]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+   With negative caching it might be possible to propagate a denial of
+   service attack by spreading a NXDOMAIN message with a very high TTL.
+   Without negative caching that would be much harder.  A similar effect
+   could be achieved previously by spreading a bad A record, so that the
+   server could not be reached - which is almost the same.  It has the
+   same effect as far as what the end user is able to do, but with a
+   different psychological effect.  With the bad A, I feel "damn the
+   network is broken again" and try again tomorrow.  With the "NXDOMAIN"
+   I feel "Oh, they've turned off the server and it doesn't exist any
+   more" and probably never bother trying this server again.
+
+   A practical example of this is a SMTP server where this behaviour is
+   encoded.  With a NXDOMAIN attack the mail message would bounce
+   immediately, where as with a bad A attack the mail would be queued
+   and could potentially get through after the attack was suspended.
+
+   For such an attack to be successful, the NXDOMAIN indiction must be
+   injected into a parent server (or a busy caching resolver).  One way
+   this might be done by the use of a CNAME which results in the parent
+   server querying an attackers server.  Resolvers that wish to prevent
+   such attacks can query again the final QNAME ignoring any NS data in
+   the query responses it has received for this query.
+
+   Implementing TTL sanity checking will reduce the effectiveness of
+   such an attack, because a successful attack would require re-
+   injection of the bogus data at more frequent intervals.
+
+   DNS Security [RFC2065] provides a mechanism to verify whether a
+   negative response is valid or not, through the use of NXT and SIG
+   records.  This document supports the use of that mechanism by
+   promoting the transmission of the relevant security records even in a
+   non security aware server.
+
+Acknowledgments
+
+   I would like to thank Rob Austein for his history of the CHIVES
+   nameserver. The DNSIND working group, in particular Robert Elz for
+   his valuable technical and editorial contributions to this document.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews                     Standards Track                    [Page 17]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+References
+
+   [RFC1034]
+           Mockapetris, P., "DOMAIN NAMES - CONCEPTS AND FACILITIES,"
+           STD 13, RFC 1034, November 1987.
+
+   [RFC1035]
+           Mockapetris, P., "DOMAIN NAMES - IMPLEMENTATION AND
+           SPECIFICATION," STD 13, RFC 1035, November 1987.
+
+   [RFC2065]
+           Eastlake, D., and C. Kaufman, "Domain Name System Security
+           Extensions," RFC 2065, January 1997.
+
+   [RFC2119]
+           Bradner, S., "Key words for use in RFCs to Indicate
+           Requirement Levels," BCP 14, RFC 2119, March 1997.
+
+   [RFC2181]
+           Elz, R., and R. Bush, "Clarifications to the DNS
+           Specification," RFC 2181, July 1997.
+
+Author's Address
+
+   Mark Andrews
+   CSIRO - Mathematical and Information Sciences
+   Locked Bag 17
+   North Ryde NSW 2113
+   AUSTRALIA
+
+   Phone: +61 2 9325 3148
+   EMail: Mark.Andrews@cmis.csiro.au
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews                     Standards Track                    [Page 18]
+
+RFC 2308                       DNS NCACHE                     March 1998
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (1998).  All Rights Reserved.
+
+   This document and translations of it may be copied and furnished to
+   others, and derivative works that comment on or otherwise explain it
+   or assist in its implementation may be prepared, copied, published
+   and distributed, in whole or in part, without restriction of any
+   kind, provided that the above copyright notice and this paragraph are
+   included on all such copies and derivative works.  However, this
+   document itself may not be modified in any way, such as by removing
+   the copyright notice or references to the Internet Society or other
+   Internet organizations, except as needed for the purpose of
+   developing Internet standards in which case the procedures for
+   copyrights defined in the Internet Standards process must be
+   followed, or as required to translate it into languages other than
+   English.
+
+   The limited permissions granted above are perpetual and will not be
+   revoked by the Internet Society or its successors or assigns.
+
+   This document and the information contained herein is provided on an
+   "AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+   TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+   BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+   HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+   MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Andrews                     Standards Track                    [Page 19]
+

--- a/rfc/dns/rfc4033.txt
+++ b/rfc/dns/rfc4033.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Network Working Group                                          R. Arends
+Request for Comments: 4033                          Telematica Instituut
+Obsoletes: 2535, 3008, 3090, 3445, 3655, 3658,                R. Austein
+           3755, 3757, 3845                                          ISC
+Updates: 1034, 1035, 2136, 2181, 2308, 3225,                   M. Larson
+         3007, 3597, 3226                                       VeriSign
+Category: Standards Track                                      D. Massey
+                                               Colorado State University
+                                                                 S. Rose
+                                                                    NIST
+                                                              March 2005
+
+
+               DNS Security Introduction and Requirements
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   The Domain Name System Security Extensions (DNSSEC) add data origin
+   authentication and data integrity to the Domain Name System.  This
+   document introduces these extensions and describes their capabilities
+   and limitations.  This document also discusses the services that the
+   DNS security extensions do and do not provide.  Last, this document
+   describes the interrelationships between the documents that
+   collectively describe DNSSEC.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 1]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . .   2
+   2.  Definitions of Important DNSSEC Terms  . . . . . . . . . . .   3
+   3.  Services Provided by DNS Security  . . . . . . . . . . . . .   7
+       3.1.  Data Origin Authentication and Data Integrity  . . . .   7
+       3.2.  Authenticating Name and Type Non-Existence . . . . . .   9
+   4.  Services Not Provided by DNS Security  . . . . . . . . . . .   9
+   5.  Scope of the DNSSEC Document Set and Last Hop Issues . . . .   9
+   6.  Resolver Considerations  . . . . . . . . . . . . . . . . . .  10
+   7.  Stub Resolver Considerations . . . . . . . . . . . . . . . .  11
+   8.  Zone Considerations  . . . . . . . . . . . . . . . . . . . .  12
+       8.1.  TTL Values vs. RRSIG Validity Period . . . . . . . . .  13
+       8.2.  New Temporal Dependency Issues for Zones . . . . . . .  13
+   9.  Name Server Considerations . . . . . . . . . . . . . . . . .  13
+   10. DNS Security Document Family . . . . . . . . . . . . . . . .  14
+   11. IANA Considerations  . . . . . . . . . . . . . . . . . . . .  15
+   12. Security Considerations  . . . . . . . . . . . . . . . . . .  15
+   13. Acknowledgements . . . . . . . . . . . . . . . . . . . . . .  17
+   14. References . . . . . . . . . . . . . . . . . . . . . . . . .  17
+       14.1. Normative References . . . . . . . . . . . . . . . . .  17
+       14.2. Informative References . . . . . . . . . . . . . . . .  18
+   Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . .  20
+   Full Copyright Statement . . . . . . . . . . . . . . . . . . . .  21
+
+1.  Introduction
+
+   This document introduces the Domain Name System Security Extensions
+   (DNSSEC).  This document and its two companion documents ([RFC4034]
+   and [RFC4035]) update, clarify, and refine the security extensions
+   defined in [RFC2535] and its predecessors.  These security extensions
+   consist of a set of new resource record types and modifications to
+   the existing DNS protocol ([RFC1035]).  The new records and protocol
+   modifications are not fully described in this document, but are
+   described in a family of documents outlined in Section 10.  Sections
+   3 and 4 describe the capabilities and limitations of the security
+   extensions in greater detail.  Section 5 discusses the scope of the
+   document set.  Sections 6, 7, 8, and 9 discuss the effect that these
+   security extensions will have on resolvers, stub resolvers, zones,
+   and name servers.
+
+   This document and its two companions obsolete [RFC2535], [RFC3008],
+   [RFC3090], [RFC3445], [RFC3655], [RFC3658], [RFC3755], [RFC3757], and
+   [RFC3845].  This document set also updates but does not obsolete
+   [RFC1034], [RFC1035], [RFC2136], [RFC2181], [RFC2308], [RFC3225],
+   [RFC3007], [RFC3597], and the portions of [RFC3226] that deal with
+   DNSSEC.
+
+
+
+
+Arends, et al.              Standards Track                     [Page 2]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   The DNS security extensions provide origin authentication and
+   integrity protection for DNS data, as well as a means of public key
+   distribution.  These extensions do not provide confidentiality.
+
+2.  Definitions of Important DNSSEC Terms
+
+   This section defines a number of terms used in this document set.
+   Because this is intended to be useful as a reference while reading
+   the rest of the document set, first-time readers may wish to skim
+   this section quickly, read the rest of this document, and then come
+   back to this section.
+
+   Authentication Chain: An alternating sequence of DNS public key
+      (DNSKEY) RRsets and Delegation Signer (DS) RRsets forms a chain of
+      signed data, with each link in the chain vouching for the next.  A
+      DNSKEY RR is used to verify the signature covering a DS RR and
+      allows the DS RR to be authenticated.  The DS RR contains a hash
+      of another DNSKEY RR and this new DNSKEY RR is authenticated by
+      matching the hash in the DS RR.  This new DNSKEY RR in turn
+      authenticates another DNSKEY RRset and, in turn, some DNSKEY RR in
+      this set may be used to authenticate another DS RR, and so forth
+      until the chain finally ends with a DNSKEY RR whose corresponding
+      private key signs the desired DNS data.  For example, the root
+      DNSKEY RRset can be used to authenticate the DS RRset for
+      "example."  The "example." DS RRset contains a hash that matches
+      some "example." DNSKEY, and this DNSKEY's corresponding private
+      key signs the "example." DNSKEY RRset.  Private key counterparts
+      of the "example." DNSKEY RRset sign data records such as
+      "www.example." and DS RRs for delegations such as
+      "subzone.example."
+
+   Authentication Key: A public key that a security-aware resolver has
+      verified and can therefore use to authenticate data.  A
+      security-aware resolver can obtain authentication keys in three
+      ways.  First, the resolver is generally configured to know about
+      at least one public key; this configured data is usually either
+      the public key itself or a hash of the public key as found in the
+      DS RR (see "trust anchor").  Second, the resolver may use an
+      authenticated public key to verify a DS RR and the DNSKEY RR to
+      which the DS RR refers.  Third, the resolver may be able to
+      determine that a new public key has been signed by the private key
+      corresponding to another public key that the resolver has
+      verified.  Note that the resolver must always be guided by local
+      policy when deciding whether to authenticate a new public key,
+      even if the local policy is simply to authenticate any new public
+      key for which the resolver is able verify the signature.
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 3]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   Authoritative RRset: Within the context of a particular zone, an
+      RRset is "authoritative" if and only if the owner name of the
+      RRset lies within the subset of the name space that is at or below
+      the zone apex and at or above the cuts that separate the zone from
+      its children, if any.  All RRsets at the zone apex are
+      authoritative, except for certain RRsets at this domain name that,
+      if present, belong to this zone's parent.  These RRset could
+      include a DS RRset, the NSEC RRset referencing this DS RRset (the
+      "parental NSEC"), and RRSIG RRs associated with these RRsets, all
+      of which are authoritative in the parent zone.  Similarly, if this
+      zone contains any delegation points, only the parental NSEC RRset,
+      DS RRsets, and any RRSIG RRs associated with these RRsets are
+      authoritative for this zone.
+
+   Delegation Point: Term used to describe the name at the parental side
+      of a zone cut.  That is, the delegation point for "foo.example"
+      would be the foo.example node in the "example" zone (as opposed to
+      the zone apex of the "foo.example" zone).  See also zone apex.
+
+   Island of Security: Term used to describe a signed, delegated zone
+      that does not have an authentication chain from its delegating
+      parent.  That is, there is no DS RR containing a hash of a DNSKEY
+      RR for the island in its delegating parent zone (see [RFC4034]).
+      An island of security is served by security-aware name servers and
+      may provide authentication chains to any delegated child zones.
+      Responses from an island of security or its descendents can only
+      be authenticated if its authentication keys can be authenticated
+      by some trusted means out of band from the DNS protocol.
+
+   Key Signing Key (KSK): An authentication key that corresponds to a
+      private key used to sign one or more other authentication keys for
+      a given zone.  Typically, the private key corresponding to a key
+      signing key will sign a zone signing key, which in turn has a
+      corresponding private key that will sign other zone data.  Local
+      policy may require that the zone signing key be changed
+      frequently, while the key signing key may have a longer validity
+      period in order to provide a more stable secure entry point into
+      the zone.  Designating an authentication key as a key signing key
+      is purely an operational issue: DNSSEC validation does not
+      distinguish between key signing keys and other DNSSEC
+      authentication keys, and it is possible to use a single key as
+      both a key signing key and a zone signing key.  Key signing keys
+      are discussed in more detail in [RFC3757].  Also see zone signing
+      key.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 4]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   Non-Validating Security-Aware Stub Resolver: A security-aware stub
+      resolver that trusts one or more security-aware recursive name
+      servers to perform most of the tasks discussed in this document
+      set on its behalf.  In particular, a non-validating security-aware
+      stub resolver is an entity that sends DNS queries, receives DNS
+      responses, and is capable of establishing an appropriately secured
+      channel to a security-aware recursive name server that will
+      provide these services on behalf of the security-aware stub
+      resolver.  See also security-aware stub resolver, validating
+      security-aware stub resolver.
+
+   Non-Validating Stub Resolver: A less tedious term for a
+      non-validating security-aware stub resolver.
+
+   Security-Aware Name Server: An entity acting in the role of a name
+      server (defined in section 2.4 of [RFC1034]) that understands the
+      DNS security extensions defined in this document set.  In
+      particular, a security-aware name server is an entity that
+      receives DNS queries, sends DNS responses, supports the EDNS0
+      ([RFC2671]) message size extension and the DO bit ([RFC3225]), and
+      supports the RR types and message header bits defined in this
+      document set.
+
+   Security-Aware Recursive Name Server: An entity that acts in both the
+      security-aware name server and security-aware resolver roles.  A
+      more cumbersome but equivalent phrase would be "a security-aware
+      name server that offers recursive service".
+
+   Security-Aware Resolver: An entity acting in the role of a resolver
+      (defined in section 2.4 of [RFC1034]) that understands the DNS
+      security extensions defined in this document set.  In particular,
+      a security-aware resolver is an entity that sends DNS queries,
+      receives DNS responses, supports the EDNS0 ([RFC2671]) message
+      size extension and the DO bit ([RFC3225]), and is capable of using
+      the RR types and message header bits defined in this document set
+      to provide DNSSEC services.
+
+   Security-Aware Stub Resolver: An entity acting in the role of a stub
+      resolver (defined in section 5.3.1 of [RFC1034]) that has enough
+      of an understanding the DNS security extensions defined in this
+      document set to provide additional services not available from a
+      security-oblivious stub resolver.  Security-aware stub resolvers
+      may be either "validating" or "non-validating", depending on
+      whether the stub resolver attempts to verify DNSSEC signatures on
+      its own or trusts a friendly security-aware name server to do so.
+      See also validating stub resolver, non-validating stub resolver.
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 5]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   Security-Oblivious <anything>: An <anything> that is not
+      "security-aware".
+
+   Signed Zone: A zone whose RRsets are signed and that contains
+      properly constructed DNSKEY, Resource Record Signature (RRSIG),
+      Next Secure (NSEC), and (optionally) DS records.
+
+   Trust Anchor: A configured DNSKEY RR or DS RR hash of a DNSKEY RR.  A
+      validating security-aware resolver uses this public key or hash as
+      a starting point for building the authentication chain to a signed
+      DNS response.  In general, a validating resolver will have to
+      obtain the initial values of its trust anchors via some secure or
+      trusted means outside the DNS protocol.  Presence of a trust
+      anchor also implies that the resolver should expect the zone to
+      which the trust anchor points to be signed.
+
+   Unsigned Zone: A zone that is not signed.
+
+   Validating Security-Aware Stub Resolver: A security-aware resolver
+      that sends queries in recursive mode but that performs signature
+      validation on its own rather than just blindly trusting an
+      upstream security-aware recursive name server.  See also
+      security-aware stub resolver, non-validating security-aware stub
+      resolver.
+
+   Validating Stub Resolver: A less tedious term for a validating
+      security-aware stub resolver.
+
+   Zone Apex: Term used to describe the name at the child's side of a
+      zone cut.  See also delegation point.
+
+   Zone Signing Key (ZSK): An authentication key that corresponds to a
+      private key used to sign a zone.  Typically, a zone signing key
+      will be part of the same DNSKEY RRset as the key signing key whose
+      corresponding private key signs this DNSKEY RRset, but the zone
+      signing key is used for a slightly different purpose and may
+      differ from the key signing key in other ways, such as validity
+      lifetime.  Designating an authentication key as a zone signing key
+      is purely an operational issue; DNSSEC validation does not
+      distinguish between zone signing keys and other DNSSEC
+      authentication keys, and it is possible to use a single key as
+      both a key signing key and a zone signing key.  See also key
+      signing key.
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 6]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+3.  Services Provided by DNS Security
+
+   The Domain Name System (DNS) security extensions provide origin
+   authentication and integrity assurance services for DNS data,
+   including mechanisms for authenticated denial of existence of DNS
+   data.  These mechanisms are described below.
+
+   These mechanisms require changes to the DNS protocol.  DNSSEC adds
+   four new resource record types: Resource Record Signature (RRSIG),
+   DNS Public Key (DNSKEY), Delegation Signer (DS), and Next Secure
+   (NSEC).  It also adds two new message header bits: Checking Disabled
+   (CD) and Authenticated Data (AD).  In order to support the larger DNS
+   message sizes that result from adding the DNSSEC RRs, DNSSEC also
+   requires EDNS0 support ([RFC2671]).  Finally, DNSSEC requires support
+   for the DNSSEC OK (DO) EDNS header bit ([RFC3225]) so that a
+   security-aware resolver can indicate in its queries that it wishes to
+   receive DNSSEC RRs in response messages.
+
+   These services protect against most of the threats to the Domain Name
+   System described in [RFC3833].  Please see Section 12 for a
+   discussion of the limitations of these extensions.
+
+3.1.  Data Origin Authentication and Data Integrity
+
+   DNSSEC provides authentication by associating cryptographically
+   generated digital signatures with DNS RRsets.  These digital
+   signatures are stored in a new resource record, the RRSIG record.
+   Typically, there will be a single private key that signs a zone's
+   data, but multiple keys are possible.  For example, there may be keys
+   for each of several different digital signature algorithms.  If a
+   security-aware resolver reliably learns a zone's public key, it can
+   authenticate that zone's signed data.  An important DNSSEC concept is
+   that the key that signs a zone's data is associated with the zone
+   itself and not with the zone's authoritative name servers.  (Public
+   keys for DNS transaction authentication mechanisms may also appear in
+   zones, as described in [RFC2931], but DNSSEC itself is concerned with
+   object security of DNS data, not channel security of DNS
+   transactions.  The keys associated with transaction security may be
+   stored in different RR types.  See [RFC3755] for details.)
+
+   A security-aware resolver can learn a zone's public key either by
+   having a trust anchor configured into the resolver or by normal DNS
+   resolution.  To allow the latter, public keys are stored in a new
+   type of resource record, the DNSKEY RR.  Note that the private keys
+   used to sign zone data must be kept secure and should be stored
+   offline when practical.  To discover a public key reliably via DNS
+   resolution, the target key itself has to be signed by either a
+   configured authentication key or another key that has been
+
+
+
+Arends, et al.              Standards Track                     [Page 7]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   authenticated previously.  Security-aware resolvers authenticate zone
+   information by forming an authentication chain from a newly learned
+   public key back to a previously known authentication public key,
+   which in turn either has been configured into the resolver or must
+   have been learned and verified previously.  Therefore, the resolver
+   must be configured with at least one trust anchor.
+
+   If the configured trust anchor is a zone signing key, then it will
+   authenticate the associated zone; if the configured key is a key
+   signing key, it will authenticate a zone signing key.  If the
+   configured trust anchor is the hash of a key rather than the key
+   itself, the resolver may have to obtain the key via a DNS query.  To
+   help security-aware resolvers establish this authentication chain,
+   security-aware name servers attempt to send the signature(s) needed
+   to authenticate a zone's public key(s) in the DNS reply message along
+   with the public key itself, provided that there is space available in
+   the message.
+
+   The Delegation Signer (DS) RR type simplifies some of the
+   administrative tasks involved in signing delegations across
+   organizational boundaries.  The DS RRset resides at a delegation
+   point in a parent zone and indicates the public key(s) corresponding
+   to the private key(s) used to self-sign the DNSKEY RRset at the
+   delegated child zone's apex.  The administrator of the child zone, in
+   turn, uses the private key(s) corresponding to one or more of the
+   public keys in this DNSKEY RRset to sign the child zone's data.  The
+   typical authentication chain is therefore
+   DNSKEY->[DS->DNSKEY]*->RRset, where "*" denotes zero or more
+   DS->DNSKEY subchains.  DNSSEC permits more complex authentication
+   chains, such as additional layers of DNSKEY RRs signing other DNSKEY
+   RRs within a zone.
+
+   A security-aware resolver normally constructs this authentication
+   chain from the root of the DNS hierarchy down to the leaf zones based
+   on configured knowledge of the public key for the root.  Local
+   policy, however, may also allow a security-aware resolver to use one
+   or more configured public keys (or hashes of public keys) other than
+   the root public key, may not provide configured knowledge of the root
+   public key, or may prevent the resolver from using particular public
+   keys for arbitrary reasons, even if those public keys are properly
+   signed with verifiable signatures.  DNSSEC provides mechanisms by
+   which a security-aware resolver can determine whether an RRset's
+   signature is "valid" within the meaning of DNSSEC.  In the final
+   analysis, however, authenticating both DNS keys and data is a matter
+   of local policy, which may extend or even override the protocol
+   extensions defined in this document set.  See Section 5 for further
+   discussion.
+
+
+
+
+Arends, et al.              Standards Track                     [Page 8]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+3.2.  Authenticating Name and Type Non-Existence
+
+   The security mechanism described in Section 3.1 only provides a way
+   to sign existing RRsets in a zone.  The problem of providing negative
+   responses with the same level of authentication and integrity
+   requires the use of another new resource record type, the NSEC
+   record.  The NSEC record allows a security-aware resolver to
+   authenticate a negative reply for either name or type non-existence
+   with the same mechanisms used to authenticate other DNS replies.  Use
+   of NSEC records requires a canonical representation and ordering for
+   domain names in zones.  Chains of NSEC records explicitly describe
+   the gaps, or "empty space", between domain names in a zone and list
+   the types of RRsets present at existing names.  Each NSEC record is
+   signed and authenticated using the mechanisms described in Section
+   3.1.
+
+4.  Services Not Provided by DNS Security
+
+   DNS was originally designed with the assumptions that the DNS will
+   return the same answer to any given query regardless of who may have
+   issued the query, and that all data in the DNS is thus visible.
+   Accordingly, DNSSEC is not designed to provide confidentiality,
+   access control lists, or other means of differentiating between
+   inquirers.
+
+   DNSSEC provides no protection against denial of service attacks.
+   Security-aware resolvers and security-aware name servers are
+   vulnerable to an additional class of denial of service attacks based
+   on cryptographic operations.  Please see Section 12 for details.
+
+   The DNS security extensions provide data and origin authentication
+   for DNS data.  The mechanisms outlined above are not designed to
+   protect operations such as zone transfers and dynamic update
+   ([RFC2136], [RFC3007]).  Message authentication schemes described in
+   [RFC2845] and [RFC2931] address security operations that pertain to
+   these transactions.
+
+5.  Scope of the DNSSEC Document Set and Last Hop Issues
+
+   The specification in this document set defines the behavior for zone
+   signers and security-aware name servers and resolvers in such a way
+   that the validating entities can unambiguously determine the state of
+   the data.
+
+   A validating resolver can determine the following 4 states:
+
+   Secure: The validating resolver has a trust anchor, has a chain of
+      trust, and is able to verify all the signatures in the response.
+
+
+
+Arends, et al.              Standards Track                     [Page 9]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   Insecure: The validating resolver has a trust anchor, a chain of
+      trust, and, at some delegation point, signed proof of the
+      non-existence of a DS record.  This indicates that subsequent
+      branches in the tree are provably insecure.  A validating resolver
+      may have a local policy to mark parts of the domain space as
+      insecure.
+
+   Bogus: The validating resolver has a trust anchor and a secure
+      delegation indicating that subsidiary data is signed, but the
+      response fails to validate for some reason: missing signatures,
+      expired signatures, signatures with unsupported algorithms, data
+      missing that the relevant NSEC RR says should be present, and so
+      forth.
+
+   Indeterminate: There is no trust anchor that would indicate that a
+      specific portion of the tree is secure.  This is the default
+      operation mode.
+
+   This specification only defines how security-aware name servers can
+   signal non-validating stub resolvers that data was found to be bogus
+   (using RCODE=2, "Server Failure"; see [RFC4035]).
+
+   There is a mechanism for security-aware name servers to signal
+   security-aware stub resolvers that data was found to be secure (using
+   the AD bit; see [RFC4035]).
+
+   This specification does not define a format for communicating why
+   responses were found to be bogus or marked as insecure.  The current
+   signaling mechanism does not distinguish between indeterminate and
+   insecure states.
+
+   A method for signaling advanced error codes and policy between a
+   security-aware stub resolver and security-aware recursive nameservers
+   is a topic for future work, as is the interface between a security-
+   aware resolver and the applications that use it.  Note, however, that
+   the lack of the specification of such communication does not prohibit
+   deployment of signed zones or the deployment of security aware
+   recursive name servers that prohibit propagation of bogus data to the
+   applications.
+
+6.  Resolver Considerations
+
+   A security-aware resolver has to be able to perform cryptographic
+   functions necessary to verify digital signatures using at least the
+   mandatory-to-implement algorithm(s).  Security-aware resolvers must
+   also be capable of forming an authentication chain from a newly
+   learned zone back to an authentication key, as described above.  This
+   process might require additional queries to intermediate DNS zones to
+
+
+
+Arends, et al.              Standards Track                    [Page 10]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   obtain necessary DNSKEY, DS, and RRSIG records.  A security-aware
+   resolver should be configured with at least one trust anchor as the
+   starting point from which it will attempt to establish authentication
+   chains.
+
+   If a security-aware resolver is separated from the relevant
+   authoritative name servers by a recursive name server or by any sort
+   of intermediary device that acts as a proxy for DNS, and if the
+   recursive name server or intermediary device is not security-aware,
+   the security-aware resolver may not be capable of operating in a
+   secure mode.  For example, if a security-aware resolver's packets are
+   routed through a network address translation (NAT) device that
+   includes a DNS proxy that is not security-aware, the security-aware
+   resolver may find it difficult or impossible to obtain or validate
+   signed DNS data.  The security-aware resolver may have a particularly
+   difficult time obtaining DS RRs in such a case, as DS RRs do not
+   follow the usual DNS rules for ownership of RRs at zone cuts.  Note
+   that this problem is not specific to NATs: any security-oblivious DNS
+   software of any kind between the security-aware resolver and the
+   authoritative name servers will interfere with DNSSEC.
+
+   If a security-aware resolver must rely on an unsigned zone or a name
+   server that is not security aware, the resolver may not be able to
+   validate DNS responses and will need a local policy on whether to
+   accept unverified responses.
+
+   A security-aware resolver should take a signature's validation period
+   into consideration when determining the TTL of data in its cache, to
+   avoid caching signed data beyond the validity period of the
+   signature.  However, it should also allow for the possibility that
+   the security-aware resolver's own clock is wrong.  Thus, a
+   security-aware resolver that is part of a security-aware recursive
+   name server will have to pay careful attention to the DNSSEC
+   "checking disabled" (CD) bit ([RFC4034]).  This is in order to avoid
+   blocking valid signatures from getting through to other
+   security-aware resolvers that are clients of this recursive name
+   server.  See [RFC4035] for how a secure recursive server handles
+   queries with the CD bit set.
+
+7.  Stub Resolver Considerations
+
+   Although not strictly required to do so by the protocol, most DNS
+   queries originate from stub resolvers.  Stub resolvers, by
+   definition, are minimal DNS resolvers that use recursive query mode
+   to offload most of the work of DNS resolution to a recursive name
+   server.  Given the widespread use of stub resolvers, the DNSSEC
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 11]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   architecture has to take stub resolvers into account, but the
+   security features needed in a stub resolver differ in some respects
+   from those needed in a security-aware iterative resolver.
+
+   Even a security-oblivious stub resolver may benefit from DNSSEC if
+   the recursive name servers it uses are security-aware, but for the
+   stub resolver to place any real reliance on DNSSEC services, the stub
+   resolver must trust both the recursive name servers in question and
+   the communication channels between itself and those name servers.
+   The first of these issues is a local policy issue: in essence, a
+   security-oblivious stub resolver has no choice but to place itself at
+   the mercy of the recursive name servers that it uses, as it does not
+   perform DNSSEC validity checks on its own.  The second issue requires
+   some kind of channel security mechanism; proper use of DNS
+   transaction authentication mechanisms such as SIG(0) ([RFC2931]) or
+   TSIG ([RFC2845]) would suffice, as would appropriate use of IPsec.
+   Particular implementations may have other choices available, such as
+   operating system specific interprocess communication mechanisms.
+   Confidentiality is not needed for this channel, but data integrity
+   and message authentication are.
+
+   A security-aware stub resolver that does trust both its recursive
+   name servers and its communication channel to them may choose to
+   examine the setting of the Authenticated Data (AD) bit in the message
+   header of the response messages it receives.  The stub resolver can
+   use this flag bit as a hint to find out whether the recursive name
+   server was able to validate signatures for all of the data in the
+   Answer and Authority sections of the response.
+
+   There is one more step that a security-aware stub resolver can take
+   if, for whatever reason, it is not able to establish a useful trust
+   relationship with the recursive name servers that it uses: it can
+   perform its own signature validation by setting the Checking Disabled
+   (CD) bit in its query messages.  A validating stub resolver is thus
+   able to treat the DNSSEC signatures as trust relationships between
+   the zone administrators and the stub resolver itself.
+
+8.  Zone Considerations
+
+   There are several differences between signed and unsigned zones.  A
+   signed zone will contain additional security-related records (RRSIG,
+   DNSKEY, DS, and NSEC records).  RRSIG and NSEC records may be
+   generated by a signing process prior to serving the zone.  The RRSIG
+   records that accompany zone data have defined inception and
+   expiration times that establish a validity period for the signatures
+   and the zone data the signatures cover.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 12]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+8.1.  TTL Values vs. RRSIG Validity Period
+
+   It is important to note the distinction between a RRset's TTL value
+   and the signature validity period specified by the RRSIG RR covering
+   that RRset.  DNSSEC does not change the definition or function of the
+   TTL value, which is intended to maintain database coherency in
+   caches.  A caching resolver purges RRsets from its cache no later
+   than the end of the time period specified by the TTL fields of those
+   RRsets, regardless of whether the resolver is security-aware.
+
+   The inception and expiration fields in the RRSIG RR ([RFC4034]), on
+   the other hand, specify the time period during which the signature
+   can be used to validate the covered RRset.  The signatures associated
+   with signed zone data are only valid for the time period specified by
+   these fields in the RRSIG RRs in question.  TTL values cannot extend
+   the validity period of signed RRsets in a resolver's cache, but the
+   resolver may use the time remaining before expiration of the
+   signature validity period of a signed RRset as an upper bound for the
+   TTL of the signed RRset and its associated RRSIG RR in the resolver's
+   cache.
+
+8.2.  New Temporal Dependency Issues for Zones
+
+   Information in a signed zone has a temporal dependency that did not
+   exist in the original DNS protocol.  A signed zone requires regular
+   maintenance to ensure that each RRset in the zone has a current valid
+   RRSIG RR.  The signature validity period of an RRSIG RR is an
+   interval during which the signature for one particular signed RRset
+   can be considered valid, and the signatures of different RRsets in a
+   zone may expire at different times.  Re-signing one or more RRsets in
+   a zone will change one or more RRSIG RRs, which will in turn require
+   incrementing the zone's SOA serial number to indicate that a zone
+   change has occurred and re-signing the SOA RRset itself.  Thus,
+   re-signing any RRset in a zone may also trigger DNS NOTIFY messages
+   and zone transfer operations.
+
+9.  Name Server Considerations
+
+   A security-aware name server should include the appropriate DNSSEC
+   records (RRSIG, DNSKEY, DS, and NSEC) in all responses to queries
+   from resolvers that have signaled their willingness to receive such
+   records via use of the DO bit in the EDNS header, subject to message
+   size limitations.  Because inclusion of these DNSSEC RRs could easily
+   cause UDP message truncation and fallback to TCP, a security-aware
+   name server must also support the EDNS "sender's UDP payload"
+   mechanism.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 13]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   If possible, the private half of each DNSSEC key pair should be kept
+   offline, but this will not be possible for a zone for which DNS
+   dynamic update has been enabled.  In the dynamic update case, the
+   primary master server for the zone will have to re-sign the zone when
+   it is updated, so the private key corresponding to the zone signing
+   key will have to be kept online.  This is an example of a situation
+   in which the ability to separate the zone's DNSKEY RRset into zone
+   signing key(s) and key signing key(s) may be useful, as the key
+   signing key(s) in such a case can still be kept offline and may have
+   a longer useful lifetime than the zone signing key(s).
+
+   By itself, DNSSEC is not enough to protect the integrity of an entire
+   zone during zone transfer operations, as even a signed zone contains
+   some unsigned, nonauthoritative data if the zone has any children.
+   Therefore, zone maintenance operations will require some additional
+   mechanisms (most likely some form of channel security, such as TSIG,
+   SIG(0), or IPsec).
+
+10.  DNS Security Document Family
+
+   The DNSSEC document set can be partitioned into several main groups,
+   under the larger umbrella of the DNS base protocol documents.
+
+   The "DNSSEC protocol document set" refers to the three documents that
+   form the core of the DNS security extensions:
+
+   1.  DNS Security Introduction and Requirements (this document)
+
+   2.  Resource Records for DNS Security Extensions [RFC4034]
+
+   3.  Protocol Modifications for the DNS Security Extensions [RFC4035]
+
+   Additionally, any document that would add to or change the core DNS
+   Security extensions would fall into this category.  This includes any
+   future work on the communication between security-aware stub
+   resolvers and upstream security-aware recursive name servers.
+
+   The "Digital Signature Algorithm Specification" document set refers
+   to the group of documents that describe how specific digital
+   signature algorithms should be implemented to fit the DNSSEC resource
+   record format.  Each document in this set deals with a specific
+   digital signature algorithm.  Please see the appendix on "DNSSEC
+   Algorithm and Digest Types" in [RFC4034] for a list of the algorithms
+   that were defined when this core specification was written.
+
+   The "Transaction Authentication Protocol" document set refers to the
+   group of documents that deal with DNS message authentication,
+   including secret key establishment and verification.  Although not
+
+
+
+Arends, et al.              Standards Track                    [Page 14]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   strictly part of the DNSSEC specification as defined in this set of
+   documents, this group is noted because of its relationship to DNSSEC.
+
+   The final document set, "New Security Uses", refers to documents that
+   seek to use proposed DNS Security extensions for other security
+   related purposes.  DNSSEC does not provide any direct security for
+   these new uses but may be used to support them.  Documents that fall
+   in this category include those describing the use of DNS in the
+   storage and distribution of certificates ([RFC2538]).
+
+11.  IANA Considerations
+
+   This overview document introduces no new IANA considerations.  Please
+   see [RFC4034] for a complete review of the IANA considerations
+   introduced by DNSSEC.
+
+12.  Security Considerations
+
+   This document introduces DNS security extensions and describes the
+   document set that contains the new security records and DNS protocol
+   modifications.  The extensions provide data origin authentication and
+   data integrity using digital signatures over resource record sets.
+   This section discusses the limitations of these extensions.
+
+   In order for a security-aware resolver to validate a DNS response,
+   all zones along the path from the trusted starting point to the zone
+   containing the response zones must be signed, and all name servers
+   and resolvers involved in the resolution process must be
+   security-aware, as defined in this document set.  A security-aware
+   resolver cannot verify responses originating from an unsigned zone,
+   from a zone not served by a security-aware name server, or for any
+   DNS data that the resolver is only able to obtain through a recursive
+   name server that is not security-aware.  If there is a break in the
+   authentication chain such that a security-aware resolver cannot
+   obtain and validate the authentication keys it needs, then the
+   security-aware resolver cannot validate the affected DNS data.
+
+   This document briefly discusses other methods of adding security to a
+   DNS query, such as using a channel secured by IPsec or using a DNS
+   transaction authentication mechanism such as TSIG ([RFC2845]) or
+   SIG(0) ([RFC2931]), but transaction security is not part of DNSSEC
+   per se.
+
+   A non-validating security-aware stub resolver, by definition, does
+   not perform DNSSEC signature validation on its own and thus is
+   vulnerable both to attacks on (and by) the security-aware recursive
+   name servers that perform these checks on its behalf and to attacks
+   on its communication with those security-aware recursive name
+
+
+
+Arends, et al.              Standards Track                    [Page 15]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   servers.  Non-validating security-aware stub resolvers should use
+   some form of channel security to defend against the latter threat.
+   The only known defense against the former threat would be for the
+   security-aware stub resolver to perform its own signature validation,
+   at which point, again by definition, it would no longer be a
+   non-validating security-aware stub resolver.
+
+   DNSSEC does not protect against denial of service attacks.  DNSSEC
+   makes DNS vulnerable to a new class of denial of service attacks
+   based on cryptographic operations against security-aware resolvers
+   and security-aware name servers, as an attacker can attempt to use
+   DNSSEC mechanisms to consume a victim's resources.  This class of
+   attacks takes at least two forms.  An attacker may be able to consume
+   resources in a security-aware resolver's signature validation code by
+   tampering with RRSIG RRs in response messages or by constructing
+   needlessly complex signature chains.  An attacker may also be able to
+   consume resources in a security-aware name server that supports DNS
+   dynamic update, by sending a stream of update messages that force the
+   security-aware name server to re-sign some RRsets in the zone more
+   frequently than would otherwise be necessary.
+
+   Due to a deliberate design choice, DNSSEC does not provide
+   confidentiality.
+
+   DNSSEC introduces the ability for a hostile party to enumerate all
+   the names in a zone by following the NSEC chain.  NSEC RRs assert
+   which names do not exist in a zone by linking from existing name to
+   existing name along a canonical ordering of all the names within a
+   zone.  Thus, an attacker can query these NSEC RRs in sequence to
+   obtain all the names in a zone.  Although this is not an attack on
+   the DNS itself, it could allow an attacker to map network hosts or
+   other resources by enumerating the contents of a zone.
+
+   DNSSEC introduces significant additional complexity to the DNS and
+   thus introduces many new opportunities for implementation bugs and
+   misconfigured zones.  In particular, enabling DNSSEC signature
+   validation in a resolver may cause entire legitimate zones to become
+   effectively unreachable due to DNSSEC configuration errors or bugs.
+
+   DNSSEC does not protect against tampering with unsigned zone data.
+   Non-authoritative data at zone cuts (glue and NS RRs in the parent
+   zone) are not signed.  This does not pose a problem when validating
+   the authentication chain, but it does mean that the non-authoritative
+   data itself is vulnerable to tampering during zone transfer
+   operations.  Thus, while DNSSEC can provide data origin
+   authentication and data integrity for RRsets, it cannot do so for
+   zones, and other mechanisms (such as TSIG, SIG(0), or IPsec) must be
+   used to protect zone transfer operations.
+
+
+
+Arends, et al.              Standards Track                    [Page 16]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   Please see [RFC4034] and [RFC4035] for additional security
+   considerations.
+
+13.  Acknowledgements
+
+   This document was created from the input and ideas of the members of
+   the DNS Extensions Working Group.  Although explicitly listing
+   everyone who has contributed during the decade in which DNSSEC has
+   been under development would be impossible, the editors would
+   particularly like to thank the following people for their
+   contributions to and comments on this document set: Jaap Akkerhuis,
+   Mark Andrews, Derek Atkins, Roy Badami, Alan Barrett, Dan Bernstein,
+   David Blacka, Len Budney, Randy Bush, Francis Dupont, Donald
+   Eastlake, Robert Elz, Miek Gieben, Michael Graff, Olafur Gudmundsson,
+   Gilles Guette, Andreas Gustafsson, Jun-ichiro Itojun Hagino, Phillip
+   Hallam-Baker, Bob Halley, Ted Hardie, Walter Howard, Greg Hudson,
+   Christian Huitema, Johan Ihren, Stephen Jacob, Jelte Jansen, Simon
+   Josefsson, Andris Kalnozols, Peter Koch, Olaf Kolkman, Mark Kosters,
+   Suresh Krishnaswamy, Ben Laurie, David Lawrence, Ted Lemon, Ed Lewis,
+   Ted Lindgreen, Josh Littlefield, Rip Loomis, Bill Manning, Russ
+   Mundy, Thomas Narten, Mans Nilsson, Masataka Ohta, Mike Patton, Rob
+   Payne, Jim Reid, Michael Richardson, Erik Rozendaal, Marcos Sanz,
+   Pekka Savola, Jakob Schlyter, Mike StJohns, Paul Vixie, Sam Weiler,
+   Brian Wellington, and Suzanne Woolf.
+
+   No doubt the above list is incomplete.  We apologize to anyone we
+   left out.
+
+14.  References
+
+14.1.  Normative References
+
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, November 1987.
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, November 1987.
+
+   [RFC2535]  Eastlake 3rd, D., "Domain Name System Security
+              Extensions", RFC 2535, March 1999.
+
+   [RFC2671]  Vixie, P., "Extension Mechanisms for DNS (EDNS0)", RFC
+              2671, August 1999.
+
+   [RFC3225]  Conrad, D., "Indicating Resolver Support of DNSSEC", RFC
+              3225, December 2001.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 17]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   [RFC3226]  Gudmundsson, O., "DNSSEC and IPv6 A6 aware server/resolver
+              message size requirements", RFC 3226, December 2001.
+
+   [RFC3445]  Massey, D. and S. Rose, "Limiting the Scope of the KEY
+              Resource Record (RR)", RFC 3445, December 2002.
+
+   [RFC4034]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Resource Records for DNS Security Extensions", RFC
+              4034, March 2005.
+
+   [RFC4035]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Protocol Modifications for the DNS Security
+              Extensions", RFC 4035, March 2005.
+
+14.2.  Informative References
+
+   [RFC2136]  Vixie, P., Thomson, S., Rekhter, Y., and J. Bound,
+              "Dynamic Updates in the Domain Name System (DNS UPDATE)",
+              RFC 2136, April 1997.
+
+   [RFC2181]  Elz, R. and R. Bush, "Clarifications to the DNS
+              Specification", RFC 2181, July 1997.
+
+   [RFC2308]  Andrews, M., "Negative Caching of DNS Queries (DNS
+              NCACHE)", RFC 2308, March 1998.
+
+   [RFC2538]  Eastlake 3rd, D. and O. Gudmundsson, "Storing Certificates
+              in the Domain Name System (DNS)", RFC 2538, March 1999.
+
+   [RFC2845]  Vixie, P., Gudmundsson, O., Eastlake 3rd, D., and B.
+              Wellington, "Secret Key Transaction Authentication for DNS
+              (TSIG)", RFC 2845, May 2000.
+
+   [RFC2931]  Eastlake 3rd, D., "DNS Request and Transaction Signatures
+              ( SIG(0)s )", RFC 2931, September 2000.
+
+   [RFC3007]  Wellington, B., "Secure Domain Name System (DNS) Dynamic
+              Update", RFC 3007, November 2000.
+
+   [RFC3008]  Wellington, B., "Domain Name System Security (DNSSEC)
+              Signing Authority", RFC 3008, November 2000.
+
+   [RFC3090]  Lewis, E., "DNS Security Extension Clarification on Zone
+              Status", RFC 3090, March 2001.
+
+   [RFC3597]  Gustafsson, A., "Handling of Unknown DNS Resource Record
+              (RR) Types", RFC 3597, September 2003.
+
+
+
+
+Arends, et al.              Standards Track                    [Page 18]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+   [RFC3655]  Wellington, B. and O. Gudmundsson, "Redefinition of DNS
+              Authenticated Data (AD) bit", RFC 3655, November 2003.
+
+   [RFC3658]  Gudmundsson, O., "Delegation Signer (DS) Resource Record
+              (RR)", RFC 3658, December 2003.
+
+   [RFC3755]  Weiler, S., "Legacy Resolver Compatibility for Delegation
+              Signer (DS)", RFC 3755, May 2004.
+
+   [RFC3757]  Kolkman, O., Schlyter, J., and E. Lewis, "Domain Name
+              System KEY (DNSKEY) Resource Record (RR) Secure Entry
+              Point (SEP) Flag", RFC 3757, April 2004.
+
+   [RFC3833]  Atkins, D. and R. Austein, "Threat Analysis of the Domain
+              Name System (DNS)", RFC 3833, August 2004.
+
+   [RFC3845]  Schlyter, J., "DNS Security (DNSSEC) NextSECure (NSEC)
+              RDATA Format", RFC 3845, August 2004.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 19]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+Authors' Addresses
+
+   Roy Arends
+   Telematica Instituut
+   Brouwerijstraat 1
+   7523 XC  Enschede
+   NL
+
+   EMail: roy.arends@telin.nl
+
+
+   Rob Austein
+   Internet Systems Consortium
+   950 Charter Street
+   Redwood City, CA  94063
+   USA
+
+   EMail: sra@isc.org
+
+
+   Matt Larson
+   VeriSign, Inc.
+   21345 Ridgetop Circle
+   Dulles, VA  20166-6503
+   USA
+
+   EMail: mlarson@verisign.com
+
+
+   Dan Massey
+   Colorado State University
+   Department of Computer Science
+   Fort Collins, CO 80523-1873
+
+   EMail: massey@cs.colostate.edu
+
+
+   Scott Rose
+   National Institute for Standards and Technology
+   100 Bureau Drive
+   Gaithersburg, MD  20899-8920
+   USA
+
+   EMail: scott.rose@nist.gov
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 20]
+
+RFC 4033       DNS Security Introduction and Requirements     March 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 21]
+

--- a/rfc/dns/rfc4034.txt
+++ b/rfc/dns/rfc4034.txt
@@ -1,0 +1,1627 @@
+
+
+
+
+
+
+Network Working Group                                          R. Arends
+Request for Comments: 4034                          Telematica Instituut
+Obsoletes: 2535, 3008, 3090, 3445, 3655, 3658,                R. Austein
+           3755, 3757, 3845                                          ISC
+Updates: 1034, 1035, 2136, 2181, 2308, 3225,                   M. Larson
+         3007, 3597, 3226                                       VeriSign
+Category: Standards Track                                      D. Massey
+                                               Colorado State University
+                                                                 S. Rose
+                                                                    NIST
+                                                              March 2005
+
+
+            Resource Records for the DNS Security Extensions
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document is part of a family of documents that describe the DNS
+   Security Extensions (DNSSEC).  The DNS Security Extensions are a
+   collection of resource records and protocol modifications that
+   provide source authentication for the DNS.  This document defines the
+   public key (DNSKEY), delegation signer (DS), resource record digital
+   signature (RRSIG), and authenticated denial of existence (NSEC)
+   resource records.  The purpose and format of each resource record is
+   described in detail, and an example of each resource record is given.
+
+   This document obsoletes RFC 2535 and incorporates changes from all
+   updates to RFC 2535.
+
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 1]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . .  3
+       1.1.  Background and Related Documents . . . . . . . . . . .  3
+       1.2.  Reserved Words . . . . . . . . . . . . . . . . . . . .  3
+   2.  The DNSKEY Resource Record . . . . . . . . . . . . . . . . .  4
+       2.1.  DNSKEY RDATA Wire Format . . . . . . . . . . . . . . .  4
+             2.1.1.  The Flags Field. . . . . . . . . . . . . . . .  4
+             2.1.2.  The Protocol Field . . . . . . . . . . . . . .  5
+             2.1.3.  The Algorithm Field. . . . . . . . . . . . . .  5
+             2.1.4.  The Public Key Field . . . . . . . . . . . . .  5
+             2.1.5.  Notes on DNSKEY RDATA Design . . . . . . . . .  5
+       2.2.  The DNSKEY RR Presentation Format. . . . . . . . . . .  5
+       2.3.  DNSKEY RR Example  . . . . . . . . . . . . . . . . . .  6
+   3.  The RRSIG Resource Record  . . . . . . . . . . . . . . . . .  6
+       3.1.  RRSIG RDATA Wire Format. . . . . . . . . . . . . . . .  7
+             3.1.1.  The Type Covered Field . . . . . . . . . . . .  7
+             3.1.2.  The Algorithm Number Field . . . . . . . . . .  8
+             3.1.3.  The Labels Field . . . . . . . . . . . . . . .  8
+             3.1.4.  Original TTL Field . . . . . . . . . . . . . .  8
+             3.1.5.  Signature Expiration and Inception Fields. . .  9
+             3.1.6.  The Key Tag Field. . . . . . . . . . . . . . .  9
+             3.1.7.  The Signer's Name Field. . . . . . . . . . . .  9
+             3.1.8.  The Signature Field. . . . . . . . . . . . . .  9
+       3.2.  The RRSIG RR Presentation Format . . . . . . . . . . . 10
+       3.3.  RRSIG RR Example . . . . . . . . . . . . . . . . . . . 11
+   4.  The NSEC Resource Record . . . . . . . . . . . . . . . . . . 12
+       4.1.  NSEC RDATA Wire Format . . . . . . . . . . . . . . . . 13
+             4.1.1.  The Next Domain Name Field . . . . . . . . . . 13
+             4.1.2.  The Type Bit Maps Field. . . . . . . . . . . . 13
+             4.1.3.  Inclusion of Wildcard Names in NSEC RDATA. . . 14
+       4.2.  The NSEC RR Presentation Format. . . . . . . . . . . . 14
+       4.3.  NSEC RR Example. . . . . . . . . . . . . . . . . . . . 15
+   5.  The DS Resource Record . . . . . . . . . . . . . . . . . . . 15
+       5.1.  DS RDATA Wire Format . . . . . . . . . . . . . . . . . 16
+             5.1.1.  The Key Tag Field. . . . . . . . . . . . . . . 16
+             5.1.2.  The Algorithm Field. . . . . . . . . . . . . . 16
+             5.1.3.  The Digest Type Field. . . . . . . . . . . . . 17
+             5.1.4.  The Digest Field . . . . . . . . . . . . . . . 17
+       5.2.  Processing of DS RRs When Validating Responses . . . . 17
+       5.3.  The DS RR Presentation Format. . . . . . . . . . . . . 17
+       5.4.  DS RR Example. . . . . . . . . . . . . . . . . . . . . 18
+   6.  Canonical Form and Order of Resource Records . . . . . . . . 18
+       6.1.  Canonical DNS Name Order . . . . . . . . . . . . . . . 18
+       6.2.  Canonical RR Form. . . . . . . . . . . . . . . . . . . 19
+       6.3.  Canonical RR Ordering within an RRset. . . . . . . . . 20
+   7.  IANA Considerations. . . . . . . . . . . . . . . . . . . . . 20
+   8.  Security Considerations. . . . . . . . . . . . . . . . . . . 21
+
+
+
+Arends, et al.              Standards Track                     [Page 2]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   9.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . 22
+   10. References . . . . . . . . . . . . . . . . . . . . . . . . . 22
+       10.1. Normative References . . . . . . . . . . . . . . . . . 22
+       10.2. Informative References . . . . . . . . . . . . . . . . 23
+   A.  DNSSEC Algorithm and Digest Types. . . . . . . . . . . . . . 24
+       A.1.  DNSSEC Algorithm Types . . . . . . . . . . . . . . . . 24
+             A.1.1.  Private Algorithm Types. . . . . . . . . . . . 25
+       A.2.  DNSSEC Digest Types. . . . . . . . . . . . . . . . . . 25
+   B.  Key Tag Calculation. . . . . . . . . . . . . . . . . . . . . 25
+       B.1.  Key Tag for Algorithm 1 (RSA/MD5). . . . . . . . . . . 27
+   Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . . 28
+   Full Copyright Statement . . . . . . . . . . . . . . . . . . . . 29
+
+1.  Introduction
+
+   The DNS Security Extensions (DNSSEC) introduce four new DNS resource
+   record types: DNS Public Key (DNSKEY), Resource Record Signature
+   (RRSIG), Next Secure (NSEC), and Delegation Signer (DS).  This
+   document defines the purpose of each resource record (RR), the RR's
+   RDATA format, and its presentation format (ASCII representation).
+
+1.1.  Background and Related Documents
+
+   This document is part of a family of documents defining DNSSEC, which
+   should be read together as a set.
+
+   [RFC4033] contains an introduction to DNSSEC and definition of common
+   terms; the reader is assumed to be familiar with this document.
+   [RFC4033] also contains a list of other documents updated by and
+   obsoleted by this document set.
+
+   [RFC4035] defines the DNSSEC protocol operations.
+
+   The reader is also assumed to be familiar with the basic DNS concepts
+   described in [RFC1034], [RFC1035], and the subsequent documents that
+   update them, particularly [RFC2181] and [RFC2308].
+
+   This document defines the DNSSEC resource records.  All numeric DNS
+   type codes given in this document are decimal integers.
+
+1.2.  Reserved Words
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 3]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+2.  The DNSKEY Resource Record
+
+   DNSSEC uses public key cryptography to sign and authenticate DNS
+   resource record sets (RRsets).  The public keys are stored in DNSKEY
+   resource records and are used in the DNSSEC authentication process
+   described in [RFC4035]: A zone signs its authoritative RRsets by
+   using a private key and stores the corresponding public key in a
+   DNSKEY RR.  A resolver can then use the public key to validate
+   signatures covering the RRsets in the zone, and thus to authenticate
+   them.
+
+   The DNSKEY RR is not intended as a record for storing arbitrary
+   public keys and MUST NOT be used to store certificates or public keys
+   that do not directly relate to the DNS infrastructure.
+
+   The Type value for the DNSKEY RR type is 48.
+
+   The DNSKEY RR is class independent.
+
+   The DNSKEY RR has no special TTL requirements.
+
+2.1.  DNSKEY RDATA Wire Format
+
+   The RDATA for a DNSKEY RR consists of a 2 octet Flags Field, a 1
+   octet Protocol Field, a 1 octet Algorithm Field, and the Public Key
+   Field.
+
+                        1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |              Flags            |    Protocol   |   Algorithm   |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   /                                                               /
+   /                            Public Key                         /
+   /                                                               /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+2.1.1.  The Flags Field
+
+   Bit 7 of the Flags field is the Zone Key flag.  If bit 7 has value 1,
+   then the DNSKEY record holds a DNS zone key, and the DNSKEY RR's
+   owner name MUST be the name of a zone.  If bit 7 has value 0, then
+   the DNSKEY record holds some other type of DNS public key and MUST
+   NOT be used to verify RRSIGs that cover RRsets.
+
+   Bit 15 of the Flags field is the Secure Entry Point flag, described
+   in [RFC3757].  If bit 15 has value 1, then the DNSKEY record holds a
+   key intended for use as a secure entry point.  This flag is only
+
+
+
+Arends, et al.              Standards Track                     [Page 4]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   intended to be a hint to zone signing or debugging software as to the
+   intended use of this DNSKEY record; validators MUST NOT alter their
+   behavior during the signature validation process in any way based on
+   the setting of this bit.  This also means that a DNSKEY RR with the
+   SEP bit set would also need the Zone Key flag set in order to be able
+   to generate signatures legally.  A DNSKEY RR with the SEP set and the
+   Zone Key flag not set MUST NOT be used to verify RRSIGs that cover
+   RRsets.
+
+   Bits 0-6 and 8-14 are reserved: these bits MUST have value 0 upon
+   creation of the DNSKEY RR and MUST be ignored upon receipt.
+
+2.1.2.  The Protocol Field
+
+   The Protocol Field MUST have value 3, and the DNSKEY RR MUST be
+   treated as invalid during signature verification if it is found to be
+   some value other than 3.
+
+2.1.3.  The Algorithm Field
+
+   The Algorithm field identifies the public key's cryptographic
+   algorithm and determines the format of the Public Key field.  A list
+   of DNSSEC algorithm types can be found in Appendix A.1
+
+2.1.4.  The Public Key Field
+
+   The Public Key Field holds the public key material.  The format
+   depends on the algorithm of the key being stored and is described in
+   separate documents.
+
+2.1.5.  Notes on DNSKEY RDATA Design
+
+   Although the Protocol Field always has value 3, it is retained for
+   backward compatibility with early versions of the KEY record.
+
+2.2.  The DNSKEY RR Presentation Format
+
+   The presentation format of the RDATA portion is as follows:
+
+   The Flag field MUST be represented as an unsigned decimal integer.
+   Given the currently defined flags, the possible values are: 0, 256,
+   and 257.
+
+   The Protocol Field MUST be represented as an unsigned decimal integer
+   with a value of 3.
+
+   The Algorithm field MUST be represented either as an unsigned decimal
+   integer or as an algorithm mnemonic as specified in Appendix A.1.
+
+
+
+Arends, et al.              Standards Track                     [Page 5]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   The Public Key field MUST be represented as a Base64 encoding of the
+   Public Key.  Whitespace is allowed within the Base64 text.  For a
+   definition of Base64 encoding, see [RFC3548].
+
+2.3.  DNSKEY RR Example
+
+   The following DNSKEY RR stores a DNS zone key for example.com.
+
+   example.com. 86400 IN DNSKEY 256 3 5 ( AQPSKmynfzW4kyBv015MUG2DeIQ3
+                                          Cbl+BBZH4b/0PY1kxkmvHjcZc8no
+                                          kfzj31GajIQKY+5CptLr3buXA10h
+                                          WqTkF7H6RfoRqXQeogmMHfpftf6z
+                                          Mv1LyBUgia7za6ZEzOJBOztyvhjL
+                                          742iU/TpPSEDhm2SNKLijfUppn1U
+                                          aNvv4w==  )
+
+   The first four text fields specify the owner name, TTL, Class, and RR
+   type (DNSKEY).  Value 256 indicates that the Zone Key bit (bit 7) in
+   the Flags field has value 1.  Value 3 is the fixed Protocol value.
+   Value 5 indicates the public key algorithm.  Appendix A.1 identifies
+   algorithm type 5 as RSA/SHA1 and indicates that the format of the
+   RSA/SHA1 public key field is defined in [RFC3110].  The remaining
+   text is a Base64 encoding of the public key.
+
+3.  The RRSIG Resource Record
+
+   DNSSEC uses public key cryptography to sign and authenticate DNS
+   resource record sets (RRsets).  Digital signatures are stored in
+   RRSIG resource records and are used in the DNSSEC authentication
+   process described in [RFC4035].  A validator can use these RRSIG RRs
+   to authenticate RRsets from the zone.  The RRSIG RR MUST only be used
+   to carry verification material (digital signatures) used to secure
+   DNS operations.
+
+   An RRSIG record contains the signature for an RRset with a particular
+   name, class, and type.  The RRSIG RR specifies a validity interval
+   for the signature and uses the Algorithm, the Signer's Name, and the
+   Key Tag to identify the DNSKEY RR containing the public key that a
+   validator can use to verify the signature.
+
+   Because every authoritative RRset in a zone must be protected by a
+   digital signature, RRSIG RRs must be present for names containing a
+   CNAME RR.  This is a change to the traditional DNS specification
+   [RFC1034], which stated that if a CNAME is present for a name, it is
+   the only type allowed at that name.  A RRSIG and NSEC (see Section 4)
+   MUST exist for the same name as a CNAME resource record in a signed
+   zone.
+
+
+
+
+Arends, et al.              Standards Track                     [Page 6]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   The Type value for the RRSIG RR type is 46.
+
+   The RRSIG RR is class independent.
+
+   An RRSIG RR MUST have the same class as the RRset it covers.
+
+   The TTL value of an RRSIG RR MUST match the TTL value of the RRset it
+   covers.  This is an exception to the [RFC2181] rules for TTL values
+   of individual RRs within a RRset: individual RRSIG RRs with the same
+   owner name will have different TTL values if the RRsets they cover
+   have different TTL values.
+
+3.1.  RRSIG RDATA Wire Format
+
+   The RDATA for an RRSIG RR consists of a 2 octet Type Covered field, a
+   1 octet Algorithm field, a 1 octet Labels field, a 4 octet Original
+   TTL field, a 4 octet Signature Expiration field, a 4 octet Signature
+   Inception field, a 2 octet Key tag, the Signer's Name field, and the
+   Signature field.
+
+                        1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |        Type Covered           |  Algorithm    |     Labels    |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                         Original TTL                          |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                      Signature Expiration                     |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |                      Signature Inception                      |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |            Key Tag            |                               /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+         Signer's Name         /
+   /                                                               /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   /                                                               /
+   /                            Signature                          /
+   /                                                               /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+3.1.1.  The Type Covered Field
+
+   The Type Covered field identifies the type of the RRset that is
+   covered by this RRSIG record.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 7]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+3.1.2.  The Algorithm Number Field
+
+   The Algorithm Number field identifies the cryptographic algorithm
+   used to create the signature.  A list of DNSSEC algorithm types can
+   be found in Appendix A.1
+
+3.1.3.  The Labels Field
+
+   The Labels field specifies the number of labels in the original RRSIG
+   RR owner name.  The significance of this field is that a validator
+   uses it to determine whether the answer was synthesized from a
+   wildcard.  If so, it can be used to determine what owner name was
+   used in generating the signature.
+
+   To validate a signature, the validator needs the original owner name
+   that was used to create the signature.  If the original owner name
+   contains a wildcard label ("*"), the owner name may have been
+   expanded by the server during the response process, in which case the
+   validator will have to reconstruct the original owner name in order
+   to validate the signature.  [RFC4035] describes how to use the Labels
+   field to reconstruct the original owner name.
+
+   The value of the Labels field MUST NOT count either the null (root)
+   label that terminates the owner name or the wildcard label (if
+   present).  The value of the Labels field MUST be less than or equal
+   to the number of labels in the RRSIG owner name.  For example,
+   "www.example.com." has a Labels field value of 3, and
+   "*.example.com." has a Labels field value of 2.  Root (".") has a
+   Labels field value of 0.
+
+   Although the wildcard label is not included in the count stored in
+   the Labels field of the RRSIG RR, the wildcard label is part of the
+   RRset's owner name when the signature is generated or verified.
+
+3.1.4.  Original TTL Field
+
+   The Original TTL field specifies the TTL of the covered RRset as it
+   appears in the authoritative zone.
+
+   The Original TTL field is necessary because a caching resolver
+   decrements the TTL value of a cached RRset.  In order to validate a
+   signature, a validator requires the original TTL.  [RFC4035]
+   describes how to use the Original TTL field value to reconstruct the
+   original TTL.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 8]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+3.1.5.  Signature Expiration and Inception Fields
+
+   The Signature Expiration and Inception fields specify a validity
+   period for the signature.  The RRSIG record MUST NOT be used for
+   authentication prior to the inception date and MUST NOT be used for
+   authentication after the expiration date.
+
+   The Signature Expiration and Inception field values specify a date
+   and time in the form of a 32-bit unsigned number of seconds elapsed
+   since 1 January 1970 00:00:00 UTC, ignoring leap seconds, in network
+   byte order.  The longest interval that can be expressed by this
+   format without wrapping is approximately 136 years.  An RRSIG RR can
+   have an Expiration field value that is numerically smaller than the
+   Inception field value if the expiration field value is near the
+   32-bit wrap-around point or if the signature is long lived.  Because
+   of this, all comparisons involving these fields MUST use "Serial
+   number arithmetic", as defined in [RFC1982].  As a direct
+   consequence, the values contained in these fields cannot refer to
+   dates more than 68 years in either the past or the future.
+
+3.1.6.  The Key Tag Field
+
+   The Key Tag field contains the key tag value of the DNSKEY RR that
+   validates this signature, in network byte order.  Appendix B explains
+   how to calculate Key Tag values.
+
+3.1.7.  The Signer's Name Field
+
+   The Signer's Name field value identifies the owner name of the DNSKEY
+   RR that a validator is supposed to use to validate this signature.
+   The Signer's Name field MUST contain the name of the zone of the
+   covered RRset.  A sender MUST NOT use DNS name compression on the
+   Signer's Name field when transmitting a RRSIG RR.
+
+3.1.8.  The Signature Field
+
+   The Signature field contains the cryptographic signature that covers
+   the RRSIG RDATA (excluding the Signature field) and the RRset
+   specified by the RRSIG owner name, RRSIG class, and RRSIG Type
+   Covered field.  The format of this field depends on the algorithm in
+   use, and these formats are described in separate companion documents.
+
+3.1.8.1.  Signature Calculation
+
+   A signature covers the RRSIG RDATA (excluding the Signature Field)
+   and covers the data RRset specified by the RRSIG owner name, RRSIG
+   class, and RRSIG Type Covered fields.  The RRset is in canonical form
+   (see Section 6), and the set RR(1),...RR(n) is signed as follows:
+
+
+
+Arends, et al.              Standards Track                     [Page 9]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+         signature = sign(RRSIG_RDATA | RR(1) | RR(2)... ) where
+
+            "|" denotes concatenation;
+
+            RRSIG_RDATA is the wire format of the RRSIG RDATA fields
+               with the Signer's Name field in canonical form and
+               the Signature field excluded;
+
+            RR(i) = owner | type | class | TTL | RDATA length | RDATA
+
+               "owner" is the fully qualified owner name of the RRset in
+               canonical form (for RRs with wildcard owner names, the
+               wildcard label is included in the owner name);
+
+               Each RR MUST have the same owner name as the RRSIG RR;
+
+               Each RR MUST have the same class as the RRSIG RR;
+
+               Each RR in the RRset MUST have the RR type listed in the
+               RRSIG RR's Type Covered field;
+
+               Each RR in the RRset MUST have the TTL listed in the
+               RRSIG Original TTL Field;
+
+               Any DNS names in the RDATA field of each RR MUST be in
+               canonical form; and
+
+               The RRset MUST be sorted in canonical order.
+
+   See Sections 6.2 and 6.3 for details on canonical form and ordering
+   of RRsets.
+
+3.2.  The RRSIG RR Presentation Format
+
+   The presentation format of the RDATA portion is as follows:
+
+   The Type Covered field is represented as an RR type mnemonic.  When
+   the mnemonic is not known, the TYPE representation as described in
+   [RFC3597], Section 5, MUST be used.
+
+   The Algorithm field value MUST be represented either as an unsigned
+   decimal integer or as an algorithm mnemonic, as specified in Appendix
+   A.1.
+
+   The Labels field value MUST be represented as an unsigned decimal
+   integer.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 10]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   The Original TTL field value MUST be represented as an unsigned
+   decimal integer.
+
+   The Signature Expiration Time and Inception Time field values MUST be
+   represented either as an unsigned decimal integer indicating seconds
+   since 1 January 1970 00:00:00 UTC, or in the form YYYYMMDDHHmmSS in
+   UTC, where:
+
+      YYYY is the year (0001-9999, but see Section 3.1.5);
+      MM is the month number (01-12);
+      DD is the day of the month (01-31);
+      HH is the hour, in 24 hour notation (00-23);
+      mm is the minute (00-59); and
+      SS is the second (00-59).
+
+   Note that it is always possible to distinguish between these two
+   formats because the YYYYMMDDHHmmSS format will always be exactly 14
+   digits, while the decimal representation of a 32-bit unsigned integer
+   can never be longer than 10 digits.
+
+   The Key Tag field MUST be represented as an unsigned decimal integer.
+
+   The Signer's Name field value MUST be represented as a domain name.
+
+   The Signature field is represented as a Base64 encoding of the
+   signature.  Whitespace is allowed within the Base64 text.  See
+   Section 2.2.
+
+3.3.  RRSIG RR Example
+
+   The following RRSIG RR stores the signature for the A RRset of
+   host.example.com:
+
+   host.example.com. 86400 IN RRSIG A 5 3 86400 20030322173103 (
+                                  20030220173103 2642 example.com.
+                                  oJB1W6WNGv+ldvQ3WDG0MQkg5IEhjRip8WTr
+                                  PYGv07h108dUKGMeDPKijVCHX3DDKdfb+v6o
+                                  B9wfuh3DTJXUAfI/M0zmO/zz8bW0Rznl8O3t
+                                  GNazPwQKkRN20XPXV6nwwfoXmJQbsLNrLfkG
+                                  J5D6fwFm8nN+6pBzeDQfsS3Ap3o= )
+
+   The first four fields specify the owner name, TTL, Class, and RR type
+   (RRSIG).  The "A" represents the Type Covered field.  The value 5
+   identifies the algorithm used (RSA/SHA1) to create the signature.
+   The value 3 is the number of Labels in the original owner name.  The
+   value 86400 in the RRSIG RDATA is the Original TTL for the covered A
+   RRset.  20030322173103 and 20030220173103 are the expiration and
+
+
+
+
+Arends, et al.              Standards Track                    [Page 11]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   inception dates, respectively.  2642 is the Key Tag, and example.com.
+   is the Signer's Name.  The remaining text is a Base64 encoding of the
+   signature.
+
+   Note that combination of RRSIG RR owner name, class, and Type Covered
+   indicates that this RRSIG covers the "host.example.com" A RRset.  The
+   Label value of 3 indicates that no wildcard expansion was used.  The
+   Algorithm, Signer's Name, and Key Tag indicate that this signature
+   can be authenticated using an example.com zone DNSKEY RR whose
+   algorithm is 5 and whose key tag is 2642.
+
+4.  The NSEC Resource Record
+
+   The NSEC resource record lists two separate things: the next owner
+   name (in the canonical ordering of the zone) that contains
+   authoritative data or a delegation point NS RRset, and the set of RR
+   types present at the NSEC RR's owner name [RFC3845].  The complete
+   set of NSEC RRs in a zone indicates which authoritative RRsets exist
+   in a zone and also form a chain of authoritative owner names in the
+   zone.  This information is used to provide authenticated denial of
+   existence for DNS data, as described in [RFC4035].
+
+   Because every authoritative name in a zone must be part of the NSEC
+   chain, NSEC RRs must be present for names containing a CNAME RR.
+   This is a change to the traditional DNS specification [RFC1034],
+   which stated that if a CNAME is present for a name, it is the only
+   type allowed at that name.  An RRSIG (see Section 3) and NSEC MUST
+   exist for the same name as does a CNAME resource record in a signed
+   zone.
+
+   See [RFC4035] for discussion of how a zone signer determines
+   precisely which NSEC RRs it has to include in a zone.
+
+   The type value for the NSEC RR is 47.
+
+   The NSEC RR is class independent.
+
+   The NSEC RR SHOULD have the same TTL value as the SOA minimum TTL
+   field.  This is in the spirit of negative caching ([RFC2308]).
+
+
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 12]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+4.1.  NSEC RDATA Wire Format
+
+   The RDATA of the NSEC RR is as shown below:
+
+                        1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   /                      Next Domain Name                         /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   /                       Type Bit Maps                           /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+4.1.1.  The Next Domain Name Field
+
+   The Next Domain field contains the next owner name (in the canonical
+   ordering of the zone) that has authoritative data or contains a
+   delegation point NS RRset; see Section 6.1 for an explanation of
+   canonical ordering.  The value of the Next Domain Name field in the
+   last NSEC record in the zone is the name of the zone apex (the owner
+   name of the zone's SOA RR).  This indicates that the owner name of
+   the NSEC RR is the last name in the canonical ordering of the zone.
+
+   A sender MUST NOT use DNS name compression on the Next Domain Name
+   field when transmitting an NSEC RR.
+
+   Owner names of RRsets for which the given zone is not authoritative
+   (such as glue records) MUST NOT be listed in the Next Domain Name
+   unless at least one authoritative RRset exists at the same owner
+   name.
+
+4.1.2.  The Type Bit Maps Field
+
+   The Type Bit Maps field identifies the RRset types that exist at the
+   NSEC RR's owner name.
+
+   The RR type space is split into 256 window blocks, each representing
+   the low-order 8 bits of the 16-bit RR type space.  Each block that
+   has at least one active RR type is encoded using a single octet
+   window number (from 0 to 255), a single octet bitmap length (from 1
+   to 32) indicating the number of octets used for the window block's
+   bitmap, and up to 32 octets (256 bits) of bitmap.
+
+   Blocks are present in the NSEC RR RDATA in increasing numerical
+   order.
+
+      Type Bit Maps Field = ( Window Block # | Bitmap Length | Bitmap )+
+
+      where "|" denotes concatenation.
+
+
+
+Arends, et al.              Standards Track                    [Page 13]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   Each bitmap encodes the low-order 8 bits of RR types within the
+   window block, in network bit order.  The first bit is bit 0.  For
+   window block 0, bit 1 corresponds to RR type 1 (A), bit 2 corresponds
+   to RR type 2 (NS), and so forth.  For window block 1, bit 1
+   corresponds to RR type 257, and bit 2 to RR type 258.  If a bit is
+   set, it indicates that an RRset of that type is present for the NSEC
+   RR's owner name.  If a bit is clear, it indicates that no RRset of
+   that type is present for the NSEC RR's owner name.
+
+   Bits representing pseudo-types MUST be clear, as they do not appear
+   in zone data.  If encountered, they MUST be ignored upon being read.
+
+   Blocks with no types present MUST NOT be included.  Trailing zero
+   octets in the bitmap MUST be omitted.  The length of each block's
+   bitmap is determined by the type code with the largest numerical
+   value, within that block, among the set of RR types present at the
+   NSEC RR's owner name.  Trailing zero octets not specified MUST be
+   interpreted as zero octets.
+
+   The bitmap for the NSEC RR at a delegation point requires special
+   attention.  Bits corresponding to the delegation NS RRset and the RR
+   types for which the parent zone has authoritative data MUST be set;
+   bits corresponding to any non-NS RRset for which the parent is not
+   authoritative MUST be clear.
+
+   A zone MUST NOT include an NSEC RR for any domain name that only
+   holds glue records.
+
+4.1.3.  Inclusion of Wildcard Names in NSEC RDATA
+
+   If a wildcard owner name appears in a zone, the wildcard label ("*")
+   is treated as a literal symbol and is treated the same as any other
+   owner name for the purposes of generating NSEC RRs.  Wildcard owner
+   names appear in the Next Domain Name field without any wildcard
+   expansion.  [RFC4035] describes the impact of wildcards on
+   authenticated denial of existence.
+
+4.2.  The NSEC RR Presentation Format
+
+   The presentation format of the RDATA portion is as follows:
+
+   The Next Domain Name field is represented as a domain name.
+
+   The Type Bit Maps field is represented as a sequence of RR type
+   mnemonics.  When the mnemonic is not known, the TYPE representation
+   described in [RFC3597], Section 5, MUST be used.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 14]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+4.3.  NSEC RR Example
+
+   The following NSEC RR identifies the RRsets associated with
+   alfa.example.com. and identifies the next authoritative name after
+   alfa.example.com.
+
+   alfa.example.com. 86400 IN NSEC host.example.com. (
+                                   A MX RRSIG NSEC TYPE1234 )
+
+   The first four text fields specify the name, TTL, Class, and RR type
+   (NSEC).  The entry host.example.com. is the next authoritative name
+   after alfa.example.com. in canonical order.  The A, MX, RRSIG, NSEC,
+   and TYPE1234 mnemonics indicate that there are A, MX, RRSIG, NSEC,
+   and TYPE1234 RRsets associated with the name alfa.example.com.
+
+   The RDATA section of the NSEC RR above would be encoded as:
+
+            0x04 'h'  'o'  's'  't'
+            0x07 'e'  'x'  'a'  'm'  'p'  'l'  'e'
+            0x03 'c'  'o'  'm'  0x00
+            0x00 0x06 0x40 0x01 0x00 0x00 0x00 0x03
+            0x04 0x1b 0x00 0x00 0x00 0x00 0x00 0x00
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+            0x00 0x00 0x00 0x00 0x00 0x00 0x00 0x00
+            0x00 0x00 0x00 0x00 0x20
+
+   Assuming that the validator can authenticate this NSEC record, it
+   could be used to prove that beta.example.com does not exist, or to
+   prove that there is no AAAA record associated with alfa.example.com.
+   Authenticated denial of existence is discussed in [RFC4035].
+
+5.  The DS Resource Record
+
+   The DS Resource Record refers to a DNSKEY RR and is used in the DNS
+   DNSKEY authentication process.  A DS RR refers to a DNSKEY RR by
+   storing the key tag, algorithm number, and a digest of the DNSKEY RR.
+   Note that while the digest should be sufficient to identify the
+   public key, storing the key tag and key algorithm helps make the
+   identification process more efficient.  By authenticating the DS
+   record, a resolver can authenticate the DNSKEY RR to which the DS
+   record points.  The key authentication process is described in
+   [RFC4035].
+
+   The DS RR and its corresponding DNSKEY RR have the same owner name,
+   but they are stored in different locations.  The DS RR appears only
+   on the upper (parental) side of a delegation, and is authoritative
+   data in the parent zone.  For example, the DS RR for "example.com" is
+   stored in the "com" zone (the parent zone) rather than in the
+
+
+
+Arends, et al.              Standards Track                    [Page 15]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   "example.com" zone (the child zone).  The corresponding DNSKEY RR is
+   stored in the "example.com" zone (the child zone).  This simplifies
+   DNS zone management and zone signing but introduces special response
+   processing requirements for the DS RR; these are described in
+   [RFC4035].
+
+   The type number for the DS record is 43.
+
+   The DS resource record is class independent.
+
+   The DS RR has no special TTL requirements.
+
+5.1.  DS RDATA Wire Format
+
+   The RDATA for a DS RR consists of a 2 octet Key Tag field, a 1 octet
+   Algorithm field, a 1 octet Digest Type field, and a Digest field.
+
+                        1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |           Key Tag             |  Algorithm    |  Digest Type  |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   /                                                               /
+   /                            Digest                             /
+   /                                                               /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+5.1.1.  The Key Tag Field
+
+   The Key Tag field lists the key tag of the DNSKEY RR referred to by
+   the DS record, in network byte order.
+
+   The Key Tag used by the DS RR is identical to the Key Tag used by
+   RRSIG RRs.  Appendix B describes how to compute a Key Tag.
+
+5.1.2.  The Algorithm Field
+
+   The Algorithm field lists the algorithm number of the DNSKEY RR
+   referred to by the DS record.
+
+   The algorithm number used by the DS RR is identical to the algorithm
+   number used by RRSIG and DNSKEY RRs.  Appendix A.1 lists the
+   algorithm number types.
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 16]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+5.1.3.  The Digest Type Field
+
+   The DS RR refers to a DNSKEY RR by including a digest of that DNSKEY
+   RR.  The Digest Type field identifies the algorithm used to construct
+   the digest.  Appendix A.2 lists the possible digest algorithm types.
+
+5.1.4.  The Digest Field
+
+   The DS record refers to a DNSKEY RR by including a digest of that
+   DNSKEY RR.
+
+   The digest is calculated by concatenating the canonical form of the
+   fully qualified owner name of the DNSKEY RR with the DNSKEY RDATA,
+   and then applying the digest algorithm.
+
+     digest = digest_algorithm( DNSKEY owner name | DNSKEY RDATA);
+
+      "|" denotes concatenation
+
+     DNSKEY RDATA = Flags | Protocol | Algorithm | Public Key.
+
+   The size of the digest may vary depending on the digest algorithm and
+   DNSKEY RR size.  As of the time of this writing, the only defined
+   digest algorithm is SHA-1, which produces a 20 octet digest.
+
+5.2.  Processing of DS RRs When Validating Responses
+
+   The DS RR links the authentication chain across zone boundaries, so
+   the DS RR requires extra care in processing.  The DNSKEY RR referred
+   to in the DS RR MUST be a DNSSEC zone key.  The DNSKEY RR Flags MUST
+   have Flags bit 7 set.  If the DNSKEY flags do not indicate a DNSSEC
+   zone key, the DS RR (and the DNSKEY RR it references) MUST NOT be
+   used in the validation process.
+
+5.3.  The DS RR Presentation Format
+
+   The presentation format of the RDATA portion is as follows:
+
+   The Key Tag field MUST be represented as an unsigned decimal integer.
+
+   The Algorithm field MUST be represented either as an unsigned decimal
+   integer or as an algorithm mnemonic specified in Appendix A.1.
+
+   The Digest Type field MUST be represented as an unsigned decimal
+   integer.
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 17]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   The Digest MUST be represented as a sequence of case-insensitive
+   hexadecimal digits.  Whitespace is allowed within the hexadecimal
+   text.
+
+5.4.  DS RR Example
+
+   The following example shows a DNSKEY RR and its corresponding DS RR.
+
+   dskey.example.com. 86400 IN DNSKEY 256 3 5 ( AQOeiiR0GOMYkDshWoSKz9Xz
+                                             fwJr1AYtsmx3TGkJaNXVbfi/
+                                             2pHm822aJ5iI9BMzNXxeYCmZ
+                                             DRD99WYwYqUSdjMmmAphXdvx
+                                             egXd/M5+X7OrzKBaMbCVdFLU
+                                             Uh6DhweJBjEVv5f2wwjM9Xzc
+                                             nOf+EPbtG9DMBmADjFDc2w/r
+                                             ljwvFw==
+                                             ) ;  key id = 60485
+
+   dskey.example.com. 86400 IN DS 60485 5 1 ( 2BB183AF5F22588179A53B0A
+                                              98631FAD1A292118 )
+
+   The first four text fields specify the name, TTL, Class, and RR type
+   (DS).  Value 60485 is the key tag for the corresponding
+   "dskey.example.com." DNSKEY RR, and value 5 denotes the algorithm
+   used by this "dskey.example.com." DNSKEY RR.  The value 1 is the
+   algorithm used to construct the digest, and the rest of the RDATA
+   text is the digest in hexadecimal.
+
+6.  Canonical Form and Order of Resource Records
+
+   This section defines a canonical form for resource records, a
+   canonical ordering of DNS names, and a canonical ordering of resource
+   records within an RRset.  A canonical name order is required to
+   construct the NSEC name chain.  A canonical RR form and ordering
+   within an RRset are required in order to construct and verify RRSIG
+   RRs.
+
+6.1.  Canonical DNS Name Order
+
+   For the purposes of DNS security, owner names are ordered by treating
+   individual labels as unsigned left-justified octet strings.  The
+   absence of a octet sorts before a zero value octet, and uppercase
+   US-ASCII letters are treated as if they were lowercase US-ASCII
+   letters.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 18]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   To compute the canonical ordering of a set of DNS names, start by
+   sorting the names according to their most significant (rightmost)
+   labels.  For names in which the most significant label is identical,
+   continue sorting according to their next most significant label, and
+   so forth.
+
+   For example, the following names are sorted in canonical DNS name
+   order.  The most significant label is "example".  At this level,
+   "example" sorts first, followed by names ending in "a.example", then
+   by names ending "z.example".  The names within each level are sorted
+   in the same way.
+
+             example
+             a.example
+             yljkjljk.a.example
+             Z.a.example
+             zABC.a.EXAMPLE
+             z.example
+             \001.z.example
+             *.z.example
+             \200.z.example
+
+6.2.  Canonical RR Form
+
+   For the purposes of DNS security, the canonical form of an RR is the
+   wire format of the RR where:
+
+   1.  every domain name in the RR is fully expanded (no DNS name
+       compression) and fully qualified;
+
+   2.  all uppercase US-ASCII letters in the owner name of the RR are
+       replaced by the corresponding lowercase US-ASCII letters;
+
+   3.  if the type of the RR is NS, MD, MF, CNAME, SOA, MB, MG, MR, PTR,
+       HINFO, MINFO, MX, HINFO, RP, AFSDB, RT, SIG, PX, NXT, NAPTR, KX,
+       SRV, DNAME, A6, RRSIG, or NSEC, all uppercase US-ASCII letters in
+       the DNS names contained within the RDATA are replaced by the
+       corresponding lowercase US-ASCII letters;
+
+   4.  if the owner name of the RR is a wildcard name, the owner name is
+       in its original unexpanded form, including the "*" label (no
+       wildcard substitution); and
+
+   5.  the RR's TTL is set to its original value as it appears in the
+       originating authoritative zone or the Original TTL field of the
+       covering RRSIG RR.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 19]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+6.3.  Canonical RR Ordering within an RRset
+
+   For the purposes of DNS security, RRs with the same owner name,
+   class, and type are sorted by treating the RDATA portion of the
+   canonical form of each RR as a left-justified unsigned octet sequence
+   in which the absence of an octet sorts before a zero octet.
+
+   [RFC2181] specifies that an RRset is not allowed to contain duplicate
+   records (multiple RRs with the same owner name, class, type, and
+   RDATA).  Therefore, if an implementation detects duplicate RRs when
+   putting the RRset in canonical form, it MUST treat this as a protocol
+   error.  If the implementation chooses to handle this protocol error
+   in the spirit of the robustness principle (being liberal in what it
+   accepts), it MUST remove all but one of the duplicate RR(s) for the
+   purposes of calculating the canonical form of the RRset.
+
+7.  IANA Considerations
+
+   This document introduces no new IANA considerations, as all of the
+   protocol parameters used in this document have already been assigned
+   by previous specifications.  However, since the evolution of DNSSEC
+   has been long and somewhat convoluted, this section attempts to
+   describe the current state of the IANA registries and other protocol
+   parameters that are (or once were) related to DNSSEC.
+
+   Please refer to [RFC4035] for additional IANA considerations.
+
+   DNS Resource Record Types: [RFC2535] assigned types 24, 25, and 30 to
+      the SIG, KEY, and NXT RRs, respectively.  [RFC3658] assigned DNS
+      Resource Record Type 43 to DS.  [RFC3755] assigned types 46, 47,
+      and 48 to the RRSIG, NSEC, and DNSKEY RRs, respectively.
+      [RFC3755] also marked type 30 (NXT) as Obsolete and restricted use
+      of types 24 (SIG) and 25 (KEY) to the "SIG(0)" transaction
+      security protocol described in [RFC2931] and to the transaction
+      KEY Resource Record described in [RFC2930].
+
+   DNS Security Algorithm Numbers: [RFC2535] created an IANA registry
+      for DNSSEC Resource Record Algorithm field numbers and assigned
+      values 1-4 and 252-255.  [RFC3110] assigned value 5.  [RFC3755]
+      altered this registry to include flags for each entry regarding
+      its use with the DNS security extensions.  Each algorithm entry
+      could refer to an algorithm that can be used for zone signing,
+      transaction security (see [RFC2931]), or both.  Values 6-251 are
+      available for assignment by IETF standards action ([RFC3755]).
+      See Appendix A for a full listing of the DNS Security Algorithm
+      Numbers entries at the time of this writing and their status for
+      use in DNSSEC.
+
+
+
+
+Arends, et al.              Standards Track                    [Page 20]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+      [RFC3658] created an IANA registry for DNSSEC DS Digest Types and
+      assigned value 0 to reserved and value 1 to SHA-1.
+
+   KEY Protocol Values: [RFC2535] created an IANA Registry for KEY
+      Protocol Values, but [RFC3445] reassigned all values other than 3
+      to reserved and closed this IANA registry.  The registry remains
+      closed, and all KEY and DNSKEY records are required to have a
+      Protocol Octet value of 3.
+
+   Flag bits in the KEY and DNSKEY RRs: [RFC3755] created an IANA
+      registry for the DNSSEC KEY and DNSKEY RR flag bits.  Initially,
+      this registry only contains assignments for bit 7 (the ZONE bit)
+      and bit 15 (the Secure Entry Point flag (SEP) bit; see [RFC3757]).
+      As stated in [RFC3755], bits 0-6 and 8-14 are available for
+      assignment by IETF Standards Action.
+
+8.  Security Considerations
+
+   This document describes the format of four DNS resource records used
+   by the DNS security extensions and presents an algorithm for
+   calculating a key tag for a public key.  Other than the items
+   described below, the resource records themselves introduce no
+   security considerations.  Please see [RFC4033] and [RFC4035] for
+   additional security considerations related to the use of these
+   records.
+
+   The DS record points to a DNSKEY RR by using a cryptographic digest,
+   the key algorithm type, and a key tag.  The DS record is intended to
+   identify an existing DNSKEY RR, but it is theoretically possible for
+   an attacker to generate a DNSKEY that matches all the DS fields.  The
+   probability of constructing a matching DNSKEY depends on the type of
+   digest algorithm in use.  The only currently defined digest algorithm
+   is SHA-1, and the working group believes that constructing a public
+   key that would match the algorithm, key tag, and SHA-1 digest given
+   in a DS record would be a sufficiently difficult problem that such an
+   attack is not a serious threat at this time.
+
+   The key tag is used to help select DNSKEY resource records
+   efficiently, but it does not uniquely identify a single DNSKEY
+   resource record.  It is possible for two distinct DNSKEY RRs to have
+   the same owner name, the same algorithm type, and the same key tag.
+   An implementation that uses only the key tag to select a DNSKEY RR
+   might select the wrong public key in some circumstances.  Please see
+   Appendix B for further details.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 21]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   The table of algorithms in Appendix A and the key tag calculation
+   algorithms in Appendix B include the RSA/MD5 algorithm for
+   completeness, but the RSA/MD5 algorithm is NOT RECOMMENDED, as
+   explained in [RFC3110].
+
+9.  Acknowledgements
+
+   This document was created from the input and ideas of the members of
+   the DNS Extensions Working Group and working group mailing list.  The
+   editors would like to express their thanks for the comments and
+   suggestions received during the revision of these security extension
+   specifications.  Although explicitly listing everyone who has
+   contributed during the decade in which DNSSEC has been under
+   development would be impossible, [RFC4033] includes a list of some of
+   the participants who were kind enough to comment on these documents.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, November 1987.
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, November 1987.
+
+   [RFC1982]  Elz, R. and R. Bush, "Serial Number Arithmetic", RFC 1982,
+              August 1996.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2181]  Elz, R. and R. Bush, "Clarifications to the DNS
+              Specification", RFC 2181, July 1997.
+
+   [RFC2308]  Andrews, M., "Negative Caching of DNS Queries (DNS
+              NCACHE)", RFC 2308, March 1998.
+
+   [RFC2536]  Eastlake 3rd, D., "DSA KEYs and SIGs in the Domain Name
+              System (DNS)", RFC 2536, March 1999.
+
+   [RFC2931]  Eastlake 3rd, D., "DNS Request and Transaction Signatures
+              ( SIG(0)s )", RFC 2931, September 2000.
+
+   [RFC3110]  Eastlake 3rd, D., "RSA/SHA-1 SIGs and RSA KEYs in the
+              Domain Name System (DNS)", RFC 3110, May 2001.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 22]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   [RFC3445]  Massey, D. and S. Rose, "Limiting the Scope of the KEY
+              Resource Record (RR)", RFC 3445, December 2002.
+
+   [RFC3548]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 3548, July 2003.
+
+   [RFC3597]  Gustafsson, A., "Handling of Unknown DNS Resource Record
+              (RR) Types", RFC 3597, September 2003.
+
+   [RFC3658]  Gudmundsson, O., "Delegation Signer (DS) Resource Record
+              (RR)", RFC 3658, December 2003.
+
+   [RFC3755]  Weiler, S., "Legacy Resolver Compatibility for Delegation
+              Signer (DS)", RFC 3755, May 2004.
+
+   [RFC3757]  Kolkman, O., Schlyter, J., and E. Lewis, "Domain Name
+              System KEY (DNSKEY) Resource Record (RR) Secure Entry
+              Point (SEP) Flag", RFC 3757, April 2004.
+
+   [RFC4033]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "DNS Security Introduction and Requirements", RFC
+              4033, March 2005.
+
+   [RFC4035]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Protocol Modifications for the DNS Security
+              Extensions", RFC 4035, March 2005.
+
+10.2.  Informative References
+
+   [RFC2535]  Eastlake 3rd, D., "Domain Name System Security
+              Extensions", RFC 2535, March 1999.
+
+   [RFC2537]  Eastlake 3rd, D., "RSA/MD5 KEYs and SIGs in the Domain
+              Name System (DNS)", RFC 2537, March 1999.
+
+   [RFC2539]  Eastlake 3rd, D., "Storage of Diffie-Hellman Keys in the
+              Domain Name System (DNS)", RFC 2539, March 1999.
+
+   [RFC2930]  Eastlake 3rd, D., "Secret Key Establishment for DNS (TKEY
+              RR)", RFC 2930, September 2000.
+
+   [RFC3845]  Schlyter, J., "DNS Security (DNSSEC) NextSECure (NSEC)
+              RDATA Format", RFC 3845, August 2004.
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 23]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+Appendix A.  DNSSEC Algorithm and Digest Types
+
+   The DNS security extensions are designed to be independent of the
+   underlying cryptographic algorithms.  The DNSKEY, RRSIG, and DS
+   resource records all use a DNSSEC Algorithm Number to identify the
+   cryptographic algorithm in use by the resource record.  The DS
+   resource record also specifies a Digest Algorithm Number to identify
+   the digest algorithm used to construct the DS record.  The currently
+   defined Algorithm and Digest Types are listed below.  Additional
+   Algorithm or Digest Types could be added as advances in cryptography
+   warrant them.
+
+   A DNSSEC aware resolver or name server MUST implement all MANDATORY
+   algorithms.
+
+A.1.  DNSSEC Algorithm Types
+
+   The DNSKEY, RRSIG, and DS RRs use an 8-bit number to identify the
+   security algorithm being used.  These values are stored in the
+   "Algorithm number" field in the resource record RDATA.
+
+   Some algorithms are usable only for zone signing (DNSSEC), some only
+   for transaction security mechanisms (SIG(0) and TSIG), and some for
+   both.  Those usable for zone signing may appear in DNSKEY, RRSIG, and
+   DS RRs.  Those usable for transaction security would be present in
+   SIG(0) and KEY RRs, as described in [RFC2931].
+
+                                Zone
+   Value Algorithm [Mnemonic]  Signing  References   Status
+   ----- -------------------- --------- ----------  ---------
+     0   reserved
+     1   RSA/MD5 [RSAMD5]         n      [RFC2537]  NOT RECOMMENDED
+     2   Diffie-Hellman [DH]      n      [RFC2539]   -
+     3   DSA/SHA-1 [DSA]          y      [RFC2536]  OPTIONAL
+     4   Elliptic Curve [ECC]              TBA       -
+     5   RSA/SHA-1 [RSASHA1]      y      [RFC3110]  MANDATORY
+   252   Indirect [INDIRECT]      n                  -
+   253   Private [PRIVATEDNS]     y      see below  OPTIONAL
+   254   Private [PRIVATEOID]     y      see below  OPTIONAL
+   255   reserved
+
+   6 - 251  Available for assignment by IETF Standards Action.
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 24]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+A.1.1.  Private Algorithm Types
+
+   Algorithm number 253 is reserved for private use and will never be
+   assigned to a specific algorithm.  The public key area in the DNSKEY
+   RR and the signature area in the RRSIG RR begin with a wire encoded
+   domain name, which MUST NOT be compressed.  The domain name indicates
+   the private algorithm to use, and the remainder of the public key
+   area is determined by that algorithm.  Entities should only use
+   domain names they control to designate their private algorithms.
+
+   Algorithm number 254 is reserved for private use and will never be
+   assigned to a specific algorithm.  The public key area in the DNSKEY
+   RR and the signature area in the RRSIG RR begin with an unsigned
+   length byte followed by a BER encoded Object Identifier (ISO OID) of
+   that length.  The OID indicates the private algorithm in use, and the
+   remainder of the area is whatever is required by that algorithm.
+   Entities should only use OIDs they control to designate their private
+   algorithms.
+
+A.2.  DNSSEC Digest Types
+
+   A "Digest Type" field in the DS resource record types identifies the
+   cryptographic digest algorithm used by the resource record.  The
+   following table lists the currently defined digest algorithm types.
+
+              VALUE   Algorithm                 STATUS
+                0      Reserved                   -
+                1      SHA-1                   MANDATORY
+              2-255    Unassigned                 -
+
+Appendix B.  Key Tag Calculation
+
+   The Key Tag field in the RRSIG and DS resource record types provides
+   a mechanism for selecting a public key efficiently.  In most cases, a
+   combination of owner name, algorithm, and key tag can efficiently
+   identify a DNSKEY record.  Both the RRSIG and DS resource records
+   have corresponding DNSKEY records.  The Key Tag field in the RRSIG
+   and DS records can be used to help select the corresponding DNSKEY RR
+   efficiently when more than one candidate DNSKEY RR is available.
+
+   However, it is essential to note that the key tag is not a unique
+   identifier.  It is theoretically possible for two distinct DNSKEY RRs
+   to have the same owner name, the same algorithm, and the same key
+   tag.  The key tag is used to limit the possible candidate keys, but
+   it does not uniquely identify a DNSKEY record.  Implementations MUST
+   NOT assume that the key tag uniquely identifies a DNSKEY RR.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 25]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+   The key tag is the same for all DNSKEY algorithm types except
+   algorithm 1 (please see Appendix B.1 for the definition of the key
+   tag for algorithm 1).  The key tag algorithm is the sum of the wire
+   format of the DNSKEY RDATA broken into 2 octet groups.  First, the
+   RDATA (in wire format) is treated as a series of 2 octet groups.
+   These groups are then added together, ignoring any carry bits.
+
+   A reference implementation of the key tag algorithm is as an ANSI C
+   function is given below, with the RDATA portion of the DNSKEY RR is
+   used as input.  It is not necessary to use the following reference
+   code verbatim, but the numerical value of the Key Tag MUST be
+   identical to what the reference implementation would generate for the
+   same input.
+
+   Please note that the algorithm for calculating the Key Tag is almost
+   but not completely identical to the familiar ones-complement checksum
+   used in many other Internet protocols.  Key Tags MUST be calculated
+   using the algorithm described here rather than the ones complement
+   checksum.
+
+   The following ANSI C reference implementation calculates the value of
+   a Key Tag.  This reference implementation applies to all algorithm
+   types except algorithm 1 (see Appendix B.1).  The input is the wire
+   format of the RDATA portion of the DNSKEY RR.  The code is written
+   for clarity, not efficiency.
+
+   /*
+    * Assumes that int is at least 16 bits.
+    * First octet of the key tag is the most significant 8 bits of the
+    * return value;
+    * Second octet of the key tag is the least significant 8 bits of the
+    * return value.
+    */
+
+   unsigned int
+   keytag (
+           unsigned char key[],  /* the RDATA part of the DNSKEY RR */
+           unsigned int keysize  /* the RDLENGTH */
+          )
+   {
+           unsigned long ac;     /* assumed to be 32 bits or larger */
+           int i;                /* loop index */
+
+           for ( ac = 0, i = 0; i < keysize; ++i )
+                   ac += (i & 1) ? key[i] : key[i] << 8;
+           ac += (ac >> 16) & 0xFFFF;
+           return ac & 0xFFFF;
+   }
+
+
+
+Arends, et al.              Standards Track                    [Page 26]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+B.1.  Key Tag for Algorithm 1 (RSA/MD5)
+
+   The key tag for algorithm 1 (RSA/MD5) is defined differently from the
+   key tag for all other algorithms, for historical reasons.  For a
+   DNSKEY RR with algorithm 1, the key tag is defined to be the most
+   significant 16 bits of the least significant 24 bits in the public
+   key modulus (in other words, the 4th to last and 3rd to last octets
+   of the public key modulus).
+
+   Please note that Algorithm 1 is NOT RECOMMENDED.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 27]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+Authors' Addresses
+
+   Roy Arends
+   Telematica Instituut
+   Brouwerijstraat 1
+   7523 XC  Enschede
+   NL
+
+   EMail: roy.arends@telin.nl
+
+
+   Rob Austein
+   Internet Systems Consortium
+   950 Charter Street
+   Redwood City, CA  94063
+   USA
+
+   EMail: sra@isc.org
+
+
+   Matt Larson
+   VeriSign, Inc.
+   21345 Ridgetop Circle
+   Dulles, VA  20166-6503
+   USA
+
+   EMail: mlarson@verisign.com
+
+
+   Dan Massey
+   Colorado State University
+   Department of Computer Science
+   Fort Collins, CO 80523-1873
+
+   EMail: massey@cs.colostate.edu
+
+
+   Scott Rose
+   National Institute for Standards and Technology
+   100 Bureau Drive
+   Gaithersburg, MD  20899-8920
+   USA
+
+   EMail: scott.rose@nist.gov
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 28]
+
+RFC 4034                DNSSEC Resource Records               March 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 29]
+

--- a/rfc/dns/rfc4035.txt
+++ b/rfc/dns/rfc4035.txt
@@ -1,0 +1,2971 @@
+
+
+
+
+
+
+Network Working Group                                          R. Arends
+Request for Comments: 4035                          Telematica Instituut
+Obsoletes: 2535, 3008, 3090, 3445, 3655, 3658,                R. Austein
+           3755, 3757, 3845                                          ISC
+Updates: 1034, 1035, 2136, 2181, 2308, 3225,                   M. Larson
+         3007, 3597, 3226                                       VeriSign
+Category: Standards Track                                      D. Massey
+                                               Colorado State University
+                                                                 S. Rose
+                                                                    NIST
+                                                              March 2005
+
+
+         Protocol Modifications for the DNS Security Extensions
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Copyright Notice
+
+   Copyright (C) The Internet Society (2005).
+
+Abstract
+
+   This document is part of a family of documents that describe the DNS
+   Security Extensions (DNSSEC).  The DNS Security Extensions are a
+   collection of new resource records and protocol modifications that
+   add data origin authentication and data integrity to the DNS.  This
+   document describes the DNSSEC protocol modifications.  This document
+   defines the concept of a signed zone, along with the requirements for
+   serving and resolving by using DNSSEC.  These techniques allow a
+   security-aware resolver to authenticate both DNS resource records and
+   authoritative DNS error indications.
+
+   This document obsoletes RFC 2535 and incorporates changes from all
+   updates to RFC 2535.
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 1]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  3
+       1.1.  Background and Related Documents . . . . . . . . . . . .  4
+       1.2.  Reserved Words . . . . . . . . . . . . . . . . . . . . .  4
+   2.  Zone Signing . . . . . . . . . . . . . . . . . . . . . . . . .  4
+       2.1.  Including DNSKEY RRs in a Zone . . . . . . . . . . . . .  5
+       2.2.  Including RRSIG RRs in a Zone  . . . . . . . . . . . . .  5
+       2.3.  Including NSEC RRs in a Zone . . . . . . . . . . . . . .  6
+       2.4.  Including DS RRs in a Zone . . . . . . . . . . . . . . .  7
+       2.5.  Changes to the CNAME Resource Record.  . . . . . . . . .  7
+       2.6.  DNSSEC RR Types Appearing at Zone Cuts.  . . . . . . . .  8
+       2.7.  Example of a Secure Zone . . . . . . . . . . . . . . . .  8
+   3.  Serving  . . . . . . . . . . . . . . . . . . . . . . . . . . .  8
+       3.1.  Authoritative Name Servers . . . . . . . . . . . . . . .  9
+             3.1.1.  Including RRSIG RRs in a Response  . . . . . . . 10
+             3.1.2.  Including DNSKEY RRs in a Response . . . . . . . 11
+             3.1.3.  Including NSEC RRs in a Response . . . . . . . . 11
+             3.1.4.  Including DS RRs in a Response . . . . . . . . . 14
+             3.1.5.  Responding to Queries for Type AXFR or IXFR  . . 15
+             3.1.6.  The AD and CD Bits in an Authoritative Response. 16
+       3.2.  Recursive Name Servers . . . . . . . . . . . . . . . . . 17
+             3.2.1.  The DO Bit . . . . . . . . . . . . . . . . . . . 17
+             3.2.2.  The CD Bit . . . . . . . . . . . . . . . . . . . 17
+             3.2.3.  The AD Bit . . . . . . . . . . . . . . . . . . . 18
+       3.3.  Example DNSSEC Responses . . . . . . . . . . . . . . . . 19
+   4.  Resolving  . . . . . . . . . . . . . . . . . . . . . . . . . . 19
+       4.1.  EDNS Support . . . . . . . . . . . . . . . . . . . . . . 19
+       4.2.  Signature Verification Support . . . . . . . . . . . . . 19
+       4.3.  Determining Security Status of Data  . . . . . . . . . . 20
+       4.4.  Configured Trust Anchors . . . . . . . . . . . . . . . . 21
+       4.5.  Response Caching . . . . . . . . . . . . . . . . . . . . 21
+       4.6.  Handling of the CD and AD Bits . . . . . . . . . . . . . 22
+       4.7.  Caching BAD Data . . . . . . . . . . . . . . . . . . . . 22
+       4.8.  Synthesized CNAMEs . . . . . . . . . . . . . . . . . . . 23
+       4.9.  Stub Resolvers . . . . . . . . . . . . . . . . . . . . . 23
+             4.9.1.  Handling of the DO Bit . . . . . . . . . . . . . 24
+             4.9.2.  Handling of the CD Bit . . . . . . . . . . . . . 24
+             4.9.3.  Handling of the AD Bit . . . . . . . . . . . . . 24
+   5.  Authenticating DNS Responses . . . . . . . . . . . . . . . . . 25
+       5.1.  Special Considerations for Islands of Security . . . . . 26
+       5.2.  Authenticating Referrals . . . . . . . . . . . . . . . . 26
+       5.3.  Authenticating an RRset with an RRSIG RR . . . . . . . . 28
+             5.3.1.  Checking the RRSIG RR Validity . . . . . . . . . 28
+             5.3.2.  Reconstructing the Signed Data . . . . . . . . . 29
+             5.3.3.  Checking the Signature . . . . . . . . . . . . . 31
+             5.3.4.  Authenticating a Wildcard Expanded RRset
+                     Positive Response. . . . . . . . . . . . . . . . 32
+
+
+
+Arends, et al.              Standards Track                     [Page 2]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+       5.4.  Authenticated Denial of Existence  . . . . . . . . . . . 32
+       5.5.  Resolver Behavior When Signatures Do Not Validate  . . . 33
+       5.6.  Authentication Example . . . . . . . . . . . . . . . . . 33
+   6.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 33
+   7.  Security Considerations  . . . . . . . . . . . . . . . . . . . 33
+   8.  Acknowledgements . . . . . . . . . . . . . . . . . . . . . . . 34
+   9.  References . . . . . . . . . . . . . . . . . . . . . . . . . . 34
+       9.1.  Normative References . . . . . . . . . . . . . . . . . . 34
+       9.2.  Informative References . . . . . . . . . . . . . . . . . 35
+   A.  Signed Zone Example  . . . . . . . . . . . . . . . . . . . . . 36
+   B.  Example Responses  . . . . . . . . . . . . . . . . . . . . . . 41
+       B.1.  Answer . . . . . . . . . . . . . . . . . . . . . . . . . 41
+       B.2.  Name Error . . . . . . . . . . . . . . . . . . . . . . . 43
+       B.3.  No Data Error  . . . . . . . . . . . . . . . . . . . . . 44
+       B.4.  Referral to Signed Zone  . . . . . . . . . . . . . . . . 44
+       B.5.  Referral to Unsigned Zone  . . . . . . . . . . . . . . . 45
+       B.6.  Wildcard Expansion . . . . . . . . . . . . . . . . . . . 46
+       B.7.  Wildcard No Data Error . . . . . . . . . . . . . . . . . 47
+       B.8.  DS Child Zone No Data Error  . . . . . . . . . . . . . . 48
+   C.  Authentication Examples  . . . . . . . . . . . . . . . . . . . 49
+       C.1.  Authenticating an Answer . . . . . . . . . . . . . . . . 49
+             C.1.1.  Authenticating the Example DNSKEY RR . . . . . . 49
+       C.2.  Name Error . . . . . . . . . . . . . . . . . . . . . . . 50
+       C.3.  No Data Error  . . . . . . . . . . . . . . . . . . . . . 50
+       C.4.  Referral to Signed Zone  . . . . . . . . . . . . . . . . 50
+       C.5.  Referral to Unsigned Zone  . . . . . . . . . . . . . . . 51
+       C.6.  Wildcard Expansion . . . . . . . . . . . . . . . . . . . 51
+       C.7.  Wildcard No Data Error . . . . . . . . . . . . . . . . . 51
+       C.8.  DS Child Zone No Data Error  . . . . . . . . . . . . . . 51
+   Authors' Addresses . . . . . . . . . . . . . . . . . . . . . . . . 52
+   Full Copyright Statement . . . . . . . . . . . . . . . . . . . . . 53
+
+1.  Introduction
+
+   The DNS Security Extensions (DNSSEC) are a collection of new resource
+   records and protocol modifications that add data origin
+   authentication and data integrity to the DNS.  This document defines
+   the DNSSEC protocol modifications.  Section 2 of this document
+   defines the concept of a signed zone and lists the requirements for
+   zone signing.  Section 3 describes the modifications to authoritative
+   name server behavior necessary for handling signed zones.  Section 4
+   describes the behavior of entities that include security-aware
+   resolver functions.  Finally, Section 5 defines how to use DNSSEC RRs
+   to authenticate a response.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 3]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+1.1.  Background and Related Documents
+
+   This document is part of a family of documents defining DNSSEC that
+   should be read together as a set.
+
+   [RFC4033] contains an introduction to DNSSEC and definitions of
+   common terms; the reader is assumed to be familiar with this
+   document.  [RFC4033] also contains a list of other documents updated
+   by and obsoleted by this document set.
+
+   [RFC4034] defines the DNSSEC resource records.
+
+   The reader is also assumed to be familiar with the basic DNS concepts
+   described in [RFC1034], [RFC1035], and the subsequent documents that
+   update them; particularly, [RFC2181] and [RFC2308].
+
+   This document defines the DNSSEC protocol operations.
+
+1.2.  Reserved Words
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+2.  Zone Signing
+
+   DNSSEC introduces the concept of signed zones.  A signed zone
+   includes DNS Public Key (DNSKEY), Resource Record Signature (RRSIG),
+   Next Secure (NSEC), and (optionally) Delegation Signer (DS) records
+   according to the rules specified in Sections 2.1, 2.2, 2.3, and 2.4,
+   respectively.  A zone that does not include these records according
+   to the rules in this section is an unsigned zone.
+
+   DNSSEC requires a change to the definition of the CNAME resource
+   record ([RFC1035]).  Section 2.5 changes the CNAME RR to allow RRSIG
+   and NSEC RRs to appear at the same owner name as does a CNAME RR.
+
+   DNSSEC specifies the placement of two new RR types, NSEC and DS,
+   which can be placed at the parental side of a zone cut (that is, at a
+   delegation point).  This is an exception to the general prohibition
+   against putting data in the parent zone at a zone cut.  Section 2.6
+   describes this change.
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 4]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+2.1.  Including DNSKEY RRs in a Zone
+
+   To sign a zone, the zone's administrator generates one or more
+   public/private key pairs and uses the private key(s) to sign
+   authoritative RRsets in the zone.  For each private key used to
+   create RRSIG RRs in a zone, the zone SHOULD include a zone DNSKEY RR
+   containing the corresponding public key.  A zone key DNSKEY RR MUST
+   have the Zone Key bit of the flags RDATA field set (see Section 2.1.1
+   of [RFC4034]).  Public keys associated with other DNS operations MAY
+   be stored in DNSKEY RRs that are not marked as zone keys but MUST NOT
+   be used to verify RRSIGs.
+
+   If the zone administrator intends a signed zone to be usable other
+   than as an island of security, the zone apex MUST contain at least
+   one DNSKEY RR to act as a secure entry point into the zone.  This
+   secure entry point could then be used as the target of a secure
+   delegation via a corresponding DS RR in the parent zone (see
+   [RFC4034]).
+
+2.2.  Including RRSIG RRs in a Zone
+
+   For each authoritative RRset in a signed zone, there MUST be at least
+   one RRSIG record that meets the following requirements:
+
+   o  The RRSIG owner name is equal to the RRset owner name.
+
+   o  The RRSIG class is equal to the RRset class.
+
+   o  The RRSIG Type Covered field is equal to the RRset type.
+
+   o  The RRSIG Original TTL field is equal to the TTL of the RRset.
+
+   o  The RRSIG RR's TTL is equal to the TTL of the RRset.
+
+   o  The RRSIG Labels field is equal to the number of labels in the
+      RRset owner name, not counting the null root label and not
+      counting the leftmost label if it is a wildcard.
+
+   o  The RRSIG Signer's Name field is equal to the name of the zone
+      containing the RRset.
+
+   o  The RRSIG Algorithm, Signer's Name, and Key Tag fields identify a
+      zone key DNSKEY record at the zone apex.
+
+   The process for constructing the RRSIG RR for a given RRset is
+   described in [RFC4034].  An RRset MAY have multiple RRSIG RRs
+   associated with it.  Note that as RRSIG RRs are closely tied to the
+   RRsets whose signatures they contain, RRSIG RRs, unlike all other DNS
+
+
+
+Arends, et al.              Standards Track                     [Page 5]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   RR types, do not form RRsets.  In particular, the TTL values among
+   RRSIG RRs with a common owner name do not follow the RRset rules
+   described in [RFC2181].
+
+   An RRSIG RR itself MUST NOT be signed, as signing an RRSIG RR would
+   add no value and would create an infinite loop in the signing
+   process.
+
+   The NS RRset that appears at the zone apex name MUST be signed, but
+   the NS RRsets that appear at delegation points (that is, the NS
+   RRsets in the parent zone that delegate the name to the child zone's
+   name servers) MUST NOT be signed.  Glue address RRsets associated
+   with delegations MUST NOT be signed.
+
+   There MUST be an RRSIG for each RRset using at least one DNSKEY of
+   each algorithm in the zone apex DNSKEY RRset.  The apex DNSKEY RRset
+   itself MUST be signed by each algorithm appearing in the DS RRset
+   located at the delegating parent (if any).
+
+2.3.  Including NSEC RRs in a Zone
+
+   Each owner name in the zone that has authoritative data or a
+   delegation point NS RRset MUST have an NSEC resource record.  The
+   format of NSEC RRs and the process for constructing the NSEC RR for a
+   given name is described in [RFC4034].
+
+   The TTL value for any NSEC RR SHOULD be the same as the minimum TTL
+   value field in the zone SOA RR.
+
+   An NSEC record (and its associated RRSIG RRset) MUST NOT be the only
+   RRset at any particular owner name.  That is, the signing process
+   MUST NOT create NSEC or RRSIG RRs for owner name nodes that were not
+   the owner name of any RRset before the zone was signed.  The main
+   reasons for this are a desire for namespace consistency between
+   signed and unsigned versions of the same zone and a desire to reduce
+   the risk of response inconsistency in security oblivious recursive
+   name servers.
+
+   The type bitmap of every NSEC resource record in a signed zone MUST
+   indicate the presence of both the NSEC record itself and its
+   corresponding RRSIG record.
+
+   The difference between the set of owner names that require RRSIG
+   records and the set of owner names that require NSEC records is
+   subtle and worth highlighting.  RRSIG records are present at the
+   owner names of all authoritative RRsets.  NSEC records are present at
+   the owner names of all names for which the signed zone is
+   authoritative and also at the owner names of delegations from the
+
+
+
+Arends, et al.              Standards Track                     [Page 6]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   signed zone to its children.  Neither NSEC nor RRSIG records are
+   present (in the parent zone) at the owner names of glue address
+   RRsets.  Note, however, that this distinction is for the most part
+   visible only during the zone signing process, as NSEC RRsets are
+   authoritative data and are therefore signed.  Thus, any owner name
+   that has an NSEC RRset will have RRSIG RRs as well in the signed
+   zone.
+
+   The bitmap for the NSEC RR at a delegation point requires special
+   attention.  Bits corresponding to the delegation NS RRset and any
+   RRsets for which the parent zone has authoritative data MUST be set;
+   bits corresponding to any non-NS RRset for which the parent is not
+   authoritative MUST be clear.
+
+2.4.  Including DS RRs in a Zone
+
+   The DS resource record establishes authentication chains between DNS
+   zones.  A DS RRset SHOULD be present at a delegation point when the
+   child zone is signed.  The DS RRset MAY contain multiple records,
+   each referencing a public key in the child zone used to verify the
+   RRSIGs in that zone.  All DS RRsets in a zone MUST be signed, and DS
+   RRsets MUST NOT appear at a zone's apex.
+
+   A DS RR SHOULD point to a DNSKEY RR that is present in the child's
+   apex DNSKEY RRset, and the child's apex DNSKEY RRset SHOULD be signed
+   by the corresponding private key.  DS RRs that fail to meet these
+   conditions are not useful for validation, but because the DS RR and
+   its corresponding DNSKEY RR are in different zones, and because the
+   DNS is only loosely consistent, temporary mismatches can occur.
+
+   The TTL of a DS RRset SHOULD match the TTL of the delegating NS RRset
+   (that is, the NS RRset from the same zone containing the DS RRset).
+
+   Construction of a DS RR requires knowledge of the corresponding
+   DNSKEY RR in the child zone, which implies communication between the
+   child and parent zones.  This communication is an operational matter
+   not covered by this document.
+
+2.5.  Changes to the CNAME Resource Record
+
+   If a CNAME RRset is present at a name in a signed zone, appropriate
+   RRSIG and NSEC RRsets are REQUIRED at that name.  A KEY RRset at that
+   name for secure dynamic update purposes is also allowed ([RFC3007]).
+   Other types MUST NOT be present at that name.
+
+   This is a modification to the original CNAME definition given in
+   [RFC1034].  The original definition of the CNAME RR did not allow any
+   other types to coexist with a CNAME record, but a signed zone
+
+
+
+Arends, et al.              Standards Track                     [Page 7]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   requires NSEC and RRSIG RRs for every authoritative name.  To resolve
+   this conflict, this specification modifies the definition of the
+   CNAME resource record to allow it to coexist with NSEC and RRSIG RRs.
+
+2.6.  DNSSEC RR Types Appearing at Zone Cuts
+
+   DNSSEC introduced two new RR types that are unusual in that they can
+   appear at the parental side of a zone cut.  At the parental side of a
+   zone cut (that is, at a delegation point), NSEC RRs are REQUIRED at
+   the owner name.  A DS RR could also be present if the zone being
+   delegated is signed and seeks to have a chain of authentication to
+   the parent zone.  This is an exception to the original DNS
+   specification ([RFC1034]), which states that only NS RRsets could
+   appear at the parental side of a zone cut.
+
+   This specification updates the original DNS specification to allow
+   NSEC and DS RR types at the parent side of a zone cut.  These RRsets
+   are authoritative for the parent when they appear at the parent side
+   of a zone cut.
+
+2.7.  Example of a Secure Zone
+
+   Appendix A shows a complete example of a small signed zone.
+
+3.  Serving
+
+   This section describes the behavior of entities that include
+   security-aware name server functions.  In many cases such functions
+   will be part of a security-aware recursive name server, but a
+   security-aware authoritative name server has some of the same
+   requirements.  Functions specific to security-aware recursive name
+   servers are described in Section 3.2; functions specific to
+   authoritative servers are described in Section 3.1.
+
+   In the following discussion, the terms "SNAME", "SCLASS", and "STYPE"
+   are as used in [RFC1034].
+
+   A security-aware name server MUST support the EDNS0 ([RFC2671])
+   message size extension, MUST support a message size of at least 1220
+   octets, and SHOULD support a message size of 4000 octets.  As IPv6
+   packets can only be fragmented by the source host, a security aware
+   name server SHOULD take steps to ensure that UDP datagrams it
+   transmits over IPv6 are fragmented, if necessary, at the minimum IPv6
+   MTU, unless the path MTU is known.  Please see [RFC1122], [RFC2460],
+   and [RFC3226] for further discussion of packet size and fragmentation
+   issues.
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 8]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   A security-aware name server that receives a DNS query that does not
+   include the EDNS OPT pseudo-RR or that has the DO bit clear MUST
+   treat the RRSIG, DNSKEY, and NSEC RRs as it would any other RRset and
+   MUST NOT perform any of the additional processing described below.
+   Because the DS RR type has the peculiar property of only existing in
+   the parent zone at delegation points, DS RRs always require some
+   special processing, as described in Section 3.1.4.1.
+
+   Security aware name servers that receive explicit queries for
+   security RR types that match the content of more than one zone that
+   it serves (for example, NSEC and RRSIG RRs above and below a
+   delegation point where the server is authoritative for both zones)
+   should behave self-consistently.  As long as the response is always
+   consistent for each query to the name server, the name server MAY
+   return one of the following:
+
+   o  The above-delegation RRsets.
+   o  The below-delegation RRsets.
+   o  Both above and below-delegation RRsets.
+   o  Empty answer section (no records).
+   o  Some other response.
+   o  An error.
+
+   DNSSEC allocates two new bits in the DNS message header: the CD
+   (Checking Disabled) bit and the AD (Authentic Data) bit.  The CD bit
+   is controlled by resolvers; a security-aware name server MUST copy
+   the CD bit from a query into the corresponding response.  The AD bit
+   is controlled by name servers; a security-aware name server MUST
+   ignore the setting of the AD bit in queries.  See Sections 3.1.6,
+   3.2.2, 3.2.3, 4, and 4.9 for details on the behavior of these bits.
+
+   A security aware name server that synthesizes CNAME RRs from DNAME
+   RRs as described in [RFC2672] SHOULD NOT generate signatures for the
+   synthesized CNAME RRs.
+
+3.1.  Authoritative Name Servers
+
+   Upon receiving a relevant query that has the EDNS ([RFC2671]) OPT
+   pseudo-RR DO bit ([RFC3225]) set, a security-aware authoritative name
+   server for a signed zone MUST include additional RRSIG, NSEC, and DS
+   RRs, according to the following rules:
+
+   o  RRSIG RRs that can be used to authenticate a response MUST be
+      included in the response according to the rules in Section 3.1.1.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                     [Page 9]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   o  NSEC RRs that can be used to provide authenticated denial of
+      existence MUST be included in the response automatically according
+      to the rules in Section 3.1.3.
+
+   o  Either a DS RRset or an NSEC RR proving that no DS RRs exist MUST
+      be included in referrals automatically according to the rules in
+      Section 3.1.4.
+
+   These rules only apply to responses where the semantics convey
+   information about the presence or absence of resource records.  That
+   is, these rules are not intended to rule out responses such as RCODE
+   4 ("Not Implemented") or RCODE 5 ("Refused").
+
+   DNSSEC does not change the DNS zone transfer protocol.  Section 3.1.5
+   discusses zone transfer requirements.
+
+3.1.1.  Including RRSIG RRs in a Response
+
+   When responding to a query that has the DO bit set, a security-aware
+   authoritative name server SHOULD attempt to send RRSIG RRs that a
+   security-aware resolver can use to authenticate the RRsets in the
+   response.  A name server SHOULD make every attempt to keep the RRset
+   and its associated RRSIG(s) together in a response.  Inclusion of
+   RRSIG RRs in a response is subject to the following rules:
+
+   o  When placing a signed RRset in the Answer section, the name server
+      MUST also place its RRSIG RRs in the Answer section.  The RRSIG
+      RRs have a higher priority for inclusion than any other RRsets
+      that may have to be included.  If space does not permit inclusion
+      of these RRSIG RRs, the name server MUST set the TC bit.
+
+   o  When placing a signed RRset in the Authority section, the name
+      server MUST also place its RRSIG RRs in the Authority section.
+      The RRSIG RRs have a higher priority for inclusion than any other
+      RRsets that may have to be included.  If space does not permit
+      inclusion of these RRSIG RRs, the name server MUST set the TC bit.
+
+   o  When placing a signed RRset in the Additional section, the name
+      server MUST also place its RRSIG RRs in the Additional section.
+      If space does not permit inclusion of both the RRset and its
+      associated RRSIG RRs, the name server MAY retain the RRset while
+      dropping the RRSIG RRs.  If this happens, the name server MUST NOT
+      set the TC bit solely because these RRSIG RRs didn't fit.
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 10]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+3.1.2.  Including DNSKEY RRs in a Response
+
+   When responding to a query that has the DO bit set and that requests
+   the SOA or NS RRs at the apex of a signed zone, a security-aware
+   authoritative name server for that zone MAY return the zone apex
+   DNSKEY RRset in the Additional section.  In this situation, the
+   DNSKEY RRset and associated RRSIG RRs have lower priority than does
+   any other information that would be placed in the additional section.
+   The name server SHOULD NOT include the DNSKEY RRset unless there is
+   enough space in the response message for both the DNSKEY RRset and
+   its associated RRSIG RR(s).  If there is not enough space to include
+   these DNSKEY and RRSIG RRs, the name server MUST omit them and MUST
+   NOT set the TC bit solely because these RRs didn't fit (see Section
+   3.1.1).
+
+3.1.3.  Including NSEC RRs in a Response
+
+   When responding to a query that has the DO bit set, a security-aware
+   authoritative name server for a signed zone MUST include NSEC RRs in
+   each of the following cases:
+
+   No Data: The zone contains RRsets that exactly match <SNAME, SCLASS>
+      but does not contain any RRsets that exactly match <SNAME, SCLASS,
+      STYPE>.
+
+   Name Error: The zone does not contain any RRsets that match <SNAME,
+      SCLASS> either exactly or via wildcard name expansion.
+
+   Wildcard Answer: The zone does not contain any RRsets that exactly
+      match <SNAME, SCLASS> but does contain an RRset that matches
+      <SNAME, SCLASS, STYPE> via wildcard name expansion.
+
+   Wildcard No Data: The zone does not contain any RRsets that exactly
+      match <SNAME, SCLASS> and does contain one or more RRsets that
+      match <SNAME, SCLASS> via wildcard name expansion, but does not
+      contain any RRsets that match <SNAME, SCLASS, STYPE> via wildcard
+      name expansion.
+
+   In each of these cases, the name server includes NSEC RRs in the
+   response to prove that an exact match for <SNAME, SCLASS, STYPE> was
+   not present in the zone and that the response that the name server is
+   returning is correct given the data in the zone.
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 11]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+3.1.3.1.  Including NSEC RRs: No Data Response
+
+   If the zone contains RRsets matching <SNAME, SCLASS> but contains no
+   RRset matching <SNAME, SCLASS, STYPE>, then the name server MUST
+   include the NSEC RR for <SNAME, SCLASS> along with its associated
+   RRSIG RR(s) in the Authority section of the response (see Section
+   3.1.1).  If space does not permit inclusion of the NSEC RR or its
+   associated RRSIG RR(s), the name server MUST set the TC bit (see
+   Section 3.1.1).
+
+   Since the search name exists, wildcard name expansion does not apply
+   to this query, and a single signed NSEC RR suffices to prove that the
+   requested RR type does not exist.
+
+3.1.3.2.  Including NSEC RRs: Name Error Response
+
+   If the zone does not contain any RRsets matching <SNAME, SCLASS>
+   either exactly or via wildcard name expansion, then the name server
+   MUST include the following NSEC RRs in the Authority section, along
+   with their associated RRSIG RRs:
+
+   o  An NSEC RR proving that there is no exact match for <SNAME,
+      SCLASS>.
+
+   o  An NSEC RR proving that the zone contains no RRsets that would
+      match <SNAME, SCLASS> via wildcard name expansion.
+
+   In some cases, a single NSEC RR may prove both of these points.  If
+   it does, the name server SHOULD only include the NSEC RR and its
+   RRSIG RR(s) once in the Authority section.
+
+   If space does not permit inclusion of these NSEC and RRSIG RRs, the
+   name server MUST set the TC bit (see Section 3.1.1).
+
+   The owner names of these NSEC and RRSIG RRs are not subject to
+   wildcard name expansion when these RRs are included in the Authority
+   section of the response.
+
+   Note that this form of response includes cases in which SNAME
+   corresponds to an empty non-terminal name within the zone (a name
+   that is not the owner name for any RRset but that is the parent name
+   of one or more RRsets).
+
+3.1.3.3.  Including NSEC RRs: Wildcard Answer Response
+
+   If the zone does not contain any RRsets that exactly match <SNAME,
+   SCLASS> but does contain an RRset that matches <SNAME, SCLASS, STYPE>
+   via wildcard name expansion, the name server MUST include the
+
+
+
+Arends, et al.              Standards Track                    [Page 12]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   wildcard-expanded answer and the corresponding wildcard-expanded
+   RRSIG RRs in the Answer section and MUST include in the Authority
+   section an NSEC RR and associated RRSIG RR(s) proving that the zone
+   does not contain a closer match for <SNAME, SCLASS>.  If space does
+   not permit inclusion of the answer, NSEC and RRSIG RRs, the name
+   server MUST set the TC bit (see Section 3.1.1).
+
+3.1.3.4.  Including NSEC RRs: Wildcard No Data Response
+
+   This case is a combination of the previous cases.  The zone does not
+   contain an exact match for <SNAME, SCLASS>, and although the zone
+   does contain RRsets that match <SNAME, SCLASS> via wildcard
+   expansion, none of those RRsets matches STYPE.  The name server MUST
+   include the following NSEC RRs in the Authority section, along with
+   their associated RRSIG RRs:
+
+   o  An NSEC RR proving that there are no RRsets matching STYPE at the
+      wildcard owner name that matched <SNAME, SCLASS> via wildcard
+      expansion.
+
+   o  An NSEC RR proving that there are no RRsets in the zone that would
+      have been a closer match for <SNAME, SCLASS>.
+
+   In some cases, a single NSEC RR may prove both of these points.  If
+   it does, the name server SHOULD only include the NSEC RR and its
+   RRSIG RR(s) once in the Authority section.
+
+   The owner names of these NSEC and RRSIG RRs are not subject to
+   wildcard name expansion when these RRs are included in the Authority
+   section of the response.
+
+   If space does not permit inclusion of these NSEC and RRSIG RRs, the
+   name server MUST set the TC bit (see Section 3.1.1).
+
+3.1.3.5.  Finding the Right NSEC RRs
+
+   As explained above, there are several situations in which a
+   security-aware authoritative name server has to locate an NSEC RR
+   that proves that no RRsets matching a particular SNAME exist.
+   Locating such an NSEC RR within an authoritative zone is relatively
+   simple, at least in concept.  The following discussion assumes that
+   the name server is authoritative for the zone that would have held
+   the non-existent RRsets matching SNAME.  The algorithm below is
+   written for clarity, not for efficiency.
+
+   To find the NSEC that proves that no RRsets matching name N exist in
+   the zone Z that would have held them, construct a sequence, S,
+   consisting of the owner names of every RRset in Z, sorted into
+
+
+
+Arends, et al.              Standards Track                    [Page 13]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   canonical order ([RFC4034]), with no duplicate names.  Find the name
+   M that would have immediately preceded N in S if any RRsets with
+   owner name N had existed.  M is the owner name of the NSEC RR that
+   proves that no RRsets exist with owner name N.
+
+   The algorithm for finding the NSEC RR that proves that a given name
+   is not covered by any applicable wildcard is similar but requires an
+   extra step.  More precisely, the algorithm for finding the NSEC
+   proving that no RRsets exist with the applicable wildcard name is
+   precisely the same as the algorithm for finding the NSEC RR that
+   proves that RRsets with any other owner name do not exist.  The part
+   that's missing is a method of determining the name of the non-
+   existent applicable wildcard.  In practice, this is easy, because the
+   authoritative name server has already checked for the presence of
+   precisely this wildcard name as part of step (1)(c) of the normal
+   lookup algorithm described in Section 4.3.2 of [RFC1034].
+
+3.1.4.  Including DS RRs in a Response
+
+   When responding to a query that has the DO bit set, a security-aware
+   authoritative name server returning a referral includes DNSSEC data
+   along with the NS RRset.
+
+   If a DS RRset is present at the delegation point, the name server
+   MUST return both the DS RRset and its associated RRSIG RR(s) in the
+   Authority section along with the NS RRset.
+
+   If no DS RRset is present at the delegation point, the name server
+   MUST return both the NSEC RR that proves that the DS RRset is not
+   present and the NSEC RR's associated RRSIG RR(s) along with the NS
+   RRset.  The name server MUST place the NS RRset before the NSEC RRset
+   and its associated RRSIG RR(s).
+
+   Including these DS, NSEC, and RRSIG RRs increases the size of
+   referral messages and may cause some or all glue RRs to be omitted.
+   If space does not permit inclusion of the DS or NSEC RRset and
+   associated RRSIG RRs, the name server MUST set the TC bit (see
+   Section 3.1.1).
+
+3.1.4.1.  Responding to Queries for DS RRs
+
+   The DS resource record type is unusual in that it appears only on the
+   parent zone's side of a zone cut.  For example, the DS RRset for the
+   delegation of "foo.example" is stored in the "example" zone rather
+   than in the "foo.example" zone.  This requires special processing
+   rules for both name servers and resolvers, as the name server for the
+   child zone is authoritative for the name at the zone cut by the
+   normal DNS rules but the child zone does not contain the DS RRset.
+
+
+
+Arends, et al.              Standards Track                    [Page 14]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   A security-aware resolver sends queries to the parent zone when
+   looking for a needed DS RR at a delegation point (see Section 4.2).
+   However, special rules are necessary to avoid confusing
+   security-oblivious resolvers which might become involved in
+   processing such a query (for example, in a network configuration that
+   forces a security-aware resolver to channel its queries through a
+   security-oblivious recursive name server).  The rest of this section
+   describes how a security-aware name server processes DS queries in
+   order to avoid this problem.
+
+   The need for special processing by a security-aware name server only
+   arises when all the following conditions are met:
+
+   o  The name server has received a query for the DS RRset at a zone
+      cut.
+
+   o  The name server is authoritative for the child zone.
+
+   o  The name server is not authoritative for the parent zone.
+
+   o  The name server does not offer recursion.
+
+   In all other cases, the name server either has some way of obtaining
+   the DS RRset or could not have been expected to have the DS RRset
+   even by the pre-DNSSEC processing rules, so the name server can
+   return either the DS RRset or an error response according to the
+   normal processing rules.
+
+   If all the above conditions are met, however, the name server is
+   authoritative for SNAME but cannot supply the requested RRset.  In
+   this case, the name server MUST return an authoritative "no data"
+   response showing that the DS RRset does not exist in the child zone's
+   apex.  See Appendix B.8 for an example of such a response.
+
+3.1.5.  Responding to Queries for Type AXFR or IXFR
+
+   DNSSEC does not change the DNS zone transfer process.  A signed zone
+   will contain RRSIG, DNSKEY, NSEC, and DS resource records, but these
+   records have no special meaning with respect to a zone transfer
+   operation.
+
+   An authoritative name server is not required to verify that a zone is
+   properly signed before sending or accepting a zone transfer.
+   However, an authoritative name server MAY choose to reject the entire
+   zone transfer if the zone fails to meet any of the signing
+   requirements described in Section 2.  The primary objective of a zone
+   transfer is to ensure that all authoritative name servers have
+   identical copies of the zone.  An authoritative name server that
+
+
+
+Arends, et al.              Standards Track                    [Page 15]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   chooses to perform its own zone validation MUST NOT selectively
+   reject some RRs and accept others.
+
+   DS RRsets appear only on the parental side of a zone cut and are
+   authoritative data in the parent zone.  As with any other
+   authoritative RRset, the DS RRset MUST be included in zone transfers
+   of the zone in which the RRset is authoritative data.  In the case of
+   the DS RRset, this is the parent zone.
+
+   NSEC RRs appear in both the parent and child zones at a zone cut and
+   are authoritative data in both the parent and child zones.  The
+   parental and child NSEC RRs at a zone cut are never identical to each
+   other, as the NSEC RR in the child zone's apex will always indicate
+   the presence of the child zone's SOA RR whereas the parental NSEC RR
+   at the zone cut will never indicate the presence of an SOA RR.  As
+   with any other authoritative RRs, NSEC RRs MUST be included in zone
+   transfers of the zone in which they are authoritative data.  The
+   parental NSEC RR at a zone cut MUST be included in zone transfers of
+   the parent zone, and the NSEC at the zone apex of the child zone MUST
+   be included in zone transfers of the child zone.
+
+   RRSIG RRs appear in both the parent and child zones at a zone cut and
+   are authoritative in whichever zone contains the authoritative RRset
+   for which the RRSIG RR provides the signature.  That is, the RRSIG RR
+   for a DS RRset or a parental NSEC RR at a zone cut will be
+   authoritative in the parent zone, and the RRSIG for any RRset in the
+   child zone's apex will be authoritative in the child zone.  Parental
+   and child RRSIG RRs at a zone cut will never be identical to each
+   other, as the Signer's Name field of an RRSIG RR in the child zone's
+   apex will indicate a DNSKEY RR in the child zone's apex whereas the
+   same field of a parental RRSIG RR at the zone cut will indicate a
+   DNSKEY RR in the parent zone's apex.  As with any other authoritative
+   RRs, RRSIG RRs MUST be included in zone transfers of the zone in
+   which they are authoritative data.
+
+3.1.6.  The AD and CD Bits in an Authoritative Response
+
+   The CD and AD bits are designed for use in communication between
+   security-aware resolvers and security-aware recursive name servers.
+   These bits are for the most part not relevant to query processing by
+   security-aware authoritative name servers.
+
+   A security-aware name server does not perform signature validation
+   for authoritative data during query processing, even when the CD bit
+   is clear.  A security-aware name server SHOULD clear the CD bit when
+   composing an authoritative response.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 16]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   A security-aware name server MUST NOT set the AD bit in a response
+   unless the name server considers all RRsets in the Answer and
+   Authority sections of the response to be authentic.  A security-aware
+   name server's local policy MAY consider data from an authoritative
+   zone to be authentic without further validation.  However, the name
+   server MUST NOT do so unless the name server obtained the
+   authoritative zone via secure means (such as a secure zone transfer
+   mechanism) and MUST NOT do so unless this behavior has been
+   configured explicitly.
+
+   A security-aware name server that supports recursion MUST follow the
+   rules for the CD and AD bits given in Section 3.2 when generating a
+   response that involves data obtained via recursion.
+
+3.2.  Recursive Name Servers
+
+   As explained in [RFC4033], a security-aware recursive name server is
+   an entity that acts in both the security-aware name server and
+   security-aware resolver roles.  This section uses the terms "name
+   server side" and "resolver side" to refer to the code within a
+   security-aware recursive name server that implements the
+   security-aware name server role and the code that implements the
+   security-aware resolver role, respectively.
+
+   The resolver side follows the usual rules for caching and negative
+   caching that would apply to any security-aware resolver.
+
+3.2.1.  The DO Bit
+
+   The resolver side of a security-aware recursive name server MUST set
+   the DO bit when sending requests, regardless of the state of the DO
+   bit in the initiating request received by the name server side.  If
+   the DO bit in an initiating query is not set, the name server side
+   MUST strip any authenticating DNSSEC RRs from the response but MUST
+   NOT strip any DNSSEC RR types that the initiating query explicitly
+   requested.
+
+3.2.2.  The CD Bit
+
+   The CD bit exists in order to allow a security-aware resolver to
+   disable signature validation in a security-aware name server's
+   processing of a particular query.
+
+   The name server side MUST copy the setting of the CD bit from a query
+   to the corresponding response.
+
+   The name server side of a security-aware recursive name server MUST
+   pass the state of the CD bit to the resolver side along with the rest
+
+
+
+Arends, et al.              Standards Track                    [Page 17]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   of an initiating query, so that the resolver side will know whether
+   it is required to verify the response data it returns to the name
+   server side.  If the CD bit is set, it indicates that the originating
+   resolver is willing to perform whatever authentication its local
+   policy requires.  Thus, the resolver side of the recursive name
+   server need not perform authentication on the RRsets in the response.
+   When the CD bit is set, the recursive name server SHOULD, if
+   possible, return the requested data to the originating resolver, even
+   if the recursive name server's local authentication policy would
+   reject the records in question.  That is, by setting the CD bit, the
+   originating resolver has indicated that it takes responsibility for
+   performing its own authentication, and the recursive name server
+   should not interfere.
+
+   If the resolver side implements a BAD cache (see Section 4.7) and the
+   name server side receives a query that matches an entry in the
+   resolver side's BAD cache, the name server side's response depends on
+   the state of the CD bit in the original query.  If the CD bit is set,
+   the name server side SHOULD return the data from the BAD cache; if
+   the CD bit is not set, the name server side MUST return RCODE 2
+   (server failure).
+
+   The intent of the above rule is to provide the raw data to clients
+   that are capable of performing their own signature verification
+   checks while protecting clients that depend on the resolver side of a
+   security-aware recursive name server to perform such checks.  Several
+   of the possible reasons why signature validation might fail involve
+   conditions that may not apply equally to the recursive name server
+   and the client that invoked it.  For example, the recursive name
+   server's clock may be set incorrectly, or the client may have
+   knowledge of a relevant island of security that the recursive name
+   server does not share.  In such cases, "protecting" a client that is
+   capable of performing its own signature validation from ever seeing
+   the "bad" data does not help the client.
+
+3.2.3.  The AD Bit
+
+   The name server side of a security-aware recursive name server MUST
+   NOT set the AD bit in a response unless the name server considers all
+   RRsets in the Answer and Authority sections of the response to be
+   authentic.  The name server side SHOULD set the AD bit if and only if
+   the resolver side considers all RRsets in the Answer section and any
+   relevant negative response RRs in the Authority section to be
+   authentic.  The resolver side MUST follow the procedure described in
+   Section 5 to determine whether the RRs in question are authentic.
+   However, for backward compatibility, a recursive name server MAY set
+   the AD bit when a response includes unsigned CNAME RRs if those CNAME
+
+
+
+
+Arends, et al.              Standards Track                    [Page 18]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   RRs demonstrably could have been synthesized from an authentic DNAME
+   RR that is also included in the response according to the synthesis
+   rules described in [RFC2672].
+
+3.3.  Example DNSSEC Responses
+
+   See Appendix B for example response packets.
+
+4.  Resolving
+
+   This section describes the behavior of entities that include
+   security-aware resolver functions.  In many cases such functions will
+   be part of a security-aware recursive name server, but a stand-alone
+   security-aware resolver has many of the same requirements.  Functions
+   specific to security-aware recursive name servers are described in
+   Section 3.2.
+
+4.1.  EDNS Support
+
+   A security-aware resolver MUST include an EDNS ([RFC2671]) OPT
+   pseudo-RR with the DO ([RFC3225]) bit set when sending queries.
+
+   A security-aware resolver MUST support a message size of at least
+   1220 octets, SHOULD support a message size of 4000 octets, and MUST
+   use the "sender's UDP payload size" field in the EDNS OPT pseudo-RR
+   to advertise the message size that it is willing to accept.  A
+   security-aware resolver's IP layer MUST handle fragmented UDP packets
+   correctly regardless of whether any such fragmented packets were
+   received via IPv4 or IPv6.  Please see [RFC1122], [RFC2460], and
+   [RFC3226] for discussion of these requirements.
+
+4.2.  Signature Verification Support
+
+   A security-aware resolver MUST support the signature verification
+   mechanisms described in Section 5 and SHOULD apply them to every
+   received response, except when:
+
+   o  the security-aware resolver is part of a security-aware recursive
+      name server, and the response is the result of recursion on behalf
+      of a query received with the CD bit set;
+
+   o  the response is the result of a query generated directly via some
+      form of application interface that instructed the security-aware
+      resolver not to perform validation for this query; or
+
+   o  validation for this query has been disabled by local policy.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 19]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   A security-aware resolver's support for signature verification MUST
+   include support for verification of wildcard owner names.
+
+   Security-aware resolvers MAY query for missing security RRs in an
+   attempt to perform validation; implementations that choose to do so
+   must be aware that the answers received may not be sufficient to
+   validate the original response.  For example, a zone update may have
+   changed (or deleted) the desired information between the original and
+   follow-up queries.
+
+   When attempting to retrieve missing NSEC RRs that reside on the
+   parental side at a zone cut, a security-aware iterative-mode resolver
+   MUST query the name servers for the parent zone, not the child zone.
+
+   When attempting to retrieve a missing DS, a security-aware
+   iterative-mode resolver MUST query the name servers for the parent
+   zone, not the child zone.  As explained in Section 3.1.4.1,
+   security-aware name servers need to apply special processing rules to
+   handle the DS RR, and in some situations the resolver may also need
+   to apply special rules to locate the name servers for the parent zone
+   if the resolver does not already have the parent's NS RRset.  To
+   locate the parent NS RRset, the resolver can start with the
+   delegation name, strip off the leftmost label, and query for an NS
+   RRset by that name.  If no NS RRset is present at that name, the
+   resolver then strips off the leftmost remaining label and retries the
+   query for that name, repeating this process of walking up the tree
+   until it either finds the NS RRset or runs out of labels.
+
+4.3.  Determining Security Status of Data
+
+   A security-aware resolver MUST be able to determine whether it should
+   expect a particular RRset to be signed.  More precisely, a
+   security-aware resolver must be able to distinguish between four
+   cases:
+
+   Secure: An RRset for which the resolver is able to build a chain of
+      signed DNSKEY and DS RRs from a trusted security anchor to the
+      RRset.  In this case, the RRset should be signed and is subject to
+      signature validation, as described above.
+
+   Insecure: An RRset for which the resolver knows that it has no chain
+      of signed DNSKEY and DS RRs from any trusted starting point to the
+      RRset.  This can occur when the target RRset lies in an unsigned
+      zone or in a descendent of an unsigned zone.  In this case, the
+      RRset may or may not be signed, but the resolver will not be able
+      to verify the signature.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 20]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   Bogus: An RRset for which the resolver believes that it ought to be
+      able to establish a chain of trust but for which it is unable to
+      do so, either due to signatures that for some reason fail to
+      validate or due to missing data that the relevant DNSSEC RRs
+      indicate should be present.  This case may indicate an attack but
+      may also indicate a configuration error or some form of data
+      corruption.
+
+   Indeterminate: An RRset for which the resolver is not able to
+      determine whether the RRset should be signed, as the resolver is
+      not able to obtain the necessary DNSSEC RRs.  This can occur when
+      the security-aware resolver is not able to contact security-aware
+      name servers for the relevant zones.
+
+4.4.  Configured Trust Anchors
+
+   A security-aware resolver MUST be capable of being configured with at
+   least one trusted public key or DS RR and SHOULD be capable of being
+   configured with multiple trusted public keys or DS RRs.  Since a
+   security-aware resolver will not be able to validate signatures
+   without such a configured trust anchor, the resolver SHOULD have some
+   reasonably robust mechanism for obtaining such keys when it boots;
+   examples of such a mechanism would be some form of non-volatile
+   storage (such as a disk drive) or some form of trusted local network
+   configuration mechanism.
+
+   Note that trust anchors also cover key material that is updated in a
+   secure manner.  This secure manner could be through physical media, a
+   key exchange protocol, or some other out-of-band means.
+
+4.5.  Response Caching
+
+   A security-aware resolver SHOULD cache each response as a single
+   atomic entry containing the entire answer, including the named RRset
+   and any associated DNSSEC RRs.  The resolver SHOULD discard the
+   entire atomic entry when any of the RRs contained in it expire.  In
+   most cases the appropriate cache index for the atomic entry will be
+   the triple <QNAME, QTYPE, QCLASS>, but in cases such as the response
+   form described in Section 3.1.3.2 the appropriate cache index will be
+   the double <QNAME,QCLASS>.
+
+   The reason for these recommendations is that, between the initial
+   query and the expiration of the data from the cache, the
+   authoritative data might have been changed (for example, via dynamic
+   update).
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 21]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   There are two situations for which this is relevant:
+
+   1.  By using the RRSIG record, it is possible to deduce that an
+       answer was synthesized from a wildcard.  A security-aware
+       recursive name server could store this wildcard data and use it
+       to generate positive responses to queries other than the name for
+       which the original answer was first received.
+
+   2.  NSEC RRs received to prove the non-existence of a name could be
+       reused by a security-aware resolver to prove the non-existence of
+       any name in the name range it spans.
+
+   In theory, a resolver could use wildcards or NSEC RRs to generate
+   positive and negative responses (respectively) until the TTL or
+   signatures on the records in question expire.  However, it seems
+   prudent for resolvers to avoid blocking new authoritative data or
+   synthesizing new data on their own.  Resolvers that follow this
+   recommendation will have a more consistent view of the namespace.
+
+4.6.  Handling of the CD and AD Bits
+
+   A security-aware resolver MAY set a query's CD bit in order to
+   indicate that the resolver takes responsibility for performing
+   whatever authentication its local policy requires on the RRsets in
+   the response.  See Section 3.2 for the effect this bit has on the
+   behavior of security-aware recursive name servers.
+
+   A security-aware resolver MUST clear the AD bit when composing query
+   messages to protect against buggy name servers that blindly copy
+   header bits that they do not understand from the query message to the
+   response message.
+
+   A resolver MUST disregard the meaning of the CD and AD bits in a
+   response unless the response was obtained by using a secure channel
+   or the resolver was specifically configured to regard the message
+   header bits without using a secure channel.
+
+4.7.  Caching BAD Data
+
+   While many validation errors will be transient, some are likely to be
+   more persistent, such as those caused by administrative error
+   (failure to re-sign a zone, clock skew, and so forth).  Since
+   requerying will not help in these cases, validating resolvers might
+   generate a significant amount of unnecessary DNS traffic as a result
+   of repeated queries for RRsets with persistent validation failures.
+
+   To prevent such unnecessary DNS traffic, security-aware resolvers MAY
+   cache data with invalid signatures, with some restrictions.
+
+
+
+Arends, et al.              Standards Track                    [Page 22]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   Conceptually, caching such data is similar to negative caching
+   ([RFC2308]), except that instead of caching a valid negative
+   response, the resolver is caching the fact that a particular answer
+   failed to validate.  This document refers to a cache of data with
+   invalid signatures as a "BAD cache".
+
+   Resolvers that implement a BAD cache MUST take steps to prevent the
+   cache from being useful as a denial-of-service attack amplifier,
+   particularly the following:
+
+   o  Since RRsets that fail to validate do not have trustworthy TTLs,
+      the implementation MUST assign a TTL.  This TTL SHOULD be small,
+      in order to mitigate the effect of caching the results of an
+      attack.
+
+   o  In order to prevent caching of a transient validation failure
+      (which might be the result of an attack), resolvers SHOULD track
+      queries that result in validation failures and SHOULD only answer
+      from the BAD cache after the number of times that responses to
+      queries for that particular <QNAME, QTYPE, QCLASS> have failed to
+      validate exceeds a threshold value.
+
+   Resolvers MUST NOT return RRsets from the BAD cache unless the
+   resolver is not required to validate the signatures of the RRsets in
+   question under the rules given in Section 4.2 of this document.  See
+   Section 3.2.2 for discussion of how the responses returned by a
+   security-aware recursive name server interact with a BAD cache.
+
+4.8.  Synthesized CNAMEs
+
+   A validating security-aware resolver MUST treat the signature of a
+   valid signed DNAME RR as also covering unsigned CNAME RRs that could
+   have been synthesized from the DNAME RR, as described in [RFC2672],
+   at least to the extent of not rejecting a response message solely
+   because it contains such CNAME RRs.  The resolver MAY retain such
+   CNAME RRs in its cache or in the answers it hands back, but is not
+   required to do so.
+
+4.9.  Stub Resolvers
+
+   A security-aware stub resolver MUST support the DNSSEC RR types, at
+   least to the extent of not mishandling responses just because they
+   contain DNSSEC RRs.
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 23]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+4.9.1.  Handling of the DO Bit
+
+   A non-validating security-aware stub resolver MAY include the DNSSEC
+   RRs returned by a security-aware recursive name server as part of the
+   data that the stub resolver hands back to the application that
+   invoked it, but is not required to do so.  A non-validating stub
+   resolver that seeks to do this will need to set the DO bit in order
+   to receive DNSSEC RRs from the recursive name server.
+
+   A validating security-aware stub resolver MUST set the DO bit,
+   because otherwise it will not receive the DNSSEC RRs it needs to
+   perform signature validation.
+
+4.9.2.  Handling of the CD Bit
+
+   A non-validating security-aware stub resolver SHOULD NOT set the CD
+   bit when sending queries unless it is requested by the application
+   layer, as by definition, a non-validating stub resolver depends on
+   the security-aware recursive name server to perform validation on its
+   behalf.
+
+   A validating security-aware stub resolver SHOULD set the CD bit,
+   because otherwise the security-aware recursive name server will
+   answer the query using the name server's local policy, which may
+   prevent the stub resolver from receiving data that would be
+   acceptable to the stub resolver's local policy.
+
+4.9.3.  Handling of the AD Bit
+
+   A non-validating security-aware stub resolver MAY chose to examine
+   the setting of the AD bit in response messages that it receives in
+   order to determine whether the security-aware recursive name server
+   that sent the response claims to have cryptographically verified the
+   data in the Answer and Authority sections of the response message.
+   Note, however, that the responses received by a security-aware stub
+   resolver are heavily dependent on the local policy of the
+   security-aware recursive name server.  Therefore, there may be little
+   practical value in checking the status of the AD bit, except perhaps
+   as a debugging aid.  In any case, a security-aware stub resolver MUST
+   NOT place any reliance on signature validation allegedly performed on
+   its behalf, except when the security-aware stub resolver obtained the
+   data in question from a trusted security-aware recursive name server
+   via a secure channel.
+
+   A validating security-aware stub resolver SHOULD NOT examine the
+   setting of the AD bit in response messages, as, by definition, the
+   stub resolver performs its own signature validation regardless of the
+   setting of the AD bit.
+
+
+
+Arends, et al.              Standards Track                    [Page 24]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+5.  Authenticating DNS Responses
+
+   To use DNSSEC RRs for authentication, a security-aware resolver
+   requires configured knowledge of at least one authenticated DNSKEY or
+   DS RR.  The process for obtaining and authenticating this initial
+   trust anchor is achieved via some external mechanism.  For example, a
+   resolver could use some off-line authenticated exchange to obtain a
+   zone's DNSKEY RR or to obtain a DS RR that identifies and
+   authenticates a zone's DNSKEY RR.  The remainder of this section
+   assumes that the resolver has somehow obtained an initial set of
+   trust anchors.
+
+   An initial DNSKEY RR can be used to authenticate a zone's apex DNSKEY
+   RRset.  To authenticate an apex DNSKEY RRset by using an initial key,
+   the resolver MUST:
+
+   1.  verify that the initial DNSKEY RR appears in the apex DNSKEY
+       RRset, and that the DNSKEY RR has the Zone Key Flag (DNSKEY RDATA
+       bit 7) set; and
+
+   2.  verify that there is some RRSIG RR that covers the apex DNSKEY
+       RRset, and that the combination of the RRSIG RR and the initial
+       DNSKEY RR authenticates the DNSKEY RRset.  The process for using
+       an RRSIG RR to authenticate an RRset is described in Section 5.3.
+
+   Once the resolver has authenticated the apex DNSKEY RRset by using an
+   initial DNSKEY RR, delegations from that zone can be authenticated by
+   using DS RRs.  This allows a resolver to start from an initial key
+   and use DS RRsets to proceed recursively down the DNS tree, obtaining
+   other apex DNSKEY RRsets.  If the resolver were configured with a
+   root DNSKEY RR, and if every delegation had a DS RR associated with
+   it, then the resolver could obtain and validate any apex DNSKEY
+   RRset.  The process of using DS RRs to authenticate referrals is
+   described in Section 5.2.
+
+   Section 5.3 shows how the resolver can use DNSKEY RRs in the apex
+   DNSKEY RRset and RRSIG RRs from the zone to authenticate any other
+   RRsets in the zone once the resolver has authenticated a zone's apex
+   DNSKEY RRset.  Section 5.4 shows how the resolver can use
+   authenticated NSEC RRsets from the zone to prove that an RRset is not
+   present in the zone.
+
+   When a resolver indicates support for DNSSEC (by setting the DO bit),
+   a security-aware name server should attempt to provide the necessary
+   DNSKEY, RRSIG, NSEC, and DS RRsets in a response (see Section 3).
+   However, a security-aware resolver may still receive a response that
+   lacks the appropriate DNSSEC RRs, whether due to configuration issues
+   such as an upstream security-oblivious recursive name server that
+
+
+
+Arends, et al.              Standards Track                    [Page 25]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   accidentally interferes with DNSSEC RRs or due to a deliberate attack
+   in which an adversary forges a response, strips DNSSEC RRs from a
+   response, or modifies a query so that DNSSEC RRs appear not to be
+   requested.  The absence of DNSSEC data in a response MUST NOT by
+   itself be taken as an indication that no authentication information
+   exists.
+
+   A resolver SHOULD expect authentication information from signed
+   zones.  A resolver SHOULD believe that a zone is signed if the
+   resolver has been configured with public key information for the
+   zone, or if the zone's parent is signed and the delegation from the
+   parent contains a DS RRset.
+
+5.1.  Special Considerations for Islands of Security
+
+   Islands of security (see [RFC4033]) are signed zones for which it is
+   not possible to construct an authentication chain to the zone from
+   its parent.  Validating signatures within an island of security
+   requires that the validator have some other means of obtaining an
+   initial authenticated zone key for the island.  If a validator cannot
+   obtain such a key, it SHOULD switch to operating as if the zones in
+   the island of security are unsigned.
+
+   All the normal processes for validating responses apply to islands of
+   security.  The only difference between normal validation and
+   validation within an island of security is in how the validator
+   obtains a trust anchor for the authentication chain.
+
+5.2.  Authenticating Referrals
+
+   Once the apex DNSKEY RRset for a signed parent zone has been
+   authenticated, DS RRsets can be used to authenticate the delegation
+   to a signed child zone.  A DS RR identifies a DNSKEY RR in the child
+   zone's apex DNSKEY RRset and contains a cryptographic digest of the
+   child zone's DNSKEY RR.  Use of a strong cryptographic digest
+   algorithm ensures that it is computationally infeasible for an
+   adversary to generate a DNSKEY RR that matches the digest.  Thus,
+   authenticating the digest allows a resolver to authenticate the
+   matching DNSKEY RR.  The resolver can then use this child DNSKEY RR
+   to authenticate the entire child apex DNSKEY RRset.
+
+   Given a DS RR for a delegation, the child zone's apex DNSKEY RRset
+   can be authenticated if all of the following hold:
+
+   o  The DS RR has been authenticated using some DNSKEY RR in the
+      parent's apex DNSKEY RRset (see Section 5.3).
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 26]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   o  The Algorithm and Key Tag in the DS RR match the Algorithm field
+      and the key tag of a DNSKEY RR in the child zone's apex DNSKEY
+      RRset, and, when the DNSKEY RR's owner name and RDATA are hashed
+      using the digest algorithm specified in the DS RR's Digest Type
+      field, the resulting digest value matches the Digest field of the
+      DS RR.
+
+   o  The matching DNSKEY RR in the child zone has the Zone Flag bit
+      set, the corresponding private key has signed the child zone's
+      apex DNSKEY RRset, and the resulting RRSIG RR authenticates the
+      child zone's apex DNSKEY RRset.
+
+   If the referral from the parent zone did not contain a DS RRset, the
+   response should have included a signed NSEC RRset proving that no DS
+   RRset exists for the delegated name (see Section 3.1.4).  A
+   security-aware resolver MUST query the name servers for the parent
+   zone for the DS RRset if the referral includes neither a DS RRset nor
+   a NSEC RRset proving that the DS RRset does not exist (see Section
+   4).
+
+   If the validator authenticates an NSEC RRset that proves that no DS
+   RRset is present for this zone, then there is no authentication path
+   leading from the parent to the child.  If the resolver has an initial
+   DNSKEY or DS RR that belongs to the child zone or to any delegation
+   below the child zone, this initial DNSKEY or DS RR MAY be used to
+   re-establish an authentication path.  If no such initial DNSKEY or DS
+   RR exists, the validator cannot authenticate RRsets in or below the
+   child zone.
+
+   If the validator does not support any of the algorithms listed in an
+   authenticated DS RRset, then the resolver has no supported
+   authentication path leading from the parent to the child.  The
+   resolver should treat this case as it would the case of an
+   authenticated NSEC RRset proving that no DS RRset exists, as
+   described above.
+
+   Note that, for a signed delegation, there are two NSEC RRs associated
+   with the delegated name.  One NSEC RR resides in the parent zone and
+   can be used to prove whether a DS RRset exists for the delegated
+   name.  The second NSEC RR resides in the child zone and identifies
+   which RRsets are present at the apex of the child zone.  The parent
+   NSEC RR and child NSEC RR can always be distinguished because the SOA
+   bit will be set in the child NSEC RR and clear in the parent NSEC RR.
+   A security-aware resolver MUST use the parent NSEC RR when attempting
+   to prove that a DS RRset does not exist.
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 27]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   If the resolver does not support any of the algorithms listed in an
+   authenticated DS RRset, then the resolver will not be able to verify
+   the authentication path to the child zone.  In this case, the
+   resolver SHOULD treat the child zone as if it were unsigned.
+
+5.3.  Authenticating an RRset with an RRSIG RR
+
+   A validator can use an RRSIG RR and its corresponding DNSKEY RR to
+   attempt to authenticate RRsets.  The validator first checks the RRSIG
+   RR to verify that it covers the RRset, has a valid time interval, and
+   identifies a valid DNSKEY RR.  The validator then constructs the
+   canonical form of the signed data by appending the RRSIG RDATA
+   (excluding the Signature Field) with the canonical form of the
+   covered RRset.  Finally, the validator uses the public key and
+   signature to authenticate the signed data.  Sections 5.3.1, 5.3.2,
+   and 5.3.3 describe each step in detail.
+
+5.3.1.  Checking the RRSIG RR Validity
+
+   A security-aware resolver can use an RRSIG RR to authenticate an
+   RRset if all of the following conditions hold:
+
+   o  The RRSIG RR and the RRset MUST have the same owner name and the
+      same class.
+
+   o  The RRSIG RR's Signer's Name field MUST be the name of the zone
+      that contains the RRset.
+
+   o  The RRSIG RR's Type Covered field MUST equal the RRset's type.
+
+   o  The number of labels in the RRset owner name MUST be greater than
+      or equal to the value in the RRSIG RR's Labels field.
+
+   o  The validator's notion of the current time MUST be less than or
+      equal to the time listed in the RRSIG RR's Expiration field.
+
+   o  The validator's notion of the current time MUST be greater than or
+      equal to the time listed in the RRSIG RR's Inception field.
+
+   o  The RRSIG RR's Signer's Name, Algorithm, and Key Tag fields MUST
+      match the owner name, algorithm, and key tag for some DNSKEY RR in
+      the zone's apex DNSKEY RRset.
+
+   o  The matching DNSKEY RR MUST be present in the zone's apex DNSKEY
+      RRset, and MUST have the Zone Flag bit (DNSKEY RDATA Flag bit 7)
+      set.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 28]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   It is possible for more than one DNSKEY RR to match the conditions
+   above.  In this case, the validator cannot predetermine which DNSKEY
+   RR to use to authenticate the signature, and it MUST try each
+   matching DNSKEY RR until either the signature is validated or the
+   validator has run out of matching public keys to try.
+
+   Note that this authentication process is only meaningful if the
+   validator authenticates the DNSKEY RR before using it to validate
+   signatures.  The matching DNSKEY RR is considered to be authentic if:
+
+   o  the apex DNSKEY RRset containing the DNSKEY RR is considered
+      authentic; or
+
+   o  the RRset covered by the RRSIG RR is the apex DNSKEY RRset itself,
+      and the DNSKEY RR either matches an authenticated DS RR from the
+      parent zone or matches a trust anchor.
+
+5.3.2.  Reconstructing the Signed Data
+
+   Once the RRSIG RR has met the validity requirements described in
+   Section 5.3.1, the validator has to reconstruct the original signed
+   data.  The original signed data includes RRSIG RDATA (excluding the
+   Signature field) and the canonical form of the RRset.  Aside from
+   being ordered, the canonical form of the RRset might also differ from
+   the received RRset due to DNS name compression, decremented TTLs, or
+   wildcard expansion.  The validator should use the following to
+   reconstruct the original signed data:
+
+         signed_data = RRSIG_RDATA | RR(1) | RR(2)...  where
+
+            "|" denotes concatenation
+
+            RRSIG_RDATA is the wire format of the RRSIG RDATA fields
+               with the Signature field excluded and the Signer's Name
+               in canonical form.
+
+            RR(i) = name | type | class | OrigTTL | RDATA length | RDATA
+
+               name is calculated according to the function below
+
+               class is the RRset's class
+
+               type is the RRset type and all RRs in the class
+
+               OrigTTL is the value from the RRSIG Original TTL field
+
+               All names in the RDATA field are in canonical form
+
+
+
+
+Arends, et al.              Standards Track                    [Page 29]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+               The set of all RR(i) is sorted into canonical order.
+
+            To calculate the name:
+               let rrsig_labels = the value of the RRSIG Labels field
+
+               let fqdn = RRset's fully qualified domain name in
+                               canonical form
+
+               let fqdn_labels = Label count of the fqdn above.
+
+               if rrsig_labels = fqdn_labels,
+                   name = fqdn
+
+               if rrsig_labels < fqdn_labels,
+                  name = "*." | the rightmost rrsig_label labels of the
+                                fqdn
+
+               if rrsig_labels > fqdn_labels
+                  the RRSIG RR did not pass the necessary validation
+                  checks and MUST NOT be used to authenticate this
+                  RRset.
+
+   The canonical forms for names and RRsets are defined in [RFC4034].
+
+   NSEC RRsets at a delegation boundary require special processing.
+   There are two distinct NSEC RRsets associated with a signed delegated
+   name.  One NSEC RRset resides in the parent zone, and specifies which
+   RRsets are present at the parent zone.  The second NSEC RRset resides
+   at the child zone and identifies which RRsets are present at the apex
+   in the child zone.  The parent NSEC RRset and child NSEC RRset can
+   always be distinguished as only a child NSEC RR will indicate that an
+   SOA RRset exists at the name.  When reconstructing the original NSEC
+   RRset for the delegation from the parent zone, the NSEC RRs MUST NOT
+   be combined with NSEC RRs from the child zone.  When reconstructing
+   the original NSEC RRset for the apex of the child zone, the NSEC RRs
+   MUST NOT be combined with NSEC RRs from the parent zone.
+
+   Note that each of the two NSEC RRsets at a delegation point has a
+   corresponding RRSIG RR with an owner name matching the delegated
+   name, and each of these RRSIG RRs is authoritative data associated
+   with the same zone that contains the corresponding NSEC RRset.  If
+   necessary, a resolver can tell these RRSIG RRs apart by checking the
+   Signer's Name field.
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 30]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+5.3.3.  Checking the Signature
+
+   Once the resolver has validated the RRSIG RR as described in Section
+   5.3.1 and reconstructed the original signed data as described in
+   Section 5.3.2, the validator can attempt to use the cryptographic
+   signature to authenticate the signed data, and thus (finally!)
+   authenticate the RRset.
+
+   The Algorithm field in the RRSIG RR identifies the cryptographic
+   algorithm used to generate the signature.  The signature itself is
+   contained in the Signature field of the RRSIG RDATA, and the public
+   key used to verify the signature is contained in the Public Key field
+   of the matching DNSKEY RR(s) (found in Section 5.3.1).  [RFC4034]
+   provides a list of algorithm types and provides pointers to the
+   documents that define each algorithm's use.
+
+   Note that it is possible for more than one DNSKEY RR to match the
+   conditions in Section 5.3.1.  In this case, the validator can only
+   determine which DNSKEY RR is correct by trying each matching public
+   key until the validator either succeeds in validating the signature
+   or runs out of keys to try.
+
+   If the Labels field of the RRSIG RR is not equal to the number of
+   labels in the RRset's fully qualified owner name, then the RRset is
+   either invalid or the result of wildcard expansion.  The resolver
+   MUST verify that wildcard expansion was applied properly before
+   considering the RRset to be authentic.  Section 5.3.4 describes how
+   to determine whether a wildcard was applied properly.
+
+   If other RRSIG RRs also cover this RRset, the local resolver security
+   policy determines whether the resolver also has to test these RRSIG
+   RRs and how to resolve conflicts if these RRSIG RRs lead to differing
+   results.
+
+   If the resolver accepts the RRset as authentic, the validator MUST
+   set the TTL of the RRSIG RR and each RR in the authenticated RRset to
+   a value no greater than the minimum of:
+
+   o  the RRset's TTL as received in the response;
+
+   o  the RRSIG RR's TTL as received in the response;
+
+   o  the value in the RRSIG RR's Original TTL field; and
+
+   o  the difference of the RRSIG RR's Signature Expiration time and the
+      current time.
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 31]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+5.3.4.  Authenticating a Wildcard Expanded RRset Positive Response
+
+   If the number of labels in an RRset's owner name is greater than the
+   Labels field of the covering RRSIG RR, then the RRset and its
+   covering RRSIG RR were created as a result of wildcard expansion.
+   Once the validator has verified the signature, as described in
+   Section 5.3, it must take additional steps to verify the non-
+   existence of an exact match or closer wildcard match for the query.
+   Section 5.4 discusses these steps.
+
+   Note that the response received by the resolver should include all
+   NSEC RRs needed to authenticate the response (see Section 3.1.3).
+
+5.4.  Authenticated Denial of Existence
+
+   A resolver can use authenticated NSEC RRs to prove that an RRset is
+   not present in a signed zone.  Security-aware name servers should
+   automatically include any necessary NSEC RRs for signed zones in
+   their responses to security-aware resolvers.
+
+   Denial of existence is determined by the following rules:
+
+   o  If the requested RR name matches the owner name of an
+      authenticated NSEC RR, then the NSEC RR's type bit map field lists
+      all RR types present at that owner name, and a resolver can prove
+      that the requested RR type does not exist by checking for the RR
+      type in the bit map.  If the number of labels in an authenticated
+      NSEC RR's owner name equals the Labels field of the covering RRSIG
+      RR, then the existence of the NSEC RR proves that wildcard
+      expansion could not have been used to match the request.
+
+   o  If the requested RR name would appear after an authenticated NSEC
+      RR's owner name and before the name listed in that NSEC RR's Next
+      Domain Name field according to the canonical DNS name order
+      defined in [RFC4034], then no RRsets with the requested name exist
+      in the zone.  However, it is possible that a wildcard could be
+      used to match the requested RR owner name and type, so proving
+      that the requested RRset does not exist also requires proving that
+      no possible wildcard RRset exists that could have been used to
+      generate a positive response.
+
+   In addition, security-aware resolvers MUST authenticate the NSEC
+   RRsets that comprise the non-existence proof as described in Section
+   5.3.
+
+   To prove the non-existence of an RRset, the resolver must be able to
+   verify both that the queried RRset does not exist and that no
+   relevant wildcard RRset exists.  Proving this may require more than
+
+
+
+Arends, et al.              Standards Track                    [Page 32]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   one NSEC RRset from the zone.  If the complete set of necessary NSEC
+   RRsets is not present in a response (perhaps due to message
+   truncation), then a security-aware resolver MUST resend the query in
+   order to attempt to obtain the full collection of NSEC RRs necessary
+   to verify the non-existence of the requested RRset.  As with all DNS
+   operations, however, the resolver MUST bound the work it puts into
+   answering any particular query.
+
+   Since a validated NSEC RR proves the existence of both itself and its
+   corresponding RRSIG RR, a validator MUST ignore the settings of the
+   NSEC and RRSIG bits in an NSEC RR.
+
+5.5.  Resolver Behavior When Signatures Do Not Validate
+
+   If for whatever reason none of the RRSIGs can be validated, the
+   response SHOULD be considered BAD.  If the validation was being done
+   to service a recursive query, the name server MUST return RCODE 2 to
+   the originating client.  However, it MUST return the full response if
+   and only if the original query had the CD bit set.  Also see Section
+   4.7 on caching responses that do not validate.
+
+5.6.  Authentication Example
+
+   Appendix C shows an example of the authentication process.
+
+6.  IANA Considerations
+
+   [RFC4034] contains a review of the IANA considerations introduced by
+   DNSSEC.  The following are additional IANA considerations discussed
+   in this document:
+
+   [RFC2535] reserved the CD and AD bits in the message header.  The
+   meaning of the AD bit was redefined in [RFC3655], and the meaning of
+   both the CD and AD bit are restated in this document.  No new bits in
+   the DNS message header are defined in this document.
+
+   [RFC2671] introduced EDNS, and [RFC3225] reserved the DNSSEC OK bit
+   and defined its use.  The use is restated but not altered in this
+   document.
+
+7.  Security Considerations
+
+   This document describes how the DNS security extensions use public
+   key cryptography to sign and authenticate DNS resource record sets.
+   Please see [RFC4033] for terminology and general security
+   considerations related to DNSSEC; see [RFC4034] for considerations
+   specific to the DNSSEC resource record types.
+
+
+
+
+Arends, et al.              Standards Track                    [Page 33]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   An active attacker who can set the CD bit in a DNS query message or
+   the AD bit in a DNS response message can use these bits to defeat the
+   protection that DNSSEC attempts to provide to security-oblivious
+   recursive-mode resolvers.  For this reason, use of these control bits
+   by a security-aware recursive-mode resolver requires a secure
+   channel.  See Sections 3.2.2 and 4.9 for further discussion.
+
+   The protocol described in this document attempts to extend the
+   benefits of DNSSEC to security-oblivious stub resolvers.  However, as
+   recovery from validation failures is likely to be specific to
+   particular applications, the facilities that DNSSEC provides for stub
+   resolvers may prove inadequate.  Operators of security-aware
+   recursive name servers will have to pay close attention to the
+   behavior of the applications that use their services when choosing a
+   local validation policy; failure to do so could easily result in the
+   recursive name server accidentally denying service to the clients it
+   is intended to support.
+
+8.  Acknowledgements
+
+   This document was created from the input and ideas of the members of
+   the DNS Extensions Working Group and working group mailing list.  The
+   editors would like to express their thanks for the comments and
+   suggestions received during the revision of these security extension
+   specifications.  Although explicitly listing everyone who has
+   contributed during the decade in which DNSSEC has been under
+   development would be impossible, [RFC4033] includes a list of some of
+   the participants who were kind enough to comment on these documents.
+
+9.  References
+
+9.1.  Normative References
+
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, November 1987.
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, November 1987.
+
+   [RFC1122]  Braden, R., "Requirements for Internet Hosts -
+              Communication Layers", STD 3, RFC 1122, October 1989.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2181]  Elz, R. and R. Bush, "Clarifications to the DNS
+              Specification", RFC 2181, July 1997.
+
+
+
+
+Arends, et al.              Standards Track                    [Page 34]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   [RFC2460]  Deering, S. and R. Hinden, "Internet Protocol, Version 6
+              (IPv6) Specification", RFC 2460, December 1998.
+
+   [RFC2671]  Vixie, P., "Extension Mechanisms for DNS (EDNS0)", RFC
+              2671, August 1999.
+
+   [RFC2672]  Crawford, M., "Non-Terminal DNS Name Redirection", RFC
+              2672, August 1999.
+
+   [RFC3225]  Conrad, D., "Indicating Resolver Support of DNSSEC", RFC
+              3225, December 2001.
+
+   [RFC3226]  Gudmundsson, O., "DNSSEC and IPv6 A6 aware server/resolver
+              message size requirements", RFC 3226, December 2001.
+
+   [RFC4033]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "DNS Security Introduction and Requirements", RFC
+              4033, March 2005.
+
+   [RFC4034]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Resource Records for DNS Security Extensions", RFC
+              4034, March 2005.
+
+9.2.  Informative References
+
+   [RFC2308]  Andrews, M., "Negative Caching of DNS Queries (DNS
+              NCACHE)", RFC 2308, March 1998.
+
+   [RFC2535]  Eastlake 3rd, D., "Domain Name System Security
+              Extensions", RFC 2535, March 1999.
+
+   [RFC3007]  Wellington, B., "Secure Domain Name System (DNS) Dynamic
+              Update", RFC 3007, November 2000.
+
+   [RFC3655]  Wellington, B. and O. Gudmundsson, "Redefinition of DNS
+              Authenticated Data (AD) bit", RFC 3655, November 2003.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 35]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+Appendix A.  Signed Zone Example
+
+   The following example shows a (small) complete signed zone.
+
+   example.       3600 IN SOA ns1.example. bugs.x.w.example. (
+                              1081539377
+                              3600
+                              300
+                              3600000
+                              3600
+                              )
+                  3600 RRSIG  SOA 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              ONx0k36rcjaxYtcNgq6iQnpNV5+drqYAsC9h
+                              7TSJaHCqbhE67Sr6aH2xDUGcqQWu/n0UVzrF
+                              vkgO9ebarZ0GWDKcuwlM6eNB5SiX2K74l5LW
+                              DA7S/Un/IbtDq4Ay8NMNLQI7Dw7n4p8/rjkB
+                              jV7j86HyQgM5e7+miRAz8V01b0I= )
+                  3600 NS     ns1.example.
+                  3600 NS     ns2.example.
+                  3600 RRSIG  NS 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              gl13F00f2U0R+SWiXXLHwsMY+qStYy5k6zfd
+                              EuivWc+wd1fmbNCyql0Tk7lHTX6UOxc8AgNf
+                              4ISFve8XqF4q+o9qlnqIzmppU3LiNeKT4FZ8
+                              RO5urFOvoMRTbQxW3U0hXWuggE4g3ZpsHv48
+                              0HjMeRaZB/FRPGfJPajngcq6Kwg= )
+                  3600 MX     1 xx.example.
+                  3600 RRSIG  MX 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              HyDHYVT5KHSZ7HtO/vypumPmSZQrcOP3tzWB
+                              2qaKkHVPfau/DgLgS/IKENkYOGL95G4N+NzE
+                              VyNU8dcTOckT+ChPcGeVjguQ7a3Ao9Z/ZkUO
+                              6gmmUW4b89rz1PUxW4jzUxj66PTwoVtUU/iM
+                              W6OISukd1EQt7a0kygkg+PEDxdI= )
+                  3600 NSEC   a.example. NS SOA MX RRSIG NSEC DNSKEY
+                  3600 RRSIG  NSEC 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              O0k558jHhyrC97ISHnislm4kLMW48C7U7cBm
+                              FTfhke5iVqNRVTB1STLMpgpbDIC9hcryoO0V
+                              Z9ME5xPzUEhbvGnHd5sfzgFVeGxr5Nyyq4tW
+                              SDBgIBiLQUv1ivy29vhXy7WgR62dPrZ0PWvm
+                              jfFJ5arXf4nPxp/kEowGgBRzY/U= )
+                  3600 DNSKEY 256 3 5 (
+                              AQOy1bZVvpPqhg4j7EJoM9rI3ZmyEx2OzDBV
+                              rZy/lvI5CQePxXHZS4i8dANH4DX3tbHol61e
+                              k8EFMcsGXxKciJFHyhl94C+NwILQdzsUlSFo
+                              vBZsyl/NX6yEbtw/xN9ZNcrbYvgjjZ/UVPZI
+
+
+
+Arends, et al.              Standards Track                    [Page 36]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              ySFNsgEYvh0z2542lzMKR4Dh8uZffQ==
+                              )
+                  3600 DNSKEY 257 3 5 (
+                              AQOeX7+baTmvpVHb2CcLnL1dMRWbuscRvHXl
+                              LnXwDzvqp4tZVKp1sZMepFb8MvxhhW3y/0QZ
+                              syCjczGJ1qk8vJe52iOhInKROVLRwxGpMfzP
+                              RLMlGybr51bOV/1se0ODacj3DomyB4QB5gKT
+                              Yot/K9alk5/j8vfd4jWCWD+E1Sze0Q==
+                              )
+                  3600 RRSIG  DNSKEY 5 1 3600 20040509183619 (
+                              20040409183619 9465 example.
+                              ZxgauAuIj+k1YoVEOSlZfx41fcmKzTFHoweZ
+                              xYnz99JVQZJ33wFS0Q0jcP7VXKkaElXk9nYJ
+                              XevO/7nAbo88iWsMkSpSR6jWzYYKwfrBI/L9
+                              hjYmyVO9m6FjQ7uwM4dCP/bIuV/DKqOAK9NY
+                              NC3AHfvCV1Tp4VKDqxqG7R5tTVM= )
+                  3600 RRSIG  DNSKEY 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              eGL0s90glUqcOmloo/2y+bSzyEfKVOQViD9Z
+                              DNhLz/Yn9CQZlDVRJffACQDAUhXpU/oP34ri
+                              bKBpysRXosczFrKqS5Oa0bzMOfXCXup9qHAp
+                              eFIku28Vqfr8Nt7cigZLxjK+u0Ws/4lIRjKk
+                              7z5OXogYVaFzHKillDt3HRxHIZM= )
+   a.example.     3600 IN NS  ns1.a.example.
+                  3600 IN NS  ns2.a.example.
+                  3600 DS     57855 5 1 (
+                              B6DCD485719ADCA18E5F3D48A2331627FDD3
+                              636B )
+                  3600 RRSIG  DS 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              oXIKit/QtdG64J/CB+Gi8dOvnwRvqrto1AdQ
+                              oRkAN15FP3iZ7suB7gvTBmXzCjL7XUgQVcoH
+                              kdhyCuzp8W9qJHgRUSwKKkczSyuL64nhgjuD
+                              EML8l9wlWVsl7PR2VnZduM9bLyBhaaPmRKX/
+                              Fm+v6ccF2EGNLRiY08kdkz+XHHo= )
+                  3600 NSEC   ai.example. NS DS RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              cOlYgqJLqlRqmBQ3iap2SyIsK4O5aqpKSoba
+                              U9fQ5SMApZmHfq3AgLflkrkXRXvgxTQSKkG2
+                              039/cRUs6Jk/25+fi7Xr5nOVJsb0lq4zsB3I
+                              BBdjyGDAHE0F5ROJj87996vJupdm1fbH481g
+                              sdkOW6Zyqtz3Zos8N0BBkEx+2G4= )
+   ns1.a.example. 3600 IN A   192.0.2.5
+   ns2.a.example. 3600 IN A   192.0.2.6
+   ai.example.    3600 IN A   192.0.2.9
+                  3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+
+
+
+Arends, et al.              Standards Track                    [Page 37]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              pAOtzLP2MU0tDJUwHOKE5FPIIHmdYsCgTb5B
+                              ERGgpnJluA9ixOyf6xxVCgrEJW0WNZSsJicd
+                              hBHXfDmAGKUajUUlYSAH8tS4ZnrhyymIvk3u
+                              ArDu2wfT130e9UHnumaHHMpUTosKe22PblOy
+                              6zrTpg9FkS0XGVmYRvOTNYx2HvQ= )
+                  3600 HINFO  "KLH-10" "ITS"
+                  3600 RRSIG  HINFO 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              Iq/RGCbBdKzcYzlGE4ovbr5YcB+ezxbZ9W0l
+                              e/7WqyvhOO9J16HxhhL7VY/IKmTUY0GGdcfh
+                              ZEOCkf4lEykZF9NPok1/R/fWrtzNp8jobuY7
+                              AZEcZadp1WdDF3jc2/ndCa5XZhLKD3JzOsBw
+                              FvL8sqlS5QS6FY/ijFEDnI4RkZA= )
+                  3600 AAAA   2001:db8::f00:baa9
+                  3600 RRSIG  AAAA 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              nLcpFuXdT35AcE+EoafOUkl69KB+/e56XmFK
+                              kewXG2IadYLKAOBIoR5+VoQV3XgTcofTJNsh
+                              1rnF6Eav2zpZB3byI6yo2bwY8MNkr4A7cL9T
+                              cMmDwV/hWFKsbGBsj8xSCN/caEL2CWY/5XP2
+                              sZM6QjBBLmukH30+w1z3h8PUP2o= )
+                  3600 NSEC   b.example. A HINFO AAAA RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              QoshyPevLcJ/xcRpEtMft1uoIrcrieVcc9pG
+                              CScIn5Glnib40T6ayVOimXwdSTZ/8ISXGj4p
+                              P8Sh0PlA6olZQ84L453/BUqB8BpdOGky4hsN
+                              3AGcLEv1Gr0QMvirQaFcjzOECfnGyBm+wpFL
+                              AhS+JOVfDI/79QtyTI0SaDWcg8U= )
+   b.example.     3600 IN NS  ns1.b.example.
+                  3600 IN NS  ns2.b.example.
+                  3600 NSEC   ns1.example. NS RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              GNuxHn844wfmUhPzGWKJCPY5ttEX/RfjDoOx
+                              9ueK1PtYkOWKOOdiJ/PJKCYB3hYX+858dDWS
+                              xb2qnV/LSTCNVBnkm6owOpysY97MVj5VQEWs
+                              0lm9tFoqjcptQkmQKYPrwUnCSNwvvclSF1xZ
+                              vhRXgWT7OuFXldoCG6TfVFMs9xE= )
+   ns1.b.example. 3600 IN A   192.0.2.7
+   ns2.b.example. 3600 IN A   192.0.2.8
+   ns1.example.   3600 IN A   192.0.2.1
+                  3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              F1C9HVhIcs10cZU09G5yIVfKJy5yRQQ3qVet
+                              5pGhp82pzhAOMZ3K22JnmK4c+IjUeFp/to06
+                              im5FVpHtbFisdjyPq84bhTv8vrXt5AB1wNB+
+                              +iAqvIfdgW4sFNC6oADb1hK8QNauw9VePJhK
+
+
+
+Arends, et al.              Standards Track                    [Page 38]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              v/iVXSYC0b7mPSU+EOlknFpVECs= )
+                  3600 NSEC   ns2.example. A RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              I4hj+Kt6+8rCcHcUdolks2S+Wzri9h3fHas8
+                              1rGN/eILdJHN7JpV6lLGPIh/8fIBkfvdyWnB
+                              jjf1q3O7JgYO1UdI7FvBNWqaaEPJK3UkddBq
+                              ZIaLi8Qr2XHkjq38BeQsbp8X0+6h4ETWSGT8
+                              IZaIGBLryQWGLw6Y6X8dqhlnxJM= )
+   ns2.example.   3600 IN A   192.0.2.2
+                  3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              V7cQRw1TR+knlaL1z/psxlS1PcD37JJDaCMq
+                              Qo6/u1qFQu6x+wuDHRH22Ap9ulJPQjFwMKOu
+                              yfPGQPC8KzGdE3vt5snFEAoE1Vn3mQqtu7SO
+                              6amIjk13Kj/jyJ4nGmdRIc/3cM3ipXFhNTKq
+                              rdhx8SZ0yy4ObIRzIzvBFLiSS8o= )
+                  3600 NSEC   *.w.example. A RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              N0QzHvaJf5NRw1rE9uxS1Ltb2LZ73Qb9bKGE
+                              VyaISkqzGpP3jYJXZJPVTq4UVEsgT3CgeHvb
+                              3QbeJ5Dfb2V9NGCHj/OvF/LBxFFWwhLwzngH
+                              l+bQAgAcMsLu/nL3nDi1y/JSQjAcdZNDl4bw
+                              Ymx28EtgIpo9A0qmP08rMBqs1Jw= )
+   *.w.example.   3600 IN MX  1 ai.example.
+                  3600 RRSIG  MX 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              OMK8rAZlepfzLWW75Dxd63jy2wswESzxDKG2
+                              f9AMN1CytCd10cYISAxfAdvXSZ7xujKAtPbc
+                              tvOQ2ofO7AZJ+d01EeeQTVBPq4/6KCWhqe2X
+                              TjnkVLNvvhnc0u28aoSsG0+4InvkkOHknKxw
+                              4kX18MMR34i8lC36SR5xBni8vHI= )
+                  3600 NSEC   x.w.example. MX RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              r/mZnRC3I/VIcrelgIcteSxDhtsdlTDt8ng9
+                              HSBlABOlzLxQtfgTnn8f+aOwJIAFe1Ee5RvU
+                              5cVhQJNP5XpXMJHfyps8tVvfxSAXfahpYqtx
+                              91gsmcV/1V9/bZAG55CefP9cM4Z9Y9NT9XQ8
+                              s1InQ2UoIv6tJEaaKkP701j8OLA= )
+   x.w.example.   3600 IN MX  1 xx.example.
+                  3600 RRSIG  MX 5 3 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              Il2WTZ+Bkv+OytBx4LItNW5mjB4RCwhOO8y1
+                              XzPHZmZUTVYL7LaA63f6T9ysVBzJRI3KRjAP
+                              H3U1qaYnDoN1DrWqmi9RJe4FoObkbcdm7P3I
+                              kx70ePCoFgRz1Yq+bVVXCvGuAU4xALv3W/Y1
+
+
+
+Arends, et al.              Standards Track                    [Page 39]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              jNSlwZ2mSWKHfxFQxPtLj8s32+k= )
+                  3600 NSEC   x.y.w.example. MX RRSIG NSEC
+                  3600 RRSIG  NSEC 5 3 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              aRbpHftxggzgMXdDlym9SsADqMZovZZl2QWK
+                              vw8J0tZEUNQByH5Qfnf5N1FqH/pS46UA7A4E
+                              mcWBN9PUA1pdPY6RVeaRlZlCr1IkVctvbtaI
+                              NJuBba/VHm+pebTbKcAPIvL9tBOoh+to1h6e
+                              IjgiM8PXkBQtxPq37wDKALkyn7Q= )
+   x.y.w.example. 3600 IN MX  1 xx.example.
+                  3600 RRSIG  MX 5 4 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              k2bJHbwP5LH5qN4is39UiPzjAWYmJA38Hhia
+                              t7i9t7nbX/e0FPnvDSQXzcK7UL+zrVA+3MDj
+                              q1ub4q3SZgcbLMgexxIW3Va//LVrxkP6Xupq
+                              GtOB9prkK54QTl/qZTXfMQpW480YOvVknhvb
+                              +gLcMZBnHJ326nb/TOOmrqNmQQE= )
+                  3600 NSEC   xx.example. MX RRSIG NSEC
+                  3600 RRSIG  NSEC 5 4 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              OvE6WUzN2ziieJcvKPWbCAyXyP6ef8cr6Csp
+                              ArVSTzKSquNwbezZmkU7E34o5lmb6CWSSSpg
+                              xw098kNUFnHcQf/LzY2zqRomubrNQhJTiDTX
+                              a0ArunJQCzPjOYq5t0SLjm6qp6McJI1AP5Vr
+                              QoKqJDCLnoAlcPOPKAm/jJkn3jk= )
+   xx.example.    3600 IN A   192.0.2.10
+                  3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              kBF4YxMGWF0D8r0cztL+2fWWOvN1U/GYSpYP
+                              7SoKoNQ4fZKyk+weWGlKLIUM+uE1zjVTPXoa
+                              0Z6WG0oZp46rkl1EzMcdMgoaeUzzAJ2BMq+Y
+                              VdxG9IK1yZkYGY9AgbTOGPoAgbJyO9EPULsx
+                              kbIDV6GPPSZVusnZU6OMgdgzHV4= )
+                  3600 HINFO  "KLH-10" "TOPS-20"
+                  3600 RRSIG  HINFO 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              GY2PLSXmMHkWHfLdggiox8+chWpeMNJLkML0
+                              t+U/SXSUsoUdR91KNdNUkTDWamwcF8oFRjhq
+                              BcPZ6EqrF+vl5v5oGuvSF7U52epfVTC+wWF8
+                              3yCUeUw8YklhLWlvk8gQ15YKth0ITQy8/wI+
+                              RgNvuwbioFSEuv2pNlkq0goYxNY= )
+                  3600 AAAA   2001:db8::f00:baaa
+                  3600 RRSIG  AAAA 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              Zzj0yodDxcBLnnOIwDsuKo5WqiaK24DlKg9C
+                              aGaxDFiKgKobUj2jilYQHpGFn2poFRetZd4z
+                              ulyQkssz2QHrVrPuTMS22knudCiwP4LWpVTr
+                              U4zfeA+rDz9stmSBP/4PekH/x2IoAYnwctd/
+
+
+
+Arends, et al.              Standards Track                    [Page 40]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              xS9cL2QgW7FChw16mzlkH6/vsfs= )
+                  3600 NSEC   example. A HINFO AAAA RRSIG NSEC
+                  3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              ZFWUln6Avc8bmGl5GFjD3BwT530DUZKHNuoY
+                              9A8lgXYyrxu+pqgFiRVbyZRQvVB5pccEOT3k
+                              mvHgEa/HzbDB4PIYY79W+VHrgOxzdQGGCZzi
+                              asXrpSGOWwSOElghPnMIi8xdF7qtCntr382W
+                              GghLahumFIpg4MO3LS/prgzVVWo= )
+
+   The apex DNSKEY set includes two DNSKEY RRs, and the DNSKEY RDATA
+   Flags indicate that each of these DNSKEY RRs is a zone key.  One of
+   these DNSKEY RRs also has the SEP flag set and has been used to sign
+   the apex DNSKEY RRset; this is the key that should be hashed to
+   generate a DS record to be inserted into the parent zone.  The other
+   DNSKEY is used to sign all the other RRsets in the zone.
+
+   The zone includes a wildcard entry, "*.w.example".  Note that the
+   name "*.w.example" is used in constructing NSEC chains, and that the
+   RRSIG covering the "*.w.example" MX RRset has a label count of 2.
+
+   The zone also includes two delegations.  The delegation to
+   "b.example" includes an NS RRset, glue address records, and an NSEC
+   RR; note that only the NSEC RRset is signed.  The delegation to
+   "a.example" provides a DS RR; note that only the NSEC and DS RRsets
+   are signed.
+
+Appendix B.  Example Responses
+
+   The examples in this section show response messages using the signed
+   zone example in Appendix A.
+
+B.1.  Answer
+
+   A successful query to an authoritative server.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   x.w.example.        IN MX
+
+   ;; Answer
+   x.w.example.   3600 IN MX  1 xx.example.
+   x.w.example.   3600 RRSIG  MX 5 3 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              Il2WTZ+Bkv+OytBx4LItNW5mjB4RCwhOO8y1
+                              XzPHZmZUTVYL7LaA63f6T9ysVBzJRI3KRjAP
+                              H3U1qaYnDoN1DrWqmi9RJe4FoObkbcdm7P3I
+
+
+
+Arends, et al.              Standards Track                    [Page 41]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              kx70ePCoFgRz1Yq+bVVXCvGuAU4xALv3W/Y1
+                              jNSlwZ2mSWKHfxFQxPtLj8s32+k= )
+
+   ;; Authority
+   example.       3600 NS     ns1.example.
+   example.       3600 NS     ns2.example.
+   example.       3600 RRSIG  NS 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              gl13F00f2U0R+SWiXXLHwsMY+qStYy5k6zfd
+                              EuivWc+wd1fmbNCyql0Tk7lHTX6UOxc8AgNf
+                              4ISFve8XqF4q+o9qlnqIzmppU3LiNeKT4FZ8
+                              RO5urFOvoMRTbQxW3U0hXWuggE4g3ZpsHv48
+                              0HjMeRaZB/FRPGfJPajngcq6Kwg= )
+
+   ;; Additional
+   xx.example.    3600 IN A   192.0.2.10
+   xx.example.    3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              kBF4YxMGWF0D8r0cztL+2fWWOvN1U/GYSpYP
+                              7SoKoNQ4fZKyk+weWGlKLIUM+uE1zjVTPXoa
+                              0Z6WG0oZp46rkl1EzMcdMgoaeUzzAJ2BMq+Y
+                              VdxG9IK1yZkYGY9AgbTOGPoAgbJyO9EPULsx
+                              kbIDV6GPPSZVusnZU6OMgdgzHV4= )
+   xx.example.    3600 AAAA   2001:db8::f00:baaa
+   xx.example.    3600 RRSIG  AAAA 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              Zzj0yodDxcBLnnOIwDsuKo5WqiaK24DlKg9C
+                              aGaxDFiKgKobUj2jilYQHpGFn2poFRetZd4z
+                              ulyQkssz2QHrVrPuTMS22knudCiwP4LWpVTr
+                              U4zfeA+rDz9stmSBP/4PekH/x2IoAYnwctd/
+                              xS9cL2QgW7FChw16mzlkH6/vsfs= )
+   ns1.example.   3600 IN A   192.0.2.1
+   ns1.example.   3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              F1C9HVhIcs10cZU09G5yIVfKJy5yRQQ3qVet
+                              5pGhp82pzhAOMZ3K22JnmK4c+IjUeFp/to06
+                              im5FVpHtbFisdjyPq84bhTv8vrXt5AB1wNB+
+                              +iAqvIfdgW4sFNC6oADb1hK8QNauw9VePJhK
+                              v/iVXSYC0b7mPSU+EOlknFpVECs= )
+   ns2.example.   3600 IN A   192.0.2.2
+   ns2.example.   3600 RRSIG  A 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              V7cQRw1TR+knlaL1z/psxlS1PcD37JJDaCMq
+                              Qo6/u1qFQu6x+wuDHRH22Ap9ulJPQjFwMKOu
+                              yfPGQPC8KzGdE3vt5snFEAoE1Vn3mQqtu7SO
+                              6amIjk13Kj/jyJ4nGmdRIc/3cM3ipXFhNTKq
+                              rdhx8SZ0yy4ObIRzIzvBFLiSS8o= )
+
+
+
+
+Arends, et al.              Standards Track                    [Page 42]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+B.2.  Name Error
+
+   An authoritative name error.  The NSEC RRs prove that the name does
+   not exist and that no covering wildcard exists.
+
+   ;; Header: QR AA DO RCODE=3
+   ;;
+   ;; Question
+   ml.example.         IN A
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   example.       3600 IN SOA ns1.example. bugs.x.w.example. (
+                              1081539377
+                              3600
+                              300
+                              3600000
+                              3600
+                              )
+   example.       3600 RRSIG  SOA 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              ONx0k36rcjaxYtcNgq6iQnpNV5+drqYAsC9h
+                              7TSJaHCqbhE67Sr6aH2xDUGcqQWu/n0UVzrF
+                              vkgO9ebarZ0GWDKcuwlM6eNB5SiX2K74l5LW
+                              DA7S/Un/IbtDq4Ay8NMNLQI7Dw7n4p8/rjkB
+                              jV7j86HyQgM5e7+miRAz8V01b0I= )
+   b.example.     3600 NSEC   ns1.example. NS RRSIG NSEC
+   b.example.     3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              GNuxHn844wfmUhPzGWKJCPY5ttEX/RfjDoOx
+                              9ueK1PtYkOWKOOdiJ/PJKCYB3hYX+858dDWS
+                              xb2qnV/LSTCNVBnkm6owOpysY97MVj5VQEWs
+                              0lm9tFoqjcptQkmQKYPrwUnCSNwvvclSF1xZ
+                              vhRXgWT7OuFXldoCG6TfVFMs9xE= )
+   example.       3600 NSEC   a.example. NS SOA MX RRSIG NSEC DNSKEY
+   example.       3600 RRSIG  NSEC 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              O0k558jHhyrC97ISHnislm4kLMW48C7U7cBm
+                              FTfhke5iVqNRVTB1STLMpgpbDIC9hcryoO0V
+                              Z9ME5xPzUEhbvGnHd5sfzgFVeGxr5Nyyq4tW
+                              SDBgIBiLQUv1ivy29vhXy7WgR62dPrZ0PWvm
+                              jfFJ5arXf4nPxp/kEowGgBRzY/U= )
+
+   ;; Additional
+   ;; (empty)
+
+
+
+
+Arends, et al.              Standards Track                    [Page 43]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+B.3.  No Data Error
+
+   A "no data" response.  The NSEC RR proves that the name exists and
+   that the requested RR type does not.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   ns1.example.        IN MX
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   example.       3600 IN SOA ns1.example. bugs.x.w.example. (
+                              1081539377
+                              3600
+                              300
+                              3600000
+                              3600
+                              )
+   example.       3600 RRSIG  SOA 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              ONx0k36rcjaxYtcNgq6iQnpNV5+drqYAsC9h
+                              7TSJaHCqbhE67Sr6aH2xDUGcqQWu/n0UVzrF
+                              vkgO9ebarZ0GWDKcuwlM6eNB5SiX2K74l5LW
+                              DA7S/Un/IbtDq4Ay8NMNLQI7Dw7n4p8/rjkB
+                              jV7j86HyQgM5e7+miRAz8V01b0I= )
+   ns1.example.   3600 NSEC   ns2.example. A RRSIG NSEC
+   ns1.example.   3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              I4hj+Kt6+8rCcHcUdolks2S+Wzri9h3fHas8
+                              1rGN/eILdJHN7JpV6lLGPIh/8fIBkfvdyWnB
+                              jjf1q3O7JgYO1UdI7FvBNWqaaEPJK3UkddBq
+                              ZIaLi8Qr2XHkjq38BeQsbp8X0+6h4ETWSGT8
+                              IZaIGBLryQWGLw6Y6X8dqhlnxJM= )
+
+   ;; Additional
+   ;; (empty)
+
+B.4.  Referral to Signed Zone
+
+   Referral to a signed zone.  The DS RR contains the data which the
+   resolver will need to validate the corresponding DNSKEY RR in the
+   child zone's apex.
+
+   ;; Header: QR DO RCODE=0
+   ;;
+
+
+
+Arends, et al.              Standards Track                    [Page 44]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   ;; Question
+   mc.a.example.       IN MX
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   a.example.     3600 IN NS  ns1.a.example.
+   a.example.     3600 IN NS  ns2.a.example.
+   a.example.     3600 DS     57855 5 1 (
+                              B6DCD485719ADCA18E5F3D48A2331627FDD3
+                              636B )
+   a.example.     3600 RRSIG  DS 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              oXIKit/QtdG64J/CB+Gi8dOvnwRvqrto1AdQ
+                              oRkAN15FP3iZ7suB7gvTBmXzCjL7XUgQVcoH
+                              kdhyCuzp8W9qJHgRUSwKKkczSyuL64nhgjuD
+                              EML8l9wlWVsl7PR2VnZduM9bLyBhaaPmRKX/
+                              Fm+v6ccF2EGNLRiY08kdkz+XHHo= )
+
+   ;; Additional
+   ns1.a.example. 3600 IN A   192.0.2.5
+   ns2.a.example. 3600 IN A   192.0.2.6
+
+B.5.  Referral to Unsigned Zone
+
+   Referral to an unsigned zone.  The NSEC RR proves that no DS RR for
+   this delegation exists in the parent zone.
+
+   ;; Header: QR DO RCODE=0
+   ;;
+   ;; Question
+   mc.b.example.       IN MX
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   b.example.     3600 IN NS  ns1.b.example.
+   b.example.     3600 IN NS  ns2.b.example.
+   b.example.     3600 NSEC   ns1.example. NS RRSIG NSEC
+   b.example.     3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              GNuxHn844wfmUhPzGWKJCPY5ttEX/RfjDoOx
+                              9ueK1PtYkOWKOOdiJ/PJKCYB3hYX+858dDWS
+                              xb2qnV/LSTCNVBnkm6owOpysY97MVj5VQEWs
+                              0lm9tFoqjcptQkmQKYPrwUnCSNwvvclSF1xZ
+                              vhRXgWT7OuFXldoCG6TfVFMs9xE= )
+
+
+
+Arends, et al.              Standards Track                    [Page 45]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   ;; Additional
+   ns1.b.example. 3600 IN A   192.0.2.7
+   ns2.b.example. 3600 IN A   192.0.2.8
+
+B.6.  Wildcard Expansion
+
+   A successful query that was answered via wildcard expansion.  The
+   label count in the answer's RRSIG RR indicates that a wildcard RRset
+   was expanded to produce this response, and the NSEC RR proves that no
+   closer match exists in the zone.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   a.z.w.example.      IN MX
+
+   ;; Answer
+   a.z.w.example. 3600 IN MX  1 ai.example.
+   a.z.w.example. 3600 RRSIG  MX 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              OMK8rAZlepfzLWW75Dxd63jy2wswESzxDKG2
+                              f9AMN1CytCd10cYISAxfAdvXSZ7xujKAtPbc
+                              tvOQ2ofO7AZJ+d01EeeQTVBPq4/6KCWhqe2X
+                              TjnkVLNvvhnc0u28aoSsG0+4InvkkOHknKxw
+                              4kX18MMR34i8lC36SR5xBni8vHI= )
+
+   ;; Authority
+   example.       3600 NS     ns1.example.
+   example.       3600 NS     ns2.example.
+   example.       3600 RRSIG  NS 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              gl13F00f2U0R+SWiXXLHwsMY+qStYy5k6zfd
+                              EuivWc+wd1fmbNCyql0Tk7lHTX6UOxc8AgNf
+                              4ISFve8XqF4q+o9qlnqIzmppU3LiNeKT4FZ8
+                              RO5urFOvoMRTbQxW3U0hXWuggE4g3ZpsHv48
+                              0HjMeRaZB/FRPGfJPajngcq6Kwg= )
+   x.y.w.example. 3600 NSEC   xx.example. MX RRSIG NSEC
+   x.y.w.example. 3600 RRSIG  NSEC 5 4 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              OvE6WUzN2ziieJcvKPWbCAyXyP6ef8cr6Csp
+                              ArVSTzKSquNwbezZmkU7E34o5lmb6CWSSSpg
+                              xw098kNUFnHcQf/LzY2zqRomubrNQhJTiDTX
+                              a0ArunJQCzPjOYq5t0SLjm6qp6McJI1AP5Vr
+                              QoKqJDCLnoAlcPOPKAm/jJkn3jk= )
+
+   ;; Additional
+   ai.example.    3600 IN A   192.0.2.9
+   ai.example.    3600 RRSIG  A 5 2 3600 20040509183619 (
+
+
+
+Arends, et al.              Standards Track                    [Page 46]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              20040409183619 38519 example.
+                              pAOtzLP2MU0tDJUwHOKE5FPIIHmdYsCgTb5B
+                              ERGgpnJluA9ixOyf6xxVCgrEJW0WNZSsJicd
+                              hBHXfDmAGKUajUUlYSAH8tS4ZnrhyymIvk3u
+                              ArDu2wfT130e9UHnumaHHMpUTosKe22PblOy
+                              6zrTpg9FkS0XGVmYRvOTNYx2HvQ= )
+   ai.example.    3600 AAAA   2001:db8::f00:baa9
+   ai.example.    3600 RRSIG  AAAA 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              nLcpFuXdT35AcE+EoafOUkl69KB+/e56XmFK
+                              kewXG2IadYLKAOBIoR5+VoQV3XgTcofTJNsh
+                              1rnF6Eav2zpZB3byI6yo2bwY8MNkr4A7cL9T
+                              cMmDwV/hWFKsbGBsj8xSCN/caEL2CWY/5XP2
+                              sZM6QjBBLmukH30+w1z3h8PUP2o= )
+
+B.7.  Wildcard No Data Error
+
+   A "no data" response for a name covered by a wildcard.  The NSEC RRs
+   prove that the matching wildcard name does not have any RRs of the
+   requested type and that no closer match exists in the zone.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   a.z.w.example.      IN AAAA
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   example.       3600 IN SOA ns1.example. bugs.x.w.example. (
+                              1081539377
+                              3600
+                              300
+                              3600000
+                              3600
+                              )
+   example.       3600 RRSIG  SOA 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              ONx0k36rcjaxYtcNgq6iQnpNV5+drqYAsC9h
+                              7TSJaHCqbhE67Sr6aH2xDUGcqQWu/n0UVzrF
+                              vkgO9ebarZ0GWDKcuwlM6eNB5SiX2K74l5LW
+                              DA7S/Un/IbtDq4Ay8NMNLQI7Dw7n4p8/rjkB
+                              jV7j86HyQgM5e7+miRAz8V01b0I= )
+   x.y.w.example. 3600 NSEC   xx.example. MX RRSIG NSEC
+   x.y.w.example. 3600 RRSIG  NSEC 5 4 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              OvE6WUzN2ziieJcvKPWbCAyXyP6ef8cr6Csp
+
+
+
+Arends, et al.              Standards Track                    [Page 47]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              ArVSTzKSquNwbezZmkU7E34o5lmb6CWSSSpg
+                              xw098kNUFnHcQf/LzY2zqRomubrNQhJTiDTX
+                              a0ArunJQCzPjOYq5t0SLjm6qp6McJI1AP5Vr
+                              QoKqJDCLnoAlcPOPKAm/jJkn3jk= )
+   *.w.example.   3600 NSEC   x.w.example. MX RRSIG NSEC
+   *.w.example.   3600 RRSIG  NSEC 5 2 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              r/mZnRC3I/VIcrelgIcteSxDhtsdlTDt8ng9
+                              HSBlABOlzLxQtfgTnn8f+aOwJIAFe1Ee5RvU
+                              5cVhQJNP5XpXMJHfyps8tVvfxSAXfahpYqtx
+                              91gsmcV/1V9/bZAG55CefP9cM4Z9Y9NT9XQ8
+                              s1InQ2UoIv6tJEaaKkP701j8OLA= )
+
+   ;; Additional
+   ;; (empty)
+
+B.8.  DS Child Zone No Data Error
+
+   A "no data" response for a QTYPE=DS query that was mistakenly sent to
+   a name server for the child zone.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   example.            IN DS
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   example.       3600 IN SOA ns1.example. bugs.x.w.example. (
+                              1081539377
+                              3600
+                              300
+                              3600000
+                              3600
+                              )
+   example.       3600 RRSIG  SOA 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              ONx0k36rcjaxYtcNgq6iQnpNV5+drqYAsC9h
+                              7TSJaHCqbhE67Sr6aH2xDUGcqQWu/n0UVzrF
+                              vkgO9ebarZ0GWDKcuwlM6eNB5SiX2K74l5LW
+                              DA7S/Un/IbtDq4Ay8NMNLQI7Dw7n4p8/rjkB
+                              jV7j86HyQgM5e7+miRAz8V01b0I= )
+   example.       3600 NSEC   a.example. NS SOA MX RRSIG NSEC DNSKEY
+   example.       3600 RRSIG  NSEC 5 1 3600 20040509183619 (
+                              20040409183619 38519 example.
+                              O0k558jHhyrC97ISHnislm4kLMW48C7U7cBm
+
+
+
+Arends, et al.              Standards Track                    [Page 48]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+                              FTfhke5iVqNRVTB1STLMpgpbDIC9hcryoO0V
+                              Z9ME5xPzUEhbvGnHd5sfzgFVeGxr5Nyyq4tW
+                              SDBgIBiLQUv1ivy29vhXy7WgR62dPrZ0PWvm
+                              jfFJ5arXf4nPxp/kEowGgBRzY/U= )
+
+   ;; Additional
+   ;; (empty)
+
+Appendix C.  Authentication Examples
+
+   The examples in this section show how the response messages in
+   Appendix B are authenticated.
+
+C.1.  Authenticating an Answer
+
+   The query in Appendix B.1 returned an MX RRset for "x.w.example.com".
+   The corresponding RRSIG indicates that the MX RRset was signed by an
+   "example" DNSKEY with algorithm 5 and key tag 38519.  The resolver
+   needs the corresponding DNSKEY RR in order to authenticate this
+   answer.  The discussion below describes how a resolver might obtain
+   this DNSKEY RR.
+
+   The RRSIG indicates the original TTL of the MX RRset was 3600, and,
+   for the purpose of authentication, the current TTL is replaced by
+   3600.  The RRSIG labels field value of 3 indicates that the answer
+   was not the result of wildcard expansion.  The "x.w.example.com" MX
+   RRset is placed in canonical form, and, assuming the current time
+   falls between the signature inception and expiration dates, the
+   signature is authenticated.
+
+C.1.1.  Authenticating the Example DNSKEY RR
+
+   This example shows the logical authentication process that starts
+   from the a configured root DNSKEY (or DS RR) and moves down the tree
+   to authenticate the desired "example" DNSKEY RR.  Note that the
+   logical order is presented for clarity.  An implementation may choose
+   to construct the authentication as referrals are received or to
+   construct the authentication chain only after all RRsets have been
+   obtained, or in any other combination it sees fit.  The example here
+   demonstrates only the logical process and does not dictate any
+   implementation rules.
+
+   We assume the resolver starts with a configured DNSKEY RR for the
+   root zone (or a configured DS RR for the root zone).  The resolver
+   checks whether this configured DNSKEY RR is present in the root
+   DNSKEY RRset (or whether the DS RR matches some DNSKEY in the root
+   DNSKEY RRset), whether this DNSKEY RR has signed the root DNSKEY
+   RRset, and whether the signature lifetime is valid.  If all these
+
+
+
+Arends, et al.              Standards Track                    [Page 49]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   conditions are met, all keys in the DNSKEY RRset are considered
+   authenticated.  The resolver then uses one (or more) of the root
+   DNSKEY RRs to authenticate the "example" DS RRset.  Note that the
+   resolver may have to query the root zone to obtain the root DNSKEY
+   RRset or "example" DS RRset.
+
+   Once the DS RRset has been authenticated using the root DNSKEY, the
+   resolver checks the "example" DNSKEY RRset for some "example" DNSKEY
+   RR that matches one of the authenticated "example" DS RRs.  If such a
+   matching "example" DNSKEY is found, the resolver checks whether this
+   DNSKEY RR has signed the "example" DNSKEY RRset and the signature
+   lifetime is valid.  If these conditions are met, all keys in the
+   "example" DNSKEY RRset are considered authenticated.
+
+   Finally, the resolver checks that some DNSKEY RR in the "example"
+   DNSKEY RRset uses algorithm 5 and has a key tag of 38519.  This
+   DNSKEY is used to authenticate the RRSIG included in the response.
+   If multiple "example" DNSKEY RRs match this algorithm and key tag,
+   then each DNSKEY RR is tried, and the answer is authenticated if any
+   of the matching DNSKEY RRs validate the signature as described above.
+
+C.2.  Name Error
+
+   The query in Appendix B.2 returned NSEC RRs that prove that the
+   requested data does not exist and no wildcard applies.  The negative
+   reply is authenticated by verifying both NSEC RRs.  The NSEC RRs are
+   authenticated in a manner identical to that of the MX RRset discussed
+   above.
+
+C.3.  No Data Error
+
+   The query in Appendix B.3 returned an NSEC RR that proves that the
+   requested name exists, but the requested RR type does not exist.  The
+   negative reply is authenticated by verifying the NSEC RR.  The NSEC
+   RR is authenticated in a manner identical to that of the MX RRset
+   discussed above.
+
+C.4.  Referral to Signed Zone
+
+   The query in Appendix B.4 returned a referral to the signed
+   "a.example." zone.  The DS RR is authenticated in a manner identical
+   to that of the MX RRset discussed above.  This DS RR is used to
+   authenticate the "a.example" DNSKEY RRset.
+
+   Once the "a.example" DS RRset has been authenticated using the
+   "example" DNSKEY, the resolver checks the "a.example" DNSKEY RRset
+   for some "a.example" DNSKEY RR that matches the DS RR.  If such a
+   matching "a.example" DNSKEY is found, the resolver checks whether
+
+
+
+Arends, et al.              Standards Track                    [Page 50]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+   this DNSKEY RR has signed the "a.example" DNSKEY RRset and whether
+   the signature lifetime is valid.  If all these conditions are met,
+   all keys in the "a.example" DNSKEY RRset are considered
+   authenticated.
+
+C.5.  Referral to Unsigned Zone
+
+   The query in Appendix B.5 returned a referral to an unsigned
+   "b.example." zone.  The NSEC proves that no authentication leads from
+   "example" to "b.example", and the NSEC RR is authenticated in a
+   manner identical to that of the MX RRset discussed above.
+
+C.6.  Wildcard Expansion
+
+   The query in Appendix B.6 returned an answer that was produced as a
+   result of wildcard expansion.  The answer section contains a wildcard
+   RRset expanded as it would be in a traditional DNS response, and the
+   corresponding RRSIG indicates that the expanded wildcard MX RRset was
+   signed by an "example" DNSKEY with algorithm 5 and key tag 38519.
+   The RRSIG indicates that the original TTL of the MX RRset was 3600,
+   and, for the purpose of authentication, the current TTL is replaced
+   by 3600.  The RRSIG labels field value of 2 indicates that the answer
+   is the result of wildcard expansion, as the "a.z.w.example" name
+   contains 4 labels.  The name "a.z.w.w.example" is replaced by
+   "*.w.example", the MX RRset is placed in canonical form, and,
+   assuming that the current time falls between the signature inception
+   and expiration dates, the signature is authenticated.
+
+   The NSEC proves that no closer match (exact or closer wildcard) could
+   have been used to answer this query, and the NSEC RR must also be
+   authenticated before the answer is considered valid.
+
+C.7.  Wildcard No Data Error
+
+   The query in Appendix B.7 returned NSEC RRs that prove that the
+   requested data does not exist and no wildcard applies.  The negative
+   reply is authenticated by verifying both NSEC RRs.
+
+C.8.  DS Child Zone No Data Error
+
+   The query in Appendix B.8 returned NSEC RRs that shows the requested
+   was answered by a child server ("example" server).  The NSEC RR
+   indicates the presence of an SOA RR, showing that the answer is from
+   the child .  Queries for the "example" DS RRset should be sent to the
+   parent servers ("root" servers).
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 51]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+Authors' Addresses
+
+   Roy Arends
+   Telematica Instituut
+   Brouwerijstraat 1
+   7523 XC  Enschede
+   NL
+
+   EMail: roy.arends@telin.nl
+
+
+   Rob Austein
+   Internet Systems Consortium
+   950 Charter Street
+   Redwood City, CA  94063
+   USA
+
+   EMail: sra@isc.org
+
+
+   Matt Larson
+   VeriSign, Inc.
+   21345 Ridgetop Circle
+   Dulles, VA  20166-6503
+   USA
+
+   EMail: mlarson@verisign.com
+
+
+   Dan Massey
+   Colorado State University
+   Department of Computer Science
+   Fort Collins, CO 80523-1873
+
+   EMail: massey@cs.colostate.edu
+
+
+   Scott Rose
+   National Institute for Standards and Technology
+   100 Bureau Drive
+   Gaithersburg, MD  20899-8920
+   USA
+
+   EMail: scott.rose@nist.gov
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 52]
+
+RFC 4035             DNSSEC Protocol Modifications            March 2005
+
+
+Full Copyright Statement
+
+   Copyright (C) The Internet Society (2005).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND THE INTERNET
+   ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE
+   INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at ietf-
+   ipr@ietf.org.
+
+Acknowledgement
+
+   Funding for the RFC Editor function is currently provided by the
+   Internet Society.
+
+
+
+
+
+
+
+Arends, et al.              Standards Track                    [Page 53]
+

--- a/rfc/dns/rfc5155.txt
+++ b/rfc/dns/rfc5155.txt
@@ -1,0 +1,2915 @@
+
+
+
+
+
+
+Network Working Group                                          B. Laurie
+Request for Comments: 5155                                     G. Sisson
+Category: Standards Track                                      R. Arends
+                                                                 Nominet
+                                                               D. Blacka
+                                                          VeriSign, Inc.
+                                                              March 2008
+
+
+     DNS Security (DNSSEC) Hashed Authenticated Denial of Existence
+
+Status of This Memo
+
+   This document specifies an Internet standards track protocol for the
+   Internet community, and requests discussion and suggestions for
+   improvements.  Please refer to the current edition of the "Internet
+   Official Protocol Standards" (STD 1) for the standardization state
+   and status of this protocol.  Distribution of this memo is unlimited.
+
+Abstract
+
+   The Domain Name System Security (DNSSEC) Extensions introduced the
+   NSEC resource record (RR) for authenticated denial of existence.
+   This document introduces an alternative resource record, NSEC3, which
+   similarly provides authenticated denial of existence.  However, it
+   also provides measures against zone enumeration and permits gradual
+   expansion of delegation-centric zones.
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  4
+     1.1.  Rationale  . . . . . . . . . . . . . . . . . . . . . . . .  4
+     1.2.  Requirements . . . . . . . . . . . . . . . . . . . . . . .  4
+     1.3.  Terminology  . . . . . . . . . . . . . . . . . . . . . . .  5
+   2.  Backwards Compatibility  . . . . . . . . . . . . . . . . . . .  6
+   3.  The NSEC3 Resource Record  . . . . . . . . . . . . . . . . . .  7
+     3.1.  RDATA Fields . . . . . . . . . . . . . . . . . . . . . . .  8
+       3.1.1.  Hash Algorithm . . . . . . . . . . . . . . . . . . . .  8
+       3.1.2.  Flags  . . . . . . . . . . . . . . . . . . . . . . . .  8
+       3.1.3.  Iterations . . . . . . . . . . . . . . . . . . . . . .  8
+       3.1.4.  Salt Length  . . . . . . . . . . . . . . . . . . . . .  8
+       3.1.5.  Salt . . . . . . . . . . . . . . . . . . . . . . . . .  8
+       3.1.6.  Hash Length  . . . . . . . . . . . . . . . . . . . . .  9
+       3.1.7.  Next Hashed Owner Name . . . . . . . . . . . . . . . .  9
+       3.1.8.  Type Bit Maps  . . . . . . . . . . . . . . . . . . . .  9
+     3.2.  NSEC3 RDATA Wire Format  . . . . . . . . . . . . . . . . .  9
+       3.2.1.  Type Bit Maps Encoding . . . . . . . . . . . . . . . . 10
+     3.3.  Presentation Format  . . . . . . . . . . . . . . . . . . . 11
+
+
+
+Laurie, et al.              Standards Track                     [Page 1]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   4.  The NSEC3PARAM Resource Record . . . . . . . . . . . . . . . . 12
+     4.1.  RDATA Fields . . . . . . . . . . . . . . . . . . . . . . . 12
+       4.1.1.  Hash Algorithm . . . . . . . . . . . . . . . . . . . . 12
+       4.1.2.  Flag Fields  . . . . . . . . . . . . . . . . . . . . . 12
+       4.1.3.  Iterations . . . . . . . . . . . . . . . . . . . . . . 13
+       4.1.4.  Salt Length  . . . . . . . . . . . . . . . . . . . . . 13
+       4.1.5.  Salt . . . . . . . . . . . . . . . . . . . . . . . . . 13
+     4.2.  NSEC3PARAM RDATA Wire Format . . . . . . . . . . . . . . . 13
+     4.3.  Presentation Format  . . . . . . . . . . . . . . . . . . . 14
+   5.  Calculation of the Hash  . . . . . . . . . . . . . . . . . . . 14
+   6.  Opt-Out  . . . . . . . . . . . . . . . . . . . . . . . . . . . 15
+   7.  Authoritative Server Considerations  . . . . . . . . . . . . . 16
+     7.1.  Zone Signing . . . . . . . . . . . . . . . . . . . . . . . 16
+     7.2.  Zone Serving . . . . . . . . . . . . . . . . . . . . . . . 17
+       7.2.1.  Closest Encloser Proof . . . . . . . . . . . . . . . . 18
+       7.2.2.  Name Error Responses . . . . . . . . . . . . . . . . . 19
+       7.2.3.  No Data Responses, QTYPE is not DS . . . . . . . . . . 19
+       7.2.4.  No Data Responses, QTYPE is DS . . . . . . . . . . . . 19
+       7.2.5.  Wildcard No Data Responses . . . . . . . . . . . . . . 19
+       7.2.6.  Wildcard Answer Responses  . . . . . . . . . . . . . . 20
+       7.2.7.  Referrals to Unsigned Subzones . . . . . . . . . . . . 20
+       7.2.8.  Responding to Queries for NSEC3 Owner Names  . . . . . 20
+       7.2.9.  Server Response to a Run-Time Collision  . . . . . . . 21
+     7.3.  Secondary Servers  . . . . . . . . . . . . . . . . . . . . 21
+     7.4.  Zones Using Unknown Hash Algorithms  . . . . . . . . . . . 21
+     7.5.  Dynamic Update . . . . . . . . . . . . . . . . . . . . . . 21
+   8.  Validator Considerations . . . . . . . . . . . . . . . . . . . 23
+     8.1.  Responses with Unknown Hash Types  . . . . . . . . . . . . 23
+     8.2.  Verifying NSEC3 RRs  . . . . . . . . . . . . . . . . . . . 23
+     8.3.  Closest Encloser Proof . . . . . . . . . . . . . . . . . . 23
+     8.4.  Validating Name Error Responses  . . . . . . . . . . . . . 24
+     8.5.  Validating No Data Responses, QTYPE is not DS  . . . . . . 24
+     8.6.  Validating No Data Responses, QTYPE is DS  . . . . . . . . 24
+     8.7.  Validating Wildcard No Data Responses  . . . . . . . . . . 25
+     8.8.  Validating Wildcard Answer Responses . . . . . . . . . . . 25
+     8.9.  Validating Referrals to Unsigned Subzones  . . . . . . . . 25
+   9.  Resolver Considerations  . . . . . . . . . . . . . . . . . . . 26
+     9.1.  NSEC3 Resource Record Caching  . . . . . . . . . . . . . . 26
+     9.2.  Use of the AD Bit  . . . . . . . . . . . . . . . . . . . . 26
+   10. Special Considerations . . . . . . . . . . . . . . . . . . . . 26
+     10.1. Domain Name Length Restrictions  . . . . . . . . . . . . . 26
+     10.2. DNAME at the Zone Apex . . . . . . . . . . . . . . . . . . 27
+     10.3. Iterations . . . . . . . . . . . . . . . . . . . . . . . . 27
+     10.4. Transitioning a Signed Zone from NSEC to NSEC3 . . . . . . 28
+     10.5. Transitioning a Signed Zone from NSEC3 to NSEC . . . . . . 28
+   11. IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 29
+   12. Security Considerations  . . . . . . . . . . . . . . . . . . . 30
+     12.1. Hashing Considerations . . . . . . . . . . . . . . . . . . 30
+
+
+
+Laurie, et al.              Standards Track                     [Page 2]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+       12.1.1. Dictionary Attacks . . . . . . . . . . . . . . . . . . 30
+       12.1.2. Collisions . . . . . . . . . . . . . . . . . . . . . . 31
+       12.1.3. Transitioning to a New Hash Algorithm  . . . . . . . . 31
+       12.1.4. Using High Iteration Values  . . . . . . . . . . . . . 31
+     12.2. Opt-Out Considerations . . . . . . . . . . . . . . . . . . 32
+     12.3. Other Considerations . . . . . . . . . . . . . . . . . . . 33
+   13. References . . . . . . . . . . . . . . . . . . . . . . . . . . 33
+     13.1. Normative References . . . . . . . . . . . . . . . . . . . 33
+     13.2. Informative References . . . . . . . . . . . . . . . . . . 34
+   Appendix A.  Example Zone  . . . . . . . . . . . . . . . . . . . . 35
+   Appendix B.  Example Responses . . . . . . . . . . . . . . . . . . 40
+     B.1.  Name Error . . . . . . . . . . . . . . . . . . . . . . . . 40
+     B.2.  No Data Error  . . . . . . . . . . . . . . . . . . . . . . 42
+       B.2.1.  No Data Error, Empty Non-Terminal  . . . . . . . . . . 43
+     B.3.  Referral to an Opt-Out Unsigned Zone . . . . . . . . . . . 44
+     B.4.  Wildcard Expansion . . . . . . . . . . . . . . . . . . . . 45
+     B.5.  Wildcard No Data Error . . . . . . . . . . . . . . . . . . 46
+     B.6.  DS Child Zone No Data Error  . . . . . . . . . . . . . . . 48
+   Appendix C.  Special Considerations  . . . . . . . . . . . . . . . 48
+     C.1.  Salting  . . . . . . . . . . . . . . . . . . . . . . . . . 49
+     C.2.  Hash Collision . . . . . . . . . . . . . . . . . . . . . . 49
+       C.2.1.  Avoiding Hash Collisions During Generation . . . . . . 50
+       C.2.2.  Second Preimage Requirement Analysis . . . . . . . . . 50
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 3]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+1.  Introduction
+
+1.1.  Rationale
+
+   The DNS Security Extensions included the NSEC RR to provide
+   authenticated denial of existence.  Though the NSEC RR meets the
+   requirements for authenticated denial of existence, it introduces a
+   side-effect in that the contents of a zone can be enumerated.  This
+   property introduces undesired policy issues.
+
+   The enumeration is enabled by the set of NSEC records that exists
+   inside a signed zone.  An NSEC record lists two names that are
+   ordered canonically, in order to show that nothing exists between the
+   two names.  The complete set of NSEC records lists all the names in a
+   zone.  It is trivial to enumerate the content of a zone by querying
+   for names that do not exist.
+
+   An enumerated zone can be used, for example, as a source of probable
+   e-mail addresses for spam, or as a key for multiple WHOIS queries to
+   reveal registrant data that many registries may have legal
+   obligations to protect.  Many registries therefore prohibit the
+   copying of their zone data; however, the use of NSEC RRs renders
+   these policies unenforceable.
+
+   A second problem is that the cost to cryptographically secure
+   delegations to unsigned zones is high, relative to the perceived
+   security benefit, in two cases: large, delegation-centric zones, and
+   zones where insecure delegations will be updated rapidly.  In these
+   cases, the costs of maintaining the NSEC RR chain may be extremely
+   high and use of the "Opt-Out" convention may be more appropriate (for
+   these unsecured zones).
+
+   This document presents the NSEC3 Resource Record which can be used as
+   an alternative to NSEC to mitigate these issues.
+
+   Earlier work to address these issues include [DNSEXT-NO], [RFC4956],
+   and [DNSEXT-NSEC2v2].
+
+1.2.  Requirements
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in [RFC2119].
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 4]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+1.3.  Terminology
+
+   The reader is assumed to be familiar with the basic DNS and DNSSEC
+   concepts described in [RFC1034], [RFC1035], [RFC4033], [RFC4034],
+   [RFC4035], and subsequent RFCs that update them: [RFC2136],
+   [RFC2181], and [RFC2308].
+
+   The following terminology is used throughout this document:
+
+   Zone enumeration:  the practice of discovering the full content of a
+      zone via successive queries.  Zone enumeration was non-trivial
+      prior to the introduction of DNSSEC.
+
+   Original owner name:  the owner name corresponding to a hashed owner
+      name.
+
+   Hashed owner name:  the owner name created after applying the hash
+      function to an owner name.
+
+   Hash order:  the order in which hashed owner names are arranged
+      according to their numerical value, treating the leftmost (lowest
+      numbered) octet as the most significant octet.  Note that this
+      order is the same as the canonical DNS name order specified in
+      [RFC4034], when the hashed owner names are in base32, encoded with
+      an Extended Hex Alphabet [RFC4648].
+
+   Empty non-terminal:  a domain name that owns no resource records, but
+      has one or more subdomains that do.
+
+   Delegation:  an NS RRSet with a name different from the current zone
+      apex (non-zone-apex), signifying a delegation to a child zone.
+
+   Secure delegation:  a name containing a delegation (NS RRSet) and a
+      signed DS RRSet, signifying a delegation to a signed child zone.
+
+   Insecure delegation:  a name containing a delegation (NS RRSet), but
+      lacking a DS RRSet, signifying a delegation to an unsigned child
+      zone.
+
+   Opt-Out NSEC3 resource record:  an NSEC3 resource record that has the
+      Opt-Out flag set to 1.
+
+   Opt-Out zone:  a zone with at least one Opt-Out NSEC3 RR.
+
+   Closest encloser:  the longest existing ancestor of a name.  See also
+      Section 3.3.1 of [RFC4592].
+
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 5]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   Closest provable encloser:  the longest ancestor of a name that can
+      be proven to exist.  Note that this is only different from the
+      closest encloser in an Opt-Out zone.
+
+   Next closer name:  the name one label longer than the closest
+      provable encloser of a name.
+
+   Base32:  the "Base 32 Encoding with Extended Hex Alphabet" as
+      specified in [RFC4648].  Note that trailing padding characters
+      ("=") are not used in the NSEC3 specification.
+
+   To cover:  An NSEC3 RR is said to "cover" a name if the hash of the
+      name or "next closer" name falls between the owner name and the
+      next hashed owner name of the NSEC3.  In other words, if it proves
+      the nonexistence of the name, either directly or by proving the
+      nonexistence of an ancestor of the name.
+
+   To match:  An NSEC3 RR is said to "match" a name if the owner name of
+      the NSEC3 RR is the same as the hashed owner name of that name.
+
+2.  Backwards Compatibility
+
+   This specification describes a protocol change that is not generally
+   backwards compatible with [RFC4033], [RFC4034], and [RFC4035].  In
+   particular, security-aware resolvers that are unaware of this
+   specification (NSEC3-unaware resolvers) may fail to validate the
+   responses introduced by this document.
+
+   In order to aid deployment, this specification uses a signaling
+   technique to prevent NSEC3-unaware resolvers from attempting to
+   validate responses from NSEC3-signed zones.
+
+   This specification allocates two new DNSKEY algorithm identifiers for
+   this purpose.  Algorithm 6, DSA-NSEC3-SHA1 is an alias for algorithm
+   3, DSA.  Algorithm 7, RSASHA1-NSEC3-SHA1 is an alias for algorithm 5,
+   RSASHA1.  These are not new algorithms, they are additional
+   identifiers for the existing algorithms.
+
+   Zones signed according to this specification MUST only use these
+   algorithm identifiers for their DNSKEY RRs.  Because these new
+   identifiers will be unknown algorithms to existing, NSEC3-unaware
+   resolvers, those resolvers will then treat responses from the NSEC3
+   signed zone as insecure, as detailed in Section 5.2 of [RFC4035].
+
+   These algorithm identifiers are used with the NSEC3 hash algorithm
+   SHA1.  Using other NSEC3 hash algorithms requires allocation of a new
+   alias (see Section 12.1.3).
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 6]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   Security aware resolvers that are aware of this specification MUST
+   recognize the new algorithm identifiers and treat them as equivalent
+   to the algorithms that they alias.
+
+   A methodology for transitioning from a DNSSEC signed zone to a zone
+   signed using NSEC3 is discussed in Section 10.4.
+
+3.  The NSEC3 Resource Record
+
+   The NSEC3 Resource Record (RR) provides authenticated denial of
+   existence for DNS Resource Record Sets.
+
+   The NSEC3 RR lists RR types present at the original owner name of the
+   NSEC3 RR.  It includes the next hashed owner name in the hash order
+   of the zone.  The complete set of NSEC3 RRs in a zone indicates which
+   RRSets exist for the original owner name of the RR and form a chain
+   of hashed owner names in the zone.  This information is used to
+   provide authenticated denial of existence for DNS data.  To provide
+   protection against zone enumeration, the owner names used in the
+   NSEC3 RR are cryptographic hashes of the original owner name
+   prepended as a single label to the name of the zone.  The NSEC3 RR
+   indicates which hash function is used to construct the hash, which
+   salt is used, and how many iterations of the hash function are
+   performed over the original owner name.  The hashing technique is
+   described fully in Section 5.
+
+   Hashed owner names of unsigned delegations may be excluded from the
+   chain.  An NSEC3 RR whose span covers the hash of an owner name or
+   "next closer" name of an unsigned delegation is referred to as an
+   Opt-Out NSEC3 RR and is indicated by the presence of a flag.
+
+   The owner name for the NSEC3 RR is the base32 encoding of the hashed
+   owner name prepended as a single label to the name of the zone.
+
+   The type value for the NSEC3 RR is 50.
+
+   The NSEC3 RR RDATA format is class independent and is described
+   below.
+
+   The class MUST be the same as the class of the original owner name.
+
+   The NSEC3 RR SHOULD have the same TTL value as the SOA minimum TTL
+   field.  This is in the spirit of negative caching [RFC2308].
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 7]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+3.1.  RDATA Fields
+
+3.1.1.  Hash Algorithm
+
+   The Hash Algorithm field identifies the cryptographic hash algorithm
+   used to construct the hash-value.
+
+   The values for this field are defined in the NSEC3 hash algorithm
+   registry defined in Section 11.
+
+3.1.2.  Flags
+
+   The Flags field contains 8 one-bit flags that can be used to indicate
+   different processing.  All undefined flags must be zero.  The only
+   flag defined by this specification is the Opt-Out flag.
+
+3.1.2.1.  Opt-Out Flag
+
+   If the Opt-Out flag is set, the NSEC3 record covers zero or more
+   unsigned delegations.
+
+   If the Opt-Out flag is clear, the NSEC3 record covers zero unsigned
+   delegations.
+
+   The Opt-Out Flag indicates whether this NSEC3 RR may cover unsigned
+   delegations.  It is the least significant bit in the Flags field.
+   See Section 6 for details about the use of this flag.
+
+3.1.3.  Iterations
+
+   The Iterations field defines the number of additional times the hash
+   function has been performed.  More iterations result in greater
+   resiliency of the hash value against dictionary attacks, but at a
+   higher computational cost for both the server and resolver.  See
+   Section 5 for details of the use of this field, and Section 10.3 for
+   limitations on the value.
+
+3.1.4.  Salt Length
+
+   The Salt Length field defines the length of the Salt field in octets,
+   ranging in value from 0 to 255.
+
+3.1.5.  Salt
+
+   The Salt field is appended to the original owner name before hashing
+   in order to defend against pre-calculated dictionary attacks.  See
+   Section 5 for details on how the salt is used.
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 8]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+3.1.6.  Hash Length
+
+   The Hash Length field defines the length of the Next Hashed Owner
+   Name field, ranging in value from 1 to 255 octets.
+
+3.1.7.  Next Hashed Owner Name
+
+   The Next Hashed Owner Name field contains the next hashed owner name
+   in hash order.  This value is in binary format.  Given the ordered
+   set of all hashed owner names, the Next Hashed Owner Name field
+   contains the hash of an owner name that immediately follows the owner
+   name of the given NSEC3 RR.  The value of the Next Hashed Owner Name
+   field in the last NSEC3 RR in the zone is the same as the hashed
+   owner name of the first NSEC3 RR in the zone in hash order.  Note
+   that, unlike the owner name of the NSEC3 RR, the value of this field
+   does not contain the appended zone name.
+
+3.1.8.  Type Bit Maps
+
+   The Type Bit Maps field identifies the RRSet types that exist at the
+   original owner name of the NSEC3 RR.
+
+3.2.  NSEC3 RDATA Wire Format
+
+   The RDATA of the NSEC3 RR is as shown below:
+
+                        1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Hash Alg.   |     Flags     |          Iterations           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  Salt Length  |                     Salt                      /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  Hash Length  |             Next Hashed Owner Name            /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   /                         Type Bit Maps                         /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Hash Algorithm is a single octet.
+
+   Flags field is a single octet, the Opt-Out flag is the least
+   significant bit, as shown below:
+
+    0 1 2 3 4 5 6 7
+   +-+-+-+-+-+-+-+-+
+   |             |O|
+   +-+-+-+-+-+-+-+-+
+
+
+
+
+Laurie, et al.              Standards Track                     [Page 9]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   Iterations is represented as a 16-bit unsigned integer, with the most
+   significant bit first.
+
+   Salt Length is represented as an unsigned octet.  Salt Length
+   represents the length of the Salt field in octets.  If the value is
+   zero, the following Salt field is omitted.
+
+   Salt, if present, is encoded as a sequence of binary octets.  The
+   length of this field is determined by the preceding Salt Length
+   field.
+
+   Hash Length is represented as an unsigned octet.  Hash Length
+   represents the length of the Next Hashed Owner Name field in octets.
+
+   The next hashed owner name is not base32 encoded, unlike the owner
+   name of the NSEC3 RR.  It is the unmodified binary hash value.  It
+   does not include the name of the containing zone.  The length of this
+   field is determined by the preceding Hash Length field.
+
+3.2.1.  Type Bit Maps Encoding
+
+   The encoding of the Type Bit Maps field is the same as that used by
+   the NSEC RR, described in [RFC4034].  It is explained and clarified
+   here for clarity.
+
+   The RR type space is split into 256 window blocks, each representing
+   the low-order 8 bits of the 16-bit RR type space.  Each block that
+   has at least one active RR type is encoded using a single octet
+   window number (from 0 to 255), a single octet bitmap length (from 1
+   to 32) indicating the number of octets used for the bitmap of the
+   window block, and up to 32 octets (256 bits) of bitmap.
+
+   Blocks are present in the NSEC3 RR RDATA in increasing numerical
+   order.
+
+      Type Bit Maps Field = ( Window Block # | Bitmap Length | Bitmap )+
+
+      where "|" denotes concatenation.
+
+   Each bitmap encodes the low-order 8 bits of RR types within the
+   window block, in network bit order.  The first bit is bit 0.  For
+   window block 0, bit 1 corresponds to RR type 1 (A), bit 2 corresponds
+   to RR type 2 (NS), and so forth.  For window block 1, bit 1
+   corresponds to RR type 257, bit 2 to RR type 258.  If a bit is set to
+   1, it indicates that an RRSet of that type is present for the
+   original owner name of the NSEC3 RR.  If a bit is set to 0, it
+   indicates that no RRSet of that type is present for the original
+   owner name of the NSEC3 RR.
+
+
+
+Laurie, et al.              Standards Track                    [Page 10]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   Since bit 0 in window block 0 refers to the non-existing RR type 0,
+   it MUST be set to 0.  After verification, the validator MUST ignore
+   the value of bit 0 in window block 0.
+
+   Bits representing Meta-TYPEs or QTYPEs as specified in Section 3.1 of
+   [RFC2929] or within the range reserved for assignment only to QTYPEs
+   and Meta-TYPEs MUST be set to 0, since they do not appear in zone
+   data.  If encountered, they must be ignored upon reading.
+
+   Blocks with no types present MUST NOT be included.  Trailing zero
+   octets in the bitmap MUST be omitted.  The length of the bitmap of
+   each block is determined by the type code with the largest numerical
+   value, within that block, among the set of RR types present at the
+   original owner name of the NSEC3 RR.  Trailing octets not specified
+   MUST be interpreted as zero octets.
+
+3.3.  Presentation Format
+
+   The presentation format of the RDATA portion is as follows:
+
+   o  The Hash Algorithm field is represented as an unsigned decimal
+      integer.  The value has a maximum of 255.
+
+   o  The Flags field is represented as an unsigned decimal integer.
+      The value has a maximum of 255.
+
+   o  The Iterations field is represented as an unsigned decimal
+      integer.  The value is between 0 and 65535, inclusive.
+
+   o  The Salt Length field is not represented.
+
+   o  The Salt field is represented as a sequence of case-insensitive
+      hexadecimal digits.  Whitespace is not allowed within the
+      sequence.  The Salt field is represented as "-" (without the
+      quotes) when the Salt Length field has a value of 0.
+
+   o  The Hash Length field is not represented.
+
+   o  The Next Hashed Owner Name field is represented as an unpadded
+      sequence of case-insensitive base32 digits, without whitespace.
+
+   o  The Type Bit Maps field is represented as a sequence of RR type
+      mnemonics.  When the mnemonic is not known, the TYPE
+      representation as described in Section 5 of [RFC3597] MUST be
+      used.
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 11]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+4.  The NSEC3PARAM Resource Record
+
+   The NSEC3PARAM RR contains the NSEC3 parameters (hash algorithm,
+   flags, iterations, and salt) needed by authoritative servers to
+   calculate hashed owner names.  The presence of an NSEC3PARAM RR at a
+   zone apex indicates that the specified parameters may be used by
+   authoritative servers to choose an appropriate set of NSEC3 RRs for
+   negative responses.  The NSEC3PARAM RR is not used by validators or
+   resolvers.
+
+   If an NSEC3PARAM RR is present at the apex of a zone with a Flags
+   field value of zero, then there MUST be an NSEC3 RR using the same
+   hash algorithm, iterations, and salt parameters present at every
+   hashed owner name in the zone.  That is, the zone MUST contain a
+   complete set of NSEC3 RRs with the same hash algorithm, iterations,
+   and salt parameters.
+
+   The owner name for the NSEC3PARAM RR is the name of the zone apex.
+
+   The type value for the NSEC3PARAM RR is 51.
+
+   The NSEC3PARAM RR RDATA format is class independent and is described
+   below.
+
+   The class MUST be the same as the NSEC3 RRs to which this RR refers.
+
+4.1.  RDATA Fields
+
+   The RDATA for this RR mirrors the first four fields in the NSEC3 RR.
+
+4.1.1.  Hash Algorithm
+
+   The Hash Algorithm field identifies the cryptographic hash algorithm
+   used to construct the hash-value.
+
+   The acceptable values are the same as the corresponding field in the
+   NSEC3 RR.
+
+4.1.2.  Flag Fields
+
+   The Opt-Out flag is not used and is set to zero.
+
+   All other flags are reserved for future use, and must be zero.
+
+   NSEC3PARAM RRs with a Flags field value other than zero MUST be
+   ignored.
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 12]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+4.1.3.  Iterations
+
+   The Iterations field defines the number of additional times the hash
+   is performed.
+
+   Its acceptable values are the same as the corresponding field in the
+   NSEC3 RR.
+
+4.1.4.  Salt Length
+
+   The Salt Length field defines the length of the salt in octets,
+   ranging in value from 0 to 255.
+
+4.1.5.  Salt
+
+   The Salt field is appended to the original owner name before hashing.
+
+4.2.  NSEC3PARAM RDATA Wire Format
+
+   The RDATA of the NSEC3PARAM RR is as shown below:
+
+                        1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |   Hash Alg.   |     Flags     |          Iterations           |
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+   |  Salt Length  |                     Salt                      /
+   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+   Hash Algorithm is a single octet.
+
+   Flags field is a single octet.
+
+   Iterations is represented as a 16-bit unsigned integer, with the most
+   significant bit first.
+
+   Salt Length is represented as an unsigned octet.  Salt Length
+   represents the length of the following Salt field in octets.  If the
+   value is zero, the Salt field is omitted.
+
+   Salt, if present, is encoded as a sequence of binary octets.  The
+   length of this field is determined by the preceding Salt Length
+   field.
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 13]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+4.3.  Presentation Format
+
+   The presentation format of the RDATA portion is as follows:
+
+   o  The Hash Algorithm field is represented as an unsigned decimal
+      integer.  The value has a maximum of 255.
+
+   o  The Flags field is represented as an unsigned decimal integer.
+      The value has a maximum value of 255.
+
+   o  The Iterations field is represented as an unsigned decimal
+      integer.  The value is between 0 and 65535, inclusive.
+
+   o  The Salt Length field is not represented.
+
+   o  The Salt field is represented as a sequence of case-insensitive
+      hexadecimal digits.  Whitespace is not allowed within the
+      sequence.  This field is represented as "-" (without the quotes)
+      when the Salt Length field is zero.
+
+5.  Calculation of the Hash
+
+   The hash calculation uses three of the NSEC3 RDATA fields: Hash
+   Algorithm, Salt, and Iterations.
+
+   Define H(x) to be the hash of x using the Hash Algorithm selected by
+   the NSEC3 RR, k to be the number of Iterations, and || to indicate
+   concatenation.  Then define:
+
+      IH(salt, x, 0) = H(x || salt), and
+
+      IH(salt, x, k) = H(IH(salt, x, k-1) || salt), if k > 0
+
+   Then the calculated hash of an owner name is
+
+      IH(salt, owner name, iterations),
+
+   where the owner name is in the canonical form, defined as:
+
+   The wire format of the owner name where:
+
+   1.  The owner name is fully expanded (no DNS name compression) and
+       fully qualified;
+
+   2.  All uppercase US-ASCII letters are replaced by the corresponding
+       lowercase US-ASCII letters;
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 14]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   3.  If the owner name is a wildcard name, the owner name is in its
+       original unexpanded form, including the "*" label (no wildcard
+       substitution);
+
+   This form is as defined in Section 6.2 of [RFC4034].
+
+   The method to calculate the Hash is based on [RFC2898].
+
+6.  Opt-Out
+
+   In this specification, as in [RFC4033], [RFC4034] and [RFC4035], NS
+   RRSets at delegation points are not signed and may be accompanied by
+   a DS RRSet.  With the Opt-Out bit clear, the security status of the
+   child zone is determined by the presence or absence of this DS RRSet,
+   cryptographically proven by the signed NSEC3 RR at the hashed owner
+   name of the delegation.  Setting the Opt-Out flag modifies this by
+   allowing insecure delegations to exist within the signed zone without
+   a corresponding NSEC3 RR at the hashed owner name of the delegation.
+
+   An Opt-Out NSEC3 RR is said to cover a delegation if the hash of the
+   owner name or "next closer" name of the delegation is between the
+   owner name of the NSEC3 RR and the next hashed owner name.
+
+   An Opt-Out NSEC3 RR does not assert the existence or non-existence of
+   the insecure delegations that it may cover.  This allows for the
+   addition or removal of these delegations without recalculating or re-
+   signing RRs in the NSEC3 RR chain.  However, Opt-Out NSEC3 RRs do
+   assert the (non)existence of other, authoritative RRSets.
+
+   An Opt-Out NSEC3 RR MAY have the same original owner name as an
+   insecure delegation.  In this case, the delegation is proven insecure
+   by the lack of a DS bit in the type map and the signed NSEC3 RR does
+   assert the existence of the delegation.
+
+   Zones using Opt-Out MAY contain a mixture of Opt-Out NSEC3 RRs and
+   non-Opt-Out NSEC3 RRs.  If an NSEC3 RR is not Opt-Out, there MUST NOT
+   be any hashed owner names of insecure delegations (nor any other RRs)
+   between it and the name indicated by the next hashed owner name in
+   the NSEC3 RDATA.  If it is Opt-Out, it MUST only cover hashed owner
+   names or hashed "next closer" names of insecure delegations.
+
+   The effects of the Opt-Out flag on signing, serving, and validating
+   responses are covered in following sections.
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 15]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+7.  Authoritative Server Considerations
+
+7.1.  Zone Signing
+
+   Zones using NSEC3 must satisfy the following properties:
+
+   o  Each owner name within the zone that owns authoritative RRSets
+      MUST have a corresponding NSEC3 RR.  Owner names that correspond
+      to unsigned delegations MAY have a corresponding NSEC3 RR.
+      However, if there is not a corresponding NSEC3 RR, there MUST be
+      an Opt-Out NSEC3 RR that covers the "next closer" name to the
+      delegation.  Other non-authoritative RRs are not represented by
+      NSEC3 RRs.
+
+   o  Each empty non-terminal MUST have a corresponding NSEC3 RR, unless
+      the empty non-terminal is only derived from an insecure delegation
+      covered by an Opt-Out NSEC3 RR.
+
+   o  The TTL value for any NSEC3 RR SHOULD be the same as the minimum
+      TTL value field in the zone SOA RR.
+
+   o  The Type Bit Maps field of every NSEC3 RR in a signed zone MUST
+      indicate the presence of all types present at the original owner
+      name, except for the types solely contributed by an NSEC3 RR
+      itself.  Note that this means that the NSEC3 type itself will
+      never be present in the Type Bit Maps.
+
+   The following steps describe a method of proper construction of NSEC3
+   RRs.  This is not the only such possible method.
+
+   1.  Select the hash algorithm and the values for salt and iterations.
+
+   2.  For each unique original owner name in the zone add an NSEC3 RR.
+
+       *  If Opt-Out is being used, owner names of unsigned delegations
+          MAY be excluded.
+
+       *  The owner name of the NSEC3 RR is the hash of the original
+          owner name, prepended as a single label to the zone name.
+
+       *  The Next Hashed Owner Name field is left blank for the moment.
+
+       *  If Opt-Out is being used, set the Opt-Out bit to one.
+
+       *  For collision detection purposes, optionally keep track of the
+          original owner name with the NSEC3 RR.
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 16]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+       *  Additionally, for collision detection purposes, optionally
+          create an additional NSEC3 RR corresponding to the original
+          owner name with the asterisk label prepended (i.e., as if a
+          wildcard existed as a child of this owner name) and keep track
+          of this original owner name.  Mark this NSEC3 RR as temporary.
+
+   3.  For each RRSet at the original owner name, set the corresponding
+       bit in the Type Bit Maps field.
+
+   4.  If the difference in number of labels between the apex and the
+       original owner name is greater than 1, additional NSEC3 RRs need
+       to be added for every empty non-terminal between the apex and the
+       original owner name.  This process may generate NSEC3 RRs with
+       duplicate hashed owner names.  Optionally, for collision
+       detection, track the original owner names of these NSEC3 RRs and
+       create temporary NSEC3 RRs for wildcard collisions in a similar
+       fashion to step 1.
+
+   5.  Sort the set of NSEC3 RRs into hash order.
+
+   6.  Combine NSEC3 RRs with identical hashed owner names by replacing
+       them with a single NSEC3 RR with the Type Bit Maps field
+       consisting of the union of the types represented by the set of
+       NSEC3 RRs.  If the original owner name was tracked, then
+       collisions may be detected when combining, as all of the matching
+       NSEC3 RRs should have the same original owner name.  Discard any
+       possible temporary NSEC3 RRs.
+
+   7.  In each NSEC3 RR, insert the next hashed owner name by using the
+       value of the next NSEC3 RR in hash order.  The next hashed owner
+       name of the last NSEC3 RR in the zone contains the value of the
+       hashed owner name of the first NSEC3 RR in the hash order.
+
+   8.  Finally, add an NSEC3PARAM RR with the same Hash Algorithm,
+       Iterations, and Salt fields to the zone apex.
+
+   If a hash collision is detected, then a new salt has to be chosen,
+   and the signing process restarted.
+
+7.2.  Zone Serving
+
+   This specification modifies DNSSEC-enabled DNS responses generated by
+   authoritative servers.  In particular, it replaces the use of NSEC
+   RRs in such responses with NSEC3 RRs.
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 17]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   In the following response cases, the NSEC RRs dictated by DNSSEC
+   [RFC4035] are replaced with NSEC3 RRs that prove the same facts.
+   Responses that would not contain NSEC RRs are unchanged by this
+   specification.
+
+   When returning responses containing multiple NSEC3 RRs, all of the
+   NSEC3 RRs MUST use the same hash algorithm, iteration, and salt
+   values.  The Flags field value MUST be either zero or one.
+
+7.2.1.  Closest Encloser Proof
+
+   For many NSEC3 responses a proof of the closest encloser is required.
+   This is a proof that some ancestor of the QNAME is the closest
+   encloser of QNAME.
+
+   This proof consists of (up to) two different NSEC3 RRs:
+
+   o  An NSEC3 RR that matches the closest (provable) encloser.
+
+   o  An NSEC3 RR that covers the "next closer" name to the closest
+      encloser.
+
+   The first NSEC3 RR essentially proposes a possible closest encloser,
+   and proves that the particular encloser does, in fact, exist.  The
+   second NSEC3 RR proves that the possible closest encloser is the
+   closest, and proves that the QNAME (and any ancestors between QNAME
+   and the closest encloser) does not exist.
+
+   These NSEC3 RRs are collectively referred to as the "closest encloser
+   proof" in the subsequent descriptions.
+
+   For example, the closest encloser proof for the nonexistent
+   "alpha.beta.gamma.example." owner name might prove that
+   "gamma.example." is the closest encloser.  This response would
+   contain the NSEC3 RR that matches "gamma.example.", and would also
+   contain the NSEC3 RR that covers "beta.gamma.example." (which is the
+   "next closer" name).
+
+   It is possible, when using Opt-Out (Section 6), to not be able to
+   prove the actual closest encloser because it is, or is part of an
+   insecure delegation covered by an Opt-Out span.  In this case,
+   instead of proving the actual closest encloser, the closest provable
+   encloser is used.  That is, the closest enclosing authoritative name
+   is used instead.  In this case, the set of NSEC3 RRs used for this
+   proof is referred to as the "closest provable encloser proof".
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 18]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+7.2.2.  Name Error Responses
+
+   To prove the nonexistence of QNAME, a closest encloser proof and an
+   NSEC3 RR covering the (nonexistent) wildcard RR at the closest
+   encloser MUST be included in the response.  This collection of (up
+   to) three NSEC3 RRs proves both that QNAME does not exist and that a
+   wildcard that could have matched QNAME also does not exist.
+
+   For example, if "gamma.example." is the closest provable encloser to
+   QNAME, then an NSEC3 RR covering "*.gamma.example." is included in
+   the authority section of the response.
+
+7.2.3.  No Data Responses, QTYPE is not DS
+
+   The server MUST include the NSEC3 RR that matches QNAME.  This NSEC3
+   RR MUST NOT have the bits corresponding to either the QTYPE or CNAME
+   set in its Type Bit Maps field.
+
+7.2.4.  No Data Responses, QTYPE is DS
+
+   If there is an NSEC3 RR that matches QNAME, the server MUST return it
+   in the response.  The bits corresponding with DS and CNAME MUST NOT
+   be set in the Type Bit Maps field of this NSEC3 RR.
+
+   If no NSEC3 RR matches QNAME, the server MUST return a closest
+   provable encloser proof for QNAME.  The NSEC3 RR that covers the
+   "next closer" name MUST have the Opt-Out bit set (note that this is
+   true by definition -- if the Opt-Out bit is not set, something has
+   gone wrong).
+
+   If a server is authoritative for both sides of a zone cut at QNAME,
+   the server MUST return the proof from the parent side of the zone
+   cut.
+
+7.2.5.  Wildcard No Data Responses
+
+   If there is a wildcard match for QNAME, but QTYPE is not present at
+   that name, the response MUST include a closest encloser proof for
+   QNAME and MUST include the NSEC3 RR that matches the wildcard.  This
+   combination proves both that QNAME itself does not exist and that a
+   wildcard that matches QNAME does exist.  Note that the closest
+   encloser to QNAME MUST be the immediate ancestor of the wildcard RR
+   (if this is not the case, then something has gone wrong).
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 19]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+7.2.6.  Wildcard Answer Responses
+
+   If there is a wildcard match for QNAME and QTYPE, then, in addition
+   to the expanded wildcard RRSet returned in the answer section of the
+   response, proof that the wildcard match was valid must be returned.
+
+   This proof is accomplished by proving that both QNAME does not exist
+   and that the closest encloser of the QNAME and the immediate ancestor
+   of the wildcard are the same (i.e., the correct wildcard matched).
+
+   To this end, the NSEC3 RR that covers the "next closer" name of the
+   immediate ancestor of the wildcard MUST be returned.  It is not
+   necessary to return an NSEC3 RR that matches the closest encloser, as
+   the existence of this closest encloser is proven by the presence of
+   the expanded wildcard in the response.
+
+7.2.7.  Referrals to Unsigned Subzones
+
+   If there is an NSEC3 RR that matches the delegation name, then that
+   NSEC3 RR MUST be included in the response.  The DS bit in the type
+   bit maps of the NSEC3 RR MUST NOT be set.
+
+   If the zone is Opt-Out, then there may not be an NSEC3 RR
+   corresponding to the delegation.  In this case, the closest provable
+   encloser proof MUST be included in the response.  The included NSEC3
+   RR that covers the "next closer" name for the delegation MUST have
+   the Opt-Out flag set to one.  (Note that this will be the case unless
+   something has gone wrong).
+
+7.2.8.  Responding to Queries for NSEC3 Owner Names
+
+   The owner names of NSEC3 RRs are not represented in the NSEC3 RR
+   chain like other owner names.  As a result, each NSEC3 owner name is
+   covered by another NSEC3 RR, effectively negating the existence of
+   the NSEC3 RR.  This is a paradox, since the existence of an NSEC3 RR
+   can be proven by its RRSIG RRSet.
+
+   If the following conditions are all true:
+
+   o  the QNAME equals the owner name of an existing NSEC3 RR, and
+
+   o  no RR types exist at the QNAME, nor at any descendant of QNAME,
+
+   then the response MUST be constructed as a Name Error response
+   (Section 7.2.2).  Or, in other words, the authoritative name server
+   will act as if the owner name of the NSEC3 RR did not exist.
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 20]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   Note that NSEC3 RRs are returned as a result of an AXFR or IXFR
+   query.
+
+7.2.9.  Server Response to a Run-Time Collision
+
+   If the hash of a non-existing QNAME collides with the owner name of
+   an existing NSEC3 RR, then the server will be unable to return a
+   response that proves that QNAME does not exist.  In this case, the
+   server MUST return a response with an RCODE of 2 (server failure).
+
+   Note that with the hash algorithm specified in this document, SHA-1,
+   such collisions are highly unlikely.
+
+7.3.  Secondary Servers
+
+   Secondary servers (and perhaps other entities) need to reliably
+   determine which NSEC3 parameters (i.e., hash, salt, and iterations)
+   are present at every hashed owner name, in order to be able to choose
+   an appropriate set of NSEC3 RRs for negative responses.  This is
+   indicated by an NSEC3PARAM RR present at the zone apex.
+
+   If there are multiple NSEC3PARAM RRs present, there are multiple
+   valid NSEC3 chains present.  The server must choose one of them, but
+   may use any criteria to do so.
+
+7.4.  Zones Using Unknown Hash Algorithms
+
+   Zones that are signed according to this specification, but are using
+   an unrecognized NSEC3 hash algorithm value, cannot be effectively
+   served.  Such zones SHOULD be rejected when loading.  Servers SHOULD
+   respond with RCODE=2 (server failure) responses when handling queries
+   that would fall under such zones.
+
+7.5.  Dynamic Update
+
+   A zone signed using NSEC3 may accept dynamic updates [RFC2136].
+   However, NSEC3 introduces some special considerations for dynamic
+   updates.
+
+   Adding and removing names in a zone MUST account for the creation or
+   removal of empty non-terminals.
+
+   o  When removing a name with a corresponding NSEC3 RR, any NSEC3 RRs
+      corresponding to empty non-terminals created by that name MUST be
+      removed.  Note that more than one name may be asserting the
+      existence of a particular empty non-terminal.
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 21]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   o  When adding a name that requires adding an NSEC3 RR, NSEC3 RRs
+      MUST also be added for any empty non-terminals that are created.
+      That is, if there is not an existing NSEC3 RR matching an empty
+      non-terminal, it must be created and added.
+
+   The presence of Opt-Out in a zone means that some additions or
+   delegations of names will not require changes to the NSEC3 RRs in a
+   zone.
+
+   o  When removing a delegation RRSet, if that delegation does not have
+      a matching NSEC3 RR, then it was opted out.  In this case, nothing
+      further needs to be done.
+
+   o  When adding a delegation RRSet, if the "next closer" name of the
+      delegation is covered by an existing Opt-Out NSEC3 RR, then the
+      delegation MAY be added without modifying the NSEC3 RRs in the
+      zone.
+
+   The presence of Opt-Out in a zone means that when adding or removing
+   NSEC3 RRs, the value of the Opt-Out flag that should be set in new or
+   modified NSEC3 RRs is ambiguous.  Servers SHOULD follow this set of
+   basic rules to resolve the ambiguity.
+
+   The central concept to these rules is that the state of the Opt-Out
+   flag of the covering NSEC3 RR is preserved.
+
+   o  When removing an NSEC3 RR, the value of the Opt-Out flag for the
+      previous NSEC3 RR (the one whose next hashed owner name is
+      modified) should not be changed.
+
+   o  When adding an NSEC3 RR, the value of the Opt-Out flag is set to
+      the value of the Opt-Out flag of the NSEC3 RR that previously
+      covered the owner name of the NSEC3 RR.  That is, the now previous
+      NSEC3 RR.
+
+   If the zone in question is consistent with its use of the Opt-Out
+   flag (that is, all NSEC3 RRs in the zone have the same value for the
+   flag) then these rules will retain that consistency.  If the zone is
+   not consistent in the use of the flag (i.e., a partially Opt-Out
+   zone), then these rules will not retain the same pattern of use of
+   the Opt-Out flag.
+
+   For zones that partially use the Opt-Out flag, if there is a logical
+   pattern for that use, the pattern could be maintained by using a
+   local policy on the server.
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 22]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+8.  Validator Considerations
+
+8.1.  Responses with Unknown Hash Types
+
+   A validator MUST ignore NSEC3 RRs with unknown hash types.  The
+   practical result of this is that responses containing only such NSEC3
+   RRs will generally be considered bogus.
+
+8.2.  Verifying NSEC3 RRs
+
+   A validator MUST ignore NSEC3 RRs with a Flag fields value other than
+   zero or one.
+
+   A validator MAY treat a response as bogus if the response contains
+   NSEC3 RRs that contain different values for hash algorithm,
+   iterations, or salt from each other for that zone.
+
+8.3.  Closest Encloser Proof
+
+   In order to verify a closest encloser proof, the validator MUST find
+   the longest name, X, such that
+
+   o  X is an ancestor of QNAME that is matched by an NSEC3 RR present
+      in the response.  This is a candidate for the closest encloser,
+      and
+
+   o  The name one label longer than X (but still an ancestor of -- or
+      equal to -- QNAME) is covered by an NSEC3 RR present in the
+      response.
+
+   One possible algorithm for verifying this proof is as follows:
+
+   1.  Set SNAME=QNAME.  Clear the flag.
+
+   2.  Check whether SNAME exists:
+
+       *  If there is no NSEC3 RR in the response that matches SNAME
+          (i.e., an NSEC3 RR whose owner name is the same as the hash of
+          SNAME, prepended as a single label to the zone name), clear
+          the flag.
+
+       *  If there is an NSEC3 RR in the response that covers SNAME, set
+          the flag.
+
+       *  If there is a matching NSEC3 RR in the response and the flag
+          was set, then the proof is complete, and SNAME is the closest
+          encloser.
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 23]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+       *  If there is a matching NSEC3 RR in the response, but the flag
+          is not set, then the response is bogus.
+
+   3.  Truncate SNAME by one label from the left, go to step 2.
+
+   Once the closest encloser has been discovered, the validator MUST
+   check that the NSEC3 RR that has the closest encloser as the original
+   owner name is from the proper zone.  The DNAME type bit must not be
+   set and the NS type bit may only be set if the SOA type bit is set.
+   If this is not the case, it would be an indication that an attacker
+   is using them to falsely deny the existence of RRs for which the
+   server is not authoritative.
+
+   In the following descriptions, the phrase "a closest (provable)
+   encloser proof for X" means that the algorithm above (or an
+   equivalent algorithm) proves that X does not exist by proving that an
+   ancestor of X is its closest encloser.
+
+8.4.  Validating Name Error Responses
+
+   A validator MUST verify that there is a closest encloser proof for
+   QNAME present in the response and that there is an NSEC3 RR that
+   covers the wildcard at the closest encloser (i.e., the name formed by
+   prepending the asterisk label to the closest encloser).
+
+8.5.  Validating No Data Responses, QTYPE is not DS
+
+   The validator MUST verify that an NSEC3 RR that matches QNAME is
+   present and that both the QTYPE and the CNAME type are not set in its
+   Type Bit Maps field.
+
+   Note that this test also covers the case where the NSEC3 RR exists
+   because it corresponds to an empty non-terminal, in which case the
+   NSEC3 RR will have an empty Type Bit Maps field.
+
+8.6.  Validating No Data Responses, QTYPE is DS
+
+   If there is an NSEC3 RR that matches QNAME present in the response,
+   then that NSEC3 RR MUST NOT have the bits corresponding to DS and
+   CNAME set in its Type Bit Maps field.
+
+   If there is no such NSEC3 RR, then the validator MUST verify that a
+   closest provable encloser proof for QNAME is present in the response,
+   and that the NSEC3 RR that covers the "next closer" name has the Opt-
+   Out bit set.
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 24]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+8.7.  Validating Wildcard No Data Responses
+
+   The validator MUST verify a closest encloser proof for QNAME and MUST
+   find an NSEC3 RR present in the response that matches the wildcard
+   name generated by prepending the asterisk label to the closest
+   encloser.  Furthermore, the bits corresponding to both QTYPE and
+   CNAME MUST NOT be set in the wildcard matching NSEC3 RR.
+
+8.8.  Validating Wildcard Answer Responses
+
+   The verified wildcard answer RRSet in the response provides the
+   validator with a (candidate) closest encloser for QNAME.  This
+   closest encloser is the immediate ancestor to the generating
+   wildcard.
+
+   Validators MUST verify that there is an NSEC3 RR that covers the
+   "next closer" name to QNAME present in the response.  This proves
+   that QNAME itself did not exist and that the correct wildcard was
+   used to generate the response.
+
+8.9.  Validating Referrals to Unsigned Subzones
+
+   The delegation name in a referral is the owner name of the NS RRSet
+   present in the authority section of the referral response.
+
+   If there is an NSEC3 RR present in the response that matches the
+   delegation name, then the validator MUST ensure that the NS bit is
+   set and that the DS bit is not set in the Type Bit Maps field of the
+   NSEC3 RR.  The validator MUST also ensure that the NSEC3 RR is from
+   the correct (i.e., parent) zone.  This is done by ensuring that the
+   SOA bit is not set in the Type Bit Maps field of this NSEC3 RR.
+
+   Note that the presence of an NS bit implies the absence of a DNAME
+   bit, so there is no need to check for the DNAME bit in the Type Bit
+   Maps field of the NSEC3 RR.
+
+   If there is no NSEC3 RR present that matches the delegation name,
+   then the validator MUST verify a closest provable encloser proof for
+   the delegation name.  The validator MUST verify that the Opt-Out bit
+   is set in the NSEC3 RR that covers the "next closer" name to the
+   delegation name.
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 25]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+9.  Resolver Considerations
+
+9.1.  NSEC3 Resource Record Caching
+
+   Caching resolvers MUST be able to retrieve the appropriate NSEC3 RRs
+   when returning responses that contain them.  In DNSSEC [RFC4035], in
+   many cases it is possible to find the correct NSEC RR to return in a
+   response by name (e.g., when returning a referral, the NSEC RR will
+   always have the same owner name as the delegation).  With this
+   specification, that will not be true, nor will a cache be able to
+   calculate the name(s) of the appropriate NSEC3 RR(s).
+   Implementations may need to use new methods for caching and
+   retrieving NSEC3 RRs.
+
+9.2.  Use of the AD Bit
+
+   The AD bit, as defined by [RFC4035], MUST NOT be set when returning a
+   response containing a closest (provable) encloser proof in which the
+   NSEC3 RR that covers the "next closer" name has the Opt-Out bit set.
+
+   This rule is based on what this closest encloser proof actually
+   proves: names that would be covered by the Opt-Out NSEC3 RR may or
+   may not exist as insecure delegations.  As such, not all the data in
+   responses containing such closest encloser proofs will have been
+   cryptographically verified, so the AD bit cannot be set.
+
+10.  Special Considerations
+
+10.1.  Domain Name Length Restrictions
+
+   Zones signed using this specification have additional domain name
+   length restrictions imposed upon them.  In particular, zones with
+   names that, when converted into hashed owner names exceed the 255
+   octet length limit imposed by [RFC1035], cannot use this
+   specification.
+
+   The actual maximum length of a domain name in a particular zone
+   depends on both the length of the zone name (versus the whole domain
+   name) and the particular hash function used.
+
+   As an example, SHA-1 produces a hash of 160 bits.  The base-32
+   encoding of 160 bits results in 32 characters.  The 32 characters are
+   prepended to the name of the zone as a single label, which includes a
+   length field of a single octet.  The maximum length of the zone name,
+   when using SHA-1, is 222 octets (255 - 33).
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 26]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+10.2.  DNAME at the Zone Apex
+
+   The DNAME specification in Section 3 of [RFC2672] has a 'no-
+   descendants' limitation.  If a DNAME RR is present at node N, there
+   MUST be no data at any descendant of N.
+
+   If N is the apex of the zone, there will be NSEC3 and RRSIG types
+   present at descendants of N.  This specification updates the DNAME
+   specification to allow NSEC3 and RRSIG types at descendants of the
+   apex regardless of the existence of DNAME at the apex.
+
+10.3.  Iterations
+
+   Setting the number of iterations used allows the zone owner to choose
+   the cost of computing a hash, and therefore the cost of generating a
+   dictionary.  Note that this is distinct from the effect of salt,
+   which prevents the use of a single precomputed dictionary for all
+   time.
+
+   Obviously the number of iterations also affects the zone owner's cost
+   of signing and serving the zone as well as the validator's cost of
+   verifying responses from the zone.  We therefore impose an upper
+   limit on the number of iterations.  We base this on the number of
+   iterations that approximates the cost of verifying an RRSet.
+
+   The limits, therefore, are based on the size of the smallest zone
+   signing key, rounded up to the nearest table value (or rounded down
+   if the key is larger than the largest table value).
+
+   A zone owner MUST NOT use a value higher than shown in the table
+   below for iterations for the given key size.  A resolver MAY treat a
+   response with a higher value as insecure, after the validator has
+   verified that the signature over the NSEC3 RR is correct.
+
+                         +----------+------------+
+                         | Key Size | Iterations |
+                         +----------+------------+
+                         | 1024     | 150        |
+                         | 2048     | 500        |
+                         | 4096     | 2,500      |
+                         +----------+------------+
+
+   This table is based on an approximation of the ratio between the cost
+   of an SHA-1 calculation and the cost of an RSA verification for keys
+   of size 1024 bits (150 to 1), 2048 bits (500 to 1), and 4096 bits
+   (2500 to 1).
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 27]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   The ratio between SHA-1 calculation and DSA verification is higher
+   (1500 to 1 for keys of size 1024).  A higher iteration count degrades
+   performance, while DSA verification is already more expensive than
+   RSA for the same key size.  Therefore the values in the table MUST be
+   used independent of the key algorithm.
+
+10.4.  Transitioning a Signed Zone from NSEC to NSEC3
+
+   When transitioning an already signed and trusted zone to this
+   specification, care must be taken to prevent client validation
+   failures during the process.
+
+   The basic procedure is as follows:
+
+   1.  Transition all DNSKEYs to DNSKEYs using the algorithm aliases
+       described in Section 2.  The actual method for safely and
+       securely changing the DNSKEY RRSet of the zone is outside the
+       scope of this specification.  However, the end result MUST be
+       that all DS RRs in the parent use the specified algorithm
+       aliases.
+
+       After this transition is complete, all NSEC3-unaware clients will
+       treat the zone as insecure.  At this point, the authoritative
+       server still returns negative and wildcard responses that contain
+       NSEC RRs.
+
+   2.  Add signed NSEC3 RRs to the zone, either incrementally or all at
+       once.  If adding incrementally, then the last RRSet added MUST be
+       the NSEC3PARAM RRSet.
+
+   3.  Upon the addition of the NSEC3PARAM RRSet, the server switches to
+       serving negative and wildcard responses with NSEC3 RRs according
+       to this specification.
+
+   4.  Remove the NSEC RRs either incrementally or all at once.
+
+10.5.  Transitioning a Signed Zone from NSEC3 to NSEC
+
+   To safely transition back to a DNSSEC [RFC4035] signed zone, simply
+   reverse the procedure above:
+
+   1.  Add NSEC RRs incrementally or all at once.
+
+   2.  Remove the NSEC3PARAM RRSet.  This will signal the server to use
+       the NSEC RRs for negative and wildcard responses.
+
+   3.  Remove the NSEC3 RRs either incrementally or all at once.
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 28]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   4.  Transition all of the DNSKEYs to DNSSEC algorithm identifiers.
+       After this transition is complete, all NSEC3-unaware clients will
+       treat the zone as secure.
+
+11.  IANA Considerations
+
+   Although the NSEC3 and NSEC3PARAM RR formats include a hash algorithm
+   parameter, this document does not define a particular mechanism for
+   safely transitioning from one NSEC3 hash algorithm to another.  When
+   specifying a new hash algorithm for use with NSEC3, a transition
+   mechanism MUST also be defined.
+
+   This document updates the IANA registry "DOMAIN NAME SYSTEM
+   PARAMETERS" (http://www.iana.org/assignments/dns-parameters) in sub-
+   registry "TYPES", by defining two new types.  Section 3 defines the
+   NSEC3 RR type 50.  Section 4 defines the NSEC3PARAM RR type 51.
+
+   This document updates the IANA registry "DNS SECURITY ALGORITHM
+   NUMBERS -- per [RFC4035]"
+   (http://www.iana.org/assignments/dns-sec-alg-numbers).  Section 2
+   defines the aliases DSA-NSEC3-SHA1 (6) and RSASHA1-NSEC3-SHA1 (7) for
+   respectively existing registrations DSA and RSASHA1 in combination
+   with NSEC3 hash algorithm SHA1.
+
+   Since these algorithm numbers are aliases for existing DNSKEY
+   algorithm numbers, the flags that exist for the original algorithm
+   are valid for the alias algorithm.
+
+   This document creates a new IANA registry for NSEC3 flags.  This
+   registry is named "DNSSEC NSEC3 Flags".  The initial contents of this
+   registry are:
+
+     0   1   2   3   4   5   6   7
+   +---+---+---+---+---+---+---+---+
+   |   |   |   |   |   |   |   |Opt|
+   |   |   |   |   |   |   |   |Out|
+   +---+---+---+---+---+---+---+---+
+
+      bit 7 is the Opt-Out flag.
+
+      bits 0 - 6 are available for assignment.
+
+   Assignment of additional NSEC3 Flags in this registry requires IETF
+   Standards Action [RFC2434].
+
+   This document creates a new IANA registry for NSEC3PARAM flags.  This
+   registry is named "DNSSEC NSEC3PARAM Flags".  The initial contents of
+   this registry are:
+
+
+
+Laurie, et al.              Standards Track                    [Page 29]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+     0   1   2   3   4   5   6   7
+   +---+---+---+---+---+---+---+---+
+   |   |   |   |   |   |   |   | 0 |
+   +---+---+---+---+---+---+---+---+
+
+      bit 7 is reserved and must be 0.
+
+      bits 0 - 6 are available for assignment.
+
+   Assignment of additional NSEC3PARAM Flags in this registry requires
+   IETF Standards Action [RFC2434].
+
+   Finally, this document creates a new IANA registry for NSEC3 hash
+   algorithms.  This registry is named "DNSSEC NSEC3 Hash Algorithms".
+   The initial contents of this registry are:
+
+      0 is Reserved.
+
+      1 is SHA-1.
+
+      2-255 Available for assignment.
+
+   Assignment of additional NSEC3 hash algorithms in this registry
+   requires IETF Standards Action [RFC2434].
+
+12.  Security Considerations
+
+12.1.  Hashing Considerations
+
+12.1.1.  Dictionary Attacks
+
+   The NSEC3 RRs are still susceptible to dictionary attacks (i.e., the
+   attacker retrieves all the NSEC3 RRs, then calculates the hashes of
+   all likely domain names, comparing against the hashes found in the
+   NSEC3 RRs, and thus enumerating the zone).  These are substantially
+   more expensive than enumerating the original NSEC RRs would have
+   been, and in any case, such an attack could also be used directly
+   against the name server itself by performing queries for all likely
+   names, though this would obviously be more detectable.  The expense
+   of this off-line attack can be chosen by setting the number of
+   iterations in the NSEC3 RR.
+
+   Zones are also susceptible to a pre-calculated dictionary attack --
+   that is, a list of hashes for all likely names is computed once, then
+   NSEC3 RR is scanned periodically and compared against the precomputed
+   hashes.  This attack is prevented by changing the salt on a regular
+   basis.
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 30]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   The salt SHOULD be at least 64 bits long and unpredictable, so that
+   an attacker cannot anticipate the value of the salt and compute the
+   next set of dictionaries before the zone is published.
+
+12.1.2.  Collisions
+
+   Hash collisions between QNAME and the owner name of an NSEC3 RR may
+   occur.  When they do, it will be impossible to prove the non-
+   existence of the colliding QNAME.  However, with SHA-1, this is
+   highly unlikely (on the order of 1 in 2^160).  Note that DNSSEC
+   already relies on the presumption that a cryptographic hash function
+   is second pre-image resistant, since these hash functions are used
+   for generating and validating signatures and DS RRs.
+
+12.1.3.  Transitioning to a New Hash Algorithm
+
+   Although the NSEC3 and NSEC3PARAM RR formats include a hash algorithm
+   parameter, this document does not define a particular mechanism for
+   safely transitioning from one NSEC3 hash algorithm to another.  When
+   specifying a new hash algorithm for use with NSEC3, a transition
+   mechanism MUST also be defined.  It is possible that the only
+   practical and palatable transition mechanisms may require an
+   intermediate transition to an insecure state, or to a state that uses
+   NSEC records instead of NSEC3.
+
+12.1.4.  Using High Iteration Values
+
+   Since validators should treat responses containing NSEC3 RRs with
+   high iteration values as insecure, presence of just one signed NSEC3
+   RR with a high iteration value in a zone provides attackers with a
+   possible downgrade attack.
+
+   The attack is simply to remove any existing NSEC3 RRs from a
+   response, and replace or add a single (or multiple) NSEC3 RR that
+   uses a high iterations value to the response.  Validators will then
+   be forced to treat the response as insecure.  This attack would be
+   effective only when all of following conditions are met:
+
+   o  There is at least one signed NSEC3 RR that uses a high iterations
+      value present in the zone.
+
+   o  The attacker has access to one or more of these NSEC3 RRs.  This
+      is trivially true when the NSEC3 RRs with high iteration values
+      are being returned in typical responses, but may also be true if
+      the attacker can access the zone via AXFR or IXFR queries, or any
+      other methodology.
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 31]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   Using a high number of iterations also introduces an additional
+   denial-of-service opportunity against servers, since servers must
+   calculate several hashes per negative or wildcard response.
+
+12.2.  Opt-Out Considerations
+
+   The Opt-Out Flag (O) allows for unsigned names, in the form of
+   delegations to unsigned zones, to exist within an otherwise signed
+   zone.  All unsigned names are, by definition, insecure, and their
+   validity or existence cannot be cryptographically proven.
+
+   In general:
+
+   o  Resource records with unsigned names (whether existing or not)
+      suffer from the same vulnerabilities as RRs in an unsigned zone.
+      These vulnerabilities are described in more detail in [RFC3833]
+      (note in particular Section 2.3, "Name Chaining" and Section 2.6,
+      "Authenticated Denial of Domain Names").
+
+   o  Resource records with signed names have the same security whether
+      or not Opt-Out is used.
+
+   Note that with or without Opt-Out, an insecure delegation may be
+   undetectably altered by an attacker.  Because of this, the primary
+   difference in security when using Opt-Out is the loss of the ability
+   to prove the existence or nonexistence of an insecure delegation
+   within the span of an Opt-Out NSEC3 RR.
+
+   In particular, this means that a malicious entity may be able to
+   insert or delete RRs with unsigned names.  These RRs are normally NS
+   RRs, but this also includes signed wildcard expansions (while the
+   wildcard RR itself is signed, its expanded name is an unsigned name).
+
+   Note that being able to add a delegation is functionally equivalent
+   to being able to add any RR type: an attacker merely has to forge a
+   delegation to name server under his/her control and place whatever
+   RRs needed at the subzone apex.
+
+   While in particular cases, this issue may not present a significant
+   security problem, in general it should not be lightly dismissed.
+   Therefore, it is strongly RECOMMENDED that Opt-Out be used sparingly.
+   In particular, zone signing tools SHOULD NOT default to using Opt-
+   Out, and MAY choose to not support Opt-Out at all.
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 32]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+12.3.  Other Considerations
+
+   Walking the NSEC3 RRs will reveal the total number of RRs in the zone
+   (plus empty non-terminals), and also what types there are.  This
+   could be mitigated by adding dummy entries, but certainly an upper
+   limit can always be found.
+
+13.  References
+
+13.1.  Normative References
+
+   [RFC1034]         Mockapetris, P., "Domain names - concepts and
+                     facilities", STD 13, RFC 1034, November 1987.
+
+   [RFC1035]         Mockapetris, P., "Domain names - implementation and
+                     specification", STD 13, RFC 1035, November 1987.
+
+   [RFC2119]         Bradner, S., "Key words for use in RFCs to Indicate
+                     Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2136]         Vixie, P., Thomson, S., Rekhter, Y., and J. Bound,
+                     "Dynamic Updates in the Domain Name System (DNS
+                     UPDATE)", RFC 2136, April 1997.
+
+   [RFC2181]         Elz, R. and R. Bush, "Clarifications to the DNS
+                     Specification", RFC 2181, July 1997.
+
+   [RFC2308]         Andrews, M., "Negative Caching of DNS Queries (DNS
+                     NCACHE)", RFC 2308, March 1998.
+
+   [RFC2434]         Narten, T. and H. Alvestrand, "Guidelines for
+                     Writing an IANA Considerations Section in RFCs",
+                     BCP 26, RFC 2434, October 1998.
+
+   [RFC2929]         Eastlake, D., Brunner-Williams, E., and B. Manning,
+                     "Domain Name System (DNS) IANA Considerations",
+                     BCP 42, RFC 2929, September 2000.
+
+   [RFC3597]         Gustafsson, A., "Handling of Unknown DNS Resource
+                     Record (RR) Types", RFC 3597, September 2003.
+
+   [RFC4033]         Arends, R., Austein, R., Larson, M., Massey, D.,
+                     and S. Rose, "DNS Security Introduction and
+                     Requirements", RFC 4033, March 2005.
+
+   [RFC4034]         Arends, R., Austein, R., Larson, M., Massey, D.,
+                     and S. Rose, "Resource Records for the DNS Security
+                     Extensions", RFC 4034, March 2005.
+
+
+
+Laurie, et al.              Standards Track                    [Page 33]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   [RFC4035]         Arends, R., Austein, R., Larson, M., Massey, D.,
+                     and S. Rose, "Protocol Modifications for the DNS
+                     Security Extensions", RFC 4035, March 2005.
+
+   [RFC4648]         Josefsson, S., "The Base16, Base32, and Base64 Data
+                     Encodings", RFC 4648, October 2006.
+
+13.2.  Informative References
+
+   [DNSEXT-NO]       Josefsson, S., "Authenticating Denial of Existence
+                     in DNS with Minimum Disclosure", Work in Progress,
+                     July 2000.
+
+   [DNSEXT-NSEC2v2]  Laurie, B., "DNSSEC NSEC2 Owner and RDATA Format",
+                     Work in Progress, December 2004.
+
+   [RFC2672]         Crawford, M., "Non-Terminal DNS Name Redirection",
+                     RFC 2672, August 1999.
+
+   [RFC2898]         Kaliski, B., "PKCS #5: Password-Based Cryptography
+                     Specification Version 2.0", RFC 2898,
+                     September 2000.
+
+   [RFC3833]         Atkins, D. and R. Austein, "Threat Analysis of the
+                     Domain Name System (DNS)", RFC 3833, August 2004.
+
+   [RFC4592]         Lewis, E., "The Role of Wildcards in the Domain
+                     Name System", RFC 4592, July 2006.
+
+   [RFC4956]         Arends, R., Kosters, M., and D. Blacka, "DNS
+                     Security (DNSSEC) Opt-In", RFC 4956, July 2007.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 34]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+Appendix A.  Example Zone
+
+   This is a zone showing its NSEC3 RRs.  They can also be used as test
+   vectors for the hash algorithm.
+
+   The overall TTL and class are specified in the SOA RR, and are
+   subsequently omitted for clarity.
+
+   The zone is preceded by a list that contains the hashes of the
+   original ownernames.
+
+   ; H(example)       = 0p9mhaveqvm6t7vbl5lop2u3t2rp3tom
+   ; H(a.example)     = 35mthgpgcu1qg68fab165klnsnk3dpvl
+   ; H(ai.example)    = gjeqe526plbf1g8mklp59enfd789njgi
+   ; H(ns1.example)   = 2t7b4g4vsa5smi47k61mv5bv1a22bojr
+   ; H(ns2.example)   = q04jkcevqvmu85r014c7dkba38o0ji5r
+   ; H(w.example)     = k8udemvp1j2f7eg6jebps17vp3n8i58h
+   ; H(*.w.example)   = r53bq7cc2uvmubfu5ocmm6pers9tk9en
+   ; H(x.w.example)   = b4um86eghhds6nea196smvmlo4ors995
+   ; H(y.w.example)   = ji6neoaepv8b5o6k4ev33abha8ht9fgc
+   ; H(x.y.w.example) = 2vptu5timamqttgl4luu9kg21e0aor3s
+   ; H(xx.example)    = t644ebqk9bibcna874givr6joj62mlhv
+   ; H(2t7b4g4vsa5smi47k61mv5bv1a22bojr.example)
+   ;                  = kohar7mbb8dc2ce8a9qvl8hon4k53uhi
+   example. 3600  IN SOA  ns1.example. bugs.x.w.example. 1 3600 300 (
+                          3600000 3600 )
+                  RRSIG   SOA 7 1 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          Hu25UIyNPmvPIVBrldN+9Mlp9Zql39qaUd8i
+                          q4ZLlYWfUUbbAS41pG+68z81q1xhkYAcEyHd
+                          VI2LmKusbZsT0Q== )
+                  NS      ns1.example.
+                  NS      ns2.example.
+                  RRSIG   NS 7 1 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          PVOgtMK1HHeSTau+HwDWC8Ts+6C8qtqd4pQJ
+                          qOtdEVgg+MA+ai4fWDEhu3qHJyLcQ9tbD2vv
+                          CnMXjtz6SyObxA== )
+                  MX      1 xx.example.
+                  RRSIG   MX 7 1 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          GgQ1A9xs47k42VPvpL/a1BWUz/6XsnHkjotw
+                          9So8MQtZtl2wJBsnOQsaoHrRCrRbyriEl/GZ
+                          n9Mto/Kx+wBo+w== )
+                  DNSKEY  256 3 7 AwEAAaetidLzsKWUt4swWR8yu0wPHPiUi8LU (
+                          sAD0QPWU+wzt89epO6tHzkMBVDkC7qphQO2h
+                          TY4hHn9npWFRw5BYubE= )
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 35]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+                  DNSKEY  257 3 7 AwEAAcUlFV1vhmqx6NSOUOq2R/dsR7Xm3upJ (
+                          j7IommWSpJABVfW8Q0rOvXdM6kzt+TAu92L9
+                          AbsUdblMFin8CVF3n4s= )
+                  RRSIG   DNSKEY 7 1 3600 20150420235959 (
+                          20051021000000 12708 example.
+                          AuU4juU9RaxescSmStrQks3Gh9FblGBlVU31
+                          uzMZ/U/FpsUb8aC6QZS+sTsJXnLnz7flGOsm
+                          MGQZf3bH+QsCtg== )
+                  NSEC3PARAM 1 0 12 aabbccdd
+                  RRSIG   NSEC3PARAM 7 1 3600 20150420235959 (
+                          20051021000000 40430 example.
+                          C1Gl8tPZNtnjlrYWDeeUV/sGLCyy/IHie2re
+                          rN05XSA3Pq0U3+4VvGWYWdUMfflOdxqnXHwJ
+                          TLQsjlkynhG6Cg== )
+   0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. NSEC3 1 1 12 aabbccdd (
+                          2t7b4g4vsa5smi47k61mv5bv1a22bojr MX DNSKEY NS
+                          SOA NSEC3PARAM RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          OSgWSm26B+cS+dDL8b5QrWr/dEWhtCsKlwKL
+                          IBHYH6blRxK9rC0bMJPwQ4mLIuw85H2EY762
+                          BOCXJZMnpuwhpA== )
+   2t7b4g4vsa5smi47k61mv5bv1a22bojr.example. A 192.0.2.127
+                  RRSIG   A 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          h6c++bzhRuWWt2bykN6mjaTNBcXNq5UuL5Ed
+                          K+iDP4eY8I0kSiKaCjg3tC1SQkeloMeub2GW
+                          k8p6xHMPZumXlw== )
+                  NSEC3   1 1 12 aabbccdd (
+                          2vptu5timamqttgl4luu9kg21e0aor3s A RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          OmBvJ1Vgg1hCKMXHFiNeIYHK9XVW0iLDLwJN
+                          4TFoNxZuP03gAXEI634YwOc4YBNITrj413iq
+                          NI6mRk/r1dOSUw== )
+   2vptu5timamqttgl4luu9kg21e0aor3s.example. NSEC3 1 1 12 aabbccdd (
+                          35mthgpgcu1qg68fab165klnsnk3dpvl MX RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          KL1V2oFYghNV0Hm7Tf2vpJjM6l+0g1JCcVYG
+                          VfI0lKrhPmTsOA96cLEACgo1x8I7kApJX+ob
+                          TuktZ+sdsZPY1w== )
+   35mthgpgcu1qg68fab165klnsnk3dpvl.example. NSEC3 1 1 12 aabbccdd (
+                          b4um86eghhds6nea196smvmlo4ors995 NS DS RRSIG )
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 36]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          g6jPUUpduAJKRljUsN8gB4UagAX0NxY9shwQ
+                          Aynzo8EUWH+z6hEIBlUTPGj15eZll6VhQqgZ
+                          XtAIR3chwgW+SA== )
+   a.example.     NS      ns1.a.example.
+                  NS      ns2.a.example.
+                  DS      58470 5 1 (
+                          3079F1593EBAD6DC121E202A8B766A6A4837206C )
+                  RRSIG   DS 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          XacFcQVHLVzdoc45EJhN616zQ4mEXtE8FzUh
+                          M2KWjfy1VfRKD9r1MeVGwwoukOKgJxBPFsWo
+                          o722vZ4UZ2dIdA== )
+   ns1.a.example. A       192.0.2.5
+   ns2.a.example. A       192.0.2.6
+   ai.example.    A       192.0.2.9
+                  RRSIG   A 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          hVe+wKYMlObTRPhX0NL67GxeZfdxqr/QeR6F
+                          tfdAj5+FgYxyzPEjIzvKWy00hWIl6wD3Vws+
+                          rznEn8sQ64UdqA== )
+                  HINFO   "KLH-10" "ITS"
+                  RRSIG   HINFO 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          Yi42uOq43eyO6qXHNvwwfFnIustWgV5urFcx
+                          enkLvs6pKRh00VBjODmf3Z4nMO7IOl6nHSQ1
+                          v0wLHpEZG7Xj2w== )
+                  AAAA    2001:db8:0:0:0:0:f00:baa9
+                  RRSIG   AAAA 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          LcdxKaCB5bGZwPDg+3JJ4O02zoMBrjxqlf6W
+                          uaHQZZfTUpb9Nf2nxFGe2XRPfR5tpJT6GdRG
+                          cHueLuXkMjBArQ== )
+   b4um86eghhds6nea196smvmlo4ors995.example. NSEC3 1 1 12 aabbccdd (
+                          gjeqe526plbf1g8mklp59enfd789njgi MX RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          ZkPG3M32lmoHM6pa3D6gZFGB/rhL//Bs3Omh
+                          5u4m/CUiwtblEVOaAKKZd7S959OeiX43aLX3
+                          pOv0TSTyiTxIZg== )
+   c.example.     NS      ns1.c.example.
+                  NS      ns2.c.example.
+   ns1.c.example. A       192.0.2.7
+   ns2.c.example. A       192.0.2.8
+   gjeqe526plbf1g8mklp59enfd789njgi.example. NSEC3 1 1 12 aabbccdd (
+                          ji6neoaepv8b5o6k4ev33abha8ht9fgc HINFO A AAAA
+                          RRSIG )
+
+
+
+Laurie, et al.              Standards Track                    [Page 37]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          IVnezTJ9iqblFF97vPSmfXZ5Zozngx3KX3by
+                          LTZC4QBH2dFWhf6scrGFZB980AfCxoD9qbbK
+                          Dy+rdGIeRSVNyw== )
+   ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 aabbccdd (
+                          k8udemvp1j2f7eg6jebps17vp3n8i58h )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          gPkFp1s2QDQ6wQzcg1uSebZ61W33rUBDcTj7
+                          2F3kQ490fEdp7k1BUIfbcZtPbX3YCpE+sIt0
+                          MpzVSKfTwx4uYA== )
+   k8udemvp1j2f7eg6jebps17vp3n8i58h.example. NSEC3 1 1 12 aabbccdd (
+                          kohar7mbb8dc2ce8a9qvl8hon4k53uhi )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          FtXGbvF0+wf8iWkyo73enAuVx03klN+pILBK
+                          S6qCcftVtfH4yVzsEZquJ27NHR7ruxJWDNMt
+                          Otx7w9WfcIg62A== )
+   kohar7mbb8dc2ce8a9qvl8hon4k53uhi.example. NSEC3 1 1 12 aabbccdd (
+                          q04jkcevqvmu85r014c7dkba38o0ji5r A RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          VrDXs2uVW21N08SyQIz88zml+y4ZCInTwgDr
+                          6zz43yAg+LFERjOrj3Ojct51ac7Dp4eZbf9F
+                          QJazmASFKGxGXg== )
+   ns1.example.   A       192.0.2.1
+                  RRSIG   A 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          bu6kx73n6XEunoVGuRfAgY7EF/AJqHy7hj0j
+                          kiqJjB0dOrx3wuz9SaBeGfqWIdn/uta3SavN
+                          4FRvZR9SCFHF5Q== )
+   ns2.example.   A       192.0.2.2
+                  RRSIG   A 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          ktQ3TqE0CfRfki0Rb/Ip5BM0VnxelbuejCC4
+                          zpLbFKA/7eD7UNAwxMgxJPtbdST+syjYSJaj
+                          4IHfeX6n8vfoGA== )
+   q04jkcevqvmu85r014c7dkba38o0ji5r.example. NSEC3 1 1 12 aabbccdd (
+                          r53bq7cc2uvmubfu5ocmm6pers9tk9en A RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          hV5I89b+4FHJDATp09g4bbN0R1F845CaXpL3
+                          ZxlMKimoPAyqletMlEWwLfFia7sdpSzn+ZlN
+                          NlkxWcLsIlMmUg== )
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 38]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   r53bq7cc2uvmubfu5ocmm6pers9tk9en.example. NSEC3 1 1 12 aabbccdd (
+                          t644ebqk9bibcna874givr6joj62mlhv MX RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          aupviViruXs4bDg9rCbezzBMf9h1ZlDvbW/C
+                          ZFKulIGXXLj8B/fsDJarXVDA9bnUoRhEbKp+
+                          HF1FWKW7RIJdtQ== )
+   t644ebqk9bibcna874givr6joj62mlhv.example. NSEC3 1 1 12 aabbccdd (
+                          0p9mhaveqvm6t7vbl5lop2u3t2rp3tom HINFO A AAAA
+                          RRSIG )
+                  RRSIG   NSEC3 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          RAjGECB8P7O+F4Pa4Dx3tC0M+Z3KmlLKImca
+                          fb9XWwx+NWUNz7NBEDBQHivIyKPVDkChcePI
+                          X1xPl1ATNa+8Dw== )
+   *.w.example.   MX      1 ai.example.
+                  RRSIG   MX 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          CikebjQwGQPwijVcxgcZcSJKtfynugtlBiKb
+                          9FcBTrmOoyQ4InoWVudhCWsh/URX3lc4WRUM
+                          ivEBP6+4KS3ldA== )
+   x.w.example.   MX      1 xx.example.
+                  RRSIG   MX 7 3 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          IrK3tq/tHFIBF0scHiE/1IwMAvckS/55hAVv
+                          QyxTFbkAdDloP3NbZzu+yoSsr3b3OX6qbBpY
+                          7WCtwwekLKRAwQ== )
+   x.y.w.example. MX      1 xx.example.
+                  RRSIG   MX 7 4 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          MqSt5HqJIN8+SLlzTOImrh5h9Xa6gDvAW/Gn
+                          nbdPc6Z7nXvCpLPJj/5lCwx3VuzVOjkbvXze
+                          8/8Ccl2Zn2hbug== )
+   xx.example.    A       192.0.2.10
+                  RRSIG   A 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          T35hBWEZ017VC5u2c4OriKyVn/pu+fVK4AlX
+                          YOxJ6iQylfV2HQIKjv6b7DzINB3aF/wjJqgX
+                          pQvhq+Ac6+ZiFg== )
+                  HINFO   "KLH-10" "TOPS-20"
+                  RRSIG   HINFO 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          KimG+rDd+7VA1zRsu0ITNAQUTRlpnsmqWrih
+                          FRnU+bRa93v2e5oFNFYCs3Rqgv62K93N7AhW
+                          6Jfqj/8NzWjvKg== )
+                  AAAA    2001:db8:0:0:0:0:f00:baaa
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 39]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+                  RRSIG   AAAA 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          IXBcXORITNwd8h3gNwyxtYFvAupS/CYWufVe
+                          uBUX0O25ivBCULjZjpDxFSxfohb/KA7YRdxE
+                          NzYfMItpILl/Xw== )
+
+Appendix B.  Example Responses
+
+   The examples in this section show response messages using the signed
+   zone example in Appendix A.
+
+B.1.  Name Error
+
+   An authoritative name error.  The NSEC3 RRs prove that the name does
+   not exist and that there is no wildcard RR that should have been
+   expanded.
+
+;; Header: QR AA DO RCODE=3
+;;
+;; Question
+a.c.x.w.example.         IN A
+
+;; Answer
+;; (empty)
+
+;; Authority
+
+example.       SOA     ns1.example. bugs.x.w.example. 1 3600 300 (
+                       3600000 3600 )
+example.       RRSIG   SOA 7 1 3600 20150420235959 20051021000000 (
+                       40430 example.
+                       Hu25UIyNPmvPIVBrldN+9Mlp9Zql39qaUd8i
+                       q4ZLlYWfUUbbAS41pG+68z81q1xhkYAcEyHd
+                       VI2LmKusbZsT0Q== )
+
+;; NSEC3 RR that covers the "next closer" name (c.x.w.example)
+;; H(c.x.w.example) = 0va5bpr2ou0vk0lbqeeljri88laipsfh
+
+0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. NSEC3 1 1 12 aabbccdd (
+                       2t7b4g4vsa5smi47k61mv5bv1a22bojr MX DNSKEY NS
+                       SOA NSEC3PARAM RRSIG )
+0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. RRSIG NSEC3 7 2 3600 (
+                       20150420235959 20051021000000 40430 example.
+                       OSgWSm26B+cS+dDL8b5QrWr/dEWhtCsKlwKL
+                       IBHYH6blRxK9rC0bMJPwQ4mLIuw85H2EY762
+                       BOCXJZMnpuwhpA== )
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 40]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+;; NSEC3 RR that matches the closest encloser (x.w.example)
+;; H(x.w.example) = b4um86eghhds6nea196smvmlo4ors995
+
+b4um86eghhds6nea196smvmlo4ors995.example. NSEC3 1 1 12 aabbccdd (
+                       gjeqe526plbf1g8mklp59enfd789njgi MX RRSIG )
+b4um86eghhds6nea196smvmlo4ors995.example. RRSIG NSEC3 7 2 3600 (
+                       20150420235959 20051021000000 40430 example.
+                       ZkPG3M32lmoHM6pa3D6gZFGB/rhL//Bs3Omh
+                       5u4m/CUiwtblEVOaAKKZd7S959OeiX43aLX3
+                       pOv0TSTyiTxIZg== )
+
+;; NSEC3 RR that covers wildcard at the closest encloser (*.x.w.example)
+;; H(*.x.w.example) = 92pqneegtaue7pjatc3l3qnk738c6v5m
+
+35mthgpgcu1qg68fab165klnsnk3dpvl.example. NSEC3 1 1 12 aabbccdd (
+                       b4um86eghhds6nea196smvmlo4ors995 NS DS RRSIG )
+35mthgpgcu1qg68fab165klnsnk3dpvl.example. RRSIG NSEC3 7 2 3600 (
+                       20150420235959 20051021000000 40430 example.
+                       g6jPUUpduAJKRljUsN8gB4UagAX0NxY9shwQ
+                       Aynzo8EUWH+z6hEIBlUTPGj15eZll6VhQqgZ
+                       XtAIR3chwgW+SA== )
+
+;; Additional
+;; (empty)
+
+   The query returned three NSEC3 RRs that prove that the requested data
+   does not exist and that no wildcard expansion applies.  The negative
+   response is authenticated by verifying the NSEC3 RRs.  The
+   corresponding RRSIGs indicate that the NSEC3 RRs are signed by an
+   "example" DNSKEY of algorithm 7 and with key tag 40430.  The resolver
+   needs the corresponding DNSKEY RR in order to authenticate this
+   answer.
+
+   One of the owner names of the NSEC3 RRs matches the closest encloser.
+   One of the NSEC3 RRs prove that there exists no longer name.  One of
+   the NSEC3 RRs prove that there exists no wildcard RRSets that should
+   have been expanded.  The closest encloser can be found by applying
+   the algorithm in Section 8.3.
+
+   In the above example, the name 'x.w.example' hashes to
+   'b4um86eghhds6nea196smvmlo4ors995'.  This indicates that this might
+   be the closest encloser.  To prove that 'c.x.w.example' and
+   '*.x.w.example' do not exist, these names are hashed to,
+   respectively, '0va5bpr2ou0vk0lbqeeljri88laipsfh' and
+   '92pqneegtaue7pjatc3l3qnk738c6v5m'.  The first and last NSEC3 RRs
+   prove that these hashed owner names do not exist.
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 41]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+B.2.  No Data Error
+
+   A "no data" response.  The NSEC3 RR proves that the name exists and
+   that the requested RR type does not.
+
+;; Header: QR AA DO RCODE=0
+;;
+;; Question
+ns1.example.        IN MX
+
+;; Answer
+;; (empty)
+
+;; Authority
+example.       SOA     ns1.example. bugs.x.w.example. 1 3600 300 (
+                       3600000 3600 )
+example.       RRSIG   SOA 7 1 3600 20150420235959 20051021000000 (
+                       40430 example.
+                       Hu25UIyNPmvPIVBrldN+9Mlp9Zql39qaUd8i
+                       q4ZLlYWfUUbbAS41pG+68z81q1xhkYAcEyHd
+                       VI2LmKusbZsT0Q== )
+
+;; NSEC3 RR matches the QNAME and shows that the MX type bit is not set.
+
+2t7b4g4vsa5smi47k61mv5bv1a22bojr.example. NSEC3 1 1 12 aabbccdd (
+                       2vptu5timamqttgl4luu9kg21e0aor3s A RRSIG )
+2t7b4g4vsa5smi47k61mv5bv1a22bojr.example. RRSIG NSEC3 7 2 3600 (
+                       20150420235959 20051021000000 40430 example.
+                       OmBvJ1Vgg1hCKMXHFiNeIYHK9XVW0iLDLwJN
+                       4TFoNxZuP03gAXEI634YwOc4YBNITrj413iq
+                       NI6mRk/r1dOSUw== )
+;; Additional
+;; (empty)
+
+   The query returned an NSEC3 RR that proves that the requested name
+   exists ("ns1.example." hashes to "2t7b4g4vsa5smi47k61mv5bv1a22bojr"),
+   but the requested RR type does not exist (type MX is absent in the
+   type code list of the NSEC3 RR), and was not a CNAME (type CNAME is
+   also absent in the type code list of the NSEC3 RR).
+
+
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 42]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+B.2.1.  No Data Error, Empty Non-Terminal
+
+   A "no data" response because of an empty non-terminal.  The NSEC3 RR
+   proves that the name exists and that the requested RR type does not.
+
+ ;; Header: QR AA DO RCODE=0
+ ;;
+ ;; Question
+ y.w.example.        IN A
+
+ ;; Answer
+ ;; (empty)
+
+ ;; Authority
+ example.       SOA     ns1.example. bugs.x.w.example. 1 3600 300 (
+                        3600000 3600 )
+ example.       RRSIG   SOA 7 1 3600 20150420235959 20051021000000 (
+                        40430 example.
+                        Hu25UIyNPmvPIVBrldN+9Mlp9Zql39qaUd8i
+                        q4ZLlYWfUUbbAS41pG+68z81q1xhkYAcEyHd
+                        VI2LmKusbZsT0Q== )
+
+ ;; NSEC3 RR matches the QNAME and shows that the A type bit is not set.
+
+ ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. NSEC3 1 1 12 aabbccdd (
+                        k8udemvp1j2f7eg6jebps17vp3n8i58h )
+ ji6neoaepv8b5o6k4ev33abha8ht9fgc.example. RRSIG NSEC3 7 2 3600 (
+                        20150420235959 20051021000000 40430 example.
+                        gPkFp1s2QDQ6wQzcg1uSebZ61W33rUBDcTj7
+                        2F3kQ490fEdp7k1BUIfbcZtPbX3YCpE+sIt0
+                        MpzVSKfTwx4uYA== )
+
+ ;; Additional
+ ;; (empty)
+
+   The query returned an NSEC3 RR that proves that the requested name
+   exists ("y.w.example." hashes to "ji6neoaepv8b5o6k4ev33abha8ht9fgc"),
+   but the requested RR type does not exist (Type A is absent in the
+   Type Bit Maps field of the NSEC3 RR).  Note that, unlike an empty
+   non-terminal proof using NSECs, this is identical to a No Data Error.
+   This example is solely mentioned to be complete.
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 43]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+B.3.  Referral to an Opt-Out Unsigned Zone
+
+   The NSEC3 RRs prove that nothing for this delegation was signed.
+   There is no proof that the unsigned delegation exists.
+
+   ;; Header: QR DO RCODE=0
+   ;;
+   ;; Question
+   mc.c.example.       IN MX
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   c.example.     NS      ns1.c.example.
+                  NS      ns2.c.example.
+
+   ;; NSEC3 RR that covers the "next closer" name (c.example)
+   ;; H(c.example) = 4g6p9u5gvfshp30pqecj98b3maqbn1ck
+
+   35mthgpgcu1qg68fab165klnsnk3dpvl.example. NSEC3 1 1 12 aabbccdd (
+                          b4um86eghhds6nea196smvmlo4ors995 NS DS RRSIG )
+   35mthgpgcu1qg68fab165klnsnk3dpvl.example. RRSIG NSEC3 7 2 3600 (
+                          20150420235959 20051021000000 40430 example.
+                          g6jPUUpduAJKRljUsN8gB4UagAX0NxY9shwQ
+                          Aynzo8EUWH+z6hEIBlUTPGj15eZll6VhQqgZ
+                          XtAIR3chwgW+SA== )
+
+   ;; NSEC3 RR that matches the closest encloser (example)
+   ;; H(example) = 0p9mhaveqvm6t7vbl5lop2u3t2rp3tom
+
+   0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. NSEC3 1 1 12 aabbccdd (
+                          2t7b4g4vsa5smi47k61mv5bv1a22bojr MX DNSKEY NS
+                          SOA NSEC3PARAM RRSIG )
+   0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. RRSIG NSEC3 7 2 3600 (
+                          20150420235959 20051021000000 40430 example.
+                          OSgWSm26B+cS+dDL8b5QrWr/dEWhtCsKlwKL
+                          IBHYH6blRxK9rC0bMJPwQ4mLIuw85H2EY762
+                          BOCXJZMnpuwhpA== )
+
+   ;; Additional
+   ns1.c.example. A       192.0.2.7
+   ns2.c.example. A       192.0.2.8
+
+   The query returned a referral to the unsigned "c.example." zone.  The
+   response contains the closest provable encloser of "c.example" to be
+   "example", since the hash of "c.example"
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 44]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   ("4g6p9u5gvfshp30pqecj98b3maqbn1ck") is covered by the first NSEC3 RR
+   and its Opt-Out bit is set.
+
+B.4.  Wildcard Expansion
+
+   A query that was answered with a response containing a wildcard
+   expansion.  The label count in the RRSIG RRSet in the answer section
+   indicates that a wildcard RRSet was expanded to produce this
+   response, and the NSEC3 RR proves that no "next closer" name exists
+   in the zone.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   a.z.w.example. IN MX
+
+   ;; Answer
+   a.z.w.example. MX      1 ai.example.
+   a.z.w.example. RRSIG   MX 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          CikebjQwGQPwijVcxgcZcSJKtfynugtlBiKb
+                          9FcBTrmOoyQ4InoWVudhCWsh/URX3lc4WRUM
+                          ivEBP6+4KS3ldA== )
+
+   ;; Authority
+   example.       NS      ns1.example.
+   example.       NS      ns2.example.
+   example.       RRSIG   NS 7 1 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          PVOgtMK1HHeSTau+HwDWC8Ts+6C8qtqd4pQJ
+                          qOtdEVgg+MA+ai4fWDEhu3qHJyLcQ9tbD2vv
+                          CnMXjtz6SyObxA== )
+
+   ;; NSEC3 RR that covers the "next closer" name (z.w.example)
+   ;; H(z.w.example) = qlu7gtfaeh0ek0c05ksfhdpbcgglbe03
+
+   q04jkcevqvmu85r014c7dkba38o0ji5r.example. NSEC3 1 1 12 aabbccdd (
+                          r53bq7cc2uvmubfu5ocmm6pers9tk9en A RRSIG )
+   q04jkcevqvmu85r014c7dkba38o0ji5r.example. RRSIG NSEC3 7 2 3600 (
+                          20150420235959 20051021000000 40430 example.
+                          hV5I89b+4FHJDATp09g4bbN0R1F845CaXpL3
+                          ZxlMKimoPAyqletMlEWwLfFia7sdpSzn+ZlN
+                          NlkxWcLsIlMmUg== )
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 45]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   ;; Additional
+   ai.example.    A       192.0.2.9
+   ai.example.    RRSIG   A 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          hVe+wKYMlObTRPhX0NL67GxeZfdxqr/QeR6F
+                          tfdAj5+FgYxyzPEjIzvKWy00hWIl6wD3Vws+
+                          rznEn8sQ64UdqA== )
+   ai.example.    AAAA    2001:db8:0:0:0:0:f00:baa9
+   ai.example.    RRSIG   AAAA 7 2 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          LcdxKaCB5bGZwPDg+3JJ4O02zoMBrjxqlf6W
+                          uaHQZZfTUpb9Nf2nxFGe2XRPfR5tpJT6GdRG
+                          cHueLuXkMjBArQ== )
+
+   The query returned an answer that was produced as a result of a
+   wildcard expansion.  The answer section contains a wildcard RRSet
+   expanded as it would be in a traditional DNS response.  The RRSIG
+   Labels field value of 2 indicates that the answer is the result of a
+   wildcard expansion, as the "a.z.w.example" name contains 4 labels.
+   This also shows that "w.example" exists, so there is no need for an
+   NSEC3 RR that matches the closest encloser.
+
+   The NSEC3 RR proves that no closer match could have been used to
+   answer this query.
+
+B.5.  Wildcard No Data Error
+
+   A "no data" response for a name covered by a wildcard.  The NSEC3 RRs
+   prove that the matching wildcard name does not have any RRs of the
+   requested type and that no closer match exists in the zone.
+
+   ;; Header: QR AA DO RCODE=0
+   ;;
+   ;; Question
+   a.z.w.example.      IN AAAA
+
+   ;; Answer
+   ;; (empty)
+
+   ;; Authority
+   example.       SOA     ns1.example. bugs.x.w.example. 1 3600 300 (
+                          3600000 3600 )
+   example.       RRSIG   SOA 7 1 3600 20150420235959 20051021000000 (
+                          40430 example.
+                          Hu25UIyNPmvPIVBrldN+9Mlp9Zql39qaUd8i
+                          q4ZLlYWfUUbbAS41pG+68z81q1xhkYAcEyHd
+                          VI2LmKusbZsT0Q== )
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 46]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+   ;; NSEC3 RR that matches the closest encloser (w.example)
+   ;; H(w.example) = k8udemvp1j2f7eg6jebps17vp3n8i58h
+
+   k8udemvp1j2f7eg6jebps17vp3n8i58h.example. NSEC3 1 1 12 aabbccdd (
+                          kohar7mbb8dc2ce8a9qvl8hon4k53uhi )
+   k8udemvp1j2f7eg6jebps17vp3n8i58h.example. RRSIG NSEC3 7 2 3600 (
+                          20150420235959 20051021000000 40430 example.
+                          FtXGbvF0+wf8iWkyo73enAuVx03klN+pILBK
+                          S6qCcftVtfH4yVzsEZquJ27NHR7ruxJWDNMt
+                          Otx7w9WfcIg62A== )
+
+   ;; NSEC3 RR that covers the "next closer" name (z.w.example)
+   ;; H(z.w.example) = qlu7gtfaeh0ek0c05ksfhdpbcgglbe03
+
+   q04jkcevqvmu85r014c7dkba38o0ji5r.example. NSEC3 1 1 12 aabbccdd (
+                          r53bq7cc2uvmubfu5ocmm6pers9tk9en A RRSIG )
+   q04jkcevqvmu85r014c7dkba38o0ji5r.example. RRSIG NSEC3 7 2 3600 (
+                          20150420235959 20051021000000 40430 example.
+                          hV5I89b+4FHJDATp09g4bbN0R1F845CaXpL3
+                          ZxlMKimoPAyqletMlEWwLfFia7sdpSzn+ZlN
+                          NlkxWcLsIlMmUg== )
+
+   ;; NSEC3 RR that matches a wildcard at the closest encloser.
+   ;; H(*.w.example) = r53bq7cc2uvmubfu5ocmm6pers9tk9en
+
+   r53bq7cc2uvmubfu5ocmm6pers9tk9en.example. NSEC3 1 1 12 aabbccdd (
+                          t644ebqk9bibcna874givr6joj62mlhv MX RRSIG )
+   r53bq7cc2uvmubfu5ocmm6pers9tk9en.example. RRSIG NSEC3 7 2 3600 (
+                          20150420235959 20051021000000 40430 example.
+                          aupviViruXs4bDg9rCbezzBMf9h1ZlDvbW/C
+                          ZFKulIGXXLj8B/fsDJarXVDA9bnUoRhEbKp+
+                          HF1FWKW7RIJdtQ== )
+
+   ;; Additional
+   ;; (empty)
+
+   The query returned the NSEC3 RRs that prove that the requested data
+   does not exist and no wildcard RR applies.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 47]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+B.6.  DS Child Zone No Data Error
+
+   A "no data" response for a QTYPE=DS query that was mistakenly sent to
+   a name server for the child zone.
+
+;; Header: QR AA DO RCODE=0
+;;
+;; Question
+example.            IN DS
+
+;; Answer
+;; (empty)
+
+;; Authority
+example.       SOA     ns1.example. bugs.x.w.example. 1 3600 300 (
+                       3600000 3600 )
+example.       RRSIG   SOA 7 1 3600 20150420235959 20051021000000 (
+                       40430 example.
+                       Hu25UIyNPmvPIVBrldN+9Mlp9Zql39qaUd8i
+                       q4ZLlYWfUUbbAS41pG+68z81q1xhkYAcEyHd
+                       VI2LmKusbZsT0Q== )
+
+;; NSEC3 RR matches the QNAME and shows that the DS type bit is not set.
+
+0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. NSEC3 1 1 12 aabbccdd (
+                       2t7b4g4vsa5smi47k61mv5bv1a22bojr MX DNSKEY NS
+                       SOA NSEC3PARAM RRSIG )
+0p9mhaveqvm6t7vbl5lop2u3t2rp3tom.example. RRSIG NSEC3 7 2 3600
+                       20150420235959 20051021000000 40430 example.
+                       OSgWSm26B+cS+dDL8b5QrWr/dEWhtCsKlwKL
+                       IBHYH6blRxK9rC0bMJPwQ4mLIuw85H2EY762
+                       BOCXJZMnpuwhpA== )
+
+;; Additional
+;; (empty)
+
+   The query returned an NSEC3 RR showing that the requested was
+   answered by the server authoritative for the zone "example".  The
+   NSEC3 RR indicates the presence of an SOA RR, showing that this NSEC3
+   RR is from the apex of the child, not from the zone cut of the
+   parent.  Queries for the "example" DS RRSet should be sent to the
+   parent servers (which are in this case the root servers).
+
+Appendix C.  Special Considerations
+
+   The following paragraphs clarify specific behavior and explain
+   special considerations for implementations.
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 48]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+C.1.  Salting
+
+   Augmenting original owner names with salt before hashing increases
+   the cost of a dictionary of pre-generated hash-values.  For every bit
+   of salt, the cost of a precomputed dictionary doubles (because there
+   must be an entry for each word combined with each possible salt
+   value).  The NSEC3 RR can use a maximum of 2040 bits (255 octets) of
+   salt, multiplying the cost by 2^2040.  This means that an attacker
+   must, in practice, recompute the dictionary each time the salt is
+   changed.
+
+   Including a salt, regardless of size, does not affect the cost of
+   constructing NSEC3 RRs.  It does increase the size of the NSEC3 RR.
+
+   There MUST be at least one complete set of NSEC3 RRs for the zone
+   using the same salt value.
+
+   The salt SHOULD be changed periodically to prevent pre-computation
+   using a single salt.  It is RECOMMENDED that the salt be changed for
+   every re-signing.
+
+   Note that this could cause a resolver to see RRs with different salt
+   values for the same zone.  This is harmless, since each RR stands
+   alone (that is, it denies the set of owner names whose hashes, using
+   the salt in the NSEC3 RR, fall between the two hashes in the NSEC3
+   RR) -- it is only the server that needs a complete set of NSEC3 RRs
+   with the same salt in order to be able to answer every possible
+   query.
+
+   There is no prohibition with having NSEC3 RRs with different salts
+   within the same zone.  However, in order for authoritative servers to
+   be able to consistently find covering NSEC3 RRs, the authoritative
+   server MUST choose a single set of parameters (algorithm, salt, and
+   iterations) to use when selecting NSEC3 RRs.
+
+C.2.  Hash Collision
+
+   Hash collisions occur when different messages have the same hash
+   value.  The expected number of domain names needed to give a 1 in 2
+   chance of a single collision is about 2^(n/2) for a hash of length n
+   bits (i.e., 2^80 for SHA-1).  Though this probability is extremely
+   low, the following paragraphs deal with avoiding collisions and
+   assessing possible damage in the event of an attack using hash
+   collisions.
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 49]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+C.2.1.  Avoiding Hash Collisions During Generation
+
+   During generation of NSEC3 RRs, hash values are supposedly unique.
+   In the (academic) case of a collision occurring, an alternative salt
+   MUST be chosen and all hash values MUST be regenerated.
+
+C.2.2.  Second Preimage Requirement Analysis
+
+   A cryptographic hash function has a second-preimage resistance
+   property.  The second-preimage resistance property means that it is
+   computationally infeasible to find another message with the same hash
+   value as a given message, i.e., given preimage X, to find a second
+   preimage X' != X such that hash(X) = hash(X').  The work factor for
+   finding a second preimage is of the order of 2^160 for SHA-1.  To
+   mount an attack using an existing NSEC3 RR, an adversary needs to
+   find a second preimage.
+
+   Assuming an adversary is capable of mounting such an extreme attack,
+   the actual damage is that a response message can be generated that
+   claims that a certain QNAME (i.e., the second pre-image) does exist,
+   while in reality QNAME does not exist (a false positive), which will
+   either cause a security-aware resolver to re-query for the non-
+   existent name, or to fail the initial query.  Note that the adversary
+   can't mount this attack on an existing name, but only on a name that
+   the adversary can't choose and that does not yet exist.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 50]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+Authors' Addresses
+
+   Ben Laurie
+   Nominet
+   17 Perryn Road
+   London  W3 7LR
+   England
+
+   Phone: +44 20 8735 0686
+   EMail: ben@links.org
+
+
+   Geoffrey Sisson
+   Nominet
+   Minerva House
+   Edmund Halley Road
+   Oxford Science Park
+   Oxford  OX4 4DQ
+   UNITED KINGDOM
+
+   Phone: +44 1865 332211
+   EMail: geoff-s@panix.com
+
+
+   Roy Arends
+   Nominet
+   Minerva House
+   Edmund Halley Road
+   Oxford Science Park
+   Oxford  OX4 4DQ
+   UNITED KINGDOM
+
+   Phone: +44 1865 332211
+   EMail: roy@nominet.org.uk
+
+
+   David Blacka
+   VeriSign, Inc.
+   21355 Ridgetop Circle
+   Dulles, VA  20166
+   US
+
+   Phone: +1 703 948 3200
+   EMail: davidb@verisign.com
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 51]
+
+RFC 5155                         NSEC3                        March 2008
+
+
+Full Copyright Statement
+
+   Copyright (C) The IETF Trust (2008).
+
+   This document is subject to the rights, licenses and restrictions
+   contained in BCP 78, and except as set forth therein, the authors
+   retain all their rights.
+
+   This document and the information contained herein are provided on an
+   "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE REPRESENTS
+   OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY, THE IETF TRUST AND
+   THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES, EXPRESS
+   OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF
+   THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED
+   WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+
+Intellectual Property
+
+   The IETF takes no position regarding the validity or scope of any
+   Intellectual Property Rights or other rights that might be claimed to
+   pertain to the implementation or use of the technology described in
+   this document or the extent to which any license under such rights
+   might or might not be available; nor does it represent that it has
+   made any independent effort to identify any such rights.  Information
+   on the procedures with respect to rights in RFC documents can be
+   found in BCP 78 and BCP 79.
+
+   Copies of IPR disclosures made to the IETF Secretariat and any
+   assurances of licenses to be made available, or the result of an
+   attempt made to obtain a general license or permission for the use of
+   such proprietary rights by implementers or users of this
+   specification can be obtained from the IETF on-line IPR repository at
+   http://www.ietf.org/ipr.
+
+   The IETF invites any interested party to bring to its attention any
+   copyrights, patents or patent applications, or other proprietary
+   rights that may cover technology that may be required to implement
+   this standard.  Please address the information to the IETF at
+   ietf-ipr@ietf.org.
+
+
+
+
+
+
+
+
+
+
+
+
+Laurie, et al.              Standards Track                    [Page 52]
+

--- a/rfc/dns/rfc6891.txt
+++ b/rfc/dns/rfc6891.txt
@@ -1,0 +1,899 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                          J. Damas
+Request for Comments: 6891                         Bond Internet Systems
+STD: 75                                                         M. Graff
+Obsoletes: 2671, 2673
+Category: Standards Track                                       P. Vixie
+ISSN: 2070-1721                              Internet Systems Consortium
+                                                              April 2013
+
+
+                 Extension Mechanisms for DNS (EDNS(0))
+
+Abstract
+
+   The Domain Name System's wire protocol includes a number of fixed
+   fields whose range has been or soon will be exhausted and does not
+   allow requestors to advertise their capabilities to responders.  This
+   document describes backward-compatible mechanisms for allowing the
+   protocol to grow.
+
+   This document updates the Extension Mechanisms for DNS (EDNS(0))
+   specification (and obsoletes RFC 2671) based on feedback from
+   deployment experience in several implementations.  It also obsoletes
+   RFC 2673 ("Binary Labels in the Domain Name System") and adds
+   considerations on the use of extended labels in the DNS.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc6891.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                    [Page 1]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+Copyright Notice
+
+   Copyright (c) 2013 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+   This document may contain material from IETF Documents or IETF
+   Contributions published or made publicly available before November
+   10, 2008.  The person(s) controlling the copyright in some of this
+   material may not have granted the IETF Trust the right to allow
+   modifications of such material outside the IETF Standards Process.
+   Without obtaining an adequate license from the person(s) controlling
+   the copyright in such materials, this document may not be modified
+   outside the IETF Standards Process, and derivative works of it may
+   not be created outside the IETF Standards Process, except to format
+   it for publication as an RFC or to translate it into languages other
+   than English.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                    [Page 2]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+Table of Contents
+
+   1.  Introduction . . . . . . . . . . . . . . . . . . . . . . . . .  4
+   2.  Terminology  . . . . . . . . . . . . . . . . . . . . . . . . .  4
+   3.  EDNS Support Requirement . . . . . . . . . . . . . . . . . . .  5
+   4.  DNS Message Changes  . . . . . . . . . . . . . . . . . . . . .  5
+     4.1.  Message Header . . . . . . . . . . . . . . . . . . . . . .  5
+     4.2.  Label Types  . . . . . . . . . . . . . . . . . . . . . . .  5
+     4.3.  UDP Message Size . . . . . . . . . . . . . . . . . . . . .  6
+   5.  Extended Label Types . . . . . . . . . . . . . . . . . . . . .  6
+   6.  The OPT Pseudo-RR  . . . . . . . . . . . . . . . . . . . . . .  6
+     6.1.  OPT Record Definition  . . . . . . . . . . . . . . . . . .  6
+       6.1.1.  Basic Elements . . . . . . . . . . . . . . . . . . . .  6
+       6.1.2.  Wire Format  . . . . . . . . . . . . . . . . . . . . .  7
+       6.1.3.  OPT Record TTL Field Use . . . . . . . . . . . . . . .  9
+       6.1.4.  Flags  . . . . . . . . . . . . . . . . . . . . . . . .  9
+     6.2.  Behaviour  . . . . . . . . . . . . . . . . . . . . . . . . 10
+       6.2.1.  Cache Behaviour  . . . . . . . . . . . . . . . . . . . 10
+       6.2.2.  Fallback . . . . . . . . . . . . . . . . . . . . . . . 10
+       6.2.3.  Requestor's Payload Size . . . . . . . . . . . . . . . 10
+       6.2.4.  Responder's Payload Size . . . . . . . . . . . . . . . 11
+       6.2.5.  Payload Size Selection . . . . . . . . . . . . . . . . 11
+       6.2.6.  Support in Middleboxes . . . . . . . . . . . . . . . . 11
+   7.  Transport Considerations . . . . . . . . . . . . . . . . . . . 12
+   8.  Security Considerations  . . . . . . . . . . . . . . . . . . . 13
+   9.  IANA Considerations  . . . . . . . . . . . . . . . . . . . . . 13
+     9.1.  OPT Option Code Allocation Procedure . . . . . . . . . . . 15
+   10. References . . . . . . . . . . . . . . . . . . . . . . . . . . 15
+     10.1. Normative References . . . . . . . . . . . . . . . . . . . 15
+     10.2. Informative References . . . . . . . . . . . . . . . . . . 15
+   Appendix A.  Changes since RFCs 2671 and 2673  . . . . . . . . . . 16
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                    [Page 3]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+1.  Introduction
+
+   DNS [RFC1035] specifies a message format, and within such messages
+   there are standard formats for encoding options, errors, and name
+   compression.  The maximum allowable size of a DNS message over UDP
+   not using the extensions described in this document is 512 bytes.
+   Many of DNS's protocol limits, such as the maximum message size over
+   UDP, are too small to efficiently support the additional information
+   that can be conveyed in the DNS (e.g., several IPv6 addresses or DNS
+   Security (DNSSEC) signatures).  Finally, RFC 1035 does not define any
+   way for implementations to advertise their capabilities to any of the
+   other actors they interact with.
+
+   [RFC2671] added extension mechanisms to DNS.  These mechanisms are
+   widely supported, and a number of new DNS uses and protocol
+   extensions depend on the presence of these extensions.  This memo
+   refines and obsoletes [RFC2671].
+
+   Unextended agents will not know how to interpret the protocol
+   extensions defined in [RFC2671] and restated here.  Extended agents
+   need to be prepared for handling the interactions with unextended
+   clients in the face of new protocol elements and fall back gracefully
+   to unextended DNS.
+
+   EDNS is a hop-by-hop extension to DNS.  This means the use of EDNS is
+   negotiated between each pair of hosts in a DNS resolution process,
+   for instance, the stub resolver communicating with the recursive
+   resolver or the recursive resolver communicating with an
+   authoritative server.
+
+   [RFC2671] specified extended label types.  The only such label
+   proposed was in [RFC2673] for a label type called "Bit-String Label"
+   or "Binary Labels", with this latest term being the one in common
+   use.  For various reasons, introducing a new label type was found to
+   be extremely difficult, and [RFC2673] was moved to Experimental.
+   This document obsoletes [RFC2673], deprecating Binary Labels.
+   Extended labels remain defined, but their use is discouraged due to
+   practical difficulties with deployment; their use in the future
+   SHOULD only be considered after careful evaluation of the deployment
+   hindrances.
+
+2.  Terminology
+
+   "Requestor" refers to the side that sends a request.  "Responder"
+   refers to an authoritative, recursive resolver or other DNS component
+   that responds to questions.  Other terminology is used here as
+   defined in the RFCs cited by this document.
+
+
+
+
+Damas, et al.                Standards Track                    [Page 4]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  EDNS Support Requirement
+
+   EDNS provides a mechanism to improve the scalability of DNS as its
+   uses get more diverse on the Internet.  It does this by enabling the
+   use of UDP transport for DNS messages with sizes beyond the limits
+   specified in RFC 1035 as well as providing extra data space for
+   additional flags and return codes (RCODEs).  However, implementation
+   experience indicates that adding new RCODEs should be avoided due to
+   the difficulty in upgrading the installed base.  Flags SHOULD be used
+   only when necessary for DNS resolution to function.
+
+   For many uses, an EDNS Option Code may be preferred.
+
+   Over time, some applications of DNS have made EDNS a requirement for
+   their deployment.  For instance, DNSSEC uses the additional flag
+   space introduced in EDNS to signal the request to include DNSSEC data
+   in a DNS response.
+
+   Given the increase in DNS response sizes when including larger data
+   items such as AAAA records, DNSSEC information (e.g., RRSIG or
+   DNSKEY), or large TXT records, the additional UDP payload
+   capabilities provided by EDNS can help improve the scalability of the
+   DNS by avoiding widespread use of TCP for DNS transport.
+
+4.  DNS Message Changes
+
+4.1.  Message Header
+
+   The DNS message header's second full 16-bit word is divided into a
+   4-bit OPCODE, a 4-bit RCODE, and a number of 1-bit flags (see Section
+   4.1.1 of [RFC1035]).  Some of these flag values were marked for
+   future use, and most of these have since been allocated.  Also, most
+   of the RCODE values are now in use.  The OPT pseudo-RR specified
+   below contains extensions to the RCODE bit field as well as
+   additional flag bits.
+
+4.2.  Label Types
+
+   The first 2 bits of a wire format domain label are used to denote the
+   type of the label.  [RFC1035] allocates 2 of the 4 possible types and
+   reserves the other 2.  More label types were defined in [RFC2671].
+   The use of the 2-bit combination defined by [RFC2671] to identify
+   extended label types remains valid.  However, it has been found that
+   deployment of new label types is noticeably difficult and so is only
+
+
+
+Damas, et al.                Standards Track                    [Page 5]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   recommended after careful evaluation of alternatives and the need for
+   deployment.
+
+4.3.  UDP Message Size
+
+   Traditional DNS messages are limited to 512 octets in size when sent
+   over UDP [RFC1035].  Fitting the increasing amounts of data that can
+   be transported in DNS in this 512-byte limit is becoming more
+   difficult.  For instance, inclusion of DNSSEC records frequently
+   requires a much larger response than a 512-byte message can hold.
+
+   EDNS(0) specifies a way to advertise additional features such as
+   larger response size capability, which is intended to help avoid
+   truncated UDP responses, which in turn cause retry over TCP.  It
+   therefore provides support for transporting these larger packet sizes
+   without needing to resort to TCP for transport.
+
+5.  Extended Label Types
+
+   The first octet in the on-the-wire representation of a DNS label
+   specifies the label type; the basic DNS specification [RFC1035]
+   dedicates the 2 most significant bits of that octet for this purpose.
+
+   [RFC2671] defined DNS label type 0b01 for use as an indication for
+   extended label types.  A specific extended label type was selected by
+   the 6 least significant bits of the first octet.  Thus, extended
+   label types were indicated by the values 64-127 (0b01xxxxxx) in the
+   first octet of the label.
+
+   Extended label types are extremely difficult to deploy due to lack of
+   support in clients and intermediate gateways, as described in
+   [RFC3363], which moved [RFC2673] to Experimental status; and
+   [RFC3364], which describes the pros and cons.  As such, proposals
+   that contemplate extended labels SHOULD weigh this deployment cost
+   against the possibility of implementing functionality in other ways.
+
+   Finally, implementations MUST NOT generate or pass Binary Labels in
+   their communications, as they are now deprecated.
+
+6.  The OPT Pseudo-RR
+
+6.1.  OPT Record Definition
+
+6.1.1.  Basic Elements
+
+   An OPT pseudo-RR (sometimes called a meta-RR) MAY be added to the
+   additional data section of a request.
+
+
+
+
+Damas, et al.                Standards Track                    [Page 6]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   The OPT RR has RR type 41.
+
+   If an OPT record is present in a received request, compliant
+   responders MUST include an OPT record in their respective responses.
+
+   An OPT record does not carry any DNS data.  It is used only to
+   contain control information pertaining to the question-and-answer
+   sequence of a specific transaction.  OPT RRs MUST NOT be cached,
+   forwarded, or stored in or loaded from master files.
+
+   The OPT RR MAY be placed anywhere within the additional data section.
+   When an OPT RR is included within any DNS message, it MUST be the
+   only OPT RR in that message.  If a query message with more than one
+   OPT RR is received, a FORMERR (RCODE=1) MUST be returned.  The
+   placement flexibility for the OPT RR does not override the need for
+   the TSIG or SIG(0) RRs to be the last in the additional section
+   whenever they are present.
+
+6.1.2.  Wire Format
+
+   An OPT RR has a fixed part and a variable set of options expressed as
+   {attribute, value} pairs.  The fixed part holds some DNS metadata,
+   and also a small collection of basic extension elements that we
+   expect to be so popular that it would be a waste of wire space to
+   encode them as {attribute, value} pairs.
+
+   The fixed part of an OPT RR is structured as follows:
+
+       +------------+--------------+------------------------------+
+       | Field Name | Field Type   | Description                  |
+       +------------+--------------+------------------------------+
+       | NAME       | domain name  | MUST be 0 (root domain)      |
+       | TYPE       | u_int16_t    | OPT (41)                     |
+       | CLASS      | u_int16_t    | requestor's UDP payload size |
+       | TTL        | u_int32_t    | extended RCODE and flags     |
+       | RDLEN      | u_int16_t    | length of all RDATA          |
+       | RDATA      | octet stream | {attribute,value} pairs      |
+       +------------+--------------+------------------------------+
+
+                               OPT RR Format
+
+
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                    [Page 7]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   The variable part of an OPT RR may contain zero or more options in
+   the RDATA.  Each option MUST be treated as a bit field.  Each option
+   is encoded as:
+
+                  +0 (MSB)                            +1 (LSB)
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    0: |                          OPTION-CODE                          |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    2: |                         OPTION-LENGTH                         |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    4: |                                                               |
+       /                          OPTION-DATA                          /
+       /                                                               /
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+
+   OPTION-CODE
+      Assigned by the Expert Review process as defined by the DNSEXT
+      working group and the IESG.
+
+   OPTION-LENGTH
+      Size (in octets) of OPTION-DATA.
+
+   OPTION-DATA
+      Varies per OPTION-CODE.  MUST be treated as a bit field.
+
+   The order of appearance of option tuples is not defined.  If one
+   option modifies the behaviour of another or multiple options are
+   related to one another in some way, they have the same effect
+   regardless of ordering in the RDATA wire encoding.
+
+   Any OPTION-CODE values not understood by a responder or requestor
+   MUST be ignored.  Specifications of such options might wish to
+   include some kind of signaled acknowledgement.  For example, an
+   option specification might say that if a responder sees and supports
+   option XYZ, it MUST include option XYZ in its response.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                    [Page 8]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+6.1.3.  OPT Record TTL Field Use
+
+   The extended RCODE and flags, which OPT stores in the RR Time to Live
+   (TTL) field, are structured as follows:
+
+                  +0 (MSB)                            +1 (LSB)
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    0: |         EXTENDED-RCODE        |            VERSION            |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+    2: | DO|                           Z                               |
+       +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+
+   EXTENDED-RCODE
+      Forms the upper 8 bits of extended 12-bit RCODE (together with the
+      4 bits defined in [RFC1035].  Note that EXTENDED-RCODE value 0
+      indicates that an unextended RCODE is in use (values 0 through
+      15).
+
+   VERSION
+      Indicates the implementation level of the setter.  Full
+      conformance with this specification is indicated by version '0'.
+      Requestors are encouraged to set this to the lowest implemented
+      level capable of expressing a transaction, to minimise the
+      responder and network load of discovering the greatest common
+      implementation level between requestor and responder.  A
+      requestor's version numbering strategy MAY ideally be a run-time
+      configuration option.
+      If a responder does not implement the VERSION level of the
+      request, then it MUST respond with RCODE=BADVERS.  All responses
+      MUST be limited in format to the VERSION level of the request, but
+      the VERSION of each response SHOULD be the highest implementation
+      level of the responder.  In this way, a requestor will learn the
+      implementation level of a responder as a side effect of every
+      response, including error responses and including RCODE=BADVERS.
+
+6.1.4.  Flags
+
+   DO
+      DNSSEC OK bit as defined by [RFC3225].
+
+   Z
+      Set to zero by senders and ignored by receivers, unless modified
+      in a subsequent specification.
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                    [Page 9]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+6.2.  Behaviour
+
+6.2.1.  Cache Behaviour
+
+   The OPT record MUST NOT be cached.
+
+6.2.2.  Fallback
+
+   If a requestor detects that the remote end does not support EDNS(0),
+   it MAY issue queries without an OPT record.  It MAY cache this
+   knowledge for a brief time in order to avoid fallback delays in the
+   future.  However, if DNSSEC or any future option using EDNS is
+   required, no fallback should be performed, as these options are only
+   signaled through EDNS.  If an implementation detects that some
+   servers for the zone support EDNS(0) while others would force the use
+   of TCP to fetch all data, preference MAY be given to servers that
+   support EDNS(0).  Implementers SHOULD analyse this choice and the
+   impact on both endpoints.
+
+6.2.3.  Requestor's Payload Size
+
+   The requestor's UDP payload size (encoded in the RR CLASS field) is
+   the number of octets of the largest UDP payload that can be
+   reassembled and delivered in the requestor's network stack.  Note
+   that path MTU, with or without fragmentation, could be smaller than
+   this.
+
+   Values lower than 512 MUST be treated as equal to 512.
+
+   The requestor SHOULD place a value in this field that it can actually
+   receive.  For example, if a requestor sits behind a firewall that
+   will block fragmented IP packets, a requestor SHOULD NOT choose a
+   value that will cause fragmentation.  Doing so will prevent large
+   responses from being received and can cause fallback to occur.  This
+   knowledge may be auto-detected by the implementation or provided by a
+   human administrator.
+
+   Note that a 512-octet UDP payload requires a 576-octet IP reassembly
+   buffer.  Choosing between 1280 and 1410 bytes for IP (v4 or v6) over
+   Ethernet would be reasonable.
+
+   Where fragmentation is not a concern, use of bigger values SHOULD be
+   considered by implementers.  Implementations SHOULD use their largest
+   configured or implemented values as a starting point in an EDNS
+   transaction in the absence of previous knowledge about the
+   destination server.
+
+
+
+
+
+Damas, et al.                Standards Track                   [Page 10]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   Choosing a very large value will guarantee fragmentation at the IP
+   layer, and may prevent answers from being received due to loss of a
+   single fragment or to misconfigured firewalls.
+
+   The requestor's maximum payload size can change over time.  It MUST
+   NOT be cached for use beyond the transaction in which it is
+   advertised.
+
+6.2.4.  Responder's Payload Size
+
+   The responder's maximum payload size can change over time but can
+   reasonably be expected to remain constant between two closely spaced
+   sequential transactions, for example, an arbitrary QUERY used as a
+   probe to discover a responder's maximum UDP payload size, followed
+   immediately by an UPDATE that takes advantage of this size.  This is
+   considered preferable to the outright use of TCP for oversized
+   requests, if there is any reason to suspect that the responder
+   implements EDNS, and if a request will not fit in the default
+   512-byte payload size limit.
+
+6.2.5.  Payload Size Selection
+
+   Due to transaction overhead, it is not recommended to advertise an
+   architectural limit as a maximum UDP payload size.  Even on system
+   stacks capable of reassembling 64 KB datagrams, memory usage at low
+   levels in the system will be a concern.  A good compromise may be the
+   use of an EDNS maximum payload size of 4096 octets as a starting
+   point.
+
+   A requestor MAY choose to implement a fallback to smaller advertised
+   sizes to work around firewall or other network limitations.  A
+   requestor SHOULD choose to use a fallback mechanism that begins with
+   a large size, such as 4096.  If that fails, a fallback around the
+   range of 1280-1410 bytes SHOULD be tried, as it has a reasonable
+   chance to fit within a single Ethernet frame.  Failing that, a
+   requestor MAY choose a 512-byte packet, which with large answers may
+   cause a TCP retry.
+
+   Values of less than 512 bytes MUST be treated as equal to 512 bytes.
+
+6.2.6.  Support in Middleboxes
+
+   In a network that carries DNS traffic, there could be active
+   equipment other than that participating directly in the DNS
+   resolution process (stub and caching resolvers, authoritative
+   servers) that affects the transmission of DNS messages (e.g.,
+   firewalls, load balancers, proxies, etc.), referred to here as
+   "middleboxes".
+
+
+
+Damas, et al.                Standards Track                   [Page 11]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   Conformant middleboxes MUST NOT limit DNS messages over UDP to 512
+   bytes.
+
+   Middleboxes that simply forward requests to a recursive resolver MUST
+   NOT modify and MUST NOT delete the OPT record contents in either
+   direction.
+
+   Middleboxes that have additional functionality, such as answering
+   queries or acting as intelligent forwarders, SHOULD be able to
+   process the OPT record and act based on its contents.  These
+   middleboxes MUST consider the incoming request and any outgoing
+   requests as separate transactions if the characteristics of the
+   messages are different.
+
+   A more in-depth discussion of this type of equipment and other
+   considerations regarding their interaction with DNS traffic is found
+   in [RFC5625].
+
+7.  Transport Considerations
+
+   The presence of an OPT pseudo-RR in a request should be taken as an
+   indication that the requestor fully implements the given version of
+   EDNS and can correctly understand any response that conforms to that
+   feature's specification.
+
+   Lack of presence of an OPT record in a request MUST be taken as an
+   indication that the requestor does not implement any part of this
+   specification and that the responder MUST NOT include an OPT record
+   in its response.
+
+   Extended agents MUST be prepared for handling interactions with
+   unextended clients in the face of new protocol elements and fall back
+   gracefully to unextended DNS when needed.
+
+   Responders that choose not to implement the protocol extensions
+   defined in this document MUST respond with a return code (RCODE) of
+   FORMERR to messages containing an OPT record in the additional
+   section and MUST NOT include an OPT record in the response.
+
+   If there is a problem with processing the OPT record itself, such as
+   an option value that is badly formatted or that includes out-of-range
+   values, a FORMERR MUST be returned.  If this occurs, the response
+   MUST include an OPT record.  This is intended to allow the requestor
+   to distinguish between servers that do not implement EDNS and format
+   errors within EDNS.
+
+
+
+
+
+
+Damas, et al.                Standards Track                   [Page 12]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   The minimal response MUST be the DNS header, question section, and an
+   OPT record.  This MUST also occur when a truncated response (using
+   the DNS header's TC bit) is returned.
+
+8.  Security Considerations
+
+   Requestor-side specification of the maximum buffer size may open a
+   DNS denial-of-service attack if responders can be made to send
+   messages that are too large for intermediate gateways to forward,
+   thus leading to potential ICMP storms between gateways and
+   responders.
+
+   Announcing very large UDP buffer sizes may result in dropping of DNS
+   messages by middleboxes (see Section 6.2.6).  This could cause
+   retransmissions with no hope of success.  Some devices have been
+   found to reject fragmented UDP packets.
+
+   Announcing UDP buffer sizes that are too small may result in fallback
+   to TCP with a corresponding load impact on DNS servers.  This is
+   especially important with DNSSEC, where answers are much larger.
+
+9.  IANA Considerations
+
+   The IANA has assigned RR type code 41 for OPT.
+
+   [RFC2671] specified a number of IANA subregistries within "DOMAIN
+   NAME SYSTEM PARAMETERS":
+
+   o  DNS EDNS(0) Options
+
+   o  EDNS Version Number
+
+   o  EDNS Header Flags
+
+   Additionally, two entries were generated in existing registries:
+
+   o  EDNS Extended Label Type in the DNS Label Types registry
+
+   o  Bad OPT Version in the DNS RCODES registry
+
+   IANA has updated references to [RFC2671] in these entries and
+   subregistries to this document.
+
+   [RFC2671] created the DNS Label Types registry.  This registry is to
+   remain open.
+
+   The registration procedure for the DNS Label Types registry is
+   Standards Action.
+
+
+
+Damas, et al.                Standards Track                   [Page 13]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+   This document assigns option code 65535 in the DNS EDNS0 Options
+   registry to "Reserved for future expansion".
+
+   The current status of the IANA registry for EDNS Option Codes at the
+   time of publication of this document is
+
+   o  0-4 assigned, per references in the registry
+
+   o  5-65000 Available for assignment, unassigned
+
+   o  65001-65534 Local/Experimental use
+
+   o  65535 Reserved for future expansion
+
+   [RFC2671] expands the RCODE space from 4 bits to 12 bits.  This
+   allows more than the 16 distinct RCODE values allowed in [RFC1035].
+   IETF Review is required to add a new RCODE.
+
+   This document assigns EDNS Extended RCODE 16 to "BADVERS" in the DNS
+   RCODES registry.
+
+   [RFC2671] called for the recording of assignment of extended label
+   types 0bxx111111 as "Reserved for future extended label types"; the
+   IANA registry currently contains "Reserved for future expansion".
+   This request implied, at that time, a request to open a new registry
+   for extended label types, but due to the possibility of ambiguity,
+   new text registrations were instead made within the general DNS Label
+   Types registry, which also registers entries originally defined by
+   [RFC1035].  There is therefore no Extended Label Types registry, with
+   all label types registered in the DNS Label Types registry.
+
+   This document deprecates Binary Labels.  Therefore, the status for
+   the DNS Label Types registration "Binary Labels" is now "Historic".
+
+   IETF Standards Action is required for assignments of new EDNS(0)
+   flags.  Flags SHOULD be used only when necessary for DNS resolution
+   to function.  For many uses, an EDNS Option Code may be preferred.
+
+   IETF Standards Action is required to create new entries in the EDNS
+   Version Number registry.  Within the EDNS Option Code space, Expert
+   Review is required for allocation of an EDNS Option Code.  Per this
+   document, IANA maintains a registry for the EDNS Option Code space.
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                   [Page 14]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+9.1.  OPT Option Code Allocation Procedure
+
+   OPT Option Codes are assigned by Expert Review.
+
+   Assignment of Option Codes should be liberal, but duplicate
+   functionality is to be avoided.
+
+10.  References
+
+10.1.  Normative References
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, November 1987.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119, March 1997.
+
+   [RFC2671]  Vixie, P., "Extension Mechanisms for DNS (EDNS0)",
+              RFC 2671, August 1999.
+
+   [RFC3225]  Conrad, D., "Indicating Resolver Support of DNSSEC",
+              RFC 3225, December 2001.
+
+10.2.  Informative References
+
+   [RFC2673]  Crawford, M., "Binary Labels in the Domain Name System",
+              RFC 2673, August 1999.
+
+   [RFC3363]  Bush, R., Durand, A., Fink, B., Gudmundsson, O., and T.
+              Hain, "Representing Internet Protocol version 6 (IPv6)
+              Addresses in the Domain Name System (DNS)", RFC 3363,
+              August 2002.
+
+   [RFC3364]  Austein, R., "Tradeoffs in Domain Name System (DNS)
+              Support for Internet Protocol version 6 (IPv6)", RFC 3364,
+              August 2002.
+
+   [RFC5625]  Bellis, R., "DNS Proxy Implementation Guidelines",
+              BCP 152, RFC 5625, August 2009.
+
+
+
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                   [Page 15]
+
+RFC 6891                   EDNS(0) Extensions                 April 2013
+
+
+Appendix A.  Changes since RFCs 2671 and 2673
+
+   Following is a list of high-level changes to RFCs 2671 and 2673.
+
+   o  Support for the OPT record is now mandatory.
+
+   o  Extended label types remain available, but their use is
+      discouraged as a general solution due to observed difficulties in
+      their deployment on the Internet, as illustrated by the work with
+      the "Binary Labels" type.
+
+   o  RFC 2673, which defined the "Binary Labels" type and is currently
+      Experimental, is requested to be moved to Historic.
+
+   o  Made changes in how EDNS buffer sizes are selected, and provided
+      recommendations on how to select them.
+
+Authors' Addresses
+
+   Joao Damas
+   Bond Internet Systems
+   Av Albufera 14
+   S.S. Reyes, Madrid  28701
+   ES
+
+   Phone: +1 650.423.1312
+   EMail: joao@bondis.org
+
+
+   Michael Graff
+
+   EMail: explorer@flame.org
+
+
+   Paul Vixie
+   Internet Systems Consortium
+   950 Charter Street
+   Redwood City, California  94063
+   US
+
+   Phone: +1 650.423.1301
+   EMail: vixie@isc.org
+
+
+
+
+
+
+
+
+
+Damas, et al.                Standards Track                   [Page 16]
+

--- a/rfc/dns/rfc7858.txt
+++ b/rfc/dns/rfc7858.txt
@@ -1,0 +1,1067 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                             Z. Hu
+Request for Comments: 7858                                        L. Zhu
+Category: Standards Track                                   J. Heidemann
+ISSN: 2070-1721                                                  USC/ISI
+                                                               A. Mankin
+                                                             Independent
+                                                              D. Wessels
+                                                           Verisign Labs
+                                                              P. Hoffman
+                                                                   ICANN
+                                                                May 2016
+
+
+       Specification for DNS over Transport Layer Security (TLS)
+
+Abstract
+
+   This document describes the use of Transport Layer Security (TLS) to
+   provide privacy for DNS.  Encryption provided by TLS eliminates
+   opportunities for eavesdropping and on-path tampering with DNS
+   queries in the network, such as discussed in RFC 7626.  In addition,
+   this document specifies two usage profiles for DNS over TLS and
+   provides advice on performance considerations to minimize overhead
+   from using TCP and TLS with DNS.
+
+   This document focuses on securing stub-to-recursive traffic, as per
+   the charter of the DPRIVE Working Group.  It does not prevent future
+   applications of the protocol to recursive-to-authoritative traffic.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 5741.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7858.
+
+
+
+
+
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 1]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+Copyright Notice
+
+   Copyright (c) 2016 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Key Words . . . . . . . . . . . . . . . . . . . . . . . . . .   4
+   3.  Establishing and Managing DNS-over-TLS Sessions . . . . . . .   4
+     3.1.  Session Initiation  . . . . . . . . . . . . . . . . . . .   4
+     3.2.  TLS Handshake and Authentication  . . . . . . . . . . . .   5
+     3.3.  Transmitting and Receiving Messages . . . . . . . . . . .   5
+     3.4.  Connection Reuse, Close, and Reestablishment  . . . . . .   6
+   4.  Usage Profiles  . . . . . . . . . . . . . . . . . . . . . . .   7
+     4.1.  Opportunistic Privacy Profile . . . . . . . . . . . . . .   7
+     4.2.  Out-of-Band Key-Pinned Privacy Profile  . . . . . . . . .   7
+   5.  Performance Considerations  . . . . . . . . . . . . . . . . .   9
+   6.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  10
+   7.  Design Evolution  . . . . . . . . . . . . . . . . . . . . . .  10
+   8.  Security Considerations . . . . . . . . . . . . . . . . . . .  11
+   9.  References  . . . . . . . . . . . . . . . . . . . . . . . . .  12
+     9.1.  Normative References  . . . . . . . . . . . . . . . . . .  12
+     9.2.  Informative References  . . . . . . . . . . . . . . . . .  13
+   Appendix A.  Out-of-Band Key-Pinned Privacy Profile Example . . .  16
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  17
+   Contributors  . . . . . . . . . . . . . . . . . . . . . . . . . .  17
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  18
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 2]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+1.  Introduction
+
+   Today, nearly all DNS queries [RFC1034] [RFC1035] are sent
+   unencrypted, which makes them vulnerable to eavesdropping by an
+   attacker that has access to the network channel, reducing the privacy
+   of the querier.  Recent news reports have elevated these concerns,
+   and recent IETF work has specified privacy considerations for DNS
+   [RFC7626].
+
+   Prior work has addressed some aspects of DNS security, but until
+   recently, there has been little work on privacy between a DNS client
+   and server.  DNS Security Extensions (DNSSEC) [RFC4033] provide
+   _response integrity_ by defining mechanisms to cryptographically sign
+   zones, allowing end users (or their first-hop resolver) to verify
+   replies are correct.  By intention, DNSSEC does not protect request
+   and response privacy.  Traditionally, either privacy was not
+   considered a requirement for DNS traffic or it was assumed that
+   network traffic was sufficiently private; however, these perceptions
+   are evolving due to recent events [RFC7258].
+
+   Other work that has offered the potential to encrypt between DNS
+   clients and servers includes DNSCurve [DNSCurve], DNSCrypt
+   [DNSCRYPT-WEBSITE], Confidential DNS [CONFIDENTIAL-DNS], and IPSECA
+   [IPSECA].  In addition to the present specification, the DPRIVE
+   Working Group has also adopted a proposal for DNS over Datagram
+   Transport Layer Security (DTLS) [DNSoD].
+
+   This document describes using DNS over TLS on a well-known port and
+   also offers advice on performance considerations to minimize
+   overheads from using TCP and TLS with DNS.
+
+   Initiation of DNS over TLS is very straightforward.  By establishing
+   a connection over a well-known port, clients and servers expect and
+   agree to negotiate a TLS session to secure the channel.  Deployment
+   will be gradual.  Not all servers will support DNS over TLS and the
+   well-known port might be blocked by some firewalls.  Clients will be
+   expected to keep track of servers that support TLS and those that
+   don't.  Clients and servers will adhere to the TLS implementation
+   recommendations and security considerations of [BCP195].
+
+   The protocol described here works for queries and responses between
+   stub clients and recursive servers.  It might work equally between
+   recursive clients and authoritative servers, but this application of
+   the protocol is out of scope for the DNS PRIVate Exchange (DPRIVE)
+   Working Group per its current charter.
+
+
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 3]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   This document describes two profiles in Section 4 that provide
+   different levels of assurance of privacy: an opportunistic privacy
+   profile and an out-of-band key-pinned privacy profile.  It is
+   expected that a future document based on [TLS-DTLS-PROFILES] will
+   further describe additional privacy profiles for DNS over both TLS
+   and DTLS.
+
+   An earlier draft version of this document described a technique for
+   upgrading a DNS-over-TCP connection to a DNS-over-TLS session with,
+   essentially, "STARTTLS for DNS".  To simplify the protocol, this
+   document now only uses a well-known port to specify TLS use, omitting
+   the upgrade approach.  The upgrade approach no longer appears in this
+   document, which now focuses exclusively on the use of a well-known
+   port for DNS over TLS.
+
+2.  Key Words
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this
+   document are to be interpreted as described in RFC 2119 [RFC2119].
+
+3.  Establishing and Managing DNS-over-TLS Sessions
+
+3.1.  Session Initiation
+
+   By default, a DNS server that supports DNS over TLS MUST listen for
+   and accept TCP connections on port 853, unless it has mutual
+   agreement with its clients to use a port other than 853 for DNS over
+   TLS.  In order to use a port other than 853, both clients and servers
+   would need a configuration option in their software.
+
+   By default, a DNS client desiring privacy from DNS over TLS from a
+   particular server MUST establish a TCP connection to port 853 on the
+   server, unless it has mutual agreement with its server to use a port
+   other than port 853 for DNS over TLS.  Such another port MUST NOT be
+   port 53 but MAY be from the "first-come, first-served" port range.
+   This recommendation against use of port 53 for DNS over TLS is to
+   avoid complication in selecting use or non-use of TLS and to reduce
+   risk of downgrade attacks.  The first data exchange on this TCP
+   connection MUST be the client and server initiating a TLS handshake
+   using the procedure described in [RFC5246].
+
+   DNS clients and servers MUST NOT use port 853 to transport cleartext
+   DNS messages.  DNS clients MUST NOT send and DNS servers MUST NOT
+   respond to cleartext DNS messages on any port used for DNS over TLS
+   (including, for example, after a failed TLS handshake).  There are
+   significant security issues in mixing protected and unprotected data,
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 4]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   and for this reason, TCP connections on a port designated by a given
+   server for DNS over TLS are reserved purely for encrypted
+   communications.
+
+   DNS clients SHOULD remember server IP addresses that don't support
+   DNS over TLS, including timeouts, connection refusals, and TLS
+   handshake failures, and not request DNS over TLS from them for a
+   reasonable period (such as one hour per server).  DNS clients
+   following an out-of-band key-pinned privacy profile (Section 4.2) MAY
+   be more aggressive about retrying DNS-over-TLS connection failures.
+
+3.2.  TLS Handshake and Authentication
+
+   Once the DNS client succeeds in connecting via TCP on the well-known
+   port for DNS over TLS, it proceeds with the TLS handshake [RFC5246],
+   following the best practices specified in [BCP195].
+
+   The client will then authenticate the server, if required.  This
+   document does not propose new ideas for authentication.  Depending on
+   the privacy profile in use (Section 4), the DNS client may choose not
+   to require authentication of the server, or it may make use of a
+   trusted Subject Public Key Info (SPKI) Fingerprint pin set.
+
+   After TLS negotiation completes, the connection will be encrypted and
+   is now protected from eavesdropping.
+
+3.3.  Transmitting and Receiving Messages
+
+   All messages (requests and responses) in the established TLS session
+   MUST use the two-octet length field described in Section 4.2.2 of
+   [RFC1035].  For reasons of efficiency, DNS clients and servers SHOULD
+   pass the two-octet length field, and the message described by that
+   length field, to the TCP layer at the same time (e.g., in a single
+   "write" system call) to make it more likely that all the data will be
+   transmitted in a single TCP segment ([RFC7766], Section 8).
+
+   In order to minimize latency, clients SHOULD pipeline multiple
+   queries over a TLS session.  When a DNS client sends multiple queries
+   to a server, it should not wait for an outstanding reply before
+   sending the next query ([RFC7766], Section 6.2.1.1).
+
+   Since pipelined responses can arrive out of order, clients MUST match
+   responses to outstanding queries on the same TLS connection using the
+   Message ID.  If the response contains a Question Section, the client
+   MUST match the QNAME, QCLASS, and QTYPE fields.  Failure by clients
+   to properly match responses to outstanding queries can have serious
+   consequences for interoperability ([RFC7766], Section 7).
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 5]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+3.4.  Connection Reuse, Close, and Reestablishment
+
+   For DNS clients that use library functions such as "getaddrinfo()"
+   and "gethostbyname()", current implementations are known to open and
+   close TCP connections for each DNS query.  To avoid excess TCP
+   connections, each with a single query, clients SHOULD reuse a single
+   TCP connection to the recursive resolver.  Alternatively, they may
+   prefer to use UDP to a DNS-over-TLS-enabled caching resolver on the
+   same machine that then uses a system-wide TCP connection to the
+   recursive resolver.
+
+   In order to amortize TCP and TLS connection setup costs, clients and
+   servers SHOULD NOT immediately close a connection after each
+   response.  Instead, clients and servers SHOULD reuse existing
+   connections for subsequent queries as long as they have sufficient
+   resources.  In some cases, this means that clients and servers may
+   need to keep idle connections open for some amount of time.
+
+   Proper management of established and idle connections is important to
+   the healthy operation of a DNS server.  An implementor of DNS over
+   TLS SHOULD follow best practices for DNS over TCP, as described in
+   [RFC7766].  Failure to do so may lead to resource exhaustion and
+   denial of service.
+
+   Whereas client and server implementations from the era of [RFC1035]
+   are known to have poor TCP connection management, this document
+   stipulates that successful negotiation of TLS indicates the
+   willingness of both parties to keep idle DNS connections open,
+   independent of timeouts or other recommendations for DNS over TCP
+   without TLS.  In other words, software implementing this protocol is
+   assumed to support idle, persistent connections and be prepared to
+   manage multiple, potentially long-lived TCP connections.
+
+   This document does not make specific recommendations for timeout
+   values on idle connections.  Clients and servers should reuse and/or
+   close connections depending on the level of available resources.
+   Timeouts may be longer during periods of low activity and shorter
+   during periods of high activity.  Current work in this area may also
+   assist DNS-over-TLS clients and servers in selecting useful timeout
+   values [RFC7828] [TDNS].
+
+   Clients and servers that keep idle connections open MUST be robust to
+   termination of idle connection by either party.  As with current DNS
+   over TCP, DNS servers MAY close the connection at any time (perhaps
+   due to resource constraints).  As with current DNS over TCP, clients
+   MUST handle abrupt closes and be prepared to reestablish connections
+   and/or retry queries.
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 6]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   When reestablishing a DNS-over-TCP connection that was terminated, as
+   discussed in [RFC7766], TCP Fast Open [RFC7413] is of benefit.
+   Underlining the requirement for sending only encrypted DNS data on a
+   DNS-over-TLS port (Section 3.2), when using TCP Fast Open, the client
+   and server MUST immediately initiate or resume a TLS handshake
+   (cleartext DNS MUST NOT be exchanged).  DNS servers SHOULD enable
+   fast TLS session resumption [RFC5077], and this SHOULD be used when
+   reestablishing connections.
+
+   When closing a connection, DNS servers SHOULD use the TLS close-
+   notify request to shift TCP TIME-WAIT state to the clients.
+   Additional requirements and guidance for optimizing DNS over TCP are
+   provided by [RFC7766].
+
+4.  Usage Profiles
+
+   This protocol provides flexibility to accommodate several different
+   use cases.  This document defines two usage profiles: (1)
+   opportunistic privacy and (2) out-of-band key-pinned authentication
+   that can be used to obtain stronger privacy guarantees if the client
+   has a trusted relationship with a DNS server supporting TLS.
+   Additional methods of authentication will be defined in a forthcoming
+   document [TLS-DTLS-PROFILES].
+
+4.1.  Opportunistic Privacy Profile
+
+   For opportunistic privacy, analogous to SMTP opportunistic security
+   [RFC7435], one does not require privacy, but one desires privacy when
+   possible.
+
+   With opportunistic privacy, a client might learn of a TLS-enabled
+   recursive DNS resolver from an untrusted source.  One possible
+   example flow would be if the client used the DHCP DNS server option
+   [RFC3646] to discover the IP address of a TLS-enabled recursive and
+   then attempted DNS over TLS on port 853.  With such a discovered DNS
+   server, the client might or might not validate the resolver.  These
+   choices maximize availability and performance, but they leave the
+   client vulnerable to on-path attacks that remove privacy.
+
+   Opportunistic privacy can be used by any current client, but it only
+   provides privacy when there are no on-path active attackers.
+
+4.2.  Out-of-Band Key-Pinned Privacy Profile
+
+   The out-of-band key-pinned privacy profile can be used in
+   environments where an established trust relationship already exists
+   between DNS clients and servers (e.g., stub-to-recursive in
+   enterprise networks, actively maintained contractual service
+
+
+
+Hu, et al.                   Standards Track                    [Page 7]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   relationships, or a client using a public DNS resolver).  The result
+   of this profile is that the client has strong guarantees about the
+   privacy of its DNS data by connecting only to servers it can
+   authenticate.  Operators of a DNS-over-TLS service in this profile
+   are expected to provide pins that are specific to the service being
+   pinned (i.e., public keys belonging directly to the end entity or to
+   a service-specific private certificate authority (CA)) and not to a
+   public key(s) of a generic public CA.
+
+   In this profile, clients authenticate servers by matching a set of
+   SPKI Fingerprints in an analogous manner to that described in
+   [RFC7469].  With this out-of-band key-pinned privacy profile, client
+   administrators SHOULD deploy a backup pin along with the primary pin,
+   for the reasons explained in [RFC7469].  A backup pin is especially
+   helpful in the event of a key rollover, so that a server operator
+   does not have to coordinate key transitions with all its clients
+   simultaneously.  After a change of keys on the server, an updated pin
+   set SHOULD be distributed to all clients in some secure way in
+   preparation for future key rollover.  The mechanism for an
+   out-of-band pin set update is out of scope for this document.
+
+   Such a client will only use DNS servers for which an SPKI Fingerprint
+   pin set has been provided.  The possession of a trusted pre-deployed
+   pin set allows the client to detect and prevent person-in-the-middle
+   and downgrade attacks.
+
+   However, a configured DNS server may be temporarily unavailable when
+   configuring a network.  For example, for clients on networks that
+   require authentication through web-based login, such authentication
+   may rely on DNS interception and spoofing.  Techniques such as those
+   used by DNSSEC-trigger [DNSSEC-TRIGGER] MAY be used during network
+   configuration, with the intent to transition to the designated DNS
+   provider after authentication.  The user MUST be alerted whenever
+   possible that the DNS is not private during such bootstrap.
+
+   Upon successful TLS connection and handshake, the client computes the
+   SPKI Fingerprints for the public keys found in the validated server's
+   certificate chain (or in the raw public key, if the server provides
+   that instead).  If a computed fingerprint exactly matches one of the
+   configured pins, the client continues with the connection as normal.
+   Otherwise, the client MUST treat the SPKI validation failure as a
+   non-recoverable error.  Appendix A provides a detailed example of how
+   this authentication could be performed in practice.
+
+   Implementations of this privacy profile MUST support the calculation
+   of a fingerprint as the SHA-256 [RFC6234] hash of the DER-encoded
+   ASN.1 representation of the SPKI of an X.509 certificate.
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 8]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   Implementations MUST support the representation of a SHA-256
+   fingerprint as a base64-encoded character string [RFC4648].
+   Additional fingerprint types MAY also be supported.
+
+5.  Performance Considerations
+
+   DNS over TLS incurs additional latency at session startup.  It also
+   requires additional state (memory) and increased processing (CPU).
+
+   Latency:  Compared to UDP, DNS over TCP requires an additional round-
+      trip time (RTT) of latency to establish a TCP connection.  TCP
+      Fast Open [RFC7413] can eliminate that RTT when information exists
+      from prior connections.  The TLS handshake adds another two RTTs
+      of latency.  Clients and servers should support connection
+      keepalive (reuse) and out-of-order processing to amortize
+      connection setup costs.  Fast TLS connection resumption [RFC5077]
+      further reduces the setup delay and avoids the DNS server keeping
+      per-client session state.
+
+      TLS False Start [TLS-FALSESTART] can also lead to a latency
+      reduction in certain situations.  Implementations supporting TLS
+      False Start need to be aware that it imposes additional
+      constraints on how one uses TLS, over and above those stated in
+      [BCP195].  It is unsafe to use False Start if your implementation
+      and deployment does not adhere to these specific requirements.
+      See [TLS-FALSESTART] for the details of these additional
+      constraints.
+
+   State:  The use of connection-oriented TCP requires keeping
+      additional state at the server in both the kernel and application.
+      The state requirements are of particular concern on servers with
+      many clients, although memory-optimized TLS can add only modest
+      state over TCP.  Smaller timeout values will reduce the number of
+      concurrent connections, and servers can preemptively close
+      connections when resource limits are exceeded.
+
+   Processing:  The use of TLS encryption algorithms results in slightly
+      higher CPU usage.  Servers can choose to refuse new DNS-over-TLS
+      clients if processing limits are exceeded.
+
+   Number of connections:  To minimize state on DNS servers and
+      connection startup time, clients SHOULD minimize the creation of
+      new TCP connections.  Use of a local DNS request aggregator (a
+      particular type of forwarder) allows a single active DNS-over-TLS
+      connection from any given client computer to its server.
+      Additional guidance can be found in [RFC7766].
+
+
+
+
+
+Hu, et al.                   Standards Track                    [Page 9]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   A full performance evaluation is outside the scope of this
+   specification.  A more detailed analysis of the performance
+   implications of DNS over TLS (and DNS over TCP) is discussed in
+   [TDNS] and [RFC7766].
+
+6.  IANA Considerations
+
+   IANA has added the following value to the "Service Name and Transport
+   Protocol Port Number Registry" in the System Range.  The registry for
+   that range requires IETF Review or IESG Approval [RFC6335], and such
+   a review was requested using the early allocation process [RFC7120]
+   for the well-known TCP port in this document.
+
+   IANA has reserved the same port number over UDP for the proposed DNS-
+   over-DTLS protocol [DNSoD].
+
+    Service Name           domain-s
+    Port Number            853
+    Transport Protocol(s)  TCP/UDP
+    Assignee               IESG
+    Contact                IETF Chair
+    Description            DNS query-response protocol run over TLS/DTLS
+    Reference              This document
+
+7.  Design Evolution
+
+   Earlier draft versions of this document proposed an upgrade-based
+   approach to establish a TLS session.  The client would signal its
+   interest in TLS by setting a "TLS OK" bit in the Extensions
+   Mechanisms for DNS (EDNS(0)) flags field.  A server would signal its
+   acceptance by responding with the TLS OK bit set.
+
+   Since we assume the client doesn't want to reveal (leak) any
+   information prior to securing the channel, we proposed the use of a
+   "dummy query" that clients could send for this purpose.  The proposed
+   query name was STARTTLS, query type TXT, and query class CH.
+
+   The TLS OK signaling approach has both advantages and disadvantages.
+   One important advantage is that clients and servers could negotiate
+   TLS.  If the server is too busy, or doesn't want to provide TLS
+   service to a particular client, it can respond negatively to the TLS
+   probe.  An ancillary benefit is that servers could collect
+   information on adoption of DNS over TLS (via the TLS OK bit in
+   queries) before implementation and deployment.  Another anticipated
+   advantage is the expectation that DNS over TLS would work over port
+   53.  That is, no need to "waste" another port and deploy new firewall
+   rules on middleboxes.
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 10]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   However, at the same time, there was uncertainty whether or not
+   middleboxes would pass the TLS OK bit, given that the EDNS0 flags
+   field has been unchanged for many years.  Another disadvantage is
+   that the TLS OK bit may make downgrade attacks easy and
+   indistinguishable from broken middleboxes.  From a performance
+   standpoint, the upgrade-based approach had the disadvantage of
+   requiring 1xRTT additional latency for the dummy query.
+
+   Following this proposal, DNS over DTLS was proposed separately.  DNS
+   over DTLS claimed it could work over port 53, but only because a non-
+   DTLS server interprets a DNS-over-DTLS query as a response.  That is,
+   the non-DTLS server observes the QR flag set to 1.  While this
+   technically works, it seems unfortunate and perhaps even undesirable.
+
+   DNS over both TLS and DTLS can benefit from a single well-known port
+   and avoid extra latency and misinterpreted queries as responses.
+
+8.  Security Considerations
+
+   Use of DNS over TLS is designed to address the privacy risks that
+   arise out of the ability to eavesdrop on DNS messages.  It does not
+   address other security issues in DNS, and there are a number of
+   residual risks that may affect its success at protecting privacy:
+
+   1.  There are known attacks on TLS, such as person-in-the-middle and
+       protocol downgrade.  These are general attacks on TLS and not
+       specific to DNS over TLS; please refer to the TLS RFCs for
+       discussion of these security issues.  Clients and servers MUST
+       adhere to the TLS implementation recommendations and security
+       considerations of [BCP195].  DNS clients keeping track of servers
+       known to support TLS enables clients to detect downgrade attacks.
+       For servers with no connection history and no apparent support
+       for TLS, depending on their privacy profile and privacy
+       requirements, clients may choose to (a) try another server when
+       available, (b) continue without TLS, or (c) refuse to forward the
+       query.
+
+   2.  Middleboxes [RFC3234] are present in some networks and have been
+       known to interfere with normal DNS resolution.  Use of a
+       designated port for DNS over TLS should avoid such interference.
+       In general, clients that attempt TLS and fail can either fall
+       back on unencrypted DNS or wait and retry later, depending on
+       their privacy profile and privacy requirements.
+
+   3.  Any DNS protocol interactions performed in the clear can be
+       modified by a person-in-the-middle attacker.  For example,
+       unencrypted queries and responses might take place over port 53
+       between a client and server.  For this reason, clients MAY
+
+
+
+Hu, et al.                   Standards Track                   [Page 11]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+       discard cached information about server capabilities advertised
+       in cleartext.
+
+   4.  This document does not, itself, specify ideas to resist known
+       traffic analysis or side-channel leaks.  Even with encrypted
+       messages, a well-positioned party may be able to glean certain
+       details from an analysis of message timings and sizes.  Clients
+       and servers may consider the use of a padding method to address
+       privacy leakage due to message sizes [RFC7830].  Since traffic
+       analysis can be based on many kinds of patterns and many kinds of
+       classifiers, simple padding schemes alone might not be sufficient
+       to mitigate such an attack.  Padding will, however, form a part
+       of more complex mitigations for traffic-analysis attacks that are
+       likely to be developed over time.  Implementors who can offer
+       flexibility in terms of how padding can be used may be in a
+       better position to enable such mitigations to be deployed in the
+       future.
+
+   As noted earlier, DNSSEC and DNS over TLS are independent and fully
+   compatible protocols, each solving different problems.  The use of
+   one does not diminish the need nor the usefulness of the other.
+
+9.  References
+
+9.1.  Normative References
+
+   [BCP195]   Sheffer, Y., Holz, R., and P. Saint-Andre,
+              "Recommendations for Secure Use of Transport Layer
+              Security (TLS) and Datagram Transport Layer Security
+              (DTLS)", BCP 195, RFC 7525, May 2015,
+              <https://www.rfc-editor.org/info/bcp195>.
+
+   [RFC1034]  Mockapetris, P., "Domain names - concepts and facilities",
+              STD 13, RFC 1034, DOI 10.17487/RFC1034, November 1987,
+              <http://www.rfc-editor.org/info/rfc1034>.
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
+              November 1987, <http://www.rfc-editor.org/info/rfc1035>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <http://www.rfc-editor.org/info/rfc4648>.
+
+
+
+Hu, et al.                   Standards Track                   [Page 12]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   [RFC5077]  Salowey, J., Zhou, H., Eronen, P., and H. Tschofenig,
+              "Transport Layer Security (TLS) Session Resumption without
+              Server-Side State", RFC 5077, DOI 10.17487/RFC5077,
+              January 2008, <http://www.rfc-editor.org/info/rfc5077>.
+
+   [RFC5246]  Dierks, T. and E. Rescorla, "The Transport Layer Security
+              (TLS) Protocol Version 1.2", RFC 5246,
+              DOI 10.17487/RFC5246, August 2008,
+              <http://www.rfc-editor.org/info/rfc5246>.
+
+   [RFC6234]  Eastlake 3rd, D. and T. Hansen, "US Secure Hash Algorithms
+              (SHA and SHA-based HMAC and HKDF)", RFC 6234,
+              DOI 10.17487/RFC6234, May 2011,
+              <http://www.rfc-editor.org/info/rfc6234>.
+
+   [RFC6335]  Cotton, M., Eggert, L., Touch, J., Westerlund, M., and S.
+              Cheshire, "Internet Assigned Numbers Authority (IANA)
+              Procedures for the Management of the Service Name and
+              Transport Protocol Port Number Registry", BCP 165,
+              RFC 6335, DOI 10.17487/RFC6335, August 2011,
+              <http://www.rfc-editor.org/info/rfc6335>.
+
+   [RFC7120]  Cotton, M., "Early IANA Allocation of Standards Track Code
+              Points", BCP 100, RFC 7120, DOI 10.17487/RFC7120, January
+              2014, <http://www.rfc-editor.org/info/rfc7120>.
+
+   [RFC7469]  Evans, C., Palmer, C., and R. Sleevi, "Public Key Pinning
+              Extension for HTTP", RFC 7469, DOI 10.17487/RFC7469, April
+              2015, <http://www.rfc-editor.org/info/rfc7469>.
+
+   [RFC7766]  Dickinson, J., Dickinson, S., Bellis, R., Mankin, A., and
+              D. Wessels, "DNS Transport over TCP - Implementation
+              Requirements", RFC 7766, DOI 10.17487/RFC7766, March 2016,
+              <http://www.rfc-editor.org/info/rfc7766>.
+
+9.2.  Informative References
+
+   [CONFIDENTIAL-DNS]
+              Wijngaards, W. and G. Wiley, "Confidential DNS", Work in
+              Progress, draft-wijngaards-dnsop-confidentialdns-03, March
+              2015.
+
+   [DNSCRYPT-WEBSITE]
+              Denis, F., "DNSCrypt", December 2015,
+              <https://www.dnscrypt.org/>.
+
+
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 13]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   [DNSCurve] Dempsky, M., "DNSCurve: Link-Level Security for the Domain
+              Name System", Work in Progress, draft-dempsky-dnscurve-01,
+              February 2010.
+
+   [DNSoD]    Reddy, T., Wing, D., and P. Patil, "DNS over DTLS
+              (DNSoD)", Work in Progress, draft-ietf-dprive-dnsodtls-06,
+              April 2016.
+
+   [DNSSEC-TRIGGER]
+              NLnet Labs, "Dnssec-Trigger", May 2014,
+              <https://www.nlnetlabs.nl/projects/dnssec-trigger/>.
+
+   [IPSECA]   Osterweil, E., Wiley, G., Okubo, T., Lavu, R., and A.
+              Mohaisen, "Opportunistic Encryption with DANE Semantics
+              and IPsec: IPSECA", Work in Progress,
+              draft-osterweil-dane-ipsec-03, July 2015.
+
+   [RFC3234]  Carpenter, B. and S. Brim, "Middleboxes: Taxonomy and
+              Issues", RFC 3234, DOI 10.17487/RFC3234, February 2002,
+              <http://www.rfc-editor.org/info/rfc3234>.
+
+   [RFC3646]  Droms, R., Ed., "DNS Configuration options for Dynamic
+              Host Configuration Protocol for IPv6 (DHCPv6)", RFC 3646,
+              DOI 10.17487/RFC3646, December 2003,
+              <http://www.rfc-editor.org/info/rfc3646>.
+
+   [RFC4033]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "DNS Security Introduction and Requirements",
+              RFC 4033, DOI 10.17487/RFC4033, March 2005,
+              <http://www.rfc-editor.org/info/rfc4033>.
+
+   [RFC7258]  Farrell, S. and H. Tschofenig, "Pervasive Monitoring Is an
+              Attack", BCP 188, RFC 7258, DOI 10.17487/RFC7258, May
+              2014, <http://www.rfc-editor.org/info/rfc7258>.
+
+   [RFC7413]  Cheng, Y., Chu, J., Radhakrishnan, S., and A. Jain, "TCP
+              Fast Open", RFC 7413, DOI 10.17487/RFC7413, December 2014,
+              <http://www.rfc-editor.org/info/rfc7413>.
+
+   [RFC7435]  Dukhovni, V., "Opportunistic Security: Some Protection
+              Most of the Time", RFC 7435, DOI 10.17487/RFC7435,
+              December 2014, <http://www.rfc-editor.org/info/rfc7435>.
+
+   [RFC7626]  Bortzmeyer, S., "DNS Privacy Considerations", RFC 7626,
+              DOI 10.17487/RFC7626, August 2015,
+              <http://www.rfc-editor.org/info/rfc7626>.
+
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 14]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   [RFC7828]  Wouters, P., Abley, J., Dickinson, S., and R. Bellis, "The
+              edns-tcp-keepalive EDNS0 Option", RFC 7828,
+              DOI 10.17487/RFC7828, April 2016,
+              <http://www.rfc-editor.org/info/rfc7828>.
+
+   [RFC7830]  Mayrhofer, A., "The EDNS(0) Padding Option", RFC 7830,
+              DOI 10.17487/RFC7830, May 2016,
+              <http://www.rfc-editor.org/info/rfc7830>.
+
+   [TDNS]     Zhu, L., Hu, Z., Heidemann, J., Wessels, D., Mankin, A.,
+              and N. Somaiya, "Connection-Oriented DNS to Improve
+              Privacy and Security", 2015 IEEE Symposium on Security and
+              Privacy (SP), DOI 10.1109/SP.2015.18,
+              <http://dx.doi.org/10.1109/SP.2015.18>.
+
+   [TLS-DTLS-PROFILES]
+              Dickinson, S., Gillmor, D., and T. Reddy, "Authentication
+              and (D)TLS Profile for DNS-over-TLS and DNS-over-DTLS",
+              Work in Progress, draft-ietf-dprive-dtls-and-tls-
+              profiles-01, March 2016.
+
+   [TLS-FALSESTART]
+              Langley, A., Modadugu, N., and B. Moeller, "Transport
+              Layer Security (TLS) False Start", Work in Progress,
+              draft-ietf-tls-falsestart-02, May 2016.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 15]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+Appendix A.  Out-of-Band Key-Pinned Privacy Profile Example
+
+   This section presents an example of how the out-of-band key-pinned
+   privacy profile could work in practice based on a minimal pin set
+   (two pins).
+
+   A DNS client system is configured with an out-of-band key-pinned
+   privacy profile from a network service, using a pin set containing
+   two pins.  Represented in HTTP Public Key Pinning (HPKP) [RFC7469]
+   style, the pins are:
+
+   o  pin-sha256="FHkyLhvI0n70E47cJlRTamTrnYVcsYdjUGbr79CfAVI="
+
+   o  pin-sha256="dFSY3wdPU8L0u/8qECuz5wtlSgnorYV2f66L6GNQg6w="
+
+   The client also configures the IP addresses of its expected DNS
+   server: perhaps 192.0.2.3 and 2001:db8::2:4.
+
+   The client connects to one of these addresses on TCP port 853 and
+   begins the TLS handshake: negotiation of TLS 1.2 with a Diffie-
+   Hellman key exchange.  The server sends a certificate message with a
+   list of three certificates (A, B, and C) and signs the
+   ServerKeyExchange message correctly with the public key found in
+   certificate A.
+
+   The client now takes the SHA-256 digest of the SPKI in cert A and
+   compares it against both pins in the pin set.  If either pin matches,
+   the verification is successful; the client continues with the TLS
+   connection and can make its first DNS query.
+
+   If neither pin matches the SPKI of cert A, the client verifies that
+   cert A is actually issued by cert B.  If it is, it takes the SHA-256
+   digest of the SPKI in cert B and compares it against both pins in the
+   pin set.  If either pin matches, the verification is successful.
+   Otherwise, it verifies that B was issued by C and then compares the
+   pins against the digest of C's SPKI.
+
+   If none of the SPKIs in the cryptographically valid chain of certs
+   match any pin in the pin set, the client closes the connection with
+   an error and marks the IP address as failed.
+
+
+
+
+
+
+
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 16]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+Acknowledgments
+
+   The authors would like to thank Stephane Bortzmeyer, John Dickinson,
+   Brian Haberman, Christian Huitema, Shumon Huque, Simon Joseffson,
+   Kim-Minh Kaplan, Simon Kelley, Warren Kumari, John Levine, Ilari
+   Liusvaara, Bill Manning, George Michaelson, Eric Osterweil, Jinmei
+   Tatuya, Tim Wicinski, and Glen Wiley for reviewing this
+   specification.  They also thank Nikita Somaiya for early work on this
+   idea.
+
+   Work by Zi Hu, Liang Zhu, and John Heidemann on this document is
+   partially sponsored by the U.S. Dept. of Homeland Security (DHS)
+   Science and Technology Directorate, Homeland Security Advanced
+   Research Projects Agency (HSARPA), Cyber Security Division, BAA
+   11-01-RIKA and Air Force Research Laboratory, Information Directorate
+   under agreement number FA8750-12-2-0344, and contract number
+   D08PC75599.
+
+Contributors
+
+   The below individuals contributed significantly to the document:
+
+   Sara Dickinson
+   Sinodun Internet Technologies
+   Magdalen Centre
+   Oxford Science Park
+   Oxford  OX4 4GA
+   United Kingdom
+
+   Email: sara@sinodun.com
+   URI:   http://sinodun.com
+
+
+   Daniel Kahn Gillmor
+   ACLU
+   125 Broad Street, 18th Floor
+   New York, NY  10004
+   United States
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 17]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+Authors' Addresses
+
+   Zi Hu
+   USC/Information Sciences Institute
+   4676 Admiralty Way, Suite 1133
+   Marina del Rey, CA  90292
+   United States
+
+   Phone: +1-213-587-1057
+   Email: zihu@outlook.com
+
+
+   Liang Zhu
+   USC/Information Sciences Institute
+   4676 Admiralty Way, Suite 1133
+   Marina del Rey, CA  90292
+   United States
+
+   Phone: +1-310-448-8323
+   Email: liangzhu@usc.edu
+
+
+   John Heidemann
+   USC/Information Sciences Institute
+   4676 Admiralty Way, Suite 1001
+   Marina del Rey, CA  90292
+   United States
+
+   Phone: +1-310-822-1511
+   Email: johnh@isi.edu
+
+
+   Allison Mankin
+   Independent
+
+   Phone: +1-301-728-7198
+   Email: Allison.mankin@gmail.com
+
+
+   Duane Wessels
+   Verisign Labs
+   12061 Bluemont Way
+   Reston, VA  20190
+   United States
+
+   Phone: +1-703-948-3200
+   Email: dwessels@verisign.com
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 18]
+
+RFC 7858                      DNS over TLS                      May 2016
+
+
+   Paul Hoffman
+   ICANN
+
+   Email: paul.hoffman@icann.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hu, et al.                   Standards Track                   [Page 19]
+

--- a/rfc/dns/rfc7873.txt
+++ b/rfc/dns/rfc7873.txt
@@ -1,0 +1,1403 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                   D. Eastlake 3rd
+Request for Comments: 7873                                        Huawei
+Category: Standards Track                                     M. Andrews
+ISSN: 2070-1721                                                      ISC
+                                                                May 2016
+
+
+                    Domain Name System (DNS) Cookies
+
+Abstract
+
+   DNS Cookies are a lightweight DNS transaction security mechanism that
+   provides limited protection to DNS servers and clients against a
+   variety of increasingly common denial-of-service and amplification/
+   forgery or cache poisoning attacks by off-path attackers.  DNS
+   Cookies are tolerant of NAT, NAT-PT (Network Address Translation -
+   Protocol Translation), and anycast and can be incrementally deployed.
+   (Since DNS Cookies are only returned to the IP address from which
+   they were originally received, they cannot be used to generally track
+   Internet users.)
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   http://www.rfc-editor.org/info/rfc7873.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 1]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+Copyright Notice
+
+   Copyright (c) 2016 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (http://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 2]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+Table of Contents
+
+   1. Introduction ....................................................4
+      1.1. Contents of This Document ..................................4
+      1.2. Definitions ................................................5
+   2. Threats Considered ..............................................5
+      2.1. Denial-of-Service Attacks ..................................6
+           2.1.1. DNS Amplification Attacks ...........................6
+           2.1.2. DNS Server Denial of Service ........................6
+      2.2. Cache Poisoning and Answer Forgery Attacks .................7
+   3. Comments on Existing DNS Security ...............................7
+      3.1. Existing DNS Data Security .................................7
+      3.2. DNS Message/Transaction Security ...........................8
+      3.3. Conclusions on Existing DNS Security .......................8
+   4. DNS COOKIE Option ...............................................8
+      4.1. Client Cookie .............................................10
+      4.2. Server Cookie .............................................10
+   5. DNS Cookies Protocol Specification .............................11
+      5.1. Originating a Request .....................................11
+      5.2. Responding to a Request ...................................11
+           5.2.1. No OPT RR or No COOKIE Option ......................12
+           5.2.2. Malformed COOKIE Option ............................12
+           5.2.3. Only a Client Cookie ...............................12
+           5.2.4. A Client Cookie and an Invalid Server Cookie .......13
+           5.2.5. A Client Cookie and a Valid Server Cookie ..........13
+      5.3. Processing Responses ......................................14
+      5.4. Querying for a Server Cookie ..............................14
+   6. NAT Considerations and Anycast Server Considerations ...........15
+   7. Operational and Deployment Considerations ......................17
+      7.1. Client and Server Secret Rollover .........................17
+      7.2. Counters ..................................................18
+   8. IANA Considerations ............................................18
+   9. Security Considerations ........................................19
+      9.1. Cookie Algorithm Considerations ...........................20
+   10. Implementation Considerations .................................20
+   11. References ....................................................20
+      11.1. Normative References .....................................20
+      11.2. Informative References ...................................21
+   Appendix A. Example Client Cookie Algorithms ......................23
+      A.1. A Simple Algorithm ........................................23
+      A.2. A More Complex Algorithm ..................................23
+   Appendix B. Example Server Cookie Algorithms ......................23
+      B.1. A Simple Algorithm ........................................23
+      B.2. A More Complex Algorithm ..................................24
+   Acknowledgments ...................................................25
+   Authors' Addresses ................................................25
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 3]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+1.  Introduction
+
+   As with many core Internet protocols, the Domain Name System (DNS)
+   was originally designed at a time when the Internet had only a small
+   pool of trusted users.  As the Internet has grown exponentially to a
+   global information utility, the DNS has increasingly been subject to
+   abuse.
+
+   This document describes DNS Cookies, a lightweight DNS transaction
+   security mechanism specified as an OPT [RFC6891] option.  The
+   DNS Cookie mechanism provides limited protection to DNS servers and
+   clients against a variety of increasingly common abuses by off-path
+   attackers.  It is compatible with, and can be used in conjunction
+   with, other DNS transaction forgery resistance measures such as those
+   in [RFC5452].  (Since DNS Cookies are only returned to the IP address
+   from which they were originally received, they cannot be used to
+   generally track Internet users.)
+
+   The protection provided by DNS Cookies is similar to that provided by
+   using TCP for DNS transactions.  Bypassing the weak protection
+   provided by using TCP requires, among other things, that an off-path
+   attacker guess the 32-bit TCP sequence number in use.  Bypassing the
+   weak protection provided by DNS Cookies requires such an attacker to
+   guess a 64-bit pseudorandom "cookie" quantity.  Where DNS Cookies are
+   not available but TCP is, falling back to using TCP is reasonable.
+
+   If only one party to a DNS transaction supports DNS Cookies, the
+   mechanism does not provide a benefit or significantly interfere, but
+   if both support it, the additional security provided is automatically
+   available.
+
+   The DNS Cookie mechanism is designed to work in the presence of NAT
+   and NAT-PT (Network Address Translation - Protocol Translation)
+   boxes, and guidance is provided herein on supporting the DNS Cookie
+   mechanism in anycast servers.
+
+1.1.  Contents of This Document
+
+   In Section 2, we discuss the threats against which the DNS Cookie
+   mechanism provides some protection.
+
+   Section 3 describes existing DNS security mechanisms and why they are
+   not adequate substitutes for DNS Cookies.
+
+   Section 4 describes the COOKIE option.
+
+   Section 5 provides a protocol description.
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 4]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   Section 6 discusses some NAT considerations and anycast-related
+   DNS Cookies design considerations.
+
+   Section 7 discusses incremental deployment considerations.
+
+   Sections 8 and 9 describe IANA considerations and security
+   considerations, respectively.
+
+1.2.  Definitions
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   [RFC2119].
+
+   "Off-path attacker", for a particular DNS client and server, is
+      defined as an attacker who cannot observe the DNS request and
+      response messages between that client and server.
+
+   "Soft state" indicates information that is learned or derived by a
+      host and that may be discarded when indicated by the policies of
+      that host but can be re-instantiated later if needed.  For
+      example, it could be discarded after a period of time or when
+      storage for caching such data becomes full.  If operations that
+      require soft state continue after the information has been
+      discarded, the information will be automatically regenerated,
+      albeit at some cost.
+
+   "Silently discarded" indicates that there are no DNS protocol message
+      consequences.
+
+   "IP address" is used herein as a length-independent term and includes
+      both IPv4 and IPv6 addresses.
+
+2.  Threats Considered
+
+   DNS Cookies are intended to provide significant but limited
+   protection against certain attacks by off-path attackers, as
+   described below.  These attacks include denial of service, cache
+   poisoning, and answer forgery.
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 5]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+2.1.  Denial-of-Service Attacks
+
+   The typical form of the denial-of-service attacks considered herein
+   is to send DNS requests with forged source IP addresses to a server.
+   The intent can be to attack that server or some other selected host,
+   as described below.
+
+   There are also on-path denial-of-service attacks that attempt to
+   saturate a server with DNS requests having correct source addresses.
+   Cookies do not protect against such attacks, but successful cookie
+   validation improves the probability that the correct source IP
+   address for the requests is known.  This facilitates contacting the
+   managers of the networks from which the requests originate or taking
+   other actions for those networks.
+
+2.1.1.  DNS Amplification Attacks
+
+   A request with a forged source IP address generally causes a response
+   to be sent to that forged IP address.  Thus, the forging of many such
+   requests with a particular source IP address can result in enough
+   traffic being sent to the forged IP address to interfere with service
+   to the host at the IP address.  Furthermore, it is generally easy in
+   the DNS to create short requests that produce much longer responses,
+   thus amplifying the attack.
+
+   The DNS Cookie mechanism can severely limit the traffic amplification
+   obtained by requests from an attacker that is off the path between
+   the server and the request's source address.  Enforced DNS Cookies
+   would make it hard for an off-path attacker to cause any more than
+   rate-limited short error responses to be sent to a forged IP address,
+   so the attack would be attenuated rather than amplified.  DNS Cookies
+   make it more effective to implement a rate-limiting scheme for error
+   responses from the server.  Such a scheme would further restrict
+   selected host denial-of-service traffic from that server.
+
+2.1.2.  DNS Server Denial of Service
+
+   DNS requests that are accepted cause work on the part of DNS servers.
+   This is particularly true for recursive servers that may issue one or
+   more requests and process the responses thereto, in order to
+   determine their response to the initial request; the situation can be
+   even worse for recursive servers implementing DNSSEC [RFC4033]
+   [RFC4034] [RFC4035], because they may be induced to perform
+   burdensome cryptographic computations in attempts to verify the
+   authenticity of data they retrieve in trying to answer the request.
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 6]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   The computational or communications burden caused by such requests
+   may not depend on a forged source IP address, but the use of such
+   addresses makes
+
+   + the source of the requests causing the denial-of-service attack
+     harder to find and
+
+   + restriction of the IP addresses from which such requests should be
+     honored hard or impossible to specify or verify.
+
+   The use of DNS Cookies should enable a server to reject forged
+   requests from an off-path attacker with relative ease and before any
+   recursive queries or public key cryptographic operations are
+   performed.
+
+2.2.  Cache Poisoning and Answer Forgery Attacks
+
+   The form of the cache poisoning attacks considered is to send forged
+   replies to a resolver.  Modern network speeds for well-connected
+   hosts are such that, by forging replies from the IP addresses of a
+   DNS server to a resolver for names that resolver has been induced to
+   resolve or for common names whose resource records have short
+   time-to-live values, there can be an unacceptably high probability of
+   randomly coming up with a reply that will be accepted and cause false
+   DNS information to be cached by that resolver (the Dan Kaminsky
+   attack [Kaminsky]).  This can be used to facilitate phishing attacks
+   and other diversions of legitimate traffic to a compromised or
+   malicious host such as a web server.
+
+   With the use of DNS Cookies, a resolver can generally reject such
+   forged replies.
+
+3.  Comments on Existing DNS Security
+
+   Two forms of security have been added to DNS: data security and
+   message/transaction security.
+
+3.1.  Existing DNS Data Security
+
+   DNS data security is one part of DNSSEC and is described in
+   [RFC4033], [RFC4034], [RFC4035], and updates thereto.  It provides
+   data origin authentication and authenticated denial of existence.
+   DNSSEC is being deployed and can provide strong protection against
+   forged data and cache poisoning; however, it has the unintended
+   effect of making some denial-of-service attacks worse because of the
+   cryptographic computational load it can require and the increased
+   size in DNS response packets that it tends to produce.
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 7]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+3.2.  DNS Message/Transaction Security
+
+   The second form of security that has been added to DNS provides
+   "transaction" security through TSIG [RFC2845] or SIG(0) [RFC2931].
+   TSIG could provide strong protection against the attacks for which
+   the DNS Cookie mechanism provides weaker protection; however, TSIG is
+   non-trivial to deploy in the general Internet because of the burdens
+   it imposes.  Among these burdens are pre-agreement and key
+   distribution between client and server, keeping track of server-side
+   key state, and required time synchronization between client and
+   server.
+
+   TKEY [RFC2930] can solve the problem of key distribution for TSIG,
+   but some modes of TKEY impose a substantial cryptographic computation
+   load and can be dependent on the deployment of DNS data security (see
+   Section 3.1).
+
+   SIG(0) [RFC2931] provides less denial-of-service protection than TSIG
+   or, in one way, even DNS Cookies, because it authenticates complete
+   transactions but does not authenticate requests.  In any case, it
+   also depends on the deployment of DNS data security and requires
+   computationally burdensome public key cryptographic operations.
+
+3.3.  Conclusions on Existing DNS Security
+
+   The existing DNS security mechanisms do not provide the services
+   provided by the DNS Cookie mechanism: lightweight message
+   authentication of DNS requests and responses with no requirement for
+   pre-configuration or per-client server-side state.
+
+4.  DNS COOKIE Option
+
+   The DNS COOKIE option is an OPT RR [RFC6891] option that can be
+   included in the RDATA portion of an OPT RR in DNS requests and
+   responses.  The option length varies, depending on the circumstances
+   in which it is being used.  There are two cases, as described below.
+   Both use the same OPTION-CODE; they are distinguished by their
+   length.
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 8]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   In a request sent by a client to a server when the client does not
+   know the server's cookie, its length is 8, consisting of an 8-byte
+   Client Cookie, as shown in Figure 1.
+
+                         1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |        OPTION-CODE = 10      |       OPTION-LENGTH = 8        |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +-+-    Client Cookie (fixed size, 8 bytes)              -+-+-+-+
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+              Figure 1: COOKIE Option, Unknown Server Cookie
+
+   In a request sent by a client when a Server Cookie is known, and in
+   all responses to such a request, the length is variable -- from 16 to
+   40 bytes, consisting of an 8-byte Client Cookie followed by the
+   variable-length (8 bytes to 32 bytes) Server Cookie, as shown in
+   Figure 2.  The variability of the option length stems from the
+   variable-length Server Cookie.  The Server Cookie is an integer
+   number of bytes, with a minimum size of 8 bytes for security and a
+   maximum size of 32 bytes for convenience of implementation.
+
+                         1 1 1 1 1 1 1 1 1 1 2 2 2 2 2 2 2 2 2 2 3 3
+     0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |        OPTION-CODE = 10      |   OPTION-LENGTH >= 16, <= 40   |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    +-+-    Client Cookie (fixed size, 8 bytes)              -+-+-+-+
+    |                                                               |
+    +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    |                                                               |
+    /       Server Cookie  (variable size, 8 to 32 bytes)           /
+    /                                                               /
+    +-+-+-+-...
+
+               Figure 2: COOKIE Option, Known Server Cookie
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                    [Page 9]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+4.1.  Client Cookie
+
+   The Client Cookie SHOULD be a pseudorandom function of the Client IP
+   Address, the Server IP Address, and a secret quantity known only to
+   the client.  This Client Secret SHOULD have at least 64 bits of
+   entropy [RFC4086] and be changed periodically (see Section 7.1).  The
+   selection of the pseudorandom function is a matter private to the
+   client, as only the client needs to recognize its own DNS Cookies.
+
+   The Client IP Address is included so that the Client Cookie cannot be
+   used to (1) track a client if the Client IP Address changes due to
+   privacy mechanisms or (2) impersonate the client by some network
+   device that was formerly on path but is no longer on path when the
+   Client IP Address changes due to mobility.  However, if the Client IP
+   Address is being changed very often, it may be necessary to fix the
+   Client Cookie for a particular server for several requests, to avoid
+   undue inefficiency due to retries caused by that server not
+   recognizing the Client Cookie.
+
+   For further discussion of the Client Cookie field, see Section 5.1.
+   For example methods of determining a Client Cookie, see Appendix A.
+
+   In order to provide minimal authentication, a client MUST send
+   Client Cookies that will usually be different for any two servers at
+   different IP addresses.
+
+4.2.  Server Cookie
+
+   The Server Cookie SHOULD consist of or include a 64-bit or larger
+   pseudorandom function of the request source (client) IP address, a
+   secret quantity known only to the server, and the request
+   Client Cookie.  (See Section 6 for a discussion of why the
+   Client Cookie is used as input to the Server Cookie but the
+   Server Cookie is not used as an input to the Client Cookie.)  This
+   Server Secret SHOULD have at least 64 bits of entropy [RFC4086] and
+   be changed periodically (see Section 7.1).  The selection of the
+   pseudorandom function is a matter private to the server, as only the
+   server needs to recognize its own DNS Cookies.
+
+   For further discussion of the Server Cookie field, see Section 5.2.
+   For example methods of determining a Server Cookie, see Appendix B.
+   When implemented as recommended, the server need not maintain any
+   cookie-related per-client state.
+
+   In order to provide minimal authentication, a server MUST send
+   Server Cookies that will usually be different for clients at any two
+   different IP addresses or with different Client Cookies.
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 10]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+5.  DNS Cookies Protocol Specification
+
+   This section discusses using DNS Cookies in the DNS protocol.  The
+   cycle of originating a request, responding to that request, and
+   processing responses is covered in Sections 5.1, 5.2, and 5.3.  A
+   de facto extension to QUERY to allow the prefetching of a
+   Server Cookie is specified in Section 5.4.  Rollover of the Client
+   Secrets and Server Secrets, and transient retention of the old cookie
+   or secret, are covered in Section 7.1.
+
+   DNS clients and servers SHOULD implement DNS Cookies to decrease
+   their vulnerability to the threats discussed in Section 2.
+
+5.1.  Originating a Request
+
+   A DNS client that implements DNS Cookies includes one DNS
+   COOKIE option containing a Client Cookie in every DNS request
+   it sends, unless DNS Cookies are disabled.
+
+   If the client has a cached Server Cookie for the server against its
+   IP address, it uses the longer cookie form and includes that
+   Server Cookie in the option along with the Client Cookie (Figure 2).
+   Otherwise, it just sends the shorter-form option with a Client Cookie
+   (Figure 1).
+
+5.2.  Responding to a Request
+
+   The Server Cookie, when it occurs in a COOKIE option in a request, is
+   intended to weakly assure the server that the request came from a
+   client that is both at the source IP address of the request and using
+   the Client Cookie included in the option.  This assurance is provided
+   by the Server Cookie that server sent to that client in an earlier
+   response appearing as the Server Cookie field in the request.
+
+   At a server where DNS Cookies are not implemented and enabled, the
+   presence of a COOKIE option is ignored and the server responds as if
+   no COOKIE option had been included in the request.
+
+   When DNS Cookies are implemented and enabled, there are five
+   possibilities:
+
+   (1) There is no OPT RR at all in the request, or there is an OPT RR
+       but the COOKIE option is absent from the OPT RR.
+
+   (2) A COOKIE option is present but is not a legal length or is
+       otherwise malformed.
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 11]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   (3) There is a COOKIE option of valid length in the request with no
+       Server Cookie.
+
+   (4) There is a COOKIE option of valid length in the request with a
+       Server Cookie, but that Server Cookie is invalid.
+
+   (5) There is a COOKIE option of valid length in the request with a
+       correct Server Cookie.
+
+   These five possibilities are discussed in the subsections below.
+
+   In all cases of multiple COOKIE options in a request, only the first
+   (the one closest to the DNS header) is considered.  All others are
+   ignored.
+
+5.2.1.  No OPT RR or No COOKIE Option
+
+   If there is no OPT record or no COOKIE option present in the request,
+   then the server responds to the request as if the server doesn't
+   implement the COOKIE option.
+
+5.2.2.  Malformed COOKIE Option
+
+   If the COOKIE option is too short to contain a Client Cookie, then
+   FORMERR is generated.  If the COOKIE option is longer than that
+   required to hold a COOKIE option with just a Client Cookie (8 bytes)
+   but is shorter than the minimum COOKIE option with both a
+   Client Cookie and a Server Cookie (16 bytes), then FORMERR is
+   generated.  If the COOKIE option is longer than the maximum valid
+   COOKIE option (40 bytes), then FORMERR is generated.
+
+   In summary, valid cookie lengths are 8 and 16 to 40 inclusive.
+
+5.2.3.  Only a Client Cookie
+
+   Based on server policy, including rate limiting, the server chooses
+   one of the following:
+
+   (1) Silently discard the request.
+
+   (2) Send a BADCOOKIE error response.
+
+   (3) Process the request and provide a normal response.  The RCODE is
+       NOERROR, unless some non-cookie error occurs in processing the
+       request.
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 12]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   If the server responds choosing (2) or (3) above, it SHALL generate
+   its own COOKIE option containing both the Client Cookie copied from
+   the request and a Server Cookie it has generated, and it will add
+   this COOKIE option to the response's OPT record.  Servers MUST, at
+   least occasionally, respond to such requests to inform the client of
+   the correct Server Cookie.  This is necessary so that such a client
+   can bootstrap to the more secure state where requests and responses
+   have recognized Server Cookies and Client Cookies.  A server is not
+   expected to maintain per-client state to achieve this.  For example,
+   it could respond to every Nth request across all clients.
+
+   If the request was received over TCP, the server SHOULD take the
+   authentication provided by the use of TCP into account and SHOULD
+   choose (3).  In this case, if the server is not willing to accept the
+   security provided by TCP as a substitute for the security provided by
+   DNS Cookies but instead chooses (2), there is some danger of an
+   indefinite loop of retries (see Section 5.3).
+
+5.2.4.  A Client Cookie and an Invalid Server Cookie
+
+   The server examines the Server Cookie to determine if it is a valid
+   Server Cookie that it had generated previously.  This determination
+   normally involves recalculating the Server Cookie (or the Hash part
+   thereof) based on the Server Secret (or the previous Server Secret,
+   if it has just changed); the received Client Cookie; the Client IP
+   Address; and, possibly, other fields.  See Appendix B.2 for an
+   example.  If the cookie is invalid, it could be because
+
+   + it is too old
+
+   + a client's IP address or Client Cookie changed, and the DNS server
+     is not aware of the change
+
+   + an anycast cluster of servers is not consistently configured, or
+
+   + an attempt to spoof the client has occurred
+
+   The server SHALL process the request as if the invalid Server Cookie
+   was not present, as described in Section 5.2.3.
+
+5.2.5.  A Client Cookie and a Valid Server Cookie
+
+   When a valid Server Cookie is present in the request, the server can
+   assume that the request is from a client that it has talked to before
+   and defensive measures for spoofed UDP requests, if any, are no
+   longer required.
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 13]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   The server SHALL process the request and include a COOKIE option in
+   the response by (a) copying the complete COOKIE option from the
+   request or (b) generating a new COOKIE option containing both the
+   Client Cookie copied from the request and a valid Server Cookie it
+   has generated.
+
+5.3.  Processing Responses
+
+   The Client Cookie, when it occurs in a COOKIE option in a DNS reply,
+   is intended to weakly assure the client that the reply came from a
+   server at the source IP address used in the response packet, because
+   the Client Cookie value is the value that client would send to that
+   server in a request.  In a DNS reply with multiple COOKIE options,
+   all but the first (the one closest to the DNS header) are ignored.
+
+   A DNS client where DNS Cookies are implemented and enabled examines
+   the response for DNS Cookies and MUST discard the response if it
+   contains an illegal COOKIE option length or an incorrect
+   Client Cookie value.  If the client is expecting the response to
+   contain a COOKIE option and it is missing, the response MUST be
+   discarded.  If the COOKIE option Client Cookie is correct, the client
+   caches the Server Cookie provided, even if the response is an error
+   response (RCODE non-zero).
+
+   If the extended RCODE in the reply is BADCOOKIE and the Client Cookie
+   in the reply matches what was sent, it means that the server was
+   unwilling to process the request because it did not have the correct
+   Server Cookie in it.  The client SHOULD retry the request using the
+   new Server Cookie from the response.  Repeated BADCOOKIE responses to
+   requests that use the Server Cookie provided in the previous response
+   may be an indication that either the shared secrets or the method for
+   generating secrets in an anycast cluster of servers is inconsistent.
+   If the reply to a retried request with a fresh Server Cookie is
+   BADCOOKIE, the client SHOULD retry using TCP as the transport, since
+   the server will likely process the request normally based on the
+   security provided by TCP (see Section 5.2.3).
+
+   If the RCODE is some value other than BADCOOKIE, including zero, the
+   further processing of the response proceeds normally.
+
+5.4.  Querying for a Server Cookie
+
+   In many cases, a client will learn the Server Cookie for a server as
+   the "side effect" of another transaction; however, there may be times
+   when this is not desirable.  Therefore, a means is provided for
+   obtaining a Server Cookie through an extension to the QUERY opcode
+   for which opcode most existing implementations require that QDCOUNT
+   be one (1) (see Section 4.1.2 of [RFC1035]).
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 14]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   For servers with DNS Cookies enabled, the QUERY opcode behavior is
+   extended to support queries with an empty Question Section (a QDCOUNT
+   of zero (0)), provided that an OPT record is present with a COOKIE
+   option.  Such servers will send a reply that has an empty
+   Answer Section and has a COOKIE option containing the Client Cookie
+   and a valid Server Cookie.
+
+   If such a query provided just a Client Cookie and no Server Cookie,
+   the response SHALL have the RCODE NOERROR.
+
+   This mechanism can also be used to confirm/re-establish an existing
+   Server Cookie by sending a cached Server Cookie with the
+   Client Cookie.  In this case, the response SHALL have the RCODE
+   BADCOOKIE if the Server Cookie sent with the query was invalid and
+   the RCODE NOERROR if it was valid.
+
+   Servers that don't support the COOKIE option will normally send
+   FORMERR in response to such a query, though REFUSED, NOTIMP, and
+   NOERROR without a COOKIE option are also possible in such responses.
+
+6.  NAT Considerations and Anycast Server Considerations
+
+   In the classic Internet, DNS Cookies could simply be a pseudorandom
+   function of the Client IP Address and a Server Secret or the Server
+   IP Address and a Client Secret.  You would want to compute the
+   Server Cookie that way, so a client could cache its Server Cookie for
+   a particular server for an indefinite amount of time and the server
+   could easily regenerate and check it.  You could consider the
+   Client Cookie to be a weak client signature over the Server IP
+   Address that the client checks in replies, and you could extend this
+   signature to cover the request ID, for example, or any other
+   information that is returned unchanged in the reply.
+
+   But we have this reality called "NAT" [RFC3022] (including, for the
+   purposes of this document, NAT-PT, which has been declared Historic
+   [RFC4966]).  There is no problem with DNS transactions between
+   clients and servers behind a NAT box using local IP addresses.  Nor
+   is there a problem with NAT translation of internal addresses to
+   external addresses or translations between IPv4 and IPv6 addresses,
+   as long as the address mapping is relatively stable.  Should the
+   external IP address to which an internal client is being mapped
+   change occasionally, the disruption is little more than when a client
+   rolls over its COOKIE secret.  Also, external access to a DNS server
+   behind a NAT box is normally handled by a fixed mapping that forwards
+   externally received DNS requests to a specific host.
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 15]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   However, NAT devices sometimes also map ports.  This can cause
+   multiple DNS requests and responses from multiple internal hosts to
+   be mapped to a smaller number of external IP addresses, such as one
+   address.  Thus, there could be many clients behind a NAT box that
+   appear to come from the same source IP address to a server outside
+   that NAT box.  If one of these were an attacker (think "zombie" or
+   "botnet") behind a NAT box, that attacker could get the Server Cookie
+   for some server for the outgoing IP address by just making some
+   random request to that server.  It could then include that
+   Server Cookie in the COOKIE option of requests to the server with the
+   forged local IP address of some other host and/or client behind the
+   NAT box.  (An attacker's possession of this Server Cookie will not
+   help in forging responses to cause cache poisoning, as such responses
+   are protected by the required Client Cookie.)
+
+   To fix this potential defect, it is necessary to distinguish
+   different clients behind a NAT box from the point of view of the
+   server.  This is why the Server Cookie is specified as a pseudorandom
+   function of both the request source IP address and the Client Cookie.
+   From this inclusion of the Client Cookie in the calculation of the
+   Server Cookie, it follows that, for any particular server, a stable
+   Client Cookie is needed.  If, for example, the request ID was
+   included in the calculation of the Client Cookie, it would normally
+   change with each request to a particular server.  This would mean
+   that each request would have to be sent twice: first, to learn the
+   new Server Cookie based on this new Client Cookie based on the new
+   ID, and then again using this new Client Cookie to actually get an
+   answer.  Thus, the input to the Client Cookie computation must be
+   limited to the Server IP Address and one or more things that change
+   slowly, such as the Client Secret.
+
+   In principle, there could be a similar problem for servers, not due
+   to NAT but due to mechanisms like anycast that may cause requests to
+   a DNS server at an IP address to be delivered to any one of several
+   machines.  (External requests to a DNS server behind a NAT box
+   usually occur via port forwarding such that all such requests go to
+   one host.)  However, it is impossible to solve this in the way that
+   the similar problem was solved for NATed clients; if the
+   Server Cookie was included in the calculation of the Client Cookie in
+   the same way that the Client Cookie is included in the Server Cookie,
+   you would just get an almost infinite series of errors as a request
+   was repeatedly retried.
+
+   For servers accessed via anycast, to successfully support
+   DNS Cookies, either (1) the server clones must all use the same
+   Server Secret or (2) the mechanism that distributes requests to the
+   server clones must cause the requests from a particular client to go
+   to a particular server for a sufficiently long period of time that
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 16]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   extra requests due to changes in Server Cookies resulting from
+   accessing different server machines are not unduly burdensome.  (When
+   such anycast-accessed servers act as recursive servers or otherwise
+   act as clients, they normally use a different unique address to
+   source their requests, to avoid confusion in the delivery of
+   responses.)
+
+   For simplicity, it is RECOMMENDED that the same Server Secret be used
+   by each DNS server in a set of anycast servers.  If there is limited
+   time skew in updating this secret in different anycast servers, this
+   can be handled by a server accepting requests containing a
+   Server Cookie based on either its old or new secret for the maximum
+   likely time period of such time skew (see also Section 7.1).
+
+7.  Operational and Deployment Considerations
+
+   The DNS Cookie mechanism is designed for incremental deployment and
+   to complement the orthogonal techniques in [RFC5452].  Either or both
+   techniques can be deployed independently at each DNS server and
+   client.  Thus, installation at the client and server end need not be
+   synchronized.
+
+   In particular, a DNS server or client that implements the DNS Cookie
+   mechanism can interoperate successfully with a DNS client or server
+   that does not implement this mechanism, although, of course, in this
+   case it will not get the benefit of the mechanism and the server
+   involved might choose to severely rate-limit responses.  When such a
+   server or client interoperates with a client or server that also
+   implements the DNS Cookie mechanism, these servers and clients get
+   the security benefits of the DNS Cookie mechanism.
+
+7.1.  Client and Server Secret Rollover
+
+   The longer a secret is used, the higher the probability that it has
+   been compromised.  Thus, clients and servers are configured with a
+   lifetime setting for their secret, and they roll over to a new secret
+   when that lifetime expires, or earlier due to deliberate jitter as
+   described below.  The default lifetime is one day, and the maximum
+   permitted is one month.  To be precise and to make it practical to
+   stay within limits despite long holiday weekends, daylight saving
+   time shifts, and the like, clients and servers MUST NOT continue to
+   use the same secret in new requests and responses for more than
+   36 days and SHOULD NOT continue to do so for more than 26 hours.
+
+   Many clients rolling over their secret at the same time could briefly
+   increase server traffic, and exactly predictable rollover times for
+   clients or servers might facilitate guessing attacks.  For example,
+   an attacker might increase the priority of attacking secrets they
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 17]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   believe will be in effect for an extended period of time.  To avoid
+   rollover synchronization and predictability, it is RECOMMENDED that
+   pseudorandom jitter in the range of plus zero to minus at least 40%
+   be applied to the time until a scheduled rollover of a COOKIE secret.
+
+   It is RECOMMENDED that a client keep the Client Cookie it is
+   expecting in a reply until there is no longer an outstanding request
+   associated with that Client Cookie that the client is tracking.  This
+   avoids rejection of replies due to a bad Client Cookie right after a
+   change in the Client Secret.
+
+   It is RECOMMENDED that a server retain its previous secret after a
+   rollover to a new secret for a configurable period of time not less
+   than 1 second or more than 300 seconds, with a default configuration
+   of 150 seconds.  Requests with Server Cookies based on its previous
+   secret are treated as a correct Server Cookie during that time.  When
+   a server responds to a request containing an old Server Cookie that
+   the server is treating as correct, the server MUST include a new
+   Server Cookie in its response.
+
+7.2.  Counters
+
+   It is RECOMMENDED that implementations include counters of the
+   occurrences of the various types of requests and responses described
+   in Section 5.
+
+8.  IANA Considerations
+
+   IANA has assigned the following DNS EDNS0 option code:
+
+       Value       Name      Status        Reference
+      --------    ------    --------    ---------------
+         10       COOKIE    Standard       RFC 7873
+
+   IANA has assigned the following DNS error code as an early allocation
+   per [RFC7120]:
+
+       RCODE       Name       Description                 Reference
+      --------  ---------  -------------------------   ---------------
+         23     BADCOOKIE  Bad/missing Server Cookie      RFC 7873
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 18]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+9.  Security Considerations
+
+   DNS Cookies provide a weak form of authentication of DNS requests and
+   responses.  In particular, they provide no protection against
+   "on-path" adversaries; that is, they provide no protection against
+   any adversary that can observe the plaintext DNS traffic, such as an
+   on-path router, bridge, or any device on an on-path shared link
+   (unless the DNS traffic in question on that path is encrypted).
+
+   For example, if a host is connected via an unsecured IEEE Std. 802.11
+   link (Wi-Fi), any device in the vicinity that could receive and
+   decode the 802.11 transmissions must be considered "on path".  On the
+   other hand, in a similar situation but one where 802.11 Robust
+   Security (WPA2, also called "Wi-Fi Protected Access 2") is
+   appropriately deployed on the Wi-Fi network nodes, only the
+   Access Point via which the host is connecting is "on path" as far as
+   the 802.11 link is concerned.
+
+   Despite these limitations, deployment of DNS Cookies on the global
+   Internet is expected to provide a significant reduction in the
+   available launch points for the traffic amplification and denial-of-
+   service forgery attacks described in Section 2 above.
+
+   Work is underway in the IETF DPRIVE working group to provide
+   confidentiality for DNS requests and responses that would be
+   compatible with DNS Cookies.
+
+   Should stronger message/transaction security be desired, it is
+   suggested that TSIG or SIG(0) security be used (see Section 3.2);
+   however, it may be useful to use DNS Cookies in conjunction with
+   these features.  In particular, DNS Cookies could screen out many DNS
+   messages before the cryptographic computations of TSIG or SIG(0) are
+   required, and if SIG(0) is in use, DNS Cookies could usefully screen
+   out many requests given that SIG(0) does not screen requests but only
+   authenticates the response of complete transactions.
+
+   An attacker that does not know the Server Cookie could do a variety
+   of things, such as omitting the COOKIE option or sending a random
+   Server Cookie.  In general, DNS servers need to take other measures,
+   including rate-limiting responses, to protect from abuse in such
+   cases.  See further information in Section 5.2.
+
+   When a server or client starts receiving an increased level of
+   requests with bad Server Cookies or replies with bad Client Cookies,
+   it would be reasonable for it to believe that it is likely under
+   attack, and it should consider a more frequent rollover of its
+   secret.  More rapid rollover decreases the benefit to a
+   cookie-guessing attacker if they succeed in guessing a cookie.
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 19]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+9.1.  Cookie Algorithm Considerations
+
+   The cookie computation algorithm for use in DNS Cookies SHOULD be
+   based on a pseudorandom function at least as strong as 64-bit FNV
+   (Fowler/Noll/Vo [FNV]), because an excessively weak or trivial
+   algorithm could enable adversaries to guess cookies.  However, in
+   light of the lightweight plaintext token security provided by
+   DNS Cookies, a strong cryptography hash algorithm may not be
+   warranted in many cases and would cause an increased computational
+   burden.  Nevertheless, there is nothing wrong with using something
+   stronger -- for example, HMAC-SHA-256 [RFC6234] truncated to 64 bits,
+   assuming that a DNS processor has adequate computational resources
+   available.  DNS implementations or applications that need somewhat
+   stronger security without a significant increase in computational
+   load should consider more frequent changes in their client and/or
+   Server Secret; however, this does require more frequent generation of
+   a cryptographically strong random number [RFC4086].  See Appendices A
+   and B for specific examples of cookie computation algorithms.
+
+10.  Implementation Considerations
+
+   The DNS COOKIE option specified herein is implemented in BIND 9.10
+   using an experimental option code.  BIND 9.10.3 (and later) use the
+   allocated option code.
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
+              November 1987, <http://www.rfc-editor.org/info/rfc1035>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <http://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC4086]  Eastlake 3rd, D., Schiller, J., and S. Crocker,
+              "Randomness Requirements for Security", BCP 106, RFC 4086,
+              DOI 10.17487/RFC4086, June 2005,
+              <http://www.rfc-editor.org/info/rfc4086>.
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 20]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   [RFC6891]  Damas, J., Graff, M., and P. Vixie, "Extension Mechanisms
+              for DNS (EDNS(0))", STD 75, RFC 6891,
+              DOI 10.17487/RFC6891, April 2013,
+              <http://www.rfc-editor.org/info/rfc6891>.
+
+   [RFC7120]  Cotton, M., "Early IANA Allocation of Standards Track Code
+              Points", BCP 100, RFC 7120, DOI 10.17487/RFC7120,
+              January 2014, <http://www.rfc-editor.org/info/rfc7120>.
+
+11.2.  Informative References
+
+   [FNV]      Fowler, G., Noll, L., Vo, K., and D. Eastlake 3rd, "The
+              FNV Non-Cryptographic Hash Algorithm", Work in Progress,
+              draft-eastlake-fnv-10, October 2015.
+
+   [Kaminsky] Olney, M., Mullen, P., and K. Miklavcic, "Dan Kaminsky's
+              2008 DNS Vulnerability", July 2008, <https://www.ietf.org/
+              mail-archive/web/dnsop/current/pdf2jgx6rzxN4.pdf>.
+
+   [RFC2845]  Vixie, P., Gudmundsson, O., Eastlake 3rd, D., and B.
+              Wellington, "Secret Key Transaction Authentication for DNS
+              (TSIG)", RFC 2845, DOI 10.17487/RFC2845, May 2000,
+              <http://www.rfc-editor.org/info/rfc2845>.
+
+   [RFC2930]  Eastlake 3rd, D., "Secret Key Establishment for DNS
+              (TKEY RR)", RFC 2930, DOI 10.17487/RFC2930,
+              September 2000, <http://www.rfc-editor.org/info/rfc2930>.
+
+   [RFC2931]  Eastlake 3rd, D., "DNS Request and Transaction Signatures
+              ( SIG(0)s )", RFC 2931, DOI 10.17487/RFC2931,
+              September 2000, <http://www.rfc-editor.org/info/rfc2931>.
+
+   [RFC3022]  Srisuresh, P. and K. Egevang, "Traditional IP Network
+              Address Translator (Traditional NAT)", RFC 3022,
+              DOI 10.17487/RFC3022, January 2001,
+              <http://www.rfc-editor.org/info/rfc3022>.
+
+   [RFC4033]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "DNS Security Introduction and Requirements",
+              RFC 4033, DOI 10.17487/RFC4033, March 2005,
+              <http://www.rfc-editor.org/info/rfc4033>.
+
+   [RFC4034]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Resource Records for the DNS Security Extensions",
+              RFC 4034, DOI 10.17487/RFC4034, March 2005,
+              <http://www.rfc-editor.org/info/rfc4034>.
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 21]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+   [RFC4035]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Protocol Modifications for the DNS Security
+              Extensions", RFC 4035, DOI 10.17487/RFC4035, March 2005,
+              <http://www.rfc-editor.org/info/rfc4035>.
+
+   [RFC4966]  Aoun, C. and E. Davies, "Reasons to Move the Network
+              Address Translator - Protocol Translator (NAT-PT) to
+              Historic Status", RFC 4966, DOI 10.17487/RFC4966,
+              July 2007, <http://www.rfc-editor.org/info/rfc4966>.
+
+   [RFC5452]  Hubert, A. and R. van Mook, "Measures for Making DNS
+              More Resilient against Forged Answers", RFC 5452,
+              DOI 10.17487/RFC5452, January 2009,
+              <http://www.rfc-editor.org/info/rfc5452>.
+
+   [RFC6234]  Eastlake 3rd, D. and T. Hansen, "US Secure Hash Algorithms
+              (SHA and SHA-based HMAC and HKDF)", RFC 6234,
+              DOI 10.17487/RFC6234, May 2011,
+              <http://www.rfc-editor.org/info/rfc6234>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 22]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+Appendix A.  Example Client Cookie Algorithms
+
+A.1.  A Simple Algorithm
+
+   A simple example method to compute Client Cookies is the FNV64 [FNV]
+   of the Client IP Address, the Server IP Address, and the Client
+   Secret:
+
+      Client Cookie =
+         FNV64( Client IP Address | Server IP Address | Client Secret )
+
+   where "|" indicates concatenation.  Some computational resources may
+   be saved by pre-computing FNV64 through the Client IP Address.  (If
+   the order of the items concatenated above is changed to put the
+   Server IP Address last, it might be possible to further reduce the
+   computational effort by pre-computing FNV64 through the bytes of both
+   the Client IP Address and the Client Secret, but this would reduce
+   the strength of the Client Cookie and is NOT RECOMMENDED.)
+
+A.2.  A More Complex Algorithm
+
+   A more complex algorithm to calculate Client Cookies is given below.
+   It uses more computational resources than the simpler algorithm shown
+   in Appendix A.1.
+
+      Client Cookie =
+         HMAC-SHA256-64( Client IP Address | Server IP Address,
+                          Client Secret )
+
+Appendix B.  Example Server Cookie Algorithms
+
+B.1.  A Simple Algorithm
+
+   An example of a simple method producing a 64-bit Server Cookie is the
+   FNV64 [FNV] of the request IP address, the Client Cookie, and the
+   Server Secret.
+
+      Server Cookie =
+         FNV64( Client IP Address | Client Cookie | Server Secret )
+
+   where "|" represents concatenation.  (If the order of the items
+   concatenated was changed, it might be possible to reduce the
+   computational effort by pre-computing FNV64 through the bytes of the
+   Server Secret and Client Cookie, but this would reduce the strength
+   of the Server Cookie and is NOT RECOMMENDED.)
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 23]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+B.2.  A More Complex Algorithm
+
+   Since the Server Cookie has a variable size, the server can store
+   various information in that field as long as it is hard for an
+   adversary to guess the entire quantity used for authentication.
+   There should be 64 bits of entropy in the Server Cookie; for example,
+   it could have a sub-field of 64 bits computed pseudorandomly with the
+   Server Secret as one of the inputs to the pseudorandom function.
+   Types of additional information that could be stored include a
+   timestamp and/or a nonce.
+
+   The example below is one variation of the Server Cookie that has been
+   implemented in BIND 9.10.3 (and later) releases, where the
+   Server Cookie is 128 bits, composed as follows:
+
+         Sub-field      Size
+         ---------   ---------
+           Nonce      32 bits
+           Time       32 bits
+           Hash       64 bits
+
+   With this algorithm, the server sends a new 128-bit cookie back with
+   every request.  The Nonce field assures a low probability that there
+   would be a duplicate.
+
+   The Time field gives the server time and makes it easy to reject old
+   cookies.
+
+   The Hash part of the Server Cookie is the part that is hard to guess.
+   In BIND 9.10.3 (and later), its computation can be configured to use
+   AES, HMAC-SHA-1, or, as shown below, HMAC-SHA-256:
+
+       hash =
+           HMAC-SHA256-64( Server Secret,
+               (Client Cookie | Nonce | Time | Client IP Address) )
+
+   where "|" represents concatenation.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 24]
+
+RFC 7873                       DNS Cookies                      May 2016
+
+
+Acknowledgments
+
+   The suggestions and contributions of the following are gratefully
+   acknowledged:
+
+      Alissa Cooper, Bob Harold, Paul Hoffman, David Malone, Yoav Nir,
+      Gayle Noble, Dan Romascanu, Tim Wicinski, and Peter Yee
+
+Authors' Addresses
+
+   Donald E. Eastlake 3rd
+   Huawei Technologies
+   155 Beaver Street
+   Milford, MA  01757
+   United States
+
+   Phone: +1-508-333-2270
+   Email: d3e3e3@gmail.com
+
+
+   Mark Andrews
+   Internet Systems Consortium
+   950 Charter Street
+   Redwood City, CA  94063
+   United States
+
+   Email: marka@isc.org
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Eastlake & Andrews           Standards Track                   [Page 25]
+

--- a/rfc/dns/rfc8484.txt
+++ b/rfc/dns/rfc8484.txt
@@ -1,0 +1,1179 @@
+
+
+
+
+
+
+Internet Engineering Task Force (IETF)                        P. Hoffman
+Request for Comments: 8484                                         ICANN
+Category: Standards Track                                     P. McManus
+ISSN: 2070-1721                                                  Mozilla
+                                                            October 2018
+
+
+                      DNS Queries over HTTPS (DoH)
+
+Abstract
+
+   This document defines a protocol for sending DNS queries and getting
+   DNS responses over HTTPS.  Each DNS query-response pair is mapped
+   into an HTTP exchange.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   https://www.rfc-editor.org/info/rfc8484.
+
+Copyright Notice
+
+   Copyright (c) 2018 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 1]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+Table of Contents
+
+   1.  Introduction  . . . . . . . . . . . . . . . . . . . . . . . .   3
+   2.  Terminology . . . . . . . . . . . . . . . . . . . . . . . . .   3
+   3.  Selection of DoH Server . . . . . . . . . . . . . . . . . . .   4
+   4.  The HTTP Exchange . . . . . . . . . . . . . . . . . . . . . .   4
+     4.1.  The HTTP Request  . . . . . . . . . . . . . . . . . . . .   4
+       4.1.1.  HTTP Request Examples . . . . . . . . . . . . . . . .   5
+     4.2.  The HTTP Response . . . . . . . . . . . . . . . . . . . .   7
+       4.2.1.  Handling DNS and HTTP Errors  . . . . . . . . . . . .   7
+       4.2.2.  HTTP Response Example . . . . . . . . . . . . . . . .   8
+   5.  HTTP Integration  . . . . . . . . . . . . . . . . . . . . . .   8
+     5.1.  Cache Interaction . . . . . . . . . . . . . . . . . . . .   8
+     5.2.  HTTP/2  . . . . . . . . . . . . . . . . . . . . . . . . .  10
+     5.3.  Server Push . . . . . . . . . . . . . . . . . . . . . . .  10
+     5.4.  Content Negotiation . . . . . . . . . . . . . . . . . . .  10
+   6.  Definition of the "application/dns-message" Media Type  . . .  10
+   7.  IANA Considerations . . . . . . . . . . . . . . . . . . . . .  11
+     7.1.  Registration of the "application/dns-message" Media Type   11
+   8.  Privacy Considerations  . . . . . . . . . . . . . . . . . . .  12
+     8.1.  On the Wire . . . . . . . . . . . . . . . . . . . . . . .  12
+     8.2.  In the Server . . . . . . . . . . . . . . . . . . . . . .  12
+   9.  Security Considerations . . . . . . . . . . . . . . . . . . .  14
+   10. Operational Considerations  . . . . . . . . . . . . . . . . .  15
+   11. References  . . . . . . . . . . . . . . . . . . . . . . . . .  16
+     11.1.  Normative References . . . . . . . . . . . . . . . . . .  16
+     11.2.  Informative References . . . . . . . . . . . . . . . . .  18
+   Appendix A.  Protocol Development . . . . . . . . . . . . . . . .  20
+   Appendix B.  Previous Work on DNS over HTTP or in Other Formats .  20
+   Acknowledgments . . . . . . . . . . . . . . . . . . . . . . . . .  21
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  21
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 2]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+1.  Introduction
+
+   This document defines a specific protocol, DNS over HTTPS (DoH), for
+   sending DNS [RFC1035] queries and getting DNS responses over HTTP
+   [RFC7540] using https [RFC2818] URIs (and therefore TLS [RFC8446]
+   security for integrity and confidentiality).  Each DNS query-response
+   pair is mapped into an HTTP exchange.
+
+   The described approach is more than a tunnel over HTTP.  It
+   establishes default media formatting types for requests and responses
+   but uses normal HTTP content negotiation mechanisms for selecting
+   alternatives that endpoints may prefer in anticipation of serving new
+   use cases.  In addition to this media type negotiation, it aligns
+   itself with HTTP features such as caching, redirection, proxying,
+   authentication, and compression.
+
+   The integration with HTTP provides a transport suitable for both
+   existing DNS clients and native web applications seeking access to
+   the DNS.
+
+   Two primary use cases were considered during this protocol's
+   development.  These use cases are preventing on-path devices from
+   interfering with DNS operations, and also allowing web applications
+   to access DNS information via existing browser APIs in a safe way
+   consistent with Cross Origin Resource Sharing (CORS) [FETCH].  No
+   special effort has been taken to enable or prevent application to
+   other use cases.  This document focuses on communication between DNS
+   clients (such as operating system stub resolvers) and recursive
+   resolvers.
+
+2.  Terminology
+
+   A server that supports this protocol is called a "DoH server" to
+   differentiate it from a "DNS server" (one that only provides DNS
+   service over one or more of the other transport protocols
+   standardized for DNS).  Similarly, a client that supports this
+   protocol is called a "DoH client".
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 3]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+3.  Selection of DoH Server
+
+   The DoH client is configured with a URI Template [RFC6570], which
+   describes how to construct the URL to use for resolution.
+   Configuration, discovery, and updating of the URI Template is done
+   out of band from this protocol.  Note that configuration might be
+   manual (such as a user typing URI Templates in a user interface for
+   "options") or automatic (such as URI Templates being supplied in
+   responses from DHCP or similar protocols).  DoH servers MAY support
+   more than one URI Template.  This allows the different endpoints to
+   have different properties, such as different authentication
+   requirements or service-level guarantees.
+
+   A DoH client uses configuration to select the URI, and thus the DoH
+   server, that is to be used for resolution.  [RFC2818] defines how
+   HTTPS verifies the DoH server's identity.
+
+   A DoH client MUST NOT use a different URI simply because it was
+   discovered outside of the client's configuration (such as through
+   HTTP/2 server push) or because a server offers an unsolicited
+   response that appears to be a valid answer to a DNS query.  This
+   specification does not extend DNS resolution privileges to URIs that
+   are not recognized by the DoH client as configured URIs.  Such
+   scenarios may create additional operational, tracking, and security
+   hazards that require limitations for safe usage.  A future
+   specification may support this use case.
+
+4.  The HTTP Exchange
+
+4.1.  The HTTP Request
+
+   A DoH client encodes a single DNS query into an HTTP request using
+   either the HTTP GET or POST method and the other requirements of this
+   section.  The DoH server defines the URI used by the request through
+   the use of a URI Template.
+
+   The URI Template defined in this document is processed without any
+   variables when the HTTP method is POST.  When the HTTP method is GET,
+   the single variable "dns" is defined as the content of the DNS
+   request (as described in Section 6), encoded with base64url
+   [RFC4648].
+
+   Future specifications for new media types for DoH MUST define the
+   variables used for URI Template processing with this protocol.
+
+   DoH servers MUST implement both the POST and GET methods.
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 4]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   When using the POST method, the DNS query is included as the message
+   body of the HTTP request, and the Content-Type request header field
+   indicates the media type of the message.  POSTed requests are
+   generally smaller than their GET equivalents.
+
+   Using the GET method is friendlier to many HTTP cache
+   implementations.
+
+   The DoH client SHOULD include an HTTP Accept request header field to
+   indicate what type of content can be understood in response.
+   Irrespective of the value of the Accept request header field, the
+   client MUST be prepared to process "application/dns-message" (as
+   described in Section 6) responses but MAY also process other DNS-
+   related media types it receives.
+
+   In order to maximize HTTP cache friendliness, DoH clients using media
+   formats that include the ID field from the DNS message header, such
+   as "application/dns-message", SHOULD use a DNS ID of 0 in every DNS
+   request.  HTTP correlates the request and response, thus eliminating
+   the need for the ID in a media type such as "application/dns-
+   message".  The use of a varying DNS ID can cause semantically
+   equivalent DNS queries to be cached separately.
+
+   DoH clients can use HTTP/2 padding and compression [RFC7540] in the
+   same way that other HTTP/2 clients use (or don't use) them.
+
+4.1.1.  HTTP Request Examples
+
+   These examples use HTTP/2-style formatting from [RFC7540].
+
+   These examples use a DoH service with a URI Template of
+   "https://dnsserver.example.net/dns-query{?dns}" to resolve IN A
+   records.
+
+   The requests are represented as bodies with media type "application/
+   dns-message".
+
+   The first example request uses GET to request "www.example.com".
+
+   :method = GET
+   :scheme = https
+   :authority = dnsserver.example.net
+   :path = /dns-query?dns=AAABAAABAAAAAAAAA3d3dwdleGFtcGxlA2NvbQAAAQAB
+   accept = application/dns-message
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 5]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   The same DNS query for "www.example.com", using the POST method would
+   be:
+
+   :method = POST
+   :scheme = https
+   :authority = dnsserver.example.net
+   :path = /dns-query
+   accept = application/dns-message
+   content-type = application/dns-message
+   content-length = 33
+
+   <33 bytes represented by the following hex encoding>
+   00 00 01 00 00 01 00 00  00 00 00 00 03 77 77 77
+   07 65 78 61 6d 70 6c 65  03 63 6f 6d 00 00 01 00
+   01
+
+   In this example, the 33 bytes are the DNS message in DNS wire format
+   [RFC1035], starting with the DNS header.
+
+   Finally, a GET-based query for "a.62characterlabel-makes-base64url-
+   distinct-from-standard-base64.example.com" is shown as an example to
+   emphasize that the encoding alphabet of base64url is different than
+   regular base64 and that padding is omitted.
+
+   The DNS query, expressed in DNS wire format, is 94 bytes represented
+   by the following:
+
+   00 00 01 00 00 01 00 00  00 00 00 00 01 61 3e 36
+   32 63 68 61 72 61 63 74  65 72 6c 61 62 65 6c 2d
+   6d 61 6b 65 73 2d 62 61  73 65 36 34 75 72 6c 2d
+   64 69 73 74 69 6e 63 74  2d 66 72 6f 6d 2d 73 74
+   61 6e 64 61 72 64 2d 62  61 73 65 36 34 07 65 78
+   61 6d 70 6c 65 03 63 6f  6d 00 00 01 00 01
+
+   :method = GET
+   :scheme = https
+   :authority = dnsserver.example.net
+   :path = /dns-query? (no space or Carriage Return (CR))
+           dns=AAABAAABAAAAAAAAAWE-NjJjaGFyYWN0ZXJsYWJl (no space or CR)
+           bC1tYWtlcy1iYXNlNjR1cmwtZGlzdGluY3QtZnJvbS1z (no space or CR)
+           dGFuZGFyZC1iYXNlNjQHZXhhbXBsZQNjb20AAAEAAQ
+   accept = application/dns-message
+
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 6]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+4.2.  The HTTP Response
+
+   The only response type defined in this document is "application/dns-
+   message", but it is possible that other response formats will be
+   defined in the future.  A DoH server MUST be able to process
+   "application/dns-message" request messages.
+
+   Different response media types will provide more or less information
+   from a DNS response.  For example, one response type might include
+   information from the DNS header bytes while another might omit it.
+   The amount and type of information that a media type gives are solely
+   up to the format, which is not defined in this protocol.
+
+   Each DNS request-response pair is mapped to one HTTP exchange.  The
+   responses may be processed and transported in any order using HTTP's
+   multi-streaming functionality (see Section 5 of [RFC7540]).
+
+   Section 5.1 discusses the relationship between DNS and HTTP response
+   caching.
+
+4.2.1.  Handling DNS and HTTP Errors
+
+   DNS response codes indicate either success or failure for the DNS
+   query.  A successful HTTP response with a 2xx status code (see
+   Section 6.3 of [RFC7231]) is used for any valid DNS response,
+   regardless of the DNS response code.  For example, a successful 2xx
+   HTTP status code is used even with a DNS message whose DNS response
+   code indicates failure, such as SERVFAIL or NXDOMAIN.
+
+   HTTP responses with non-successful HTTP status codes do not contain
+   replies to the original DNS question in the HTTP request.  DoH
+   clients need to use the same semantic processing of non-successful
+   HTTP status codes as other HTTP clients.  This might mean that the
+   DoH client retries the query with the same DoH server, such as if
+   there are authorization failures (HTTP status code 401; see
+   Section 3.1 of [RFC7235]).  It could also mean that the DoH client
+   retries with a different DoH server, such as for unsupported media
+   types (HTTP status code 415; see Section 6.5.13 of [RFC7231]), or
+   where the server cannot generate a representation suitable for the
+   client (HTTP status code 406; see Section 6.5.6 of [RFC7231]), and so
+   on.
+
+
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 7]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+4.2.2.  HTTP Response Example
+
+   This is an example response for a query for the IN AAAA records for
+   "www.example.com" with recursion turned on.  The response bears one
+   answer record with an address of 2001:db8:abcd:12:1:2:3:4 and a TTL
+   of 3709 seconds.
+
+   :status = 200
+   content-type = application/dns-message
+   content-length = 61
+   cache-control = max-age=3709
+
+   <61 bytes represented by the following hex encoding>
+   00 00 81 80 00 01 00 01  00 00 00 00 03 77 77 77
+   07 65 78 61 6d 70 6c 65  03 63 6f 6d 00 00 1c 00
+   01 c0 0c 00 1c 00 01 00  00 0e 7d 00 10 20 01 0d
+   b8 ab cd 00 12 00 01 00  02 00 03 00 04
+
+5.  HTTP Integration
+
+   This protocol MUST be used with the https URI scheme [RFC7230].
+
+   Sections 8 and 9 discuss additional considerations for the
+   integration with HTTP.
+
+5.1.  Cache Interaction
+
+   A DoH exchange can pass through a hierarchy of caches that include
+   both HTTP- and DNS-specific caches.  These caches may exist between
+   the DoH server and client, or they may exist on the DoH client
+   itself.  HTTP caches are generic by design; that is, they do not
+   understand this protocol.  Even if a DoH client has modified its
+   cache implementation to be aware of DoH semantics, it does not follow
+   that all upstream caches (for example, inline proxies, server-side
+   gateways, and content delivery networks) will be.
+
+   As a result, DoH servers need to carefully consider the HTTP caching
+   metadata they send in response to GET requests (responses to POST
+   requests are not cacheable unless specific response header fields are
+   sent; this is not widely implemented and is not advised for DoH).
+
+   In particular, DoH servers SHOULD assign an explicit HTTP freshness
+   lifetime (see Section 4.2 of [RFC7234]) so that the DoH client is
+   more likely to use fresh DNS data.  This requirement is due to HTTP
+   caches being able to assign their own heuristic freshness (such as
+   that described in Section 4.2.2 of [RFC7234]), which would take
+   control of the cache contents out of the hands of the DoH server.
+
+
+
+
+Hoffman & McManus            Standards Track                    [Page 8]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   The assigned freshness lifetime of a DoH HTTP response MUST be less
+   than or equal to the smallest TTL in the Answer section of the DNS
+   response.  A freshness lifetime equal to the smallest TTL in the
+   Answer section is RECOMMENDED.  For example, if a HTTP response
+   carries three RRsets with TTLs of 30, 600, and 300, the HTTP
+   freshness lifetime should be 30 seconds (which could be specified as
+   "Cache-Control: max-age=30").  This requirement helps prevent expired
+   RRsets in messages in an HTTP cache from unintentionally being
+   served.
+
+   If the DNS response has no records in the Answer section, and the DNS
+   response has an SOA record in the Authority section, the response
+   freshness lifetime MUST NOT be greater than the MINIMUM field from
+   that SOA record (see [RFC2308]).
+
+   The stale-while-revalidate and stale-if-error Cache-Control
+   directives [RFC5861] could be well suited to a DoH implementation
+   when allowed by server policy.  Those mechanisms allow a client, at
+   the server's discretion, to reuse an HTTP cache entry that is no
+   longer fresh.  In such a case, the client reuses either all of a
+   cached entry or none of it.
+
+   DoH servers also need to consider HTTP caching when generating
+   responses that are not globally valid.  For instance, if a DoH server
+   customizes a response based on the client's identity, it would not
+   want to allow global reuse of that response.  This could be
+   accomplished through a variety of HTTP techniques, such as a Cache-
+   Control max-age of 0, or by using the Vary response header field (see
+   Section 7.1.4 of [RFC7231]) to establish a secondary cache key (see
+   Section 4.1 of [RFC7234]).
+
+   DoH clients MUST account for the Age response header field's value
+   [RFC7234] when calculating the DNS TTL of a response.  For example,
+   if an RRset is received with a DNS TTL of 600, but the Age header
+   field indicates that the response has been cached for 250 seconds,
+   the remaining lifetime of the RRset is 350 seconds.  This requirement
+   applies to both DoH client HTTP caches and DoH client DNS caches.
+
+   DoH clients can request an uncached copy of a HTTP response by using
+   the "no-cache" request Cache-Control directive (see Section 5.2.1.4
+   of [RFC7234]) and similar controls.  Note that some caches might not
+   honor these directives, either due to configuration or interaction
+   with traditional DNS caches that do not have such a mechanism.
+
+   HTTP conditional requests [RFC7232] may be of limited value to DoH,
+   as revalidation provides only a bandwidth benefit and DNS
+   transactions are normally latency bound.  Furthermore, the HTTP
+   response header fields that enable revalidation (such as "Last-
+
+
+
+Hoffman & McManus            Standards Track                    [Page 9]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   Modified" and "Etag") are often fairly large when compared to the
+   overall DNS response size and have a variable nature that creates
+   constant pressure on the HTTP/2 compression dictionary [RFC7541].
+   Other types of DNS data, such as zone transfers, may be larger and
+   benefit more from revalidation.
+
+5.2.  HTTP/2
+
+   HTTP/2 [RFC7540] is the minimum RECOMMENDED version of HTTP for use
+   with DoH.
+
+   The messages in classic UDP-based DNS [RFC1035] are inherently
+   unordered and have low overhead.  A competitive HTTP transport needs
+   to support reordering, parallelism, priority, and header compression
+   to achieve similar performance.  Those features were introduced to
+   HTTP in HTTP/2 [RFC7540].  Earlier versions of HTTP are capable of
+   conveying the semantic requirements of DoH but may result in very
+   poor performance.
+
+5.3.  Server Push
+
+   Before using DoH response data for DNS resolution, the client MUST
+   establish that the HTTP request URI can be used for the DoH query.
+   For HTTP requests initiated by the DoH client, this is implicit in
+   the selection of URI.  For HTTP server push (see Section 8.2 of
+   [RFC7540]), extra care must be taken to ensure that the pushed URI is
+   one that the client would have directed the same query to if the
+   client had initiated the request (in addition to the other security
+   checks normally needed for server push).
+
+5.4.  Content Negotiation
+
+   In order to maximize interoperability, DoH clients and DoH servers
+   MUST support the "application/dns-message" media type.  Other media
+   types MAY be used as defined by HTTP Content Negotiation (see
+   Section 3.4 of [RFC7231]).  Those media types MUST be flexible enough
+   to express every DNS query that would normally be sent in DNS over
+   UDP (including queries and responses that use DNS extensions, but not
+   those that require multiple responses).
+
+6.  Definition of the "application/dns-message" Media Type
+
+   The data payload for the "application/dns-message" media type is a
+   single message of the DNS on-the-wire format defined in Section 4.2.1
+   of [RFC1035], which in turn refers to the full wire format defined in
+   Section 4.1 of that RFC.
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 10]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   Although [RFC1035] says "Messages carried by UDP are restricted to
+   512 bytes", that was later updated by [RFC6891].  This media type
+   restricts the maximum size of the DNS message to 65535 bytes.
+
+   Note that the wire format used in this media type is different than
+   the wire format used in [RFC7858] (which uses the format defined in
+   Section 4.2.2 of [RFC1035] that includes two length bytes).
+
+   DoH clients using this media type MAY have one or more Extension
+   Mechanisms for DNS (EDNS) options [RFC6891] in the request.  DoH
+   servers using this media type MUST ignore the value given for the
+   EDNS UDP payload size in DNS requests.
+
+   When using the GET method, the data payload for this media type MUST
+   be encoded with base64url [RFC4648] and then provided as a variable
+   named "dns" to the URI Template expansion.  Padding characters for
+   base64url MUST NOT be included.
+
+   When using the POST method, the data payload for this media type MUST
+   NOT be encoded and is used directly as the HTTP message body.
+
+7.  IANA Considerations
+
+7.1.  Registration of the "application/dns-message" Media Type
+
+   Type name: application
+
+   Subtype name: dns-message
+
+   Required parameters: N/A
+
+   Optional parameters: N/A
+
+   Encoding considerations: This is a binary format.  The contents are a
+      DNS message as defined in RFC 1035.  The format used here is for
+      DNS over UDP, which is the format defined in the diagrams in
+      RFC 1035.
+
+   Security considerations: See RFC 8484.  The content is a DNS message
+      and thus not executable code.
+
+   Interoperability considerations: None.
+
+   Published specification: RFC 8484.
+
+   Applications that use this media type:
+      Systems that want to exchange full DNS messages.
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 11]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   Additional information:
+
+      Deprecated alias names for this type: N/A
+      Magic number(s): N/A
+      File extension(s): N/A
+      Macintosh file type code(s): N/A
+
+   Person & email address to contact for further information:
+      Paul Hoffman <paul.hoffman@icann.org>
+
+   Intended usage: COMMON
+
+   Restrictions on usage: N/A
+
+   Author: Paul Hoffman <paul.hoffman@icann.org>
+
+   Change controller: IESG
+
+8.  Privacy Considerations
+
+   [RFC7626] discusses DNS privacy considerations in both "on the wire"
+   (Section 2.4 of [RFC7626]) and "in the server" (Section 2.5 of
+   [RFC7626]) contexts.  This is also a useful framing for DoH's privacy
+   considerations.
+
+8.1.  On the Wire
+
+   DoH encrypts DNS traffic and requires authentication of the server.
+   This mitigates both passive surveillance [RFC7258] and active attacks
+   that attempt to divert DNS traffic to rogue servers (see
+   Section 2.5.1 of [RFC7626]).  DNS over TLS [RFC7858] provides similar
+   protections, while direct UDP- and TCP-based transports are
+   vulnerable to this class of attack.  An experimental effort to offer
+   guidance on choosing the padding length can be found in [RFC8467].
+
+   Additionally, the use of the HTTPS default port 443 and the ability
+   to mix DoH traffic with other HTTPS traffic on the same connection
+   can deter unprivileged on-path devices from interfering with DNS
+   operations and make DNS traffic analysis more difficult.
+
+8.2.  In the Server
+
+   The DNS wire format [RFC1035] contains no client identifiers;
+   however, various transports of DNS queries and responses do provide
+   data that can be used to correlate requests.  HTTPS presents new
+   considerations for correlation, such as explicit HTTP cookies and
+   implicit fingerprinting of the unique set and ordering of HTTP
+   request header fields.
+
+
+
+Hoffman & McManus            Standards Track                   [Page 12]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   A DoH implementation is built on IP, TCP, TLS, and HTTP.  Each layer
+   contains one or more common features that can be used to correlate
+   queries to the same identity.  DNS transports will generally carry
+   the same privacy properties of the layers used to implement them.
+   For example, the properties of IP, TCP, and TLS apply to
+   implementations of DNS over TLS.
+
+   The privacy considerations of using the HTTPS layer in DoH are
+   incremental to those of DNS over TLS.  DoH is not known to introduce
+   new concerns beyond those associated with HTTPS.
+
+   At the IP level, the client address provides obvious correlation
+   information.  This can be mitigated by use of a NAT, proxy, VPN, or
+   simple address rotation over time.  It may be aggravated by use of a
+   DNS server that can correlate real-time addressing information with
+   other personal identifiers, such as when a DNS server and DHCP server
+   are operated by the same entity.
+
+   DNS implementations that use one TCP connection for multiple DNS
+   requests directly group those requests.  Long-lived connections have
+   better performance behaviors than short-lived connections; however,
+   they group more requests, which can expose more information to
+   correlation and consolidation.  TCP-based solutions may also seek
+   performance through the use of TCP Fast Open [RFC7413].  The cookies
+   used in TCP Fast Open allow servers to correlate TCP sessions.
+
+   TLS-based implementations often achieve better handshake performance
+   through the use of some form of session resumption mechanism, such as
+   Section 2.2 of [RFC8446].  Session resumption creates trivial
+   mechanisms for a server to correlate TLS connections together.
+
+   HTTP's feature set can also be used for identification and tracking
+   in a number of different ways.  For example, Authentication request
+   header fields explicitly identify profiles in use, and HTTP cookies
+   are designed as an explicit state-tracking mechanism between the
+   client and serving site and often are used as an authentication
+   mechanism.
+
+   Additionally, the User-Agent and Accept-Language request header
+   fields often convey specific information about the client version or
+   locale.  This facilitates content negotiation and operational work-
+   arounds for implementation bugs.  Request header fields that control
+   caching can expose state information about a subset of the client's
+   history.  Mixing DoH requests with other HTTP requests on the same
+   connection also provides an opportunity for richer data correlation.
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 13]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   The DoH protocol design allows applications to fully leverage the
+   HTTP ecosystem, including features that are not enumerated here.
+   Utilizing the full set of HTTP features enables DoH to be more than
+   an HTTP tunnel, but it is at the cost of opening up implementations
+   to the full set of privacy considerations of HTTP.
+
+   Implementations of DoH clients and servers need to consider the
+   benefit and privacy impact of these features, and their deployment
+   context, when deciding whether or not to enable them.
+   Implementations are advised to expose the minimal set of data needed
+   to achieve the desired feature set.
+
+   Determining whether or not a DoH implementation requires HTTP cookie
+   [RFC6265] support is particularly important because HTTP cookies are
+   the primary state tracking mechanism in HTTP.  HTTP cookies SHOULD
+   NOT be accepted by DOH clients unless they are explicitly required by
+   a use case.
+
+9.  Security Considerations
+
+   Running DNS over HTTPS relies on the security of the underlying HTTP
+   transport.  This mitigates classic amplification attacks for UDP-
+   based DNS.  Implementations utilizing HTTP/2 benefit from the TLS
+   profile defined in Section 9.2 of [RFC7540].
+
+   Session-level encryption has well-known weaknesses with respect to
+   traffic analysis, which might be particularly acute when dealing with
+   DNS queries.  HTTP/2 provides further advice about the use of
+   compression (see Section 10.6 of [RFC7540]) and padding (see
+   Section 10.7 of [RFC7540]).  DoH servers can also add DNS padding
+   [RFC7830] if the DoH client requests it in the DNS query.  An
+   experimental effort to offer guidance on choosing the padding length
+   can be found in [RFC8467].
+
+   The HTTPS connection provides transport security for the interaction
+   between the DoH server and client, but it does not provide the
+   response integrity of DNS data provided by DNSSEC.  DNSSEC and DoH
+   are independent and fully compatible protocols, each solving
+   different problems.  The use of one does not diminish the need nor
+   the usefulness of the other.  It is the choice of a client to either
+   perform full DNSSEC validation of answers or to trust the DoH server
+   to do DNSSEC validation and inspect the AD (Authentic Data) bit in
+   the returned message to determine whether an answer was authentic or
+   not.  As noted in Section 4.2, different response media types will
+   provide more or less information from a DNS response, so this choice
+   may be affected by the response media type.
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 14]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   Section 5.1 describes the interaction of this protocol with HTTP
+   caching.  An adversary that can control the cache used by the client
+   can affect that client's view of the DNS.  This is no different than
+   the security implications of HTTP caching for other protocols that
+   use HTTP.
+
+   In the absence of DNSSEC information, a DoH server can give a client
+   invalid data in response to a DNS query.  Section 3 disallows the use
+   of DoH DNS responses that do not originate from configured servers.
+   This prohibition does not guarantee protection against invalid data,
+   but it does reduce the risk.
+
+10.  Operational Considerations
+
+   Local policy considerations and similar factors mean different DNS
+   servers may provide different results to the same query, for
+   instance, in split DNS configurations [RFC6950].  It logically
+   follows that the server that is queried can influence the end result.
+   Therefore, a client's choice of DNS server may affect the responses
+   it gets to its queries.  For example, in the case of DNS64 [RFC6147],
+   the choice could affect whether IPv6/IPv4 translation will work at
+   all.
+
+   The HTTPS channel used by this specification establishes secure two-
+   party communication between the DoH client and the DoH server.
+   Filtering or inspection systems that rely on unsecured transport of
+   DNS will not function in a DNS over HTTPS environment due to the
+   confidentiality and integrity protection provided by TLS.
+
+   Some HTTPS client implementations perform real time third-party
+   checks of the revocation status of the certificates being used by
+   TLS.  If this check is done as part of the DoH server connection
+   procedure and the check itself requires DNS resolution to connect to
+   the third party, a deadlock can occur.  The use of Online Certificate
+   Status Protocol (OCSP) [RFC6960] servers or Authority Information
+   Access (AIA) for Certificate Revocation List (CRL) fetching (see
+   Section 4.2.2.1 of [RFC5280]) are examples of how this deadlock can
+   happen.  To mitigate the possibility of deadlock, the authentication
+   given DoH servers SHOULD NOT rely on DNS-based references to external
+   resources in the TLS handshake.  For OCSP, the server can bundle the
+   certificate status as part of the handshake using a mechanism
+   appropriate to the version of TLS, such as using Section 4.4.2.1 of
+   [RFC8446] for TLS version 1.3.  AIA deadlocks can be avoided by
+   providing intermediate certificates that might otherwise be obtained
+   through additional requests.  Note that these deadlocks also need to
+   be considered for servers that a DoH server might redirect to.
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 15]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   A DoH client may face a similar bootstrapping problem when the HTTP
+   request needs to resolve the hostname portion of the DNS URI.  Just
+   as the address of a traditional DNS nameserver cannot be originally
+   determined from that same server, a DoH client cannot use its DoH
+   server to initially resolve the server's host name into an address.
+   Alternative strategies a client might employ include 1) making the
+   initial resolution part of the configuration, 2) IP-based URIs and
+   corresponding IP-based certificates for HTTPS, or 3) resolving the
+   DNS API server's hostname via traditional DNS or another DoH server
+   while still authenticating the resulting connection via HTTPS.
+
+   HTTP [RFC7230] is a stateless application-level protocol, and
+   therefore DoH implementations do not provide stateful ordering
+   guarantees between different requests.  DoH cannot be used as a
+   transport for other protocols that require strict ordering.
+
+   A DoH server is allowed to answer queries with any valid DNS
+   response.  For example, a valid DNS response might have the TC
+   (truncation) bit set in the DNS header to indicate that the server
+   was not able to retrieve a full answer for the query but is providing
+   the best answer it could get.  A DoH server can reply to queries with
+   an HTTP error for queries that it cannot fulfill.  In this same
+   example, a DoH server could use an HTTP error instead of a non-error
+   response that has the TC bit set.
+
+   Many extensions to DNS, using [RFC6891], have been defined over the
+   years.  Extensions that are specific to the choice of transport, such
+   as [RFC7828], are not applicable to DoH.
+
+11.  References
+
+11.1.  Normative References
+
+   [RFC1035]  Mockapetris, P., "Domain names - implementation and
+              specification", STD 13, RFC 1035, DOI 10.17487/RFC1035,
+              November 1987, <https://www.rfc-editor.org/info/rfc1035>.
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC2308]  Andrews, M., "Negative Caching of DNS Queries (DNS
+              NCACHE)", RFC 2308, DOI 10.17487/RFC2308, March 1998,
+              <https://www.rfc-editor.org/info/rfc2308>.
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 16]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   [RFC4648]  Josefsson, S., "The Base16, Base32, and Base64 Data
+              Encodings", RFC 4648, DOI 10.17487/RFC4648, October 2006,
+              <https://www.rfc-editor.org/info/rfc4648>.
+
+   [RFC6265]  Barth, A., "HTTP State Management Mechanism", RFC 6265,
+              DOI 10.17487/RFC6265, April 2011,
+              <https://www.rfc-editor.org/info/rfc6265>.
+
+   [RFC6570]  Gregorio, J., Fielding, R., Hadley, M., Nottingham, M.,
+              and D. Orchard, "URI Template", RFC 6570,
+              DOI 10.17487/RFC6570, March 2012,
+              <https://www.rfc-editor.org/info/rfc6570>.
+
+   [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Message Syntax and Routing",
+              RFC 7230, DOI 10.17487/RFC7230, June 2014,
+              <https://www.rfc-editor.org/info/rfc7230>.
+
+   [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
+              DOI 10.17487/RFC7231, June 2014,
+              <https://www.rfc-editor.org/info/rfc7231>.
+
+   [RFC7232]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Conditional Requests", RFC 7232,
+              DOI 10.17487/RFC7232, June 2014,
+              <https://www.rfc-editor.org/info/rfc7232>.
+
+   [RFC7234]  Fielding, R., Ed., Nottingham, M., Ed., and J. Reschke,
+              Ed., "Hypertext Transfer Protocol (HTTP/1.1): Caching",
+              RFC 7234, DOI 10.17487/RFC7234, June 2014,
+              <https://www.rfc-editor.org/info/rfc7234>.
+
+   [RFC7235]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
+              Protocol (HTTP/1.1): Authentication", RFC 7235,
+              DOI 10.17487/RFC7235, June 2014,
+              <https://www.rfc-editor.org/info/rfc7235>.
+
+   [RFC7540]  Belshe, M., Peon, R., and M. Thomson, Ed., "Hypertext
+              Transfer Protocol Version 2 (HTTP/2)", RFC 7540,
+              DOI 10.17487/RFC7540, May 2015,
+              <https://www.rfc-editor.org/info/rfc7540>.
+
+   [RFC7541]  Peon, R. and H. Ruellan, "HPACK: Header Compression for
+              HTTP/2", RFC 7541, DOI 10.17487/RFC7541, May 2015,
+              <https://www.rfc-editor.org/info/rfc7541>.
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 17]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   [RFC7626]  Bortzmeyer, S., "DNS Privacy Considerations", RFC 7626,
+              DOI 10.17487/RFC7626, August 2015,
+              <https://www.rfc-editor.org/info/rfc7626>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC8446]  Rescorla, E., "The Transport Layer Security (TLS) Protocol
+              Version 1.3", RFC 8446, DOI 10.17487/RFC8446, August 2018,
+              <https://www.rfc-editor.org/info/rfc8446>.
+
+11.2.  Informative References
+
+   [FETCH]    "Fetch Living Standard", August 2018,
+              <https://fetch.spec.whatwg.org/>.
+
+   [RFC2818]  Rescorla, E., "HTTP Over TLS", RFC 2818,
+              DOI 10.17487/RFC2818, May 2000,
+              <https://www.rfc-editor.org/info/rfc2818>.
+
+   [RFC5280]  Cooper, D., Santesson, S., Farrell, S., Boeyen, S.,
+              Housley, R., and W. Polk, "Internet X.509 Public Key
+              Infrastructure Certificate and Certificate Revocation List
+              (CRL) Profile", RFC 5280, DOI 10.17487/RFC5280, May 2008,
+              <https://www.rfc-editor.org/info/rfc5280>.
+
+   [RFC5861]  Nottingham, M., "HTTP Cache-Control Extensions for Stale
+              Content", RFC 5861, DOI 10.17487/RFC5861, May 2010,
+              <https://www.rfc-editor.org/info/rfc5861>.
+
+   [RFC6147]  Bagnulo, M., Sullivan, A., Matthews, P., and I. van
+              Beijnum, "DNS64: DNS Extensions for Network Address
+              Translation from IPv6 Clients to IPv4 Servers", RFC 6147,
+              DOI 10.17487/RFC6147, April 2011,
+              <https://www.rfc-editor.org/info/rfc6147>.
+
+   [RFC6891]  Damas, J., Graff, M., and P. Vixie, "Extension Mechanisms
+              for DNS (EDNS(0))", STD 75, RFC 6891,
+              DOI 10.17487/RFC6891, April 2013,
+              <https://www.rfc-editor.org/info/rfc6891>.
+
+   [RFC6950]  Peterson, J., Kolkman, O., Tschofenig, H., and B. Aboba,
+              "Architectural Considerations on Application Features in
+              the DNS", RFC 6950, DOI 10.17487/RFC6950, October 2013,
+              <https://www.rfc-editor.org/info/rfc6950>.
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 18]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   [RFC6960]  Santesson, S., Myers, M., Ankney, R., Malpani, A.,
+              Galperin, S., and C. Adams, "X.509 Internet Public Key
+              Infrastructure Online Certificate Status Protocol - OCSP",
+              RFC 6960, DOI 10.17487/RFC6960, June 2013,
+              <https://www.rfc-editor.org/info/rfc6960>.
+
+   [RFC7258]  Farrell, S. and H. Tschofenig, "Pervasive Monitoring Is an
+              Attack", BCP 188, RFC 7258, DOI 10.17487/RFC7258, May
+              2014, <https://www.rfc-editor.org/info/rfc7258>.
+
+   [RFC7413]  Cheng, Y., Chu, J., Radhakrishnan, S., and A. Jain, "TCP
+              Fast Open", RFC 7413, DOI 10.17487/RFC7413, December 2014,
+              <https://www.rfc-editor.org/info/rfc7413>.
+
+   [RFC7828]  Wouters, P., Abley, J., Dickinson, S., and R. Bellis, "The
+              edns-tcp-keepalive EDNS0 Option", RFC 7828,
+              DOI 10.17487/RFC7828, April 2016,
+              <https://www.rfc-editor.org/info/rfc7828>.
+
+   [RFC7830]  Mayrhofer, A., "The EDNS(0) Padding Option", RFC 7830,
+              DOI 10.17487/RFC7830, May 2016,
+              <https://www.rfc-editor.org/info/rfc7830>.
+
+   [RFC7858]  Hu, Z., Zhu, L., Heidemann, J., Mankin, A., Wessels, D.,
+              and P. Hoffman, "Specification for DNS over Transport
+              Layer Security (TLS)", RFC 7858, DOI 10.17487/RFC7858, May
+              2016, <https://www.rfc-editor.org/info/rfc7858>.
+
+   [RFC8467]  Mayrhofer, A., "Padding Policies for Extension Mechanisms
+              for DNS (EDNS(0))", RFC 8467, DOI 10.17487/RFC8467,
+              October 2018, <https://www.rfc-editor.org/info/rfc8467>.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 19]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+Appendix A.  Protocol Development
+
+   This appendix describes the requirements used to design DoH.  These
+   requirements are listed here to help readers understand the current
+   protocol, not to limit how the protocol might be developed in the
+   future.  This appendix is non-normative.
+
+   The protocol described in this document based its design on the
+   following protocol requirements:
+
+   o  The protocol must use normal HTTP semantics.
+
+   o  The queries and responses must be able to be flexible enough to
+      express every DNS query that would normally be sent in DNS over
+      UDP (including queries and responses that use DNS extensions, but
+      not those that require multiple responses).
+
+   o  The protocol must permit the addition of new formats for DNS
+      queries and responses.
+
+   o  The protocol must ensure interoperability by specifying a single
+      format for requests and responses that is mandatory to implement.
+      That format must be able to support future modifications to the
+      DNS protocol including the inclusion of one or more EDNS options
+      (including those not yet defined).
+
+   o  The protocol must use a secure transport that meets the
+      requirements for HTTPS.
+
+   The following were considered non-requirements:
+
+   o  Supporting network-specific DNS64 [RFC6147]
+
+   o  Supporting other network-specific inferences from plaintext DNS
+      queries
+
+   o  Supporting insecure HTTP
+
+Appendix B.  Previous Work on DNS over HTTP or in Other Formats
+
+   The following is an incomplete list of earlier work that related to
+   DNS over HTTP/1 or representing DNS data in other formats.
+
+   The list includes links to the tools.ietf.org site (because these
+   documents are all expired) and web sites of software.
+
+   o  <https://tools.ietf.org/html/draft-mohan-dns-query-xml>
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 20]
+
+RFC 8484              DNS Queries over HTTPS (DoH)          October 2018
+
+
+   o  <https://tools.ietf.org/html/draft-daley-dnsxml>
+
+   o  <https://tools.ietf.org/html/draft-dulaunoy-dnsop-passive-dns-cof>
+
+   o  <https://tools.ietf.org/html/draft-bortzmeyer-dns-json>
+
+   o  <https://www.nlnetlabs.nl/projects/dnssec-trigger/>
+
+Acknowledgments
+
+   This work required a high level of cooperation between experts in
+   different technologies.  Thank you Ray Bellis, Stephane Bortzmeyer,
+   Manu Bretelle, Sara Dickinson, Massimiliano Fantuzzi, Tony Finch,
+   Daniel Kahn Gilmor, Olafur Gudmundsson, Wes Hardaker, Rory Hewitt,
+   Joe Hildebrand, David Lawrence, Eliot Lear, John Mattsson, Alex
+   Mayrhofer, Mark Nottingham, Jim Reid, Adam Roach, Ben Schwartz, Davey
+   Song, Daniel Stenberg, Andrew Sullivan, Martin Thomson, and Sam
+   Weiler.
+
+Authors' Addresses
+
+   Paul Hoffman
+   ICANN
+
+   Email: paul.hoffman@icann.org
+
+
+   Patrick McManus
+   Mozilla
+
+   Email: mcmanus@ducksong.com
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+Hoffman & McManus            Standards Track                   [Page 21]
+

--- a/rfc/dns/rfc8914.txt
+++ b/rfc/dns/rfc8914.txt
@@ -1,0 +1,638 @@
+﻿
+
+
+
+Internet Engineering Task Force (IETF)                         W. Kumari
+Request for Comments: 8914                                        Google
+Category: Standards Track                                        E. Hunt
+ISSN: 2070-1721                                                      ISC
+                                                               R. Arends
+                                                                   ICANN
+                                                             W. Hardaker
+                                                                 USC/ISI
+                                                             D. Lawrence
+                                                              Salesforce
+                                                            October 2020
+
+
+                          Extended DNS Errors
+
+Abstract
+
+   This document defines an extensible method to return additional
+   information about the cause of DNS errors.  Though created primarily
+   to extend SERVFAIL to provide additional information about the cause
+   of DNS and DNSSEC failures, the Extended DNS Errors option defined in
+   this document allows all response types to contain extended error
+   information.  Extended DNS Error information does not change the
+   processing of RCODEs.
+
+Status of This Memo
+
+   This is an Internet Standards Track document.
+
+   This document is a product of the Internet Engineering Task Force
+   (IETF).  It represents the consensus of the IETF community.  It has
+   received public review and has been approved for publication by the
+   Internet Engineering Steering Group (IESG).  Further information on
+   Internet Standards is available in Section 2 of RFC 7841.
+
+   Information about the current status of this document, any errata,
+   and how to provide feedback on it may be obtained at
+   https://www.rfc-editor.org/info/rfc8914.
+
+Copyright Notice
+
+   Copyright (c) 2020 IETF Trust and the persons identified as the
+   document authors.  All rights reserved.
+
+   This document is subject to BCP 78 and the IETF Trust's Legal
+   Provisions Relating to IETF Documents
+   (https://trustee.ietf.org/license-info) in effect on the date of
+   publication of this document.  Please review these documents
+   carefully, as they describe your rights and restrictions with respect
+   to this document.  Code Components extracted from this document must
+   include Simplified BSD License text as described in Section 4.e of
+   the Trust Legal Provisions and are provided without warranty as
+   described in the Simplified BSD License.
+
+Table of Contents
+
+   1.  Introduction and Background
+     1.1.  Requirements Notation
+   2.  Extended DNS Error EDNS0 Option Format
+   3.  Extended DNS Error Processing
+   4.  Defined Extended DNS Errors
+     4.1.  Extended DNS Error Code 0 - Other
+     4.2.  Extended DNS Error Code 1 - Unsupported DNSKEY Algorithm
+     4.3.  Extended DNS Error Code 2 - Unsupported DS Digest Type
+     4.4.  Extended DNS Error Code 3 - Stale Answer
+     4.5.  Extended DNS Error Code 4 - Forged Answer
+     4.6.  Extended DNS Error Code 5 - DNSSEC Indeterminate
+     4.7.  Extended DNS Error Code 6 - DNSSEC Bogus
+     4.8.  Extended DNS Error Code 7 - Signature Expired
+     4.9.  Extended DNS Error Code 8 - Signature Not Yet Valid
+     4.10. Extended DNS Error Code 9 - DNSKEY Missing
+     4.11. Extended DNS Error Code 10 - RRSIGs Missing
+     4.12. Extended DNS Error Code 11 - No Zone Key Bit Set
+     4.13. Extended DNS Error Code 12 - NSEC Missing
+     4.14. Extended DNS Error Code 13 - Cached Error
+     4.15. Extended DNS Error Code 14 - Not Ready
+     4.16. Extended DNS Error Code 15 - Blocked
+     4.17. Extended DNS Error Code 16 - Censored
+     4.18. Extended DNS Error Code 17 - Filtered
+     4.19. Extended DNS Error Code 18 - Prohibited
+     4.20. Extended DNS Error Code 19 - Stale NXDOMAIN Answer
+     4.21. Extended DNS Error Code 20 - Not Authoritative
+     4.22. Extended DNS Error Code 21 - Not Supported
+     4.23. Extended DNS Error Code 22 - No Reachable Authority
+     4.24. Extended DNS Error Code 23 - Network Error
+     4.25. Extended DNS Error Code 24 - Invalid Data
+   5.  IANA Considerations
+     5.1.  A New Extended DNS Error Code EDNS Option
+     5.2.  New Registry for Extended DNS Error Codes
+   6.  Security Considerations
+   7.  References
+     7.1.  Normative References
+     7.2.  Informative References
+   Acknowledgements
+   Authors' Addresses
+
+1.  Introduction and Background
+
+   There are many reasons that a DNS query may fail -- some of them
+   transient, some permanent; some can be resolved by querying another
+   server, some are likely best handled by stopping resolution.
+   Unfortunately, the error signals that a DNS server can return are
+   very limited and are not very expressive.  This means that
+   applications and resolvers often have to "guess" at what the issue
+   is, e.g., was the answer marked REFUSED because of a lame delegation
+   or because the nameserver is still starting up and loading zones?  Is
+   a SERVFAIL a DNSSEC validation issue, or is the nameserver
+   experiencing some other failure?  What error messages should be
+   presented to the user or logged under these conditions?
+
+   A good example of issues that would benefit from additional error
+   information are errors caused by DNSSEC validation issues.  When a
+   stub resolver queries a name that is DNSSEC bogus [RFC8499] (using a
+   validating resolver), the stub resolver receives only a SERVFAIL in
+   response.  Unfortunately, the SERVFAIL Response Code (RCODE) is used
+   to signal many sorts of DNS errors, and so the stub resolver's only
+   option is to ask the next configured DNS resolver.  The result of
+   trying the next resolver is one of two outcomes: either the next
+   resolver also validates and a SERVFAIL is returned again or the next
+   resolver is not a validating resolver and the user is returned a
+   potentially harmful result.  With an Extended DNS Error (EDE) option
+   enclosed in the response message, the resolver is able to return a
+   more descriptive reason as to why any failures happened or add
+   additional context to a message containing a NOERROR RCODE.
+
+   This document specifies a mechanism to extend DNS errors to provide
+   additional information about the cause of an error.  The Extended DNS
+   Error codes described in this document can be used by any system that
+   sends DNS queries and receives a response containing an EDE option.
+   Different codes are useful in different circumstances, and thus
+   different systems (stub resolvers, recursive resolvers, and
+   authoritative resolvers) might receive and use them.
+
+1.1.  Requirements Notation
+
+   The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
+   "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
+   "OPTIONAL" in this document are to be interpreted as described in
+   BCP 14 [RFC2119] [RFC8174] when, and only when, they appear in all
+   capitals, as shown here.
+
+2.  Extended DNS Error EDNS0 Option Format
+
+   This document uses an Extended Mechanism for DNS (EDNS0) [RFC6891]
+   option to include Extended DNS Error (EDE) information in DNS
+   messages.  The option is structured as follows:
+
+                                                1   1   1   1   1   1
+        0   1   2   3   4   5   6   7   8   9   0   1   2   3   4   5
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   0: |                            OPTION-CODE                        |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   2: |                           OPTION-LENGTH                       |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   4: | INFO-CODE                                                     |
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+   6: / EXTRA-TEXT ...                                                /
+      +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+
+
+   Field definition details:
+
+   OPTION-CODE:
+      2 octets / 16 bits (defined in [RFC6891]) contains the value 15
+      for EDE.
+
+   OPTION-LENGTH:
+      2 octets / 16 bits (defined in [RFC6891]) contains the length of
+      the payload (everything after OPTION-LENGTH) in octets and should
+      be 2 plus the length of the EXTRA-TEXT field (which may be a zero-
+      length string).
+
+   INFO-CODE:
+      16 bits, which is the principal contribution of this document.
+      This 16-bit value, encoded in network most significant bit (MSB)
+      byte order, provides the additional context for the RESPONSE-CODE
+      of the DNS message.  The INFO-CODE serves as an index into the
+      "Extended DNS Errors" registry, defined and created in
+      Section 5.2.
+
+   EXTRA-TEXT:
+      a variable-length, UTF-8-encoded [RFC5198] text field that may
+      hold additional textual information.  This information is intended
+      for human consumption (not automated parsing).  EDE text may be
+      null terminated but MUST NOT be assumed to be; the length MUST be
+      derived from the OPTION-LENGTH field.  The EXTRA-TEXT field may be
+      zero octets in length, indicating that there is no EXTRA-TEXT
+      included.  Care should be taken not to include private information
+      in the EXTRA-TEXT field that an observer would not otherwise have
+      access to, such as account numbers.
+
+   The Extended DNS Error (EDE) option can be included in any response
+   (SERVFAIL, NXDOMAIN, REFUSED, even NOERROR, etc.) to a query that
+   includes an OPT pseudo-RR [RFC6891].  This document includes a set of
+   initial codepoints but is extensible via the IANA registry defined
+   and created in Section 5.2.
+
+3.  Extended DNS Error Processing
+
+   When the response grows beyond the requestor's UDP payload size
+   [RFC6891], servers SHOULD truncate messages by dropping EDE options
+   before dropping other data from packets.  Implementations SHOULD set
+   the truncation bit when dropping EDE options.  Because long EXTRA-
+   TEXT fields may trigger truncation (which is undesirable given the
+   supplemental nature of EDE), implementers and operators creating EDE
+   options SHOULD avoid lengthy EXTRA-TEXT contents.
+
+   When a resolver or forwarder receives an EDE option, whether or not
+   (and how) to pass along EDE information on to their original client
+   is implementation dependent.  Implementations MAY choose to not
+   forward information, or they MAY choose to create a new EDE option(s)
+   that conveys the information encoded in the received EDE.  When doing
+   so, the source of the error SHOULD be attributed in the EXTRA-TEXT
+   field, since an EDNS0 option received by the original client will
+   appear to have come from the resolver or forwarder sending it.
+
+   This document does not allow or prohibit any particular extended
+   error codes and information to be matched with any particular RCODEs.
+   Some combinations of extended error codes and RCODEs may seem
+   nonsensical (such as resolver-specific extended error codes received
+   in responses from authoritative servers), so systems interpreting the
+   extended error codes MUST NOT assume that a combination will make
+   sense.  Receivers MUST be able to accept EDE codes and EXTRA-TEXT in
+   all messages, including those with a NOERROR RCODE but need not act
+   on them.  Applications MUST continue to follow requirements from
+   applicable specifications on how to process RCODEs no matter what EDE
+   values are also received.  Senders MAY include more than one EDE
+   option and receivers MUST be able to accept (but not necessarily
+   process or act on) multiple EDE options in a DNS message.
+
+4.  Defined Extended DNS Errors
+
+   This document defines some initial EDE codes.  The mechanism is
+   intended to be extensible, and additional codepoints can be
+   registered in the "Extended DNS Errors" registry (Section 5.2).  The
+   INFO-CODE from the EDE EDNS option is used to serve as an index into
+   the "Extended DNS Error" IANA registry, the initial values for which
+   are defined in the following subsections.
+
+4.1.  Extended DNS Error Code 0 - Other
+
+   The error in question falls into a category that does not match known
+   extended error codes.  Implementations SHOULD include an EXTRA-TEXT
+   value to augment this error code with additional information.
+
+4.2.  Extended DNS Error Code 1 - Unsupported DNSKEY Algorithm
+
+   The resolver attempted to perform DNSSEC validation, but a DNSKEY
+   RRset contained only unsupported DNSSEC algorithms.
+
+4.3.  Extended DNS Error Code 2 - Unsupported DS Digest Type
+
+   The resolver attempted to perform DNSSEC validation, but a DS RRset
+   contained only unsupported Digest Types.
+
+4.4.  Extended DNS Error Code 3 - Stale Answer
+
+   The resolver was unable to resolve the answer within its time limits
+   and decided to answer with previously cached data instead of
+   answering with an error.  This is typically caused by problems
+   communicating with an authoritative server, possibly as result of a
+   denial of service (DoS) attack against another network.  (See also
+   Code 19.)
+
+4.5.  Extended DNS Error Code 4 - Forged Answer
+
+   For policy reasons (legal obligation or malware filtering, for
+   instance), an answer was forged.  Note that this should be used when
+   an answer is still provided, not when failure codes are returned
+   instead.  See Blocked (15), Censored (16), and Filtered (17) for use
+   when returning other response codes.
+
+4.6.  Extended DNS Error Code 5 - DNSSEC Indeterminate
+
+   The resolver attempted to perform DNSSEC validation, but validation
+   ended in the Indeterminate state [RFC4035].
+
+4.7.  Extended DNS Error Code 6 - DNSSEC Bogus
+
+   The resolver attempted to perform DNSSEC validation, but validation
+   ended in the Bogus state.
+
+4.8.  Extended DNS Error Code 7 - Signature Expired
+
+   The resolver attempted to perform DNSSEC validation, but no
+   signatures are presently valid and some (often all) are expired.
+
+4.9.  Extended DNS Error Code 8 - Signature Not Yet Valid
+
+   The resolver attempted to perform DNSSEC validation, but no
+   signatures are presently valid and at least some are not yet valid.
+
+4.10.  Extended DNS Error Code 9 - DNSKEY Missing
+
+   A DS record existed at a parent, but no supported matching DNSKEY
+   record could be found for the child.
+
+4.11.  Extended DNS Error Code 10 - RRSIGs Missing
+
+   The resolver attempted to perform DNSSEC validation, but no RRSIGs
+   could be found for at least one RRset where RRSIGs were expected.
+
+4.12.  Extended DNS Error Code 11 - No Zone Key Bit Set
+
+   The resolver attempted to perform DNSSEC validation, but no Zone Key
+   Bit was set in a DNSKEY.
+
+4.13.  Extended DNS Error Code 12 - NSEC Missing
+
+   The resolver attempted to perform DNSSEC validation, but the
+   requested data was missing and a covering NSEC or NSEC3 was not
+   provided.
+
+4.14.  Extended DNS Error Code 13 - Cached Error
+
+   The resolver is returning the SERVFAIL RCODE from its cache.
+
+4.15.  Extended DNS Error Code 14 - Not Ready
+
+   The server is unable to answer the query, as it was not fully
+   functional when the query was received.
+
+4.16.  Extended DNS Error Code 15 - Blocked
+
+   The server is unable to respond to the request because the domain is
+   on a blocklist due to an internal security policy imposed by the
+   operator of the server resolving or forwarding the query.
+
+4.17.  Extended DNS Error Code 16 - Censored
+
+   The server is unable to respond to the request because the domain is
+   on a blocklist due to an external requirement imposed by an entity
+   other than the operator of the server resolving or forwarding the
+   query.  Note that how the imposed policy is applied is irrelevant
+   (in-band DNS filtering, court order, etc.).
+
+4.18.  Extended DNS Error Code 17 - Filtered
+
+   The server is unable to respond to the request because the domain is
+   on a blocklist as requested by the client.  Functionally, this
+   amounts to "you requested that we filter domains like this one."
+
+4.19.  Extended DNS Error Code 18 - Prohibited
+
+   An authoritative server or recursive resolver that receives a query
+   from an "unauthorized" client can annotate its REFUSED message with
+   this code.  Examples of "unauthorized" clients are recursive queries
+   from IP addresses outside the network, blocklisted IP addresses,
+   local policy, etc.
+
+4.20.  Extended DNS Error Code 19 - Stale NXDOMAIN Answer
+
+   The resolver was unable to resolve an answer within its configured
+   time limits and decided to answer with a previously cached NXDOMAIN
+   answer instead of answering with an error.  This may be caused, for
+   example, by problems communicating with an authoritative server,
+   possibly as result of a denial of service (DoS) attack against
+   another network.  (See also Code 3.)
+
+4.21.  Extended DNS Error Code 20 - Not Authoritative
+
+   An authoritative server that receives a query with the Recursion
+   Desired (RD) bit clear, or when it is not configured for recursion
+   for a domain for which it is not authoritative, SHOULD include this
+   EDE code in the REFUSED response.  A resolver that receives a query
+   with the RD bit clear SHOULD include this EDE code in the REFUSED
+   response.
+
+4.22.  Extended DNS Error Code 21 - Not Supported
+
+   The requested operation or query is not supported.
+
+4.23.  Extended DNS Error Code 22 - No Reachable Authority
+
+   The resolver could not reach any of the authoritative name servers
+   (or they potentially refused to reply).
+
+4.24.  Extended DNS Error Code 23 - Network Error
+
+   An unrecoverable error occurred while communicating with another
+   server.
+
+4.25.  Extended DNS Error Code 24 - Invalid Data
+
+   The authoritative server cannot answer with data for a zone it is
+   otherwise configured to support.  Examples of this include its most
+   recent zone being too old or having expired.
+
+5.  IANA Considerations
+
+5.1.  A New Extended DNS Error Code EDNS Option
+
+   This document defines a new EDNS(0) option, entitled "Extended DNS
+   Error", with the assigned value of 15 from the "DNS EDNS0 Option
+   Codes (OPT)" registry:
+
+           +=======+====================+==========+===========+
+           | Value | Name               | Status   | Reference |
+           +=======+====================+==========+===========+
+           | 15    | Extended DNS Error | Standard | RFC 8914  |
+           +-------+--------------------+----------+-----------+
+
+                                  Table 1
+
+5.2.  New Registry for Extended DNS Error Codes
+
+   IANA has created and will maintain a new registry called "Extended
+   DNS Error Codes" on the "Domain Name System (DNS) Parameters" web
+   page as follows:
+
+                +===============+=========================+
+                | Range         | Registration Procedures |
+                +===============+=========================+
+                | 0 - 49151     | First Come First Served |
+                +---------------+-------------------------+
+                | 49152 - 65535 | Private Use             |
+                +---------------+-------------------------+
+
+                                  Table 2
+
+   The "Extended DNS Error Codes" registry is a table with three
+   columns: INFO-CODE, Purpose, and Reference.  The initial content is
+   as below.
+
+      +=============+==============================+===============+
+      | INFO-CODE   | Purpose                      | Reference     |
+      +=============+==============================+===============+
+      | 0           | Other Error                  | Section 4.1   |
+      +-------------+------------------------------+---------------+
+      | 1           | Unsupported DNSKEY Algorithm | Section 4.2   |
+      +-------------+------------------------------+---------------+
+      | 2           | Unsupported DS Digest Type   | Section 4.3   |
+      +-------------+------------------------------+---------------+
+      | 3           | Stale Answer                 | Section 4.4   |
+      |             |                              | and [RFC8767] |
+      +-------------+------------------------------+---------------+
+      | 4           | Forged Answer                | Section 4.5   |
+      +-------------+------------------------------+---------------+
+      | 5           | DNSSEC Indeterminate         | Section 4.6   |
+      +-------------+------------------------------+---------------+
+      | 6           | DNSSEC Bogus                 | Section 4.7   |
+      +-------------+------------------------------+---------------+
+      | 7           | Signature Expired            | Section 4.8   |
+      +-------------+------------------------------+---------------+
+      | 8           | Signature Not Yet Valid      | Section 4.9   |
+      +-------------+------------------------------+---------------+
+      | 9           | DNSKEY Missing               | Section 4.10  |
+      +-------------+------------------------------+---------------+
+      | 10          | RRSIGs Missing               | Section 4.11  |
+      +-------------+------------------------------+---------------+
+      | 11          | No Zone Key Bit Set          | Section 4.12  |
+      +-------------+------------------------------+---------------+
+      | 12          | NSEC Missing                 | Section 4.13  |
+      +-------------+------------------------------+---------------+
+      | 13          | Cached Error                 | Section 4.14  |
+      +-------------+------------------------------+---------------+
+      | 14          | Not Ready                    | Section 4.15  |
+      +-------------+------------------------------+---------------+
+      | 15          | Blocked                      | Section 4.16  |
+      +-------------+------------------------------+---------------+
+      | 16          | Censored                     | Section 4.17  |
+      +-------------+------------------------------+---------------+
+      | 17          | Filtered                     | Section 4.18  |
+      +-------------+------------------------------+---------------+
+      | 18          | Prohibited                   | Section 4.19  |
+      +-------------+------------------------------+---------------+
+      | 19          | Stale NXDomain Answer        | Section 4.20  |
+      +-------------+------------------------------+---------------+
+      | 20          | Not Authoritative            | Section 4.21  |
+      +-------------+------------------------------+---------------+
+      | 21          | Not Supported                | Section 4.22  |
+      +-------------+------------------------------+---------------+
+      | 22          | No Reachable Authority       | Section 4.23  |
+      +-------------+------------------------------+---------------+
+      | 23          | Network Error                | Section 4.24  |
+      +-------------+------------------------------+---------------+
+      | 24          | Invalid Data                 | Section 4.25  |
+      +-------------+------------------------------+---------------+
+      | 25-49151    | Unassigned                   |               |
+      +-------------+------------------------------+---------------+
+      | 49152-65535 | Reserved for Private Use     | Section 5.2   |
+      +-------------+------------------------------+---------------+
+
+                                 Table 3
+
+6.  Security Considerations
+
+   Though DNSSEC continues to be deployed, unfortunately a significant
+   number of clients (~11% according to [GeoffValidation]) that receive
+   a SERVFAIL from a validating resolver because of a DNSSEC validation
+   issue will simply ask the next (potentially non-validating) resolver
+   in their list and thus don't get the protections that DNSSEC should
+   provide.
+
+   EDE information is unauthenticated information, unless secured by a
+   form of secured DNS transaction, such as [RFC2845], [RFC2931],
+   [RFC8094], or [RFC8484].  An attacker (e.g., a man in the middle
+   (MITM) or malicious recursive server) could insert an extended error
+   response into untrusted data -- although, ideally, clients and
+   resolvers would not trust any unauthenticated information.  As such,
+   EDE content should be treated only as diagnostic information and MUST
+   NOT alter DNS protocol processing.  Until all DNS answers are
+   authenticated via DNSSEC or the other mechanisms mentioned above,
+   there are some trade-offs.  As an example, an attacker who is able to
+   insert the DNSSEC Bogus Extended Error into a DNS message could
+   instead simply reply with a fictitious address (A or AAAA) record.
+   Note that DNS RCODEs also contain no authentication and can be just
+   as easily manipulated.
+
+   By design, EDE potentially exposes additional information via DNS
+   resolution processes that may leak information.  An example of this
+   is the Prohibited EDE code (18), which may leak the fact that the
+   name is on a blocklist.
+
+7.  References
+
+7.1.  Normative References
+
+   [RFC2119]  Bradner, S., "Key words for use in RFCs to Indicate
+              Requirement Levels", BCP 14, RFC 2119,
+              DOI 10.17487/RFC2119, March 1997,
+              <https://www.rfc-editor.org/info/rfc2119>.
+
+   [RFC4035]  Arends, R., Austein, R., Larson, M., Massey, D., and S.
+              Rose, "Protocol Modifications for the DNS Security
+              Extensions", RFC 4035, DOI 10.17487/RFC4035, March 2005,
+              <https://www.rfc-editor.org/info/rfc4035>.
+
+   [RFC5198]  Klensin, J. and M. Padlipsky, "Unicode Format for Network
+              Interchange", RFC 5198, DOI 10.17487/RFC5198, March 2008,
+              <https://www.rfc-editor.org/info/rfc5198>.
+
+   [RFC6891]  Damas, J., Graff, M., and P. Vixie, "Extension Mechanisms
+              for DNS (EDNS(0))", STD 75, RFC 6891,
+              DOI 10.17487/RFC6891, April 2013,
+              <https://www.rfc-editor.org/info/rfc6891>.
+
+   [RFC8174]  Leiba, B., "Ambiguity of Uppercase vs Lowercase in RFC
+              2119 Key Words", BCP 14, RFC 8174, DOI 10.17487/RFC8174,
+              May 2017, <https://www.rfc-editor.org/info/rfc8174>.
+
+   [RFC8499]  Hoffman, P., Sullivan, A., and K. Fujiwara, "DNS
+              Terminology", BCP 219, RFC 8499, DOI 10.17487/RFC8499,
+              January 2019, <https://www.rfc-editor.org/info/rfc8499>.
+
+   [RFC8767]  Lawrence, D., Kumari, W., and P. Sood, "Serving Stale Data
+              to Improve DNS Resiliency", RFC 8767,
+              DOI 10.17487/RFC8767, March 2020,
+              <https://www.rfc-editor.org/info/rfc8767>.
+
+7.2.  Informative References
+
+   [GeoffValidation]
+              Huston, G., "A quick review of DNSSEC Validation in
+              today's Internet", June 2016, <http://www.potaroo.net/
+              presentations/2016-06-27-dnssec.pdf>.
+
+   [RFC2845]  Vixie, P., Gudmundsson, O., Eastlake 3rd, D., and B.
+              Wellington, "Secret Key Transaction Authentication for DNS
+              (TSIG)", RFC 2845, DOI 10.17487/RFC2845, May 2000,
+              <https://www.rfc-editor.org/info/rfc2845>.
+
+   [RFC2931]  Eastlake 3rd, D., "DNS Request and Transaction Signatures
+              ( SIG(0)s )", RFC 2931, DOI 10.17487/RFC2931, September
+              2000, <https://www.rfc-editor.org/info/rfc2931>.
+
+   [RFC8094]  Reddy, T., Wing, D., and P. Patil, "DNS over Datagram
+              Transport Layer Security (DTLS)", RFC 8094,
+              DOI 10.17487/RFC8094, February 2017,
+              <https://www.rfc-editor.org/info/rfc8094>.
+
+   [RFC8484]  Hoffman, P. and P. McManus, "DNS Queries over HTTPS
+              (DoH)", RFC 8484, DOI 10.17487/RFC8484, October 2018,
+              <https://www.rfc-editor.org/info/rfc8484>.
+
+Acknowledgements
+
+   The authors wish to thank Joe Abley, Mark Andrews, Tim April,
+   Vittorio Bertola, Stephane Bortzmeyer, Vladimir Cunat, Ralph Dolmans,
+   Peter DeVries, Peter van Dijk, Mats Dufberg, Donald Eastlake, Bob
+   Harold, Paul Hoffman, Geoff Huston, Shane Kerr, Edward Lewis, Carlos
+   M. Martinez, George Michelson, Eric Orth, Michael Sheldon, Puneet
+   Sood, Petr Spacek, Ondrej Sury, John Todd, Loganaden Velvindron, and
+   Paul Vixie.  They also vaguely remember discussing this with a number
+   of people over the years but have forgotten who all of them were.
+   Apologies if we forgot to acknowledge your contributions.
+
+   One author also wants to thank the band Infected Mushroom for
+   providing a good background soundtrack.  Another author would like to
+   thank the band Mushroom Infectors.  This was funny at the time we
+   wrote it, but we cannot remember why...
+
+Authors' Addresses
+
+   Warren Kumari
+   Google
+   1600 Amphitheatre Parkway
+   Mountain View, CA 94043
+   United States of America
+
+   Email: warren@kumari.net
+
+
+   Evan Hunt
+   ISC
+   950 Charter St
+   Redwood City, CA 94063
+   United States of America
+
+   Email: each@isc.org
+
+
+   Roy Arends
+   ICANN
+
+   Email: roy.arends@icann.org
+
+
+   Wes Hardaker
+   USC/ISI
+   P.O. Box 382
+   Davis, CA 95617
+   United States of America
+
+   Email: ietf@hardakers.net
+
+
+   David C Lawrence
+   Salesforce
+   415 Mission St
+   San Francisco, CA 94105
+   United States of America
+
+   Email: tale@dd.org


### PR DESCRIPTION
## Summary

Add comprehensive RFC documentation and 8-phase implementation plan for the DNS resolver.

### RFC Documents Added (10 files)

| RFC | Title |
|-----|-------|
| RFC 2308 | Negative Caching of DNS Queries |
| RFC 4033 | DNS Security Introduction and Requirements |
| RFC 4034 | Resource Records for DNS Security Extensions |
| RFC 4035 | Protocol Modifications for DNS Security Extensions |
| RFC 5155 | NSEC3 Hashed Authenticated Denial of Existence |
| RFC 6891 | Extension Mechanisms for DNS (EDNS0) |
| RFC 7858 | Specification for DNS over TLS |
| RFC 7873 | Domain Name System (DNS) Cookies |
| RFC 8484 | DNS Queries over HTTPS (DoH) |
| RFC 8914 | Extended DNS Errors |

### Implementation Plan

`DNS_IMPLEMENTATION_PLAN.md` provides a complete roadmap:

| Phase | Issues | Description |
|-------|--------|-------------|
| 1 | #128-#133, #149 | Wire format foundation |
| 2 | #134, #135, #143 | UDP/TCP transport |
| 3 | #136-#138, #144, #145 | Resolver core with caching |
| 4 | #139, #140 | HappyEyeballs integration |
| 5 | #150, #151 | EDNS0 extensions |
| 6 | #146, #147 | Encrypted DNS (DoT, DoH) |
| 7 | #148 | DNSSEC validation |
| 8 | #141 | Testing and fuzzing |

Fixes #152

## Test plan

- [x] Documentation only - no code changes
- [x] RFC files are plain text from IETF
- [x] Implementation plan references valid issue numbers