### PR TITLE
feat(dns): implement CNAME RDATA parsing (RFC 1035 §3.3.1)

### DIFF
--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -649,6 +649,39 @@ extern int SocketDNS_rdata_parse_a (const SocketDNS_RR *rr,
 extern int SocketDNS_rdata_parse_aaaa (const SocketDNS_RR *rr,
                                        struct in6_addr *addr);
 
+/**
+ * @brief Parse CNAME record RDATA (canonical name).
+ * @ingroup dns_rdata
+ *
+ * Extracts the canonical domain name from a CNAME record's RDATA field.
+ * The domain name may use compression pointers, so the full message
+ * context is required for pointer resolution.
+ *
+ * @param[in]  msg      Full DNS message buffer (for compression pointers).
+ * @param[in]  msglen   Total length of the DNS message.
+ * @param[in]  rr       Resource record with TYPE=CNAME.
+ * @param[out] cname    Output buffer for canonical name.
+ * @param[in]  cnamelen Size of output buffer.
+ * @return Length of canonical name on success, -1 on error.
+ *
+ * @code{.c}
+ * SocketDNS_RR rr;
+ * if (SocketDNS_rr_decode(msg, msglen, offset, &rr, NULL) == 0) {
+ *     if (rr.type == DNS_TYPE_CNAME) {
+ *         char cname[DNS_MAX_NAME_LEN];
+ *         int len = SocketDNS_rdata_parse_cname(msg, msglen, &rr,
+ *                                                cname, sizeof(cname));
+ *         if (len >= 0) {
+ *             printf("Canonical name: %s\n", cname);
+ *         }
+ *     }
+ * }
+ * @endcode
+ */
+extern int SocketDNS_rdata_parse_cname (const unsigned char *msg, size_t msglen,
+                                        const SocketDNS_RR *rr, char *cname,
+                                        size_t cnamelen);
+
 /** @} */ /* End of dns_rdata group */
 
 /** @} */ /* End of dns_wire group */


### PR DESCRIPTION
## Summary
- Add `SocketDNS_rdata_parse_cname()` for extracting canonical names from CNAME records
- Handle compression pointers in CNAME RDATA (requires full message context)
- Leverage existing `SocketDNS_name_decode()` for compression handling

## Key Difference from A/AAAA
Unlike A/AAAA which contain raw bytes (4 or 16), CNAME RDATA contains a domain name that may use compression pointers. This requires the full DNS message buffer for pointer resolution.

Fixes #133

## Test Plan
- [x] All 80 DNS wire tests pass (8 new CNAME tests)
- [x] All 75 tests pass with AddressSanitizer and UBSan
- [x] Compression pointer resolution verified
- [x] Integration test validates full decode path

## RFC Reference
RFC 1035 Section 3.3.1:
```
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
/                     CNAME                     /
/                                               /
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
```
CNAME: A `<domain-name>` specifying the canonical/primary name for the owner.