### PR TITLE
feat(dns): implement response validation and security hardening

### DIFF
--- a/include/dns/SocketDNSResolver.h
+++ b/include/dns/SocketDNSResolver.h
@@ -124,6 +124,23 @@
 /** Memory allocation failed. */
 #define RESOLVER_ERROR_NOMEM -10
 
+/** Response QNAME does not match query (RFC 5452). */
+#define RESOLVER_ERROR_VALIDATION_QNAME -11
+
+/** Response QTYPE does not match query (RFC 5452). */
+#define RESOLVER_ERROR_VALIDATION_QTYPE -12
+
+/** Response QCLASS does not match query (RFC 5452). */
+#define RESOLVER_ERROR_VALIDATION_QCLASS -13
+
+/** Answer record outside queried zone (RFC 5452 bailiwick check). */
+#define RESOLVER_ERROR_VALIDATION_BAILIWICK -14
+
+/* TTL limits per RFC 8767 */
+
+/** Maximum TTL in seconds (7 days per RFC 8767). */
+#define DNS_TTL_MAX 604800
+
 /* Configuration defaults */
 
 /** Default query timeout in milliseconds. */

--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -919,6 +919,38 @@ extern uint16_t SocketDNS_opt_extended_rcode (const SocketDNS_Header *hdr,
 
 /** @} */ /* End of dns_edns0 group */
 
+/**
+ * @defgroup dns_security DNS Security Utilities
+ * @brief Security-related validation functions (RFC 5452).
+ * @ingroup dns
+ * @{
+ */
+
+/**
+ * @brief Check if a name is within the bailiwick of a zone (RFC 5452).
+ * @ingroup dns_security
+ *
+ * A name is in-bailiwick if it equals the zone or is a subdomain of it.
+ * For example, "www.example.com" is in-bailiwick of "example.com".
+ * This prevents cache poisoning via out-of-zone answer injection.
+ *
+ * @param record_name Name from the answer record.
+ * @param query_name  Original query name (defines the bailiwick).
+ * @return 1 if in-bailiwick, 0 if out-of-bailiwick.
+ *
+ * @code{.c}
+ * // Accept: subdomain of queried name
+ * assert(SocketDNS_name_in_bailiwick("www.example.com", "example.com") == 1);
+ *
+ * // Reject: unrelated domain
+ * assert(SocketDNS_name_in_bailiwick("attacker.com", "example.com") == 0);
+ * @endcode
+ */
+extern int SocketDNS_name_in_bailiwick (const char *record_name,
+                                        const char *query_name);
+
+/** @} */ /* End of dns_security group */
+
 /** @} */ /* End of dns_wire group */
 
 #endif /* SOCKETDNSWIRE_INCLUDED */


### PR DESCRIPTION
## Summary

Implement DNS response validation per RFC 1035, RFC 5452, and RFC 8767 to prevent cache poisoning attacks.

### Security Improvements
- **Cryptographic ID generation**: Replace weak sequential ID (monotonic clock) with `getrandom()` for full 16-bit entropy
- **QNAME/QTYPE/QCLASS validation**: Verify response question section matches query (RFC 5452 §3)
- **Bailiwick checking**: Reject out-of-zone records that could poison cache (RFC 5452 §5)
- **TTL capping**: Cap TTL at 7 days (604800s) per RFC 8767 §5

### Changes
- `include/dns/SocketDNSResolver.h`: Add validation error codes and `DNS_TTL_MAX` constant
- `src/dns/SocketDNSResolver.c`: Crypto ID generation, response validation, TTL capping
- `include/dns/SocketDNSWire.h`: Declare `SocketDNS_name_in_bailiwick()`
- `src/dns/SocketDNSWire.c`: Implement bailiwick checking
- `src/test/test_dns_resolver.c`: Add validation tests

Fixes #144

## Test plan
- [x] All 79 tests pass with ASan/UBSan enabled
- [x] Bailiwick validation accepts valid subdomains
- [x] Bailiwick validation rejects out-of-zone names
- [x] TTL capping constant defined correctly
- [x] New error strings available via strerror()

## RFC Compliance

| Requirement | RFC | Implementation |
|-------------|-----|----------------|
| Random query IDs | 5452 §4 | `getrandom()` with full 16-bit entropy |
| Source port randomization | 5452 §4 | Already done (bind to port 0) |
| QNAME verification | 5452 §3 | `validate_response_question()` |
| QTYPE verification | 5452 §3 | `validate_response_question()` |
| Bailiwick checking | 5452 §5 | `SocketDNS_name_in_bailiwick()` |
| TTL capping | 8767 §5 | `cap_ttl()` with `DNS_TTL_MAX=604800` |