### PR TITLE
feat(dns): implement UDP transport layer per RFC 1035 §4.2.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,6 +262,7 @@ set(LIB_SOURCES
     src/dns/SocketDNS.c
     src/dns/SocketDNS-internal.c
     src/dns/SocketDNSWire.c
+    src/dns/SocketDNSTransport.c
 
     # Poll module (consolidated)
     src/poll/SocketPoll.c
@@ -481,6 +482,7 @@ set(SOCKET_HEADERS
 set(DNS_HEADERS
     include/dns/SocketDNS.h
     include/dns/SocketDNSWire.h
+    include/dns/SocketDNSTransport.h
 )
 
 set(POLL_HEADERS
@@ -606,6 +608,7 @@ set(TEST_SOURCES
     test_pool_health
     test_socketdns
     test_dns_wire
+    test_dns_transport
     test_integration
     test_threadsafety
     test_happy_eyeballs

--- a/include/dns/SocketDNSTransport.h
+++ b/include/dns/SocketDNSTransport.h
@@ -1,0 +1,367 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETDNSTRANSPORT_INCLUDED
+#define SOCKETDNSTRANSPORT_INCLUDED
+
+/**
+ * @file SocketDNSTransport.h
+ * @brief DNS UDP transport layer (RFC 1035 Section 4.2.1).
+ * @ingroup dns
+ *
+ * Provides async UDP transport for DNS queries with automatic retry,
+ * timeout handling, and nameserver rotation. Integrates with SocketPoll
+ * for event-driven operation.
+ *
+ * ## RFC References
+ *
+ * - RFC 1035 Section 4.2.1: UDP usage (port 53, 512 byte limit)
+ * - RFC 1035 Section 4.2.2: TCP usage (for truncated responses)
+ *
+ * ## Features
+ *
+ * - Non-blocking async queries with callbacks
+ * - Automatic retry with exponential backoff
+ * - Nameserver rotation on failure
+ * - Truncation detection (TC bit)
+ * - IPv4 and IPv6 nameserver support
+ *
+ * @see SocketDNSWire.h for message encoding/decoding.
+ * @see SocketDNS.h for the high-level resolver API.
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "dns/SocketDNSWire.h"
+#include "poll/SocketPoll.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup dns_transport DNS Transport Layer
+ * @brief UDP and TCP transport for DNS queries.
+ * @ingroup dns
+ * @{
+ */
+
+/** Maximum UDP message size per RFC 1035 Section 4.2.1 (512 bytes). */
+#define DNS_UDP_MAX_SIZE 512
+
+/** Default DNS port (RFC 1035). */
+#define DNS_PORT 53
+
+/** Default initial retry timeout in milliseconds (RFC 1035 recommends 2-5s). */
+#define DNS_RETRY_INITIAL_MS 2000
+
+/** Maximum retry timeout in milliseconds. */
+#define DNS_RETRY_MAX_MS 5000
+
+/** Default maximum retry attempts. */
+#define DNS_RETRY_MAX_ATTEMPTS 3
+
+/** Maximum configurable nameservers. */
+#define DNS_MAX_NAMESERVERS 8
+
+/** Maximum pending queries (resource limit). */
+#define DNS_MAX_PENDING_QUERIES 1000
+
+/* Error codes for callback */
+#define DNS_ERROR_SUCCESS 0    /**< Query completed successfully */
+#define DNS_ERROR_TIMEOUT -1   /**< All retries exhausted */
+#define DNS_ERROR_TRUNCATED -2 /**< Response TC bit set (use TCP) */
+#define DNS_ERROR_CANCELLED -3 /**< Query cancelled by user */
+#define DNS_ERROR_NETWORK -4   /**< Network/socket error */
+#define DNS_ERROR_INVALID -5   /**< Invalid response (bad ID, etc.) */
+#define DNS_ERROR_FORMERR -6   /**< Server returned FORMERR */
+#define DNS_ERROR_SERVFAIL -7  /**< Server returned SERVFAIL */
+#define DNS_ERROR_NXDOMAIN -8  /**< Domain does not exist */
+#define DNS_ERROR_REFUSED -9   /**< Server refused query */
+#define DNS_ERROR_NONS -10     /**< No nameservers configured */
+
+/**
+ * @brief DNS transport operation failure exception.
+ * @ingroup dns_transport
+ *
+ * Raised for transport initialization failures, invalid parameters,
+ * or resource exhaustion.
+ */
+extern const Except_T SocketDNSTransport_Failed;
+
+#define T SocketDNSTransport_T
+typedef struct T *T;
+
+/**
+ * @brief Opaque handle for a pending DNS query.
+ * @ingroup dns_transport
+ */
+typedef struct SocketDNSQuery *SocketDNSQuery_T;
+
+/**
+ * @brief Query completion callback function type.
+ * @ingroup dns_transport
+ *
+ * Invoked when a DNS query completes (success, error, or timeout).
+ * The callback is invoked during SocketDNSTransport_process().
+ *
+ * @param query    Query handle that completed.
+ * @param response Response buffer (NULL on error/timeout).
+ * @param len      Response length in bytes.
+ * @param error    Error code (0=success, negative=error).
+ * @param userdata User data passed to query function.
+ *
+ * @note Response buffer is only valid during callback; copy if needed.
+ * @note Do not call SocketDNSTransport_free() from within callback.
+ */
+typedef void (*SocketDNSTransport_Callback) (SocketDNSQuery_T query,
+                                             const unsigned char *response,
+                                             size_t len, int error,
+                                             void *userdata);
+
+/**
+ * @brief Nameserver address information.
+ * @ingroup dns_transport
+ */
+typedef struct
+{
+  char address[64]; /**< IPv4 or IPv6 address string */
+  int port;         /**< Port number (default: 53) */
+  int family;       /**< AF_INET or AF_INET6 (0 for auto-detect) */
+} SocketDNS_Nameserver;
+
+/**
+ * @brief Transport configuration options.
+ * @ingroup dns_transport
+ */
+typedef struct
+{
+  int initial_timeout_ms; /**< Initial retry timeout (default: 2000ms) */
+  int max_timeout_ms;     /**< Maximum retry timeout (default: 5000ms) */
+  int max_retries;        /**< Maximum retry attempts (default: 3) */
+  int rotate_nameservers; /**< Rotate through nameservers on retry (default: 1) */
+} SocketDNSTransport_Config;
+
+/**
+ * @brief Create a new DNS UDP transport instance.
+ * @ingroup dns_transport
+ *
+ * Creates transport with UDP sockets for both IPv4 and IPv6.
+ * Sockets are configured non-blocking for async operation.
+ *
+ * @param arena Arena for memory allocation (must outlive transport).
+ * @param poll  Poll instance for timer integration (may be NULL for sync mode).
+ * @return New transport instance.
+ * @throws SocketDNSTransport_Failed on allocation or socket creation failure.
+ *
+ * @code{.c}
+ * Arena_T arena = Arena_new();
+ * SocketPoll_T poll = SocketPoll_new(64);
+ * SocketDNSTransport_T transport = SocketDNSTransport_new(arena, poll);
+ * SocketDNSTransport_add_nameserver(transport, "8.8.8.8", DNS_PORT);
+ * @endcode
+ */
+extern T SocketDNSTransport_new (Arena_T arena, SocketPoll_T poll);
+
+/**
+ * @brief Dispose of a DNS transport instance.
+ * @ingroup dns_transport
+ *
+ * Cancels all pending queries (callbacks invoked with DNS_ERROR_CANCELLED)
+ * and releases resources. The transport pointer is set to NULL.
+ *
+ * @param transport Pointer to transport instance.
+ */
+extern void SocketDNSTransport_free (T *transport);
+
+/**
+ * @brief Add a nameserver to the transport.
+ * @ingroup dns_transport
+ *
+ * @param transport Transport instance.
+ * @param address   IPv4 or IPv6 address string.
+ * @param port      Port number (use DNS_PORT for default).
+ * @return 0 on success, -1 if max nameservers reached or invalid address.
+ *
+ * @code{.c}
+ * SocketDNSTransport_add_nameserver(transport, "8.8.8.8", DNS_PORT);
+ * SocketDNSTransport_add_nameserver(transport, "8.8.4.4", DNS_PORT);
+ * SocketDNSTransport_add_nameserver(transport, "2001:4860:4860::8888", DNS_PORT);
+ * @endcode
+ */
+extern int SocketDNSTransport_add_nameserver (T transport, const char *address,
+                                              int port);
+
+/**
+ * @brief Remove all configured nameservers.
+ * @ingroup dns_transport
+ *
+ * @param transport Transport instance.
+ */
+extern void SocketDNSTransport_clear_nameservers (T transport);
+
+/**
+ * @brief Get configured nameserver count.
+ * @ingroup dns_transport
+ *
+ * @param transport Transport instance.
+ * @return Number of configured nameservers.
+ */
+extern int SocketDNSTransport_nameserver_count (T transport);
+
+/**
+ * @brief Configure transport options.
+ * @ingroup dns_transport
+ *
+ * @param transport Transport instance.
+ * @param config    Configuration options (NULL members use defaults).
+ */
+extern void SocketDNSTransport_configure (T transport,
+                                          const SocketDNSTransport_Config *config);
+
+/**
+ * @brief Send a DNS query asynchronously via UDP.
+ * @ingroup dns_transport
+ *
+ * Sends the query to the current nameserver. On timeout or failure,
+ * automatically retries with exponential backoff per RFC 1035.
+ *
+ * @param transport Transport instance.
+ * @param query     Encoded DNS query message (header + question).
+ * @param len       Query length in bytes (must be <= DNS_UDP_MAX_SIZE).
+ * @param callback  Completion callback (required).
+ * @param userdata  User data passed to callback.
+ * @return Query handle on success, NULL on error.
+ * @throws SocketDNSTransport_Failed on invalid parameters or resource exhaustion.
+ *
+ * @note If response TC (truncation) bit is set, callback receives
+ *       DNS_ERROR_TRUNCATED. Caller should retry via TCP (issue #135).
+ *
+ * @code{.c}
+ * unsigned char query[512];
+ * size_t len;
+ * SocketDNS_Header hdr;
+ * SocketDNS_header_init_query(&hdr, 0x1234, 1);
+ * SocketDNS_header_encode(&hdr, query, sizeof(query));
+ * // ... encode question ...
+ *
+ * SocketDNSQuery_T q = SocketDNSTransport_query_udp(transport, query, len,
+ *                                                   my_callback, my_data);
+ * @endcode
+ */
+extern SocketDNSQuery_T SocketDNSTransport_query_udp (
+    T transport, const unsigned char *query, size_t len,
+    SocketDNSTransport_Callback callback, void *userdata);
+
+/**
+ * @brief Cancel a pending query.
+ * @ingroup dns_transport
+ *
+ * The callback will be invoked with DNS_ERROR_CANCELLED during the
+ * next SocketDNSTransport_process() call.
+ *
+ * @param transport Transport instance.
+ * @param query     Query handle to cancel.
+ * @return 0 on success, -1 if query not found or already completed.
+ */
+extern int SocketDNSTransport_cancel (T transport, SocketDNSQuery_T query);
+
+/**
+ * @brief Process pending queries (receive responses, handle timeouts).
+ * @ingroup dns_transport
+ *
+ * This function must be called regularly to:
+ * - Receive and process DNS responses
+ * - Fire timeout callbacks
+ * - Handle retries
+ *
+ * In async mode with SocketPoll, call this when the UDP socket FDs
+ * are readable or when timers expire.
+ *
+ * @param transport Transport instance.
+ * @param timeout_ms Maximum time to wait for events (0 = non-blocking).
+ * @return Number of queries completed, or -1 on error.
+ *
+ * @code{.c}
+ * // Event loop
+ * while (running) {
+ *     SocketDNSTransport_process(transport, 100);  // 100ms timeout
+ * }
+ * @endcode
+ */
+extern int SocketDNSTransport_process (T transport, int timeout_ms);
+
+/**
+ * @brief Get query ID from query handle.
+ * @ingroup dns_transport
+ *
+ * @param query Query handle.
+ * @return DNS message ID (uint16_t).
+ */
+extern uint16_t SocketDNSQuery_get_id (SocketDNSQuery_T query);
+
+/**
+ * @brief Get current retry count for a query.
+ * @ingroup dns_transport
+ *
+ * @param query Query handle.
+ * @return Number of retries so far (0 = first attempt).
+ */
+extern int SocketDNSQuery_get_retry_count (SocketDNSQuery_T query);
+
+/**
+ * @brief Check if a query is still pending.
+ * @ingroup dns_transport
+ *
+ * @param transport Transport instance.
+ * @param query     Query handle.
+ * @return 1 if pending, 0 if completed or cancelled.
+ */
+extern int SocketDNSTransport_is_pending (T transport, SocketDNSQuery_T query);
+
+/**
+ * @brief Get the IPv4 socket file descriptor.
+ * @ingroup dns_transport
+ *
+ * For external poll integration.
+ *
+ * @param transport Transport instance.
+ * @return File descriptor (>= 0) or -1 if not initialized.
+ */
+extern int SocketDNSTransport_fd_v4 (T transport);
+
+/**
+ * @brief Get the IPv6 socket file descriptor.
+ * @ingroup dns_transport
+ *
+ * For external poll integration.
+ *
+ * @param transport Transport instance.
+ * @return File descriptor (>= 0) or -1 if not initialized.
+ */
+extern int SocketDNSTransport_fd_v6 (T transport);
+
+/**
+ * @brief Get number of pending queries.
+ * @ingroup dns_transport
+ *
+ * @param transport Transport instance.
+ * @return Number of queries awaiting response.
+ */
+extern int SocketDNSTransport_pending_count (T transport);
+
+/**
+ * @brief Convert DNS error code to string.
+ * @ingroup dns_transport
+ *
+ * @param error Error code (DNS_ERROR_*).
+ * @return Human-readable error string.
+ */
+extern const char *SocketDNSTransport_strerror (int error);
+
+/** @} */ /* End of dns_transport group */
+
+#undef T
+
+#endif /* SOCKETDNSTRANSPORT_INCLUDED */

--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -1,0 +1,771 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketDNSTransport.c
+ * @brief DNS UDP transport implementation (RFC 1035 Section 4.2.1).
+ * @ingroup dns_transport
+ *
+ * Implements async UDP transport for DNS queries with retry and timeout
+ * handling. Uses non-blocking sockets with poll() for event processing.
+ */
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <errno.h>
+#include <poll.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "core/Arena.h"
+#include "core/SocketTimer.h"
+#include "dns/SocketDNSTransport.h"
+#include "dns/SocketDNSWire.h"
+#include "socket/SocketDgram.h"
+
+#undef T
+#define T SocketDNSTransport_T
+
+/* Internal query state */
+struct SocketDNSQuery
+{
+  uint16_t id;                           /* DNS message ID */
+  unsigned char query[DNS_UDP_MAX_SIZE]; /* Query copy */
+  size_t query_len;                      /* Query length */
+  int current_ns;                        /* Current nameserver index */
+  int retry_count;                       /* Number of retries */
+  int timeout_ms;                        /* Current timeout (backoff) */
+  int64_t sent_time_ms;                  /* Timestamp when sent */
+  int cancelled;                         /* Cancelled flag */
+  int completed;                         /* Completed flag */
+  SocketDNSTransport_Callback callback;  /* User callback */
+  void *userdata;                        /* User data */
+  struct SocketDNSQuery *next;           /* Linked list next */
+  struct SocketDNSQuery *prev;           /* Linked list prev */
+};
+
+/* Main transport structure */
+struct T
+{
+  Arena_T arena;              /* Memory arena */
+  SocketPoll_T poll;          /* Poll instance (for timers) */
+  SocketDgram_T socket_v4;    /* IPv4 UDP socket */
+  SocketDgram_T socket_v6;    /* IPv6 UDP socket */
+  int fd_v4;                  /* IPv4 socket fd */
+  int fd_v6;                  /* IPv6 socket fd */
+
+  /* Nameserver configuration */
+  SocketDNS_Nameserver nameservers[DNS_MAX_NAMESERVERS];
+  int nameserver_count;
+  int current_ns; /* Current nameserver for rotation */
+
+  /* Configuration */
+  int initial_timeout_ms;
+  int max_timeout_ms;
+  int max_retries;
+  int rotate_nameservers;
+
+  /* Query tracking */
+  struct SocketDNSQuery *pending_head;
+  struct SocketDNSQuery *pending_tail;
+  int pending_count;
+
+  /* Receive buffer */
+  unsigned char recv_buf[DNS_UDP_MAX_SIZE];
+};
+
+const Except_T SocketDNSTransport_Failed
+    = { &SocketDNSTransport_Failed, "DNS transport operation failed" };
+
+/* Get monotonic time in milliseconds */
+static int64_t
+get_monotonic_ms (void)
+{
+  struct timespec ts;
+  clock_gettime (CLOCK_MONOTONIC, &ts);
+  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
+}
+
+/* Detect address family from string */
+static int
+detect_address_family (const char *address)
+{
+  struct in_addr addr4;
+  struct in6_addr addr6;
+
+  if (inet_pton (AF_INET, address, &addr4) == 1)
+    return AF_INET;
+  if (inet_pton (AF_INET6, address, &addr6) == 1)
+    return AF_INET6;
+  return -1;
+}
+
+/* Add query to pending list */
+static void
+add_to_pending (T transport, struct SocketDNSQuery *query)
+{
+  query->next = NULL;
+  query->prev = transport->pending_tail;
+  if (transport->pending_tail)
+    transport->pending_tail->next = query;
+  else
+    transport->pending_head = query;
+  transport->pending_tail = query;
+  transport->pending_count++;
+}
+
+/* Remove query from pending list */
+static void
+remove_from_pending (T transport, struct SocketDNSQuery *query)
+{
+  if (query->prev)
+    query->prev->next = query->next;
+  else
+    transport->pending_head = query->next;
+
+  if (query->next)
+    query->next->prev = query->prev;
+  else
+    transport->pending_tail = query->prev;
+
+  query->next = NULL;
+  query->prev = NULL;
+  transport->pending_count--;
+}
+
+/* Find query by ID */
+static struct SocketDNSQuery *
+find_query_by_id (T transport, uint16_t id)
+{
+  struct SocketDNSQuery *q;
+  for (q = transport->pending_head; q != NULL; q = q->next)
+    {
+      if (q->id == id && !q->cancelled && !q->completed)
+        return q;
+    }
+  return NULL;
+}
+
+/* Map DNS RCODE to error code */
+static int
+rcode_to_error (int rcode)
+{
+  switch (rcode)
+    {
+    case DNS_RCODE_NOERROR:
+      return DNS_ERROR_SUCCESS;
+    case DNS_RCODE_FORMERR:
+      return DNS_ERROR_FORMERR;
+    case DNS_RCODE_SERVFAIL:
+      return DNS_ERROR_SERVFAIL;
+    case DNS_RCODE_NXDOMAIN:
+      return DNS_ERROR_NXDOMAIN;
+    case DNS_RCODE_REFUSED:
+      return DNS_ERROR_REFUSED;
+    default:
+      return DNS_ERROR_INVALID;
+    }
+}
+
+/* Send query to current nameserver */
+static int
+send_query (T transport, struct SocketDNSQuery *query)
+{
+  SocketDNS_Nameserver *ns;
+  volatile SocketDgram_T sock;
+  volatile ssize_t sent;
+
+  if (transport->nameserver_count == 0)
+    return -1;
+
+  ns = &transport->nameservers[query->current_ns];
+
+  /* Select appropriate socket */
+  if (ns->family == AF_INET6)
+    sock = transport->socket_v6;
+  else
+    sock = transport->socket_v4;
+
+  if (!sock)
+    return -1;
+
+  /* Send the query */
+  TRY
+  {
+    sent = SocketDgram_sendto (sock, query->query, query->query_len,
+                               ns->address, ns->port);
+  }
+  EXCEPT (SocketDgram_Failed)
+  {
+    return -1;
+  }
+  END_TRY;
+
+  if (sent <= 0)
+    return -1;
+
+  query->sent_time_ms = get_monotonic_ms ();
+  return 0;
+}
+
+/* Complete a query with result */
+static void
+complete_query (T transport, struct SocketDNSQuery *query,
+                const unsigned char *response, size_t len, int error)
+{
+  query->completed = 1;
+  remove_from_pending (transport, query);
+
+  if (query->callback)
+    query->callback (query, response, len, error, query->userdata);
+}
+
+/* Process a single received response */
+static int
+process_response (T transport, const unsigned char *data, size_t len,
+                  const char *sender_addr, int sender_port)
+{
+  SocketDNS_Header hdr;
+  struct SocketDNSQuery *query;
+  int error;
+
+  (void)sender_addr;
+  (void)sender_port;
+
+  /* Validate minimum size */
+  if (len < DNS_HEADER_SIZE)
+    return 0;
+
+  /* Decode header */
+  if (SocketDNS_header_decode (data, len, &hdr) != 0)
+    return 0;
+
+  /* Must be a response */
+  if (hdr.qr != 1)
+    return 0;
+
+  /* Find matching query */
+  query = find_query_by_id (transport, hdr.id);
+  if (!query)
+    return 0;
+
+  /* Check truncation */
+  if (hdr.tc)
+    {
+      complete_query (transport, query, data, len, DNS_ERROR_TRUNCATED);
+      return 1;
+    }
+
+  /* Map RCODE to error */
+  error = rcode_to_error (hdr.rcode);
+
+  /* Complete the query */
+  complete_query (transport, query, data, len, error);
+  return 1;
+}
+
+/* Receive and process responses from a socket */
+static int
+receive_responses (T transport, SocketDgram_T sock)
+{
+  volatile int processed = 0;
+  volatile ssize_t len;
+  char sender_addr[64];
+  int sender_port;
+
+  if (!sock)
+    return 0;
+
+  /* Try to receive responses (non-blocking) */
+  while (1)
+    {
+      TRY
+      {
+        len = SocketDgram_recvfrom (sock, transport->recv_buf,
+                                    sizeof (transport->recv_buf), sender_addr,
+                                    sizeof (sender_addr), &sender_port);
+      }
+      EXCEPT (SocketDgram_Failed)
+      {
+        break;
+      }
+      END_TRY;
+
+      if (len <= 0)
+        break;
+
+      processed
+          += process_response (transport, transport->recv_buf, (size_t)len,
+                               sender_addr, sender_port);
+    }
+
+  return processed;
+}
+
+/* Check for timed out queries */
+static int
+check_timeouts (T transport)
+{
+  struct SocketDNSQuery *query, *next;
+  int64_t now_ms = get_monotonic_ms ();
+  int processed = 0;
+
+  for (query = transport->pending_head; query != NULL; query = next)
+    {
+      next = query->next;
+
+      if (query->completed || query->cancelled)
+        continue;
+
+      /* Check if timed out */
+      if (now_ms - query->sent_time_ms >= query->timeout_ms)
+        {
+          /* Check if we should retry */
+          if (query->retry_count < transport->max_retries)
+            {
+              query->retry_count++;
+
+              /* Exponential backoff */
+              query->timeout_ms *= 2;
+              if (query->timeout_ms > transport->max_timeout_ms)
+                query->timeout_ms = transport->max_timeout_ms;
+
+              /* Rotate nameserver if enabled */
+              if (transport->rotate_nameservers
+                  && transport->nameserver_count > 1)
+                {
+                  query->current_ns
+                      = (query->current_ns + 1) % transport->nameserver_count;
+                }
+
+              /* Resend */
+              if (send_query (transport, query) != 0)
+                {
+                  complete_query (transport, query, NULL, 0, DNS_ERROR_NETWORK);
+                  processed++;
+                }
+            }
+          else
+            {
+              /* Max retries exhausted */
+              complete_query (transport, query, NULL, 0, DNS_ERROR_TIMEOUT);
+              processed++;
+            }
+        }
+    }
+
+  return processed;
+}
+
+/* Process cancelled queries */
+static int
+process_cancelled (T transport)
+{
+  struct SocketDNSQuery *query, *next;
+  int processed = 0;
+
+  for (query = transport->pending_head; query != NULL; query = next)
+    {
+      next = query->next;
+
+      if (query->cancelled && !query->completed)
+        {
+          complete_query (transport, query, NULL, 0, DNS_ERROR_CANCELLED);
+          processed++;
+        }
+    }
+
+  return processed;
+}
+
+/* Public API implementation */
+
+T
+SocketDNSTransport_new (Arena_T arena, SocketPoll_T poll)
+{
+  T transport;
+
+  assert (arena);
+
+  transport = Arena_alloc (arena, sizeof (*transport), __FILE__, __LINE__);
+  memset (transport, 0, sizeof (*transport));
+
+  transport->arena = arena;
+  transport->poll = poll;
+
+  /* Default configuration */
+  transport->initial_timeout_ms = DNS_RETRY_INITIAL_MS;
+  transport->max_timeout_ms = DNS_RETRY_MAX_MS;
+  transport->max_retries = DNS_RETRY_MAX_ATTEMPTS;
+  transport->rotate_nameservers = 1;
+
+  /* Create IPv4 socket */
+  TRY
+  {
+    transport->socket_v4 = SocketDgram_new (AF_INET, 0);
+    if (transport->socket_v4)
+      {
+        SocketDgram_setnonblocking (transport->socket_v4);
+        transport->fd_v4 = SocketDgram_fd (transport->socket_v4);
+      }
+  }
+  EXCEPT (SocketDgram_Failed)
+  {
+    transport->socket_v4 = NULL;
+    transport->fd_v4 = -1;
+  }
+  END_TRY;
+
+  /* Create IPv6 socket */
+  TRY
+  {
+    transport->socket_v6 = SocketDgram_new (AF_INET6, 0);
+    if (transport->socket_v6)
+      {
+        SocketDgram_setnonblocking (transport->socket_v6);
+        transport->fd_v6 = SocketDgram_fd (transport->socket_v6);
+      }
+  }
+  EXCEPT (SocketDgram_Failed)
+  {
+    transport->socket_v6 = NULL;
+    transport->fd_v6 = -1;
+  }
+  END_TRY;
+
+  /* At least one socket must be available */
+  if (!transport->socket_v4 && !transport->socket_v6)
+    {
+      RAISE (SocketDNSTransport_Failed);
+    }
+
+  return transport;
+}
+
+void
+SocketDNSTransport_free (T *transport)
+{
+  struct SocketDNSQuery *query, *next;
+
+  if (!transport || !*transport)
+    return;
+
+  /* Cancel all pending queries */
+  for (query = (*transport)->pending_head; query != NULL; query = next)
+    {
+      next = query->next;
+      if (!query->completed)
+        {
+          query->cancelled = 1;
+          if (query->callback)
+            query->callback (query, NULL, 0, DNS_ERROR_CANCELLED,
+                             query->userdata);
+        }
+    }
+
+  /* Free sockets */
+  if ((*transport)->socket_v4)
+    SocketDgram_free (&(*transport)->socket_v4);
+  if ((*transport)->socket_v6)
+    SocketDgram_free (&(*transport)->socket_v6);
+
+  /* Arena will clean up the rest */
+  *transport = NULL;
+}
+
+int
+SocketDNSTransport_add_nameserver (T transport, const char *address, int port)
+{
+  SocketDNS_Nameserver *ns;
+  int family;
+
+  assert (transport);
+  assert (address);
+
+  if (transport->nameserver_count >= DNS_MAX_NAMESERVERS)
+    return -1;
+
+  family = detect_address_family (address);
+  if (family < 0)
+    return -1;
+
+  /* Check we have the right socket */
+  if (family == AF_INET6 && !transport->socket_v6)
+    return -1;
+  if (family == AF_INET && !transport->socket_v4)
+    return -1;
+
+  ns = &transport->nameservers[transport->nameserver_count];
+  strncpy (ns->address, address, sizeof (ns->address) - 1);
+  ns->address[sizeof (ns->address) - 1] = '\0';
+  ns->port = port > 0 ? port : DNS_PORT;
+  ns->family = family;
+
+  transport->nameserver_count++;
+  return 0;
+}
+
+void
+SocketDNSTransport_clear_nameservers (T transport)
+{
+  assert (transport);
+  transport->nameserver_count = 0;
+  transport->current_ns = 0;
+}
+
+int
+SocketDNSTransport_nameserver_count (T transport)
+{
+  assert (transport);
+  return transport->nameserver_count;
+}
+
+void
+SocketDNSTransport_configure (T transport,
+                              const SocketDNSTransport_Config *config)
+{
+  assert (transport);
+  assert (config);
+
+  if (config->initial_timeout_ms > 0)
+    transport->initial_timeout_ms = config->initial_timeout_ms;
+  if (config->max_timeout_ms > 0)
+    transport->max_timeout_ms = config->max_timeout_ms;
+  if (config->max_retries >= 0)
+    transport->max_retries = config->max_retries;
+  transport->rotate_nameservers = config->rotate_nameservers;
+}
+
+SocketDNSQuery_T
+SocketDNSTransport_query_udp (T transport, const unsigned char *query_data,
+                              size_t len, SocketDNSTransport_Callback callback,
+                              void *userdata)
+{
+  struct SocketDNSQuery *query;
+  SocketDNS_Header hdr;
+
+  assert (transport);
+  assert (query_data);
+  assert (callback);
+
+  /* Validate size - return NULL for invalid parameters */
+  if (len < DNS_HEADER_SIZE || len > DNS_UDP_MAX_SIZE)
+    return NULL;
+
+  /* Check nameservers - call callback with error */
+  if (transport->nameserver_count == 0)
+    {
+      callback (NULL, NULL, 0, DNS_ERROR_NONS, userdata);
+      return NULL;
+    }
+
+  /* Check pending limit */
+  if (transport->pending_count >= DNS_MAX_PENDING_QUERIES)
+    return NULL;
+
+  /* Decode header to get ID */
+  if (SocketDNS_header_decode (query_data, len, &hdr) != 0)
+    return NULL;
+
+  /* Allocate query struct */
+  query = Arena_alloc (transport->arena, sizeof (*query), __FILE__, __LINE__);
+  memset (query, 0, sizeof (*query));
+
+  query->id = hdr.id;
+  memcpy (query->query, query_data, len);
+  query->query_len = len;
+  query->current_ns = transport->current_ns;
+  query->retry_count = 0;
+  query->timeout_ms = transport->initial_timeout_ms;
+  query->callback = callback;
+  query->userdata = userdata;
+
+  /* Add to pending list */
+  add_to_pending (transport, query);
+
+  /* Send query */
+  if (send_query (transport, query) != 0)
+    {
+      remove_from_pending (transport, query);
+      RAISE (SocketDNSTransport_Failed);
+    }
+
+  /* Rotate current nameserver for next query */
+  if (transport->rotate_nameservers && transport->nameserver_count > 1)
+    {
+      transport->current_ns
+          = (transport->current_ns + 1) % transport->nameserver_count;
+    }
+
+  return query;
+}
+
+int
+SocketDNSTransport_cancel (T transport, SocketDNSQuery_T query)
+{
+  struct SocketDNSQuery *q;
+
+  assert (transport);
+
+  if (!query)
+    return -1;
+
+  /* Verify query is in our pending list */
+  for (q = transport->pending_head; q != NULL; q = q->next)
+    {
+      if (q == query && !q->completed)
+        {
+          q->cancelled = 1;
+          return 0;
+        }
+    }
+
+  return -1;
+}
+
+int
+SocketDNSTransport_process (T transport, int timeout_ms)
+{
+  struct pollfd fds[2];
+  int nfds = 0;
+  int ret;
+  int processed = 0;
+
+  assert (transport);
+
+  /* Set up poll fds */
+  if (transport->fd_v4 >= 0)
+    {
+      fds[nfds].fd = transport->fd_v4;
+      fds[nfds].events = POLLIN;
+      fds[nfds].revents = 0;
+      nfds++;
+    }
+  if (transport->fd_v6 >= 0)
+    {
+      fds[nfds].fd = transport->fd_v6;
+      fds[nfds].events = POLLIN;
+      fds[nfds].revents = 0;
+      nfds++;
+    }
+
+  /* Process cancelled queries first */
+  processed += process_cancelled (transport);
+
+  if (nfds == 0)
+    {
+      /* No sockets, just check timeouts */
+      processed += check_timeouts (transport);
+      return processed;
+    }
+
+  /* Poll for readable sockets */
+  ret = poll (fds, (nfds_t)nfds, timeout_ms);
+
+  if (ret > 0)
+    {
+      /* Check which sockets are readable */
+      for (int i = 0; i < nfds; i++)
+        {
+          if (fds[i].revents & POLLIN)
+            {
+              if (fds[i].fd == transport->fd_v4)
+                processed += receive_responses (transport, transport->socket_v4);
+              else if (fds[i].fd == transport->fd_v6)
+                processed += receive_responses (transport, transport->socket_v6);
+            }
+        }
+    }
+
+  /* Check for timeouts */
+  processed += check_timeouts (transport);
+
+  return processed;
+}
+
+uint16_t
+SocketDNSQuery_get_id (SocketDNSQuery_T query)
+{
+  assert (query);
+  return query->id;
+}
+
+int
+SocketDNSQuery_get_retry_count (SocketDNSQuery_T query)
+{
+  assert (query);
+  return query->retry_count;
+}
+
+int
+SocketDNSTransport_is_pending (T transport, SocketDNSQuery_T query)
+{
+  struct SocketDNSQuery *q;
+
+  assert (transport);
+  assert (query);
+
+  for (q = transport->pending_head; q != NULL; q = q->next)
+    {
+      if (q == query && !q->completed && !q->cancelled)
+        return 1;
+    }
+  return 0;
+}
+
+int
+SocketDNSTransport_fd_v4 (T transport)
+{
+  assert (transport);
+  return transport->fd_v4;
+}
+
+int
+SocketDNSTransport_fd_v6 (T transport)
+{
+  assert (transport);
+  return transport->fd_v6;
+}
+
+int
+SocketDNSTransport_pending_count (T transport)
+{
+  assert (transport);
+  return transport->pending_count;
+}
+
+const char *
+SocketDNSTransport_strerror (int error)
+{
+  switch (error)
+    {
+    case DNS_ERROR_SUCCESS:
+      return "Success";
+    case DNS_ERROR_TIMEOUT:
+      return "Query timed out";
+    case DNS_ERROR_TRUNCATED:
+      return "Response truncated (TC bit set)";
+    case DNS_ERROR_CANCELLED:
+      return "Query cancelled";
+    case DNS_ERROR_NETWORK:
+      return "Network error";
+    case DNS_ERROR_INVALID:
+      return "Invalid response";
+    case DNS_ERROR_FORMERR:
+      return "Server format error";
+    case DNS_ERROR_SERVFAIL:
+      return "Server failure";
+    case DNS_ERROR_NXDOMAIN:
+      return "Domain does not exist";
+    case DNS_ERROR_REFUSED:
+      return "Query refused";
+    case DNS_ERROR_NONS:
+      return "No nameservers configured";
+    default:
+      return "Unknown error";
+    }
+}

--- a/src/test/test_dns_transport.c
+++ b/src/test/test_dns_transport.c
@@ -1,0 +1,446 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/*
+ * test_dns_transport.c - Unit tests for DNS UDP transport (RFC 1035 §4.2.1)
+ *
+ * Tests the DNS transport layer functionality including:
+ * - Transport instance lifecycle
+ * - Nameserver configuration
+ * - Query submission and validation
+ * - Error code handling
+ */
+
+#include "core/Arena.h"
+#include "dns/SocketDNSTransport.h"
+#include "dns/SocketDNSWire.h"
+#include "test/Test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* Test basic transport instantiation */
+TEST (dns_transport_new_creates_instance)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+
+  ASSERT_NOT_NULL (transport);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 0);
+  ASSERT_EQ (SocketDNSTransport_pending_count (transport), 0);
+
+  SocketDNSTransport_free (&transport);
+  ASSERT_NULL (transport);
+  Arena_dispose (&arena);
+}
+
+/* Test adding IPv4 nameserver */
+TEST (dns_transport_add_nameserver_ipv4)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int ret;
+
+  ret = SocketDNSTransport_add_nameserver (transport, "8.8.8.8", DNS_PORT);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 1);
+
+  ret = SocketDNSTransport_add_nameserver (transport, "8.8.4.4", DNS_PORT);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 2);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test adding IPv6 nameserver */
+TEST (dns_transport_add_nameserver_ipv6)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int ret;
+
+  ret = SocketDNSTransport_add_nameserver (transport, "2001:4860:4860::8888",
+                                           DNS_PORT);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 1);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test maximum nameserver limit */
+TEST (dns_transport_max_nameservers)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int ret;
+  int i;
+  char addr[32];
+
+  /* Add maximum allowed nameservers */
+  for (i = 0; i < DNS_MAX_NAMESERVERS; i++)
+    {
+      snprintf (addr, sizeof (addr), "10.0.0.%d", i + 1);
+      ret = SocketDNSTransport_add_nameserver (transport, addr, DNS_PORT);
+      ASSERT_EQ (ret, 0);
+    }
+
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport),
+             DNS_MAX_NAMESERVERS);
+
+  /* Try to add one more - should fail */
+  ret = SocketDNSTransport_add_nameserver (transport, "10.0.0.100", DNS_PORT);
+  ASSERT_EQ (ret, -1);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport),
+             DNS_MAX_NAMESERVERS);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test clearing nameservers */
+TEST (dns_transport_clear_nameservers)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+
+  SocketDNSTransport_add_nameserver (transport, "8.8.8.8", DNS_PORT);
+  SocketDNSTransport_add_nameserver (transport, "8.8.4.4", DNS_PORT);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 2);
+
+  SocketDNSTransport_clear_nameservers (transport);
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 0);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test invalid address rejection */
+TEST (dns_transport_add_nameserver_invalid)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int ret;
+
+  /* Invalid IPv4 */
+  ret = SocketDNSTransport_add_nameserver (transport, "999.999.999.999",
+                                           DNS_PORT);
+  ASSERT_EQ (ret, -1);
+
+  /* Not an address */
+  ret = SocketDNSTransport_add_nameserver (transport, "not-an-address",
+                                           DNS_PORT);
+  ASSERT_EQ (ret, -1);
+
+  /* Empty string */
+  ret = SocketDNSTransport_add_nameserver (transport, "", DNS_PORT);
+  ASSERT_EQ (ret, -1);
+
+  ASSERT_EQ (SocketDNSTransport_nameserver_count (transport), 0);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test configuration */
+TEST (dns_transport_configure)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  SocketDNSTransport_Config config;
+
+  config.initial_timeout_ms = 3000;
+  config.max_timeout_ms = 10000;
+  config.max_retries = 5;
+  config.rotate_nameservers = 0;
+
+  SocketDNSTransport_configure (transport, &config);
+
+  /* Configuration is internal, but we can verify via query behavior later */
+  ASSERT_NOT_NULL (transport);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Callback flag for tests */
+static volatile int callback_invoked = 0;
+static volatile int callback_error = 0;
+
+static void
+test_callback (SocketDNSQuery_T query, const unsigned char *response,
+               size_t len, int error, void *userdata)
+{
+  (void)query;
+  (void)response;
+  (void)len;
+  (void)userdata;
+  callback_invoked = 1;
+  callback_error = error;
+}
+
+/* Test query returns handle with nameserver configured */
+TEST (dns_transport_query_returns_handle)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  SocketDNSQuery_T query;
+  unsigned char query_buf[DNS_UDP_MAX_SIZE];
+  SocketDNS_Header hdr;
+  size_t len = DNS_HEADER_SIZE;
+
+  /* Add a nameserver first */
+  SocketDNSTransport_add_nameserver (transport, "127.0.0.1", DNS_PORT);
+
+  /* Build a minimal query */
+  memset (&hdr, 0, sizeof (hdr));
+  hdr.id = 0x1234;
+  hdr.rd = 1;
+  hdr.qdcount = 1;
+  SocketDNS_header_encode (&hdr, query_buf, sizeof (query_buf));
+
+  query = SocketDNSTransport_query_udp (transport, query_buf, len,
+                                        test_callback, NULL);
+  ASSERT_NOT_NULL (query);
+  ASSERT_EQ (SocketDNSQuery_get_id (query), 0x1234);
+  ASSERT_EQ (SocketDNSQuery_get_retry_count (query), 0);
+  ASSERT_EQ (SocketDNSTransport_pending_count (transport), 1);
+  ASSERT (SocketDNSTransport_is_pending (transport, query));
+
+  /* Cancel to clean up */
+  SocketDNSTransport_cancel (transport, query);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test query without nameserver returns NULL and calls callback with error */
+TEST (dns_transport_query_no_nameserver)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  SocketDNSQuery_T query;
+  unsigned char query_buf[DNS_HEADER_SIZE];
+  SocketDNS_Header hdr;
+
+  callback_invoked = 0;
+  callback_error = 0;
+
+  /* No nameserver configured */
+  memset (&hdr, 0, sizeof (hdr));
+  hdr.id = 0x5678;
+  hdr.rd = 1;
+  SocketDNS_header_encode (&hdr, query_buf, sizeof (query_buf));
+
+  query = SocketDNSTransport_query_udp (transport, query_buf, DNS_HEADER_SIZE,
+                                        test_callback, NULL);
+  ASSERT_NULL (query);
+  ASSERT_EQ (callback_invoked, 1);
+  ASSERT_EQ (callback_error, DNS_ERROR_NONS);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test cancel removes pending query */
+TEST (dns_transport_cancel_removes_query)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  SocketDNSQuery_T query;
+  unsigned char query_buf[DNS_UDP_MAX_SIZE];
+  SocketDNS_Header hdr;
+  int ret;
+
+  SocketDNSTransport_add_nameserver (transport, "127.0.0.1", DNS_PORT);
+
+  memset (&hdr, 0, sizeof (hdr));
+  hdr.id = 0xABCD;
+  hdr.rd = 1;
+  SocketDNS_header_encode (&hdr, query_buf, sizeof (query_buf));
+
+  query = SocketDNSTransport_query_udp (transport, query_buf, DNS_HEADER_SIZE,
+                                        test_callback, NULL);
+  ASSERT_NOT_NULL (query);
+  ASSERT_EQ (SocketDNSTransport_pending_count (transport), 1);
+
+  ret = SocketDNSTransport_cancel (transport, query);
+  ASSERT_EQ (ret, 0);
+
+  /* Cancelled query is no longer considered pending */
+  ASSERT (!SocketDNSTransport_is_pending (transport, query));
+
+  /* Process to invoke cancelled callback */
+  callback_invoked = 0;
+  SocketDNSTransport_process (transport, 0);
+  ASSERT_EQ (callback_invoked, 1);
+  ASSERT_EQ (callback_error, DNS_ERROR_CANCELLED);
+  ASSERT_EQ (SocketDNSTransport_pending_count (transport), 0);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test cancelling non-existent query */
+TEST (dns_transport_cancel_nonexistent)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int ret;
+
+  ret = SocketDNSTransport_cancel (transport, NULL);
+  ASSERT_EQ (ret, -1);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test socket file descriptors */
+TEST (dns_transport_file_descriptors)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int fd_v4, fd_v6;
+
+  fd_v4 = SocketDNSTransport_fd_v4 (transport);
+  fd_v6 = SocketDNSTransport_fd_v6 (transport);
+
+  /* At least one should be valid (depends on system IPv6 support) */
+  ASSERT (fd_v4 >= 0 || fd_v6 >= 0);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test error string conversion */
+TEST (dns_transport_strerror)
+{
+  const char *str;
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_SUCCESS);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_TIMEOUT);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_TRUNCATED);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_CANCELLED);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_NETWORK);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_INVALID);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_NXDOMAIN);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  str = SocketDNSTransport_strerror (DNS_ERROR_NONS);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strlen (str) > 0);
+
+  /* Unknown error */
+  str = SocketDNSTransport_strerror (-999);
+  ASSERT_NOT_NULL (str);
+}
+
+/* Test query size validation (must be <= 512 bytes per RFC 1035) */
+TEST (dns_transport_query_size_validation)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  SocketDNSQuery_T query;
+  unsigned char query_buf[DNS_UDP_MAX_SIZE + 1];
+
+  SocketDNSTransport_add_nameserver (transport, "127.0.0.1", DNS_PORT);
+
+  /* Query too large */
+  memset (query_buf, 0, sizeof (query_buf));
+  query = SocketDNSTransport_query_udp (transport, query_buf, sizeof (query_buf),
+                                        test_callback, NULL);
+  ASSERT_NULL (query);
+
+  /* Query at exact limit should be accepted */
+  query = SocketDNSTransport_query_udp (transport, query_buf, DNS_UDP_MAX_SIZE,
+                                        test_callback, NULL);
+  ASSERT_NOT_NULL (query);
+
+  SocketDNSTransport_cancel (transport, query);
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test process with no pending queries */
+TEST (dns_transport_process_empty)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  int ret;
+
+  SocketDNSTransport_add_nameserver (transport, "127.0.0.1", DNS_PORT);
+
+  /* Should return 0 (no queries processed) */
+  ret = SocketDNSTransport_process (transport, 0);
+  ASSERT_EQ (ret, 0);
+
+  SocketDNSTransport_free (&transport);
+  Arena_dispose (&arena);
+}
+
+/* Test free cancels all pending queries */
+TEST (dns_transport_free_cancels_queries)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSTransport_T transport = SocketDNSTransport_new (arena, NULL);
+  unsigned char query_buf[DNS_HEADER_SIZE];
+  SocketDNS_Header hdr;
+
+  SocketDNSTransport_add_nameserver (transport, "127.0.0.1", DNS_PORT);
+
+  memset (&hdr, 0, sizeof (hdr));
+  hdr.id = 0x1111;
+  hdr.rd = 1;
+  SocketDNS_header_encode (&hdr, query_buf, sizeof (query_buf));
+
+  callback_invoked = 0;
+  SocketDNSTransport_query_udp (transport, query_buf, DNS_HEADER_SIZE,
+                                test_callback, NULL);
+
+  hdr.id = 0x2222;
+  SocketDNS_header_encode (&hdr, query_buf, sizeof (query_buf));
+  SocketDNSTransport_query_udp (transport, query_buf, DNS_HEADER_SIZE,
+                                test_callback, NULL);
+
+  ASSERT_EQ (SocketDNSTransport_pending_count (transport), 2);
+
+  /* Free should cancel all pending queries */
+  SocketDNSTransport_free (&transport);
+  ASSERT_NULL (transport);
+
+  /* Callbacks should have been invoked with CANCELLED */
+  ASSERT_EQ (callback_invoked, 1);
+  ASSERT_EQ (callback_error, DNS_ERROR_CANCELLED);
+
+  Arena_dispose (&arena);
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Implement async DNS UDP transport layer per RFC 1035 Section 4.2.1:

- Non-blocking UDP sockets for both IPv4 and IPv6 nameservers
- Automatic retry with exponential backoff (2-5 seconds per RFC 1035)
- Nameserver rotation on failure for resilience
- Truncation detection (TC bit) signaling for TCP fallback (issue #135)
- Query cancellation support
- Resource limits (max 1000 pending queries, 8 nameservers)

### New API

| Function | Description |
|----------|-------------|
| `SocketDNSTransport_new` | Create transport instance |
| `SocketDNSTransport_free` | Dispose transport |
| `SocketDNSTransport_add_nameserver` | Add IPv4/IPv6 nameserver |
| `SocketDNSTransport_query_udp` | Submit async DNS query |
| `SocketDNSTransport_process` | Process responses/timeouts |
| `SocketDNSTransport_cancel` | Cancel pending query |

### Files Changed

- `include/dns/SocketDNSTransport.h` - Public API header
- `src/dns/SocketDNSTransport.c` - Implementation
- `src/test/test_dns_transport.c` - 16 unit tests
- `CMakeLists.txt` - Build integration

Fixes #134

## Test plan

- [x] All 16 new unit tests pass
- [x] Full test suite passes (76 tests)
- [x] Tested with AddressSanitizer + UBSan
- [x] No memory leaks detected