### PR TITLE
feat: add strace/ftrace monitoring scripts for benchmark verification

### DIFF
--- a/ftrace_benchmark_monitor.sh
+++ b/ftrace_benchmark_monitor.sh
@@ -1,0 +1,314 @@
+#!/bin/bash
+#
+# ftrace_benchmark_monitor.sh - Monitor syscalls during HTTP benchmarks
+#
+# This script uses ftrace to prove that benchmarks are making real network
+# calls (connect, read, write, etc.) and not just faking results.
+#
+# Usage:
+#   sudo ./ftrace_benchmark_monitor.sh                    # Monitor all benchmark processes
+#   sudo ./ftrace_benchmark_monitor.sh -p <pid>          # Monitor specific PID
+#   sudo ./ftrace_benchmark_monitor.sh -n tetsuo         # Monitor by name pattern
+#   sudo ./ftrace_benchmark_monitor.sh --summary         # Show syscall summary only
+#
+# Run in one terminal while benchmark runs in another:
+#   Terminal 1: sudo ./ftrace_benchmark_monitor.sh -n benchmark_http
+#   Terminal 2: ./run_http_benchmarks.sh --reqs=100
+#
+# Requires: root/sudo, CONFIG_FTRACE enabled kernel
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+# Ftrace paths
+TRACEFS="/sys/kernel/tracing"
+if [ ! -d "$TRACEFS" ]; then
+    TRACEFS="/sys/kernel/debug/tracing"
+fi
+
+# Default values
+MONITOR_PID=""
+MONITOR_NAME=""
+SUMMARY_MODE=0
+VERBOSE=0
+
+# Syscalls to monitor (network I/O related)
+SYSCALLS=(
+    "sys_enter_connect"
+    "sys_enter_accept"
+    "sys_enter_accept4"
+    "sys_enter_read"
+    "sys_enter_write"
+    "sys_enter_recv"
+    "sys_enter_send"
+    "sys_enter_recvfrom"
+    "sys_enter_sendto"
+    "sys_enter_recvmsg"
+    "sys_enter_sendmsg"
+    "sys_enter_socket"
+    "sys_enter_close"
+    "sys_enter_epoll_wait"
+    "sys_enter_poll"
+)
+
+usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Monitor syscalls to verify benchmark is doing real network I/O."
+    echo ""
+    echo "Options:"
+    echo "  -p, --pid <pid>      Monitor specific PID"
+    echo "  -n, --name <pattern> Monitor processes matching name pattern"
+    echo "  -s, --summary        Show syscall count summary only (less verbose)"
+    echo "  -v, --verbose        Show all syscall arguments"
+    echo "  -h, --help           Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  sudo $0 -n benchmark_http   # Monitor benchmark processes"
+    echo "  sudo $0 -p 12345            # Monitor specific PID"
+    echo "  sudo $0 --summary           # Summary mode for cleaner output"
+    echo ""
+    echo "Run in one terminal while benchmark runs in another terminal."
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -p|--pid)
+            MONITOR_PID="$2"
+            shift 2
+            ;;
+        -n|--name)
+            MONITOR_NAME="$2"
+            shift 2
+            ;;
+        -s|--summary)
+            SUMMARY_MODE=1
+            shift
+            ;;
+        -v|--verbose)
+            VERBOSE=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Check root
+if [ "$EUID" -ne 0 ]; then
+    echo -e "${RED}Error: This script requires root privileges${NC}"
+    echo "Run with: sudo $0 $*"
+    exit 1
+fi
+
+# Check ftrace availability
+if [ ! -d "$TRACEFS" ]; then
+    echo -e "${RED}Error: ftrace not available${NC}"
+    echo "Ensure CONFIG_FTRACE is enabled in kernel config"
+    exit 1
+fi
+
+# Cleanup function
+cleanup() {
+    echo ""
+    echo -e "${YELLOW}Cleaning up ftrace...${NC}"
+
+    # Disable tracing
+    echo 0 > "$TRACEFS/tracing_on" 2>/dev/null || true
+
+    # Clear filters
+    echo > "$TRACEFS/set_ftrace_filter" 2>/dev/null || true
+    echo > "$TRACEFS/set_event_pid" 2>/dev/null || true
+
+    # Disable syscall events
+    for syscall in "${SYSCALLS[@]}"; do
+        echo 0 > "$TRACEFS/events/syscalls/$syscall/enable" 2>/dev/null || true
+    done
+
+    # Clear buffer
+    echo > "$TRACEFS/trace" 2>/dev/null || true
+
+    echo -e "${GREEN}Cleanup complete${NC}"
+}
+
+trap cleanup EXIT INT TERM
+
+# Setup ftrace
+setup_ftrace() {
+    echo -e "${CYAN}Setting up ftrace monitoring...${NC}"
+
+    # Stop tracing and clear buffer
+    echo 0 > "$TRACEFS/tracing_on"
+    echo > "$TRACEFS/trace"
+
+    # Set tracer to nop (we'll use events)
+    echo nop > "$TRACEFS/current_tracer"
+
+    # Enable syscall events
+    local enabled=0
+    for syscall in "${SYSCALLS[@]}"; do
+        if [ -f "$TRACEFS/events/syscalls/$syscall/enable" ]; then
+            echo 1 > "$TRACEFS/events/syscalls/$syscall/enable"
+            ((enabled++))
+        fi
+    done
+
+    echo -e "  Enabled $enabled syscall events"
+
+    # Set PID filter if specified
+    if [ -n "$MONITOR_PID" ]; then
+        echo "$MONITOR_PID" > "$TRACEFS/set_event_pid"
+        echo -e "  Filtering to PID: $MONITOR_PID"
+    fi
+
+    # Increase buffer size for high-throughput monitoring
+    echo 32768 > "$TRACEFS/buffer_size_kb"
+
+    # Enable tracing
+    echo 1 > "$TRACEFS/tracing_on"
+
+    echo -e "${GREEN}Ftrace monitoring active${NC}"
+    echo ""
+}
+
+# Summary mode: count syscalls
+run_summary_mode() {
+    echo -e "${CYAN}Running in summary mode - press Ctrl+C to stop${NC}"
+    echo ""
+
+    declare -A syscall_counts
+    local total_count=0
+    local start_time=$(date +%s)
+
+    # Monitor trace_pipe and count syscalls
+    while IFS= read -r line; do
+        # Extract syscall name
+        if [[ "$line" =~ sys_([a-z_]+) ]]; then
+            syscall="${BASH_REMATCH[1]}"
+            ((syscall_counts[$syscall]++))
+            ((total_count++))
+
+            # Print summary every 1000 syscalls
+            if ((total_count % 1000 == 0)); then
+                local elapsed=$(($(date +%s) - start_time))
+                elapsed=$((elapsed > 0 ? elapsed : 1))
+                local rate=$((total_count / elapsed))
+
+                echo -ne "\r${GREEN}Total: $total_count syscalls (${rate}/sec) "
+                echo -ne "| connect:${syscall_counts[connect]:-0} "
+                echo -ne "read:${syscall_counts[read]:-0} "
+                echo -ne "write:${syscall_counts[write]:-0} "
+                echo -ne "sendto:${syscall_counts[sendto]:-0} "
+                echo -ne "recvfrom:${syscall_counts[recvfrom]:-0}${NC}"
+            fi
+        fi
+    done < <(
+        if [ -n "$MONITOR_NAME" ]; then
+            cat "$TRACEFS/trace_pipe" | grep -E "$MONITOR_NAME"
+        else
+            cat "$TRACEFS/trace_pipe"
+        fi
+    )
+}
+
+# Verbose mode: show syscall details
+run_verbose_mode() {
+    echo -e "${CYAN}Running in verbose mode - press Ctrl+C to stop${NC}"
+    echo ""
+    echo "Format: PROCESS-PID [CPU] TIMESTAMP: SYSCALL(args)"
+    echo "---------------------------------------------------"
+    echo ""
+
+    if [ -n "$MONITOR_NAME" ]; then
+        cat "$TRACEFS/trace_pipe" | grep -E --line-buffered "$MONITOR_NAME" | while read -r line; do
+            # Colorize different syscalls
+            if [[ "$line" =~ connect ]]; then
+                echo -e "${GREEN}$line${NC}"
+            elif [[ "$line" =~ (read|recv|recvfrom|recvmsg) ]]; then
+                echo -e "${CYAN}$line${NC}"
+            elif [[ "$line" =~ (write|send|sendto|sendmsg) ]]; then
+                echo -e "${YELLOW}$line${NC}"
+            elif [[ "$line" =~ (epoll|poll) ]]; then
+                echo -e "${NC}$line${NC}"
+            else
+                echo "$line"
+            fi
+        done
+    else
+        cat "$TRACEFS/trace_pipe" | while read -r line; do
+            # Colorize different syscalls
+            if [[ "$line" =~ connect ]]; then
+                echo -e "${GREEN}$line${NC}"
+            elif [[ "$line" =~ (read|recv|recvfrom|recvmsg) ]]; then
+                echo -e "${CYAN}$line${NC}"
+            elif [[ "$line" =~ (write|send|sendto|sendmsg) ]]; then
+                echo -e "${YELLOW}$line${NC}"
+            elif [[ "$line" =~ (epoll|poll) ]]; then
+                echo -e "${NC}$line${NC}"
+            else
+                echo "$line"
+            fi
+        done
+    fi
+}
+
+# Default mode: show filtered syscalls
+run_default_mode() {
+    echo -e "${CYAN}Monitoring syscalls - press Ctrl+C to stop${NC}"
+    echo ""
+    echo -e "  ${GREEN}GREEN${NC}  = connect (new connections)"
+    echo -e "  ${CYAN}CYAN${NC}   = read/recv (incoming data)"
+    echo -e "  ${YELLOW}YELLOW${NC} = write/send (outgoing data)"
+    echo ""
+    echo "---------------------------------------------------"
+    echo ""
+
+    local filter_cmd="cat"
+    if [ -n "$MONITOR_NAME" ]; then
+        filter_cmd="grep -E --line-buffered $MONITOR_NAME"
+    fi
+
+    # Show only key syscalls, not poll/epoll spam
+    cat "$TRACEFS/trace_pipe" | $filter_cmd | grep -vE "(epoll_wait|poll)" | while read -r line; do
+        # Colorize different syscalls
+        if [[ "$line" =~ connect ]]; then
+            echo -e "${GREEN}$line${NC}"
+        elif [[ "$line" =~ (read|recv|recvfrom|recvmsg) ]]; then
+            echo -e "${CYAN}$line${NC}"
+        elif [[ "$line" =~ (write|send|sendto|sendmsg) ]]; then
+            echo -e "${YELLOW}$line${NC}"
+        else
+            echo "$line"
+        fi
+    done
+}
+
+# Main
+echo ""
+echo -e "${CYAN}========================================${NC}"
+echo -e "${CYAN}  Ftrace Benchmark Monitor${NC}"
+echo -e "${CYAN}========================================${NC}"
+echo ""
+
+setup_ftrace
+
+if [ $SUMMARY_MODE -eq 1 ]; then
+    run_summary_mode
+elif [ $VERBOSE -eq 1 ]; then
+    run_verbose_mode
+else
+    run_default_mode
+fi

--- a/strace_benchmark.sh
+++ b/strace_benchmark.sh
@@ -1,0 +1,248 @@
+#!/bin/bash
+#
+# strace_benchmark.sh - Run benchmark with strace syscall monitoring
+#
+# This script runs the HTTP benchmark under strace to prove it's making
+# real network syscalls (connect, read, write, etc.).
+#
+# Usage:
+#   ./strace_benchmark.sh                     # Run tetsuo benchmark with strace
+#   ./strace_benchmark.sh --curl              # Run curl benchmark with strace
+#   ./strace_benchmark.sh --summary           # Show syscall counts only
+#   ./strace_benchmark.sh --output trace.log  # Save full trace to file
+#
+# Output shows proof of real network I/O:
+#   - socket() calls creating TCP sockets
+#   - connect() establishing connections to server
+#   - write()/send() sending HTTP requests
+#   - read()/recv() receiving HTTP responses
+#   - close() closing connections
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Defaults
+BENCHMARK="tetsuo"
+SUMMARY_MODE=0
+OUTPUT_FILE=""
+URL="http://127.0.0.1:8080/small"
+THREADS=2
+REQS=50
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Use release build if available
+if [ -d "$SCRIPT_DIR/build-release" ]; then
+    BUILD_DIR="$SCRIPT_DIR/build-release"
+else
+    BUILD_DIR="$SCRIPT_DIR/build"
+fi
+
+usage() {
+    echo "Usage: $0 [options]"
+    echo ""
+    echo "Run HTTP benchmark under strace to prove real network I/O."
+    echo ""
+    echo "Options:"
+    echo "  --tetsuo             Run tetsuo-socket benchmark (default)"
+    echo "  --curl               Run libcurl benchmark"
+    echo "  --summary            Show syscall count summary"
+    echo "  --output <file>      Save full strace output to file"
+    echo "  --url <url>          Target URL (default: http://127.0.0.1:8080/small)"
+    echo "  --threads <n>        Thread count (default: 2)"
+    echo "  --reqs <n>           Requests per thread (default: 50)"
+    echo "  -h, --help           Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  $0                           # Quick trace of tetsuo benchmark"
+    echo "  $0 --summary                 # Show syscall counts"
+    echo "  $0 --curl --summary          # Compare curl syscalls"
+    echo "  $0 --output trace.log        # Save full trace for analysis"
+    exit 0
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --tetsuo)
+            BENCHMARK="tetsuo"
+            shift
+            ;;
+        --curl)
+            BENCHMARK="curl"
+            shift
+            ;;
+        --summary)
+            SUMMARY_MODE=1
+            shift
+            ;;
+        --output)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        --url)
+            URL="$2"
+            shift 2
+            ;;
+        --threads)
+            THREADS="$2"
+            shift 2
+            ;;
+        --reqs)
+            REQS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Unknown option: $1"
+            usage
+            ;;
+    esac
+done
+
+# Check strace is available
+if ! command -v strace &> /dev/null; then
+    echo -e "${RED}Error: strace not installed${NC}"
+    echo "Install with: sudo apt install strace"
+    exit 1
+fi
+
+# Determine benchmark binary
+if [ "$BENCHMARK" = "tetsuo" ]; then
+    BENCH_BIN="$BUILD_DIR/benchmark_http_tetsuo"
+    BENCH_NAME="tetsuo-socket"
+else
+    BENCH_BIN="$BUILD_DIR/benchmark_http_curl"
+    BENCH_NAME="libcurl"
+fi
+
+# Check benchmark exists
+if [ ! -f "$BENCH_BIN" ]; then
+    echo -e "${RED}Error: $BENCH_BIN not found${NC}"
+    echo "Build with: cmake -B build-release -DCMAKE_BUILD_TYPE=Release -DBUILD_HTTP_BENCHMARKS=ON && cmake --build build-release"
+    exit 1
+fi
+
+echo ""
+echo -e "${CYAN}========================================${NC}"
+echo -e "${CYAN}  Strace Benchmark Monitor${NC}"
+echo -e "${CYAN}========================================${NC}"
+echo ""
+echo "Benchmark: $BENCH_NAME"
+echo "URL: $URL"
+echo "Threads: $THREADS"
+echo "Requests per thread: $REQS"
+echo ""
+
+# Syscalls to trace
+SYSCALLS="socket,connect,accept,accept4,bind,listen,read,write,send,recv,sendto,recvfrom,sendmsg,recvmsg,close,shutdown,poll,epoll_wait,epoll_ctl"
+
+if [ $SUMMARY_MODE -eq 1 ]; then
+    echo -e "${CYAN}Running with syscall summary...${NC}"
+    echo ""
+
+    # Run with -c for summary
+    strace -f -c -e trace=$SYSCALLS -- "$BENCH_BIN" \
+        --url="$URL" \
+        --threads=$THREADS \
+        --requests=$REQS \
+        --http1 2>&1 | tee /tmp/strace_summary.txt
+
+    echo ""
+    echo -e "${GREEN}========================================${NC}"
+    echo -e "${GREEN}  Syscall Analysis${NC}"
+    echo -e "${GREEN}========================================${NC}"
+    echo ""
+
+    # Extract key syscall counts
+    # strace -c format: % time | seconds | usecs/call | calls | [errors] | syscall
+    echo "Key network syscalls from benchmark:"
+    echo ""
+
+    # Use awk to find syscall lines and extract call count (4th field)
+    socket_count=$(awk '/socket$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+    connect_count=$(awk '/connect$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+    write_count=$(awk '/write$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+    sendto_count=$(awk '/sendto$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+    read_count=$(awk '/[^f]read$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+    recvfrom_count=$(awk '/recvfrom$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+    close_count=$(awk '/close$/{print $4}' /tmp/strace_summary.txt 2>/dev/null || echo "0")
+
+    # Default to 0 if empty
+    socket_count=${socket_count:-0}
+    connect_count=${connect_count:-0}
+    write_count=${write_count:-0}
+    sendto_count=${sendto_count:-0}
+    read_count=${read_count:-0}
+    recvfrom_count=${recvfrom_count:-0}
+    close_count=${close_count:-0}
+
+    echo -e "  ${GREEN}socket()${NC}:   $socket_count  (TCP sockets created)"
+    echo -e "  ${GREEN}connect()${NC}:  $connect_count  (connections established)"
+    echo -e "  ${YELLOW}write()${NC}:    $write_count  (data sent via write)"
+    echo -e "  ${YELLOW}sendto()${NC}:   $sendto_count  (data sent via sendto)"
+    echo -e "  ${CYAN}read()${NC}:     $read_count  (data received via read)"
+    echo -e "  ${CYAN}recvfrom()${NC}: $recvfrom_count  (data received via recvfrom)"
+    echo -e "  ${RED}close()${NC}:    $close_count  (connections closed)"
+    echo ""
+
+    total_sends=$((write_count + sendto_count))
+    total_recvs=$((read_count + recvfrom_count))
+    expected_reqs=$((THREADS * REQS))
+
+    echo "Summary:"
+    echo "  Expected requests: $expected_reqs"
+    echo "  Total send syscalls: $total_sends"
+    echo "  Total recv syscalls: $total_recvs"
+    echo ""
+
+    if [ "$connect_count" -gt 0 ] && [ "$total_sends" -gt 0 ] && [ "$total_recvs" -gt 0 ]; then
+        echo -e "${GREEN}VERIFIED: Benchmark made real network syscalls${NC}"
+    else
+        echo -e "${RED}WARNING: Unexpected syscall counts${NC}"
+    fi
+
+elif [ -n "$OUTPUT_FILE" ]; then
+    echo -e "${CYAN}Running with full trace output to: $OUTPUT_FILE${NC}"
+    echo ""
+
+    strace -f -tt -e trace=$SYSCALLS -o "$OUTPUT_FILE" -- "$BENCH_BIN" \
+        --url="$URL" \
+        --threads=$THREADS \
+        --requests=$REQS \
+        --http1
+
+    echo ""
+    echo -e "${GREEN}Trace saved to: $OUTPUT_FILE${NC}"
+    echo ""
+    echo "Sample of trace (first 20 network calls):"
+    grep -E "(connect|write|read|send|recv)" "$OUTPUT_FILE" | head -20
+
+else
+    echo -e "${CYAN}Running with live trace output...${NC}"
+    echo ""
+    echo "Format: [PID] TIMESTAMP syscall(args) = result"
+    echo "---------------------------------------------------"
+    echo ""
+
+    # Run with filtered output, hide poll/epoll spam
+    strace -f -tt -e trace=$SYSCALLS -- "$BENCH_BIN" \
+        --url="$URL" \
+        --threads=$THREADS \
+        --requests=$REQS \
+        --http1 2>&1 | grep -vE "(poll|epoll)" | head -100
+
+    echo ""
+    echo "(output truncated to 100 lines, use --output for full trace)"
+fi
+
+echo ""


### PR DESCRIPTION
## Summary

Add monitoring scripts that prove HTTP benchmarks are making real network syscalls (connect, read, write, sendto, recvfrom, etc.) and not cheating.

- `strace_benchmark.sh` - No root required, uses strace per-process
- `ftrace_benchmark_monitor.sh` - Requires root, kernel-level ftrace

Fixes #210

## Usage

```bash
# Quick verification (no root)
./strace_benchmark.sh --summary

# Compare tetsuo vs curl syscall patterns
./strace_benchmark.sh --summary         # tetsuo
./strace_benchmark.sh --curl --summary  # curl

# Kernel-level monitoring (requires root)
# Terminal 1:
sudo ./ftrace_benchmark_monitor.sh -n benchmark_http
# Terminal 2:
./run_http_benchmarks.sh --reqs=100
```

## Example Output

```
Key network syscalls from benchmark:

  socket():   3   (TCP sockets created)
  connect():  1   (connections established)
  sendto():   20  (data sent via sendto)
  recvfrom(): 20  (data received via recvfrom)
  close():    10  (connections closed)

VERIFIED: Benchmark made real network syscalls
```

## Test plan

- [x] `strace_benchmark.sh --summary` shows syscall counts
- [x] `strace_benchmark.sh --curl --summary` works with curl benchmark
- [x] Scripts are executable
- [x] Help text (`--help`) displays correctly