### PR TITLE
feat(dns): implement DNS message header encoding/decoding (RFC 1035 §4.1.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,7 @@ set(LIB_SOURCES
     # DNS module (consolidated)
     src/dns/SocketDNS.c
     src/dns/SocketDNS-internal.c
+    src/dns/SocketDNSWire.c
 
     # Poll module (consolidated)
     src/poll/SocketPoll.c
@@ -479,6 +480,7 @@ set(SOCKET_HEADERS
 
 set(DNS_HEADERS
     include/dns/SocketDNS.h
+    include/dns/SocketDNSWire.h
 )
 
 set(POLL_HEADERS
@@ -603,6 +605,7 @@ set(TEST_SOURCES
     test_socketpool
     test_pool_health
     test_socketdns
+    test_dns_wire
     test_integration
     test_threadsafety
     test_happy_eyeballs

--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -1,0 +1,217 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETDNSWIRE_INCLUDED
+#define SOCKETDNSWIRE_INCLUDED
+
+/**
+ * @file SocketDNSWire.h
+ * @brief DNS wire format encoding/decoding (RFC 1035).
+ * @ingroup dns
+ *
+ * Implements DNS message wire format as specified in RFC 1035 Section 4.1.
+ * This module handles serialization and deserialization of DNS protocol
+ * messages for network transmission.
+ *
+ * ## RFC References
+ *
+ * - RFC 1035 Section 4.1.1: Header format
+ * - RFC 1035 Section 4.1.2: Question section format
+ * - RFC 1035 Section 4.1.3: Resource record format
+ *
+ * @see SocketDNS.h for the async resolver API.
+ */
+
+#include "core/Except.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup dns_wire DNS Wire Format
+ * @brief DNS message encoding and decoding.
+ * @ingroup dns
+ * @{
+ */
+
+/** DNS message header size in bytes (RFC 1035 Section 4.1.1). */
+#define DNS_HEADER_SIZE 12
+
+/**
+ * @brief DNS operation codes (RFC 1035 Section 4.1.1).
+ *
+ * OPCODE field values for DNS header. Specifies the kind of query.
+ */
+typedef enum
+{
+  DNS_OPCODE_QUERY = 0,  /**< Standard query (QUERY) */
+  DNS_OPCODE_IQUERY = 1, /**< Inverse query (IQUERY, obsolete) */
+  DNS_OPCODE_STATUS = 2, /**< Server status request (STATUS) */
+  DNS_OPCODE_NOTIFY = 4, /**< Zone change notification (RFC 1996) */
+  DNS_OPCODE_UPDATE = 5  /**< Dynamic update (RFC 2136) */
+} SocketDNS_Opcode;
+
+/**
+ * @brief DNS response codes (RFC 1035 Section 4.1.1).
+ *
+ * RCODE field values indicating response status.
+ */
+typedef enum
+{
+  DNS_RCODE_NOERROR = 0,  /**< No error condition */
+  DNS_RCODE_FORMERR = 1,  /**< Format error - server could not interpret */
+  DNS_RCODE_SERVFAIL = 2, /**< Server failure - internal error */
+  DNS_RCODE_NXDOMAIN = 3, /**< Name Error - domain does not exist */
+  DNS_RCODE_NOTIMP = 4,   /**< Not Implemented - query type not supported */
+  DNS_RCODE_REFUSED = 5,  /**< Refused - policy restriction */
+  DNS_RCODE_YXDOMAIN = 6, /**< Name exists when it should not (RFC 2136) */
+  DNS_RCODE_YXRRSET = 7,  /**< RR set exists when it should not (RFC 2136) */
+  DNS_RCODE_NXRRSET = 8,  /**< RR set does not exist (RFC 2136) */
+  DNS_RCODE_NOTAUTH = 9,  /**< Server not authoritative (RFC 2136) */
+  DNS_RCODE_NOTZONE = 10  /**< Name not in zone (RFC 2136) */
+} SocketDNS_Rcode;
+
+/**
+ * @brief DNS message header structure (unpacked representation).
+ *
+ * Represents the 12-byte DNS header in an easily accessible form.
+ * Use SocketDNS_header_encode() to serialize to wire format and
+ * SocketDNS_header_decode() to parse from wire format.
+ *
+ * ## Wire Format (RFC 1035 Section 4.1.1)
+ *
+ * ```
+ *                                 1  1  1  1  1  1
+ *   0  1  2  3  4  5  6  7  8  9  0  1  2  3  4  5
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * |                      ID                       |
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * |QR|   Opcode  |AA|TC|RD|RA|   Z    |   RCODE   |
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * |                    QDCOUNT                    |
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * |                    ANCOUNT                    |
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * |                    NSCOUNT                    |
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * |                    ARCOUNT                    |
+ * +--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
+ * ```
+ */
+typedef struct
+{
+  uint16_t id; /**< Query identifier (matches responses to queries) */
+
+  /* Flags - bits 15-0 of the second 16-bit word */
+  uint8_t qr;     /**< Query (0) or Response (1) - bit 15 */
+  uint8_t opcode; /**< Operation code (4 bits) - bits 14-11 */
+  uint8_t aa;     /**< Authoritative Answer - bit 10 */
+  uint8_t tc;     /**< TrunCation - bit 9 */
+  uint8_t rd;     /**< Recursion Desired - bit 8 */
+  uint8_t ra;     /**< Recursion Available - bit 7 */
+  uint8_t z;      /**< Reserved, must be 0 (3 bits) - bits 6-4 */
+  uint8_t rcode;  /**< Response code (4 bits) - bits 3-0 */
+
+  /* Section counts */
+  uint16_t qdcount; /**< Number of entries in Question section */
+  uint16_t ancount; /**< Number of entries in Answer section */
+  uint16_t nscount; /**< Number of entries in Authority section */
+  uint16_t arcount; /**< Number of entries in Additional section */
+} SocketDNS_Header;
+
+/**
+ * @brief DNS wire format operation failure exception.
+ * @ingroup dns_wire
+ *
+ * Raised when DNS wire format encoding or decoding fails due to:
+ * - Buffer too small
+ * - Invalid field values
+ * - Malformed input data
+ */
+extern const Except_T SocketDNS_WireError;
+
+/**
+ * @brief Encode DNS header to wire format.
+ * @ingroup dns_wire
+ *
+ * Serializes a DNS header structure to the 12-byte network format
+ * as specified in RFC 1035 Section 4.1.1. All multi-byte fields
+ * are encoded in network byte order (big-endian).
+ *
+ * @param[in]  header  Header structure to encode.
+ * @param[out] buf     Output buffer (must be at least DNS_HEADER_SIZE bytes).
+ * @param[in]  buflen  Size of output buffer.
+ * @return 0 on success, -1 on error (buffer too small or NULL pointers).
+ *
+ * @code{.c}
+ * SocketDNS_Header header = {
+ *     .id = 0x1234,
+ *     .qr = 0,           // Query
+ *     .opcode = DNS_OPCODE_QUERY,
+ *     .rd = 1,           // Recursion desired
+ *     .qdcount = 1       // One question
+ * };
+ * unsigned char buf[DNS_HEADER_SIZE];
+ * if (SocketDNS_header_encode(&header, buf, sizeof(buf)) == 0) {
+ *     // buf now contains wire format header
+ * }
+ * @endcode
+ *
+ * @see SocketDNS_header_decode() for parsing wire format.
+ */
+extern int SocketDNS_header_encode (const SocketDNS_Header *header,
+                                    unsigned char *buf, size_t buflen);
+
+/**
+ * @brief Decode DNS header from wire format.
+ * @ingroup dns_wire
+ *
+ * Parses a 12-byte DNS header from network format into a structure.
+ * Multi-byte fields are converted from network byte order (big-endian).
+ *
+ * @param[in]  data    Input buffer containing wire format header.
+ * @param[in]  datalen Size of input buffer (must be >= DNS_HEADER_SIZE).
+ * @param[out] header  Output header structure.
+ * @return 0 on success, -1 on error (buffer too small or NULL pointers).
+ *
+ * @code{.c}
+ * unsigned char packet[512];
+ * // ... receive packet from network ...
+ * SocketDNS_Header header;
+ * if (SocketDNS_header_decode(packet, packet_len, &header) == 0) {
+ *     if (header.qr == 1 && header.rcode == DNS_RCODE_NOERROR) {
+ *         // Process successful response
+ *     }
+ * }
+ * @endcode
+ *
+ * @see SocketDNS_header_encode() for creating wire format.
+ */
+extern int SocketDNS_header_decode (const unsigned char *data, size_t datalen,
+                                    SocketDNS_Header *header);
+
+/**
+ * @brief Initialize a DNS header for a standard query.
+ * @ingroup dns_wire
+ *
+ * Convenience function to set up a header for a typical recursive query.
+ * Sets RD (recursion desired) and clears all other flags.
+ *
+ * @param[out] header  Header structure to initialize.
+ * @param[in]  id      Query identifier.
+ * @param[in]  qdcount Number of questions (typically 1).
+ *
+ * @code{.c}
+ * SocketDNS_Header header;
+ * SocketDNS_header_init_query(&header, random_id(), 1);
+ * // header is now ready to encode
+ * @endcode
+ */
+extern void SocketDNS_header_init_query (SocketDNS_Header *header, uint16_t id,
+                                         uint16_t qdcount);
+
+/** @} */ /* End of dns_wire group */
+
+#endif /* SOCKETDNSWIRE_INCLUDED */

--- a/src/dns/SocketDNSWire.c
+++ b/src/dns/SocketDNSWire.c
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/*
+ * SocketDNSWire.c - DNS wire format encoding/decoding (RFC 1035)
+ */
+
+#include "dns/SocketDNSWire.h"
+
+#include <string.h>
+
+const Except_T SocketDNS_WireError
+    = { &SocketDNS_WireError, "DNS wire format error" };
+
+/*
+ * Big-endian pack/unpack helpers.
+ * Following the pattern from SocketHTTP2-frame.c for explicit byte
+ * manipulation rather than relying on htons/ntohs macros.
+ */
+
+static inline uint16_t
+dns_unpack_be16 (const unsigned char *p)
+{
+  return ((uint16_t)p[0] << 8) | (uint16_t)p[1];
+}
+
+static inline void
+dns_pack_be16 (unsigned char *p, uint16_t v)
+{
+  p[0] = (unsigned char)((v >> 8) & 0xFF);
+  p[1] = (unsigned char)(v & 0xFF);
+}
+
+/*
+ * Flags word layout (16 bits):
+ *
+ *   Bit 15: QR (1 bit)      - Query/Response
+ *   Bits 14-11: OPCODE (4)  - Operation code
+ *   Bit 10: AA (1)          - Authoritative Answer
+ *   Bit 9: TC (1)           - Truncation
+ *   Bit 8: RD (1)           - Recursion Desired
+ *   Bit 7: RA (1)           - Recursion Available
+ *   Bits 6-4: Z (3)         - Reserved (must be 0)
+ *   Bits 3-0: RCODE (4)     - Response code
+ *
+ * Bit positions from MSB (bit 15) to LSB (bit 0):
+ *   QR: bit 15 (0x8000)
+ *   OPCODE: bits 14-11 (0x7800), shift 11
+ *   AA: bit 10 (0x0400)
+ *   TC: bit 9 (0x0200)
+ *   RD: bit 8 (0x0100)
+ *   RA: bit 7 (0x0080)
+ *   Z: bits 6-4 (0x0070), shift 4
+ *   RCODE: bits 3-0 (0x000F)
+ */
+
+#define DNS_FLAG_QR_MASK     0x8000
+#define DNS_FLAG_QR_SHIFT    15
+#define DNS_FLAG_OPCODE_MASK 0x7800
+#define DNS_FLAG_OPCODE_SHIFT 11
+#define DNS_FLAG_AA_MASK     0x0400
+#define DNS_FLAG_AA_SHIFT    10
+#define DNS_FLAG_TC_MASK     0x0200
+#define DNS_FLAG_TC_SHIFT    9
+#define DNS_FLAG_RD_MASK     0x0100
+#define DNS_FLAG_RD_SHIFT    8
+#define DNS_FLAG_RA_MASK     0x0080
+#define DNS_FLAG_RA_SHIFT    7
+#define DNS_FLAG_Z_MASK      0x0070
+#define DNS_FLAG_Z_SHIFT     4
+#define DNS_FLAG_RCODE_MASK  0x000F
+#define DNS_FLAG_RCODE_SHIFT 0
+
+static inline uint16_t
+dns_pack_flags (const SocketDNS_Header *h)
+{
+  uint16_t flags = 0;
+
+  flags |= ((uint16_t)(h->qr & 0x01)) << DNS_FLAG_QR_SHIFT;
+  flags |= ((uint16_t)(h->opcode & 0x0F)) << DNS_FLAG_OPCODE_SHIFT;
+  flags |= ((uint16_t)(h->aa & 0x01)) << DNS_FLAG_AA_SHIFT;
+  flags |= ((uint16_t)(h->tc & 0x01)) << DNS_FLAG_TC_SHIFT;
+  flags |= ((uint16_t)(h->rd & 0x01)) << DNS_FLAG_RD_SHIFT;
+  flags |= ((uint16_t)(h->ra & 0x01)) << DNS_FLAG_RA_SHIFT;
+  flags |= ((uint16_t)(h->z & 0x07)) << DNS_FLAG_Z_SHIFT;
+  flags |= ((uint16_t)(h->rcode & 0x0F)) << DNS_FLAG_RCODE_SHIFT;
+
+  return flags;
+}
+
+static inline void
+dns_unpack_flags (uint16_t flags, SocketDNS_Header *h)
+{
+  h->qr = (uint8_t)((flags & DNS_FLAG_QR_MASK) >> DNS_FLAG_QR_SHIFT);
+  h->opcode = (uint8_t)((flags & DNS_FLAG_OPCODE_MASK) >> DNS_FLAG_OPCODE_SHIFT);
+  h->aa = (uint8_t)((flags & DNS_FLAG_AA_MASK) >> DNS_FLAG_AA_SHIFT);
+  h->tc = (uint8_t)((flags & DNS_FLAG_TC_MASK) >> DNS_FLAG_TC_SHIFT);
+  h->rd = (uint8_t)((flags & DNS_FLAG_RD_MASK) >> DNS_FLAG_RD_SHIFT);
+  h->ra = (uint8_t)((flags & DNS_FLAG_RA_MASK) >> DNS_FLAG_RA_SHIFT);
+  h->z = (uint8_t)((flags & DNS_FLAG_Z_MASK) >> DNS_FLAG_Z_SHIFT);
+  h->rcode = (uint8_t)((flags & DNS_FLAG_RCODE_MASK) >> DNS_FLAG_RCODE_SHIFT);
+}
+
+int
+SocketDNS_header_encode (const SocketDNS_Header *header, unsigned char *buf,
+                         size_t buflen)
+{
+  uint16_t flags;
+
+  if (!header || !buf)
+    return -1;
+
+  if (buflen < DNS_HEADER_SIZE)
+    return -1;
+
+  /* Bytes 0-1: ID */
+  dns_pack_be16 (buf + 0, header->id);
+
+  /* Bytes 2-3: Flags */
+  flags = dns_pack_flags (header);
+  dns_pack_be16 (buf + 2, flags);
+
+  /* Bytes 4-5: QDCOUNT */
+  dns_pack_be16 (buf + 4, header->qdcount);
+
+  /* Bytes 6-7: ANCOUNT */
+  dns_pack_be16 (buf + 6, header->ancount);
+
+  /* Bytes 8-9: NSCOUNT */
+  dns_pack_be16 (buf + 8, header->nscount);
+
+  /* Bytes 10-11: ARCOUNT */
+  dns_pack_be16 (buf + 10, header->arcount);
+
+  return 0;
+}
+
+int
+SocketDNS_header_decode (const unsigned char *data, size_t datalen,
+                         SocketDNS_Header *header)
+{
+  uint16_t flags;
+
+  if (!data || !header)
+    return -1;
+
+  if (datalen < DNS_HEADER_SIZE)
+    return -1;
+
+  /* Bytes 0-1: ID */
+  header->id = dns_unpack_be16 (data + 0);
+
+  /* Bytes 2-3: Flags */
+  flags = dns_unpack_be16 (data + 2);
+  dns_unpack_flags (flags, header);
+
+  /* Bytes 4-5: QDCOUNT */
+  header->qdcount = dns_unpack_be16 (data + 4);
+
+  /* Bytes 6-7: ANCOUNT */
+  header->ancount = dns_unpack_be16 (data + 6);
+
+  /* Bytes 8-9: NSCOUNT */
+  header->nscount = dns_unpack_be16 (data + 8);
+
+  /* Bytes 10-11: ARCOUNT */
+  header->arcount = dns_unpack_be16 (data + 10);
+
+  return 0;
+}
+
+void
+SocketDNS_header_init_query (SocketDNS_Header *header, uint16_t id,
+                             uint16_t qdcount)
+{
+  if (!header)
+    return;
+
+  memset (header, 0, sizeof (*header));
+  header->id = id;
+  header->qr = 0;                 /* Query */
+  header->opcode = DNS_OPCODE_QUERY;
+  header->rd = 1;                 /* Request recursion */
+  header->qdcount = qdcount;
+}

--- a/src/test/test_dns_wire.c
+++ b/src/test/test_dns_wire.c
@@ -1,0 +1,479 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/*
+ * test_dns_wire.c - Unit tests for DNS wire format encoding/decoding
+ *
+ * Tests RFC 1035 Section 4.1.1 header format implementation.
+ */
+
+#include "dns/SocketDNSWire.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* Test basic header encoding and decoding round-trip */
+TEST (dns_wire_header_roundtrip)
+{
+  SocketDNS_Header orig = { 0 };
+  SocketDNS_Header decoded = { 0 };
+  unsigned char buf[DNS_HEADER_SIZE];
+  int ret;
+
+  /* Set up a typical query header */
+  orig.id = 0x1234;
+  orig.qr = 0;                    /* Query */
+  orig.opcode = DNS_OPCODE_QUERY;
+  orig.aa = 0;
+  orig.tc = 0;
+  orig.rd = 1;                    /* Recursion desired */
+  orig.ra = 0;
+  orig.z = 0;
+  orig.rcode = DNS_RCODE_NOERROR;
+  orig.qdcount = 1;
+  orig.ancount = 0;
+  orig.nscount = 0;
+  orig.arcount = 0;
+
+  ret = SocketDNS_header_encode (&orig, buf, sizeof (buf));
+  ASSERT_EQ (ret, 0);
+
+  ret = SocketDNS_header_decode (buf, sizeof (buf), &decoded);
+  ASSERT_EQ (ret, 0);
+
+  /* Verify all fields match */
+  ASSERT_EQ (decoded.id, orig.id);
+  ASSERT_EQ (decoded.qr, orig.qr);
+  ASSERT_EQ (decoded.opcode, orig.opcode);
+  ASSERT_EQ (decoded.aa, orig.aa);
+  ASSERT_EQ (decoded.tc, orig.tc);
+  ASSERT_EQ (decoded.rd, orig.rd);
+  ASSERT_EQ (decoded.ra, orig.ra);
+  ASSERT_EQ (decoded.z, orig.z);
+  ASSERT_EQ (decoded.rcode, orig.rcode);
+  ASSERT_EQ (decoded.qdcount, orig.qdcount);
+  ASSERT_EQ (decoded.ancount, orig.ancount);
+  ASSERT_EQ (decoded.nscount, orig.nscount);
+  ASSERT_EQ (decoded.arcount, orig.arcount);
+}
+
+/* Test response header with all flags set */
+TEST (dns_wire_header_all_flags)
+{
+  SocketDNS_Header orig = { 0 };
+  SocketDNS_Header decoded = { 0 };
+  unsigned char buf[DNS_HEADER_SIZE];
+  int ret;
+
+  /* Response with all flags set */
+  orig.id = 0xABCD;
+  orig.qr = 1;                    /* Response */
+  orig.opcode = DNS_OPCODE_STATUS;
+  orig.aa = 1;                    /* Authoritative */
+  orig.tc = 1;                    /* Truncated */
+  orig.rd = 1;                    /* Recursion desired */
+  orig.ra = 1;                    /* Recursion available */
+  orig.z = 0;                     /* Reserved, must be 0 */
+  orig.rcode = DNS_RCODE_REFUSED;
+  orig.qdcount = 0xFFFF;
+  orig.ancount = 0x1234;
+  orig.nscount = 0x5678;
+  orig.arcount = 0x9ABC;
+
+  ret = SocketDNS_header_encode (&orig, buf, sizeof (buf));
+  ASSERT_EQ (ret, 0);
+
+  ret = SocketDNS_header_decode (buf, sizeof (buf), &decoded);
+  ASSERT_EQ (ret, 0);
+
+  ASSERT_EQ (decoded.id, 0xABCD);
+  ASSERT_EQ (decoded.qr, 1);
+  ASSERT_EQ (decoded.opcode, DNS_OPCODE_STATUS);
+  ASSERT_EQ (decoded.aa, 1);
+  ASSERT_EQ (decoded.tc, 1);
+  ASSERT_EQ (decoded.rd, 1);
+  ASSERT_EQ (decoded.ra, 1);
+  ASSERT_EQ (decoded.z, 0);
+  ASSERT_EQ (decoded.rcode, DNS_RCODE_REFUSED);
+  ASSERT_EQ (decoded.qdcount, 0xFFFF);
+  ASSERT_EQ (decoded.ancount, 0x1234);
+  ASSERT_EQ (decoded.nscount, 0x5678);
+  ASSERT_EQ (decoded.arcount, 0x9ABC);
+}
+
+/* Test decoding a known DNS query packet */
+TEST (dns_wire_decode_known_query)
+{
+  /* DNS query for "example.com" A record
+   * ID: 0x1234
+   * Flags: 0x0100 (standard query, recursion desired)
+   * Questions: 1
+   * Answers: 0
+   * Authority: 0
+   * Additional: 0
+   */
+  unsigned char query[] = {
+    0x12, 0x34,   /* ID */
+    0x01, 0x00,   /* Flags: RD=1, rest 0 */
+    0x00, 0x01,   /* QDCOUNT = 1 */
+    0x00, 0x00,   /* ANCOUNT = 0 */
+    0x00, 0x00,   /* NSCOUNT = 0 */
+    0x00, 0x00    /* ARCOUNT = 0 */
+  };
+
+  SocketDNS_Header h;
+  int ret = SocketDNS_header_decode (query, sizeof (query), &h);
+
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (h.id, 0x1234);
+  ASSERT_EQ (h.qr, 0);
+  ASSERT_EQ (h.opcode, DNS_OPCODE_QUERY);
+  ASSERT_EQ (h.rd, 1);
+  ASSERT_EQ (h.aa, 0);
+  ASSERT_EQ (h.tc, 0);
+  ASSERT_EQ (h.ra, 0);
+  ASSERT_EQ (h.qdcount, 1);
+  ASSERT_EQ (h.ancount, 0);
+}
+
+/* Test decoding a known DNS response packet */
+TEST (dns_wire_decode_known_response)
+{
+  /* DNS response for "example.com" A record
+   * ID: 0x1234
+   * Flags: 0x8180 (QR=1, RD=1, RA=1)
+   * Questions: 1
+   * Answers: 1
+   * Authority: 0
+   * Additional: 0
+   */
+  unsigned char response[] = {
+    0x12, 0x34,   /* ID */
+    0x81, 0x80,   /* Flags: QR=1, RD=1, RA=1 */
+    0x00, 0x01,   /* QDCOUNT = 1 */
+    0x00, 0x01,   /* ANCOUNT = 1 */
+    0x00, 0x00,   /* NSCOUNT = 0 */
+    0x00, 0x00    /* ARCOUNT = 0 */
+  };
+
+  SocketDNS_Header h;
+  int ret = SocketDNS_header_decode (response, sizeof (response), &h);
+
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (h.id, 0x1234);
+  ASSERT_EQ (h.qr, 1);
+  ASSERT_EQ (h.opcode, DNS_OPCODE_QUERY);
+  ASSERT_EQ (h.aa, 0);
+  ASSERT_EQ (h.tc, 0);
+  ASSERT_EQ (h.rd, 1);
+  ASSERT_EQ (h.ra, 1);
+  ASSERT_EQ (h.rcode, DNS_RCODE_NOERROR);
+  ASSERT_EQ (h.qdcount, 1);
+  ASSERT_EQ (h.ancount, 1);
+}
+
+/* Test NXDOMAIN response */
+TEST (dns_wire_decode_nxdomain)
+{
+  /* NXDOMAIN response
+   * Flags: 0x8183 (QR=1, RD=1, RA=1, RCODE=3)
+   */
+  unsigned char nxdomain[] = {
+    0x56, 0x78,   /* ID */
+    0x81, 0x83,   /* Flags: QR=1, RD=1, RA=1, RCODE=NXDOMAIN(3) */
+    0x00, 0x01,   /* QDCOUNT = 1 */
+    0x00, 0x00,   /* ANCOUNT = 0 */
+    0x00, 0x01,   /* NSCOUNT = 1 (SOA for negative caching) */
+    0x00, 0x00    /* ARCOUNT = 0 */
+  };
+
+  SocketDNS_Header h;
+  int ret = SocketDNS_header_decode (nxdomain, sizeof (nxdomain), &h);
+
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (h.id, 0x5678);
+  ASSERT_EQ (h.qr, 1);
+  ASSERT_EQ (h.rcode, DNS_RCODE_NXDOMAIN);
+  ASSERT_EQ (h.nscount, 1);
+}
+
+/* Test truncated response (TC bit) */
+TEST (dns_wire_truncated_response)
+{
+  /* Truncated response - needs TCP retry
+   * Flags: 0x8280 (QR=1, TC=1, RA=1)
+   */
+  unsigned char truncated[] = {
+    0xAB, 0xCD,   /* ID */
+    0x82, 0x80,   /* Flags: QR=1, TC=1, RA=1 */
+    0x00, 0x01,   /* QDCOUNT = 1 */
+    0x00, 0x05,   /* ANCOUNT = 5 (but truncated) */
+    0x00, 0x00,   /* NSCOUNT = 0 */
+    0x00, 0x00    /* ARCOUNT = 0 */
+  };
+
+  SocketDNS_Header h;
+  int ret = SocketDNS_header_decode (truncated, sizeof (truncated), &h);
+
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (h.tc, 1);
+  ASSERT_EQ (h.qr, 1);
+}
+
+/* Test authoritative answer (AA bit) */
+TEST (dns_wire_authoritative_answer)
+{
+  /* Authoritative answer
+   * Flags: 0x8400 (QR=1, AA=1)
+   */
+  unsigned char auth[] = {
+    0x11, 0x22,   /* ID */
+    0x84, 0x00,   /* Flags: QR=1, AA=1 */
+    0x00, 0x01,   /* QDCOUNT = 1 */
+    0x00, 0x01,   /* ANCOUNT = 1 */
+    0x00, 0x00,   /* NSCOUNT = 0 */
+    0x00, 0x00    /* ARCOUNT = 0 */
+  };
+
+  SocketDNS_Header h;
+  int ret = SocketDNS_header_decode (auth, sizeof (auth), &h);
+
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (h.aa, 1);
+  ASSERT_EQ (h.qr, 1);
+}
+
+/* Test buffer too small for encode */
+TEST (dns_wire_encode_buffer_too_small)
+{
+  SocketDNS_Header h = { 0 };
+  unsigned char buf[DNS_HEADER_SIZE - 1]; /* Too small */
+  int ret;
+
+  ret = SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT_EQ (ret, -1);
+}
+
+/* Test buffer too small for decode */
+TEST (dns_wire_decode_buffer_too_small)
+{
+  unsigned char buf[DNS_HEADER_SIZE - 1] = { 0 }; /* Too small */
+  SocketDNS_Header h;
+  int ret;
+
+  ret = SocketDNS_header_decode (buf, sizeof (buf), &h);
+  ASSERT_EQ (ret, -1);
+}
+
+/* Test NULL pointer handling */
+TEST (dns_wire_null_pointers)
+{
+  SocketDNS_Header h = { 0 };
+  unsigned char buf[DNS_HEADER_SIZE] = { 0 };
+  int ret;
+
+  ret = SocketDNS_header_encode (NULL, buf, sizeof (buf));
+  ASSERT_EQ (ret, -1);
+
+  ret = SocketDNS_header_encode (&h, NULL, sizeof (buf));
+  ASSERT_EQ (ret, -1);
+
+  ret = SocketDNS_header_decode (buf, sizeof (buf), NULL);
+  ASSERT_EQ (ret, -1);
+
+  ret = SocketDNS_header_decode (NULL, sizeof (buf), &h);
+  ASSERT_EQ (ret, -1);
+}
+
+/* Test init_query helper */
+TEST (dns_wire_init_query)
+{
+  SocketDNS_Header h;
+  unsigned char buf[DNS_HEADER_SIZE];
+  SocketDNS_Header decoded;
+
+  SocketDNS_header_init_query (&h, 0x4321, 1);
+
+  ASSERT_EQ (h.id, 0x4321);
+  ASSERT_EQ (h.qr, 0);
+  ASSERT_EQ (h.opcode, DNS_OPCODE_QUERY);
+  ASSERT_EQ (h.rd, 1);
+  ASSERT_EQ (h.qdcount, 1);
+  ASSERT_EQ (h.ancount, 0);
+  ASSERT_EQ (h.nscount, 0);
+  ASSERT_EQ (h.arcount, 0);
+
+  /* Verify it encodes correctly */
+  ASSERT_EQ (SocketDNS_header_encode (&h, buf, sizeof (buf)), 0);
+  ASSERT_EQ (SocketDNS_header_decode (buf, sizeof (buf), &decoded), 0);
+  ASSERT_EQ (decoded.id, 0x4321);
+  ASSERT_EQ (decoded.rd, 1);
+}
+
+/* Test OPCODE values */
+TEST (dns_wire_opcode_values)
+{
+  SocketDNS_Header h = { 0 };
+  SocketDNS_Header decoded;
+  unsigned char buf[DNS_HEADER_SIZE];
+  uint8_t opcodes[] = { DNS_OPCODE_QUERY, DNS_OPCODE_IQUERY, DNS_OPCODE_STATUS,
+                        DNS_OPCODE_NOTIFY, DNS_OPCODE_UPDATE };
+  size_t i;
+
+  for (i = 0; i < sizeof (opcodes) / sizeof (opcodes[0]); i++)
+    {
+      memset (&h, 0, sizeof (h));
+      h.id = (uint16_t)(i + 1);
+      h.opcode = opcodes[i];
+
+      ASSERT_EQ (SocketDNS_header_encode (&h, buf, sizeof (buf)), 0);
+      ASSERT_EQ (SocketDNS_header_decode (buf, sizeof (buf), &decoded), 0);
+      ASSERT_EQ (decoded.opcode, opcodes[i]);
+    }
+}
+
+/* Test RCODE values */
+TEST (dns_wire_rcode_values)
+{
+  SocketDNS_Header h = { 0 };
+  SocketDNS_Header decoded;
+  unsigned char buf[DNS_HEADER_SIZE];
+  uint8_t rcodes[] = { DNS_RCODE_NOERROR,  DNS_RCODE_FORMERR,
+                       DNS_RCODE_SERVFAIL, DNS_RCODE_NXDOMAIN,
+                       DNS_RCODE_NOTIMP,   DNS_RCODE_REFUSED };
+  size_t i;
+
+  for (i = 0; i < sizeof (rcodes) / sizeof (rcodes[0]); i++)
+    {
+      memset (&h, 0, sizeof (h));
+      h.id = (uint16_t)(i + 1);
+      h.qr = 1;
+      h.rcode = rcodes[i];
+
+      ASSERT_EQ (SocketDNS_header_encode (&h, buf, sizeof (buf)), 0);
+      ASSERT_EQ (SocketDNS_header_decode (buf, sizeof (buf), &decoded), 0);
+      ASSERT_EQ (decoded.rcode, rcodes[i]);
+    }
+}
+
+/* Test byte order (big-endian) */
+TEST (dns_wire_byte_order)
+{
+  SocketDNS_Header h = { 0 };
+  unsigned char buf[DNS_HEADER_SIZE];
+
+  h.id = 0x0102;        /* Should encode as 0x01, 0x02 */
+  h.qdcount = 0x0304;   /* Should encode as 0x03, 0x04 */
+  h.ancount = 0x0506;
+  h.nscount = 0x0708;
+  h.arcount = 0x090A;
+
+  ASSERT_EQ (SocketDNS_header_encode (&h, buf, sizeof (buf)), 0);
+
+  /* Verify byte order (big-endian / network order) */
+  ASSERT (buf[0] == 0x01 && buf[1] == 0x02);
+  ASSERT (buf[4] == 0x03 && buf[5] == 0x04);
+  ASSERT (buf[6] == 0x05 && buf[7] == 0x06);
+  ASSERT (buf[8] == 0x07 && buf[9] == 0x08);
+  ASSERT (buf[10] == 0x09 && buf[11] == 0x0A);
+}
+
+/* Test boundary values */
+TEST (dns_wire_boundary_values)
+{
+  SocketDNS_Header h = { 0 };
+  SocketDNS_Header decoded;
+  unsigned char buf[DNS_HEADER_SIZE];
+
+  /* Test maximum values */
+  h.id = 0xFFFF;
+  h.qr = 1;
+  h.opcode = 0x0F;      /* Max 4-bit value */
+  h.aa = 1;
+  h.tc = 1;
+  h.rd = 1;
+  h.ra = 1;
+  h.z = 0x07;           /* Max 3-bit value (though should be 0) */
+  h.rcode = 0x0F;       /* Max 4-bit value */
+  h.qdcount = 0xFFFF;
+  h.ancount = 0xFFFF;
+  h.nscount = 0xFFFF;
+  h.arcount = 0xFFFF;
+
+  ASSERT_EQ (SocketDNS_header_encode (&h, buf, sizeof (buf)), 0);
+  ASSERT_EQ (SocketDNS_header_decode (buf, sizeof (buf), &decoded), 0);
+
+  ASSERT_EQ (decoded.id, 0xFFFF);
+  ASSERT_EQ (decoded.opcode, 0x0F);
+  ASSERT_EQ (decoded.rcode, 0x0F);
+  ASSERT_EQ (decoded.qdcount, 0xFFFF);
+
+  /* Test zero values */
+  memset (&h, 0, sizeof (h));
+  ASSERT_EQ (SocketDNS_header_encode (&h, buf, sizeof (buf)), 0);
+  ASSERT_EQ (SocketDNS_header_decode (buf, sizeof (buf), &decoded), 0);
+
+  ASSERT_EQ (decoded.id, 0);
+  ASSERT_EQ (decoded.qr, 0);
+  ASSERT_EQ (decoded.opcode, 0);
+  ASSERT_EQ (decoded.rcode, 0);
+  ASSERT_EQ (decoded.qdcount, 0);
+}
+
+/* Test wire format flags byte layout */
+TEST (dns_wire_flags_byte_layout)
+{
+  unsigned char buf[DNS_HEADER_SIZE];
+  SocketDNS_Header h = { 0 };
+
+  /* Test QR bit (bit 15 = 0x80 in first flags byte) */
+  h.qr = 1;
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[2] & 0x80) == 0x80);
+
+  /* Test OPCODE (bits 14-11 = 0x78 in first flags byte) */
+  memset (&h, 0, sizeof (h));
+  h.opcode = 0x0F;      /* All bits set */
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[2] & 0x78) == 0x78);
+
+  /* Test AA bit (bit 10 = 0x04 in first flags byte) */
+  memset (&h, 0, sizeof (h));
+  h.aa = 1;
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[2] & 0x04) == 0x04);
+
+  /* Test TC bit (bit 9 = 0x02 in first flags byte) */
+  memset (&h, 0, sizeof (h));
+  h.tc = 1;
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[2] & 0x02) == 0x02);
+
+  /* Test RD bit (bit 8 = 0x01 in first flags byte) */
+  memset (&h, 0, sizeof (h));
+  h.rd = 1;
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[2] & 0x01) == 0x01);
+
+  /* Test RA bit (bit 7 = 0x80 in second flags byte) */
+  memset (&h, 0, sizeof (h));
+  h.ra = 1;
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[3] & 0x80) == 0x80);
+
+  /* Test RCODE (bits 3-0 = 0x0F in second flags byte) */
+  memset (&h, 0, sizeof (h));
+  h.rcode = 0x0F;
+  SocketDNS_header_encode (&h, buf, sizeof (buf));
+  ASSERT ((buf[3] & 0x0F) == 0x0F);
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Implements DNS message header encoding/decoding as the foundation for the DNS resolver implementation (Phase 1 of the DNS Implementation Plan).

- Add `SocketDNSWire.h` and `SocketDNSWire.c` for DNS wire format handling
- Implement `SocketDNS_header_encode()` to serialize headers to 12-byte wire format
- Implement `SocketDNS_header_decode()` to parse headers from wire format
- Add `SocketDNS_header_init_query()` convenience function for standard queries
- Define OPCODE and RCODE enums per RFC 1035
- Add comprehensive test suite with 16 tests

Wire format follows RFC 1035 Section 4.1.1 exactly:
- ID (16 bits)
- Flags: QR, OPCODE, AA, TC, RD, RA, Z, RCODE (16 bits)
- Section counts: QDCOUNT, ANCOUNT, NSCOUNT, ARCOUNT (4 × 16 bits)

Fixes #128

## Test plan

- [x] 16 unit tests covering round-trip, known packets, boundary values, error handling
- [x] All tests pass with sanitizers enabled (ASan + UBSan)
- [x] Full test suite (75 tests) passes