### PR TITLE
perf(http): zero-copy header parsing in HTTP/1.1

### DIFF
--- a/include/http/SocketHTTP-private.h
+++ b/include/http/SocketHTTP-private.h
@@ -34,6 +34,7 @@ typedef struct HeaderEntry
   struct HeaderEntry *hash_next;
   struct HeaderEntry *list_next;
   struct HeaderEntry *list_prev;
+  int is_ref; /* 1 = zero-copy reference, 0 = owned copy */
 } HeaderEntry;
 
 struct SocketHTTP_Headers

--- a/include/http/SocketHTTP.h
+++ b/include/http/SocketHTTP.h
@@ -461,6 +461,27 @@ extern int SocketHTTP_Headers_add_n (SocketHTTP_Headers_T headers,
                                      const char *value, size_t value_len);
 
 /**
+ * @brief Add header as zero-copy reference (no string allocation).
+ * @return 0 on success, -1 on error
+ *
+ * Stores pointers directly without copying. The name and value buffers
+ * must remain valid until headers are freed or materialize() is called.
+ * Used internally by parser for performance.
+ */
+extern int SocketHTTP_Headers_add_ref (SocketHTTP_Headers_T headers,
+                                       const char *name, size_t name_len,
+                                       const char *value, size_t value_len);
+
+/**
+ * @brief Materialize all reference headers by copying strings to arena.
+ * @return 0 on success, -1 on error
+ *
+ * Converts zero-copy reference headers to owned copies. Call this before
+ * the source buffers are reused or freed.
+ */
+extern int SocketHTTP_Headers_materialize (SocketHTTP_Headers_T headers);
+
+/**
  * @brief Set header (replace if exists).
  * @return 0 on success, -1 on error
  *


### PR DESCRIPTION
## Summary
- Reduce per-header allocation overhead by storing pointers directly into parser token buffers
- Previously: 3 arena allocations per header (entry struct + name copy + value copy)
- Now: 1 allocation per header (entry struct only)

## Changes
- Add `is_ref` field to `HeaderEntry` to track zero-copy references
- Add `SocketHTTP_Headers_add_ref()` for zero-copy header storage
- Add `SocketHTTP_Headers_materialize()` to copy refs when needed
- Add `http1_tokenbuf_release()` to release buffer ownership
- Update HTTP/1.1 parser to use zero-copy with `tokenbuf_release()`

Fixes #187

## Test plan
- [x] All 79 tests pass with AddressSanitizer + UBSan enabled
- [x] No memory leaks detected
- [x] Benchmark runs successfully (~31-35k req/sec)