### PR TITLE
feat(dns): integrate async resolver with HappyEyeballs and Proxy

### DIFF
--- a/include/socket/SocketHappyEyeballs.h
+++ b/include/socket/SocketHappyEyeballs.h
@@ -71,7 +71,7 @@
  */
 
 #include "core/Except.h"
-#include "dns/SocketDNS.h"
+#include "dns/SocketDNSResolver.h"
 #include "poll/SocketPoll.h"
 #include "socket/Socket.h"
 
@@ -291,7 +291,7 @@ extern Socket_T SocketHappyEyeballs_connect (const char *host, int port,
 /**
  * @brief Start asynchronous Happy Eyeballs connection.
  * @ingroup async_io
- * @param[in] dns DNS resolver instance (caller-owned, must outlive operation).
+ * @param[in] resolver Async DNS resolver instance (caller-owned, must outlive operation).
  * @param[in] poll Poll instance for connection monitoring (caller-owned).
  * @param[in] host Hostname or IP address to connect to.
  * @param[in] port Port number (1-65535).
@@ -346,10 +346,10 @@ extern Socket_T SocketHappyEyeballs_connect (const char *host, int port,
  *
  * @see SocketHappyEyeballs_connect() for synchronous version.
  * @see SocketHappyEyeballs_config_defaults() for config setup.
- * @see @ref SocketDNS_T "SocketDNS" for DNS integration.
+ * @see @ref SocketDNSResolver_T "SocketDNSResolver" for DNS integration.
  * @see @ref SocketPoll_T "SocketPoll" for event loop integration.
  */
-extern T SocketHappyEyeballs_start (SocketDNS_T dns, SocketPoll_T poll,
+extern T SocketHappyEyeballs_start (SocketDNSResolver_T resolver, SocketPoll_T poll,
                                     const char *host, int port,
                                     const SocketHE_Config_T *config);
 

--- a/include/socket/SocketProxy-private.h
+++ b/include/socket/SocketProxy-private.h
@@ -76,7 +76,7 @@
 
 #include "core/Arena.h"
 #include "core/SocketUtil.h"
-#include "dns/SocketDNS.h"
+#include "dns/SocketDNSResolver.h"
 #include "http/SocketHTTP1.h"
 #include "poll/SocketPoll.h"
 #include "socket/Socket.h"
@@ -638,10 +638,10 @@ struct SocketProxy_Conn_T
   SocketBuf_T recvbuf; /**< Receive buffer for protocol parsing */
 
   /* Async connection resources */
-  SocketDNS_T dns;   /**< DNS resolver for async connection */
-  SocketPoll_T poll; /**< Poll instance for async connection */
-  SocketHE_T he;     /**< HappyEyeballs context (during connect) */
-  int owns_dns_poll; /**< 1 if we own dns/poll (sync wrapper), 0 if external */
+  SocketDNSResolver_T resolver; /**< DNS resolver for async connection */
+  SocketPoll_T poll;            /**< Poll instance for async connection */
+  SocketHE_T he;                /**< HappyEyeballs context (during connect) */
+  int owns_resolver_poll; /**< 1 if we own resolver/poll (sync wrapper), 0 if external */
 
   /* HTTP CONNECT specific */
   SocketHTTP1_Parser_T http_parser; /**< HTTP response parser */

--- a/include/socket/SocketProxy.h
+++ b/include/socket/SocketProxy.h
@@ -85,7 +85,7 @@
 
 #include "core/Arena.h"
 #include "core/Except.h"
-#include "dns/SocketDNS.h"
+#include "dns/SocketDNSResolver.h"
 #include "poll/SocketPoll.h"
 #include "socket/Socket.h"
 
@@ -619,7 +619,7 @@ SocketProxy_tunnel (Socket_T socket, const SocketProxy_Config *proxy,
  * @see docs/ASYNC_IO.md for full event loop patterns.
  * @see docs/PROXY.md#async-api for advanced async features.
  */
-extern T SocketProxy_Conn_start (SocketDNS_T dns, SocketPoll_T poll,
+extern T SocketProxy_Conn_start (SocketDNSResolver_T resolver, SocketPoll_T poll,
                                  const SocketProxy_Config *proxy,
                                  const char *target_host, int target_port);
 


### PR DESCRIPTION
## Summary

This PR integrates the new event-loop driven `SocketDNSResolver_T` with the `SocketHappyEyeballs` and `SocketProxy` modules, replacing the old thread-pool based `SocketDNS_T`.

### Key Changes

- **SocketHappyEyeballs**: Updated to use `SocketDNSResolver_T` with callback-based async DNS
  - Added `resolver_arena` field for proper memory cleanup in sync wrapper
  - Created `he_convert_resolver_result()` to convert results to `addrinfo*` for compatibility
  - Handle cancellation callbacks properly to avoid use-after-free
  
- **SocketDNSResolver**: Added localhost fast path for `/etc/hosts`-like resolution
  - Returns 127.0.0.1/::1 for "localhost" without network queries
  
- **SocketProxy**: Updated to use new resolver type

Fixes #139

## Test plan

- [x] All 79 tests pass with ASan/UBSan enabled
- [x] Happy Eyeballs tests cover sync/async connections
- [x] DNS resolver tests verify localhost handling
- [x] No memory leaks detected