### PR TITLE
fix(simple): add volatile for socket parameter in async functions

### DIFF
--- a/src/simple/SocketSimple-async.c
+++ b/src/simple/SocketSimple-async.c
@@ -176,6 +176,8 @@ Socket_simple_async_send_timeout (SocketSimple_Async_T async,
                                   void *user_data, SocketSimple_AsyncFlags flags,
                                   int64_t timeout_ms)
 {
+  /* Volatile copy to survive potential longjmp in TRY/EXCEPT */
+  SocketSimple_Socket_T volatile safe_socket = socket;
   Socket_T core_socket;
   struct CallbackContext *ctx;
   volatile unsigned request_id = 0;
@@ -188,7 +190,7 @@ Socket_simple_async_send_timeout (SocketSimple_Async_T async,
       return 0;
     }
 
-  core_socket = get_core_socket (socket);
+  core_socket = get_core_socket ((SocketSimple_Socket_T)safe_socket);
   if (!core_socket)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
@@ -213,7 +215,7 @@ Socket_simple_async_send_timeout (SocketSimple_Async_T async,
 
   ctx->user_cb = cb;
   ctx->user_data = user_data;
-  ctx->simple_socket = socket;
+  ctx->simple_socket = (SocketSimple_Socket_T)safe_socket;
 
   TRY
   {
@@ -249,6 +251,8 @@ Socket_simple_async_recv_timeout (SocketSimple_Async_T async,
                                   void *user_data, SocketSimple_AsyncFlags flags,
                                   int64_t timeout_ms)
 {
+  /* Volatile copy to survive potential longjmp in TRY/EXCEPT */
+  SocketSimple_Socket_T volatile safe_socket = socket;
   Socket_T core_socket;
   struct CallbackContext *ctx;
   volatile unsigned request_id = 0;
@@ -261,7 +265,7 @@ Socket_simple_async_recv_timeout (SocketSimple_Async_T async,
       return 0;
     }
 
-  core_socket = get_core_socket (socket);
+  core_socket = get_core_socket ((SocketSimple_Socket_T)safe_socket);
   if (!core_socket)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
@@ -286,7 +290,7 @@ Socket_simple_async_recv_timeout (SocketSimple_Async_T async,
 
   ctx->user_cb = cb;
   ctx->user_data = user_data;
-  ctx->simple_socket = socket;
+  ctx->simple_socket = (SocketSimple_Socket_T)safe_socket;
 
   TRY
   {


### PR DESCRIPTION
## Summary

- Add volatile copies for `socket` parameter in async functions to fix GCC `-Wclobbered` warning

## Problem

Release builds with `-Werror` fail because GCC detects that the `socket` parameter may be clobbered by `longjmp` (used by TRY/EXCEPT macros):

```
error: argument 'socket' might be clobbered by 'longjmp' or 'vfork' [-Werror=clobbered]
```

## Solution

Create volatile local copies of the socket parameter before entering TRY blocks:

```c
SocketSimple_Socket_T volatile safe_socket = socket;
```

Affected functions:
- `Socket_simple_async_send_timeout()`
- `Socket_simple_async_recv_timeout()`

## Test Plan

- [x] Release build completes successfully
- [x] No warnings with `-Werror`

🤖 Generated with [Claude Code](https://claude.com/claude-code)