### PR TITLE
feat(dns): implement EDNS0 OPT record encoding/decoding (RFC 6891)

### DIFF
--- a/include/dns/SocketDNSTransport.h
+++ b/include/dns/SocketDNSTransport.h
@@ -9,7 +9,7 @@
 
 /**
  * @file SocketDNSTransport.h
- * @brief DNS UDP and TCP transport layer (RFC 1035 Section 4.2).
+ * @brief DNS UDP and TCP transport layer (RFC 1035 Section 4.2, RFC 6891).
  * @ingroup dns
  *
  * Provides async UDP and TCP transport for DNS queries with automatic retry,
@@ -20,6 +20,7 @@
  *
  * - RFC 1035 Section 4.2.1: UDP usage (port 53, 512 byte limit)
  * - RFC 1035 Section 4.2.2: TCP usage (2-byte length prefix, for truncated responses)
+ * - RFC 6891: EDNS0 (larger UDP payload, up to 4096 bytes)
  *
  * ## Features
  *
@@ -30,6 +31,7 @@
  * - TCP transport with 2-byte length prefix per RFC 1035
  * - TCP connection reuse for multiple queries
  * - IPv4 and IPv6 nameserver support
+ * - EDNS0 support for larger UDP responses (up to 4096 bytes)
  *
  * @see SocketDNSWire.h for message encoding/decoding.
  * @see SocketDNS.h for the high-level resolver API.

--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -17,6 +17,11 @@
  * - Used when UDP response truncated (TC bit)
  * - Non-blocking connect and I/O
  * - Connection reuse for multiple queries
+ *
+ * EDNS0 support (RFC 6891):
+ * - UDP receive buffer supports up to 4096 bytes
+ * - Queries with OPT record can request larger payload sizes
+ * - FORMERR fallback for non-EDNS0 servers handled at higher layer
  */
 
 #include <arpa/inet.h>
@@ -111,8 +116,8 @@ struct T
   struct SocketDNSQuery *pending_tail;
   int pending_count;
 
-  /* Receive buffer (for UDP) */
-  unsigned char recv_buf[DNS_UDP_MAX_SIZE];
+  /* Receive buffer (for UDP, sized for EDNS0 per RFC 6891) */
+  unsigned char recv_buf[DNS_EDNS0_DEFAULT_UDPSIZE];
 };
 
 const Except_T SocketDNSTransport_Failed


### PR DESCRIPTION
## Summary

Implements core EDNS0 (RFC 6891) support for DNS messages larger than 512 bytes:

- Add `SocketDNS_OPT` structure for OPT pseudo-RR fields
- Implement `SocketDNS_opt_init()` with 4096-byte default payload
- Implement `SocketDNS_opt_encode()` for wire format encoding  
- Implement `SocketDNS_opt_decode()` for parsing OPT records
- Add `SocketDNS_opt_extended_rcode()` for 12-bit RCODE calculation
- Increase UDP receive buffer from 512 to 4096 bytes

### RFC 6891 Wire Format

```
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
|           NAME = 0x00 (root)           |  1 byte
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
|           TYPE = 41 (OPT)              |  2 bytes
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
|           CLASS = UDP payload size     |  2 bytes
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
|  EXT-RCODE | VERSION |       Z         |  4 bytes
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
|              RDLENGTH                  |  2 bytes
+--+--+--+--+--+--+--+--+--+--+--+--+--+--+
```

### Related Issues

- #166: EDNS option parsing framework
- #167: Version negotiation and BADVERS
- #168: UDP payload size fallback
- #169: OPT record validation

Fixes #143

## Test plan

- [x] 12 unit tests added covering:
  - Default initialization and minimum size enforcement
  - Wire format encoding with/without DO bit
  - Decoding with validation (name, type, truncation)
  - Roundtrip encode/decode
  - Extended RCODE calculation
- [x] All tests pass with ASan + UBSan
- [x] No memory leaks detected