### PR TITLE
feat: implement DNS Cookies (RFC 7873)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -323,6 +323,7 @@ set(LIB_SOURCES
     src/dns/SocketDNSConfig.c
     src/dns/SocketDNSResolver.c
     src/dns/SocketDNSSEC.c
+    src/dns/SocketDNSCookie.c
 
     # Poll module (consolidated)
     src/poll/SocketPoll.c
@@ -553,6 +554,7 @@ set(DNS_HEADERS
     include/dns/SocketDNSoverTLS.h
     include/dns/SocketDNSoverHTTPS.h
     include/dns/SocketDNSSEC.h
+    include/dns/SocketDNSCookie.h
 )
 
 set(POLL_HEADERS
@@ -688,6 +690,7 @@ set(TEST_SOURCES
     test_dns_cache
     test_dns_resolver
     test_dnssec
+    test_dnscookie
     test_integration
     test_threadsafety
     test_happy_eyeballs

--- a/include/dns/SocketDNSCookie.h
+++ b/include/dns/SocketDNSCookie.h
@@ -1,0 +1,534 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETDNSCOOKIE_INCLUDED
+#define SOCKETDNSCOOKIE_INCLUDED
+
+/**
+ * @file SocketDNSCookie.h
+ * @brief DNS Cookies for spoofing and amplification protection (RFC 7873).
+ * @ingroup dns
+ *
+ * Implements DNS Cookies as defined in RFC 7873 to provide lightweight
+ * protection against off-path DNS spoofing and amplification attacks.
+ * Cookies are transported via EDNS0 option (code 10).
+ *
+ * ## RFC References
+ *
+ * - RFC 7873: Domain Name System (DNS) Cookies
+ * - RFC 6891: EDNS0 (Extension Mechanisms for DNS)
+ *
+ * ## How It Works
+ *
+ * 1. Client generates an 8-byte Client Cookie per server IP
+ * 2. Client sends query with Client Cookie in EDNS0 option
+ * 3. Server responds with Client Cookie + Server Cookie (8-32 bytes)
+ * 4. Client caches Server Cookie for future queries to same server
+ * 5. Future queries include both cookies
+ * 6. Server verifies cookies before responding
+ *
+ * ## Cookie Format (EDNS0 Option Code 10)
+ *
+ * ```
+ * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * |                    OPTION-CODE = 10                          |
+ * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * |                    OPTION-LENGTH                             |
+ * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * |                Client Cookie (8 bytes)                       |
+ * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * |           Server Cookie (8-32 bytes, optional)               |
+ * +---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
+ * ```
+ *
+ * ## Security Notes
+ *
+ * - Cookies provide protection against **off-path** attackers only
+ * - No protection against on-path adversaries who can observe traffic
+ * - Client secret should have at least 64 bits of entropy
+ * - Secret rotation recommended every 24 hours (max 36 days per RFC)
+ *
+ * @see SocketDNSWire.h for EDNS0 option encoding/decoding.
+ * @see SocketDNSTransport.h for transport integration.
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include <netinet/in.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <time.h>
+
+/**
+ * @defgroup dns_cookie DNS Cookies
+ * @brief DNS Cookie generation, caching, and validation.
+ * @ingroup dns
+ * @{
+ */
+
+/** EDNS0 option code for DNS Cookies (RFC 7873). */
+#define DNS_COOKIE_OPTION_CODE 10
+
+/** Client Cookie size in bytes (fixed per RFC 7873). */
+#define DNS_CLIENT_COOKIE_SIZE 8
+
+/** Minimum Server Cookie size in bytes. */
+#define DNS_SERVER_COOKIE_MIN_SIZE 8
+
+/** Maximum Server Cookie size in bytes. */
+#define DNS_SERVER_COOKIE_MAX_SIZE 32
+
+/** Minimum valid COOKIE option length (client cookie only). */
+#define DNS_COOKIE_OPTION_MIN_LEN 8
+
+/** Maximum valid COOKIE option length (client + max server). */
+#define DNS_COOKIE_OPTION_MAX_LEN 40
+
+/** Default client secret lifetime in seconds (1 day per RFC 7873). */
+#define DNS_COOKIE_SECRET_LIFETIME_DEFAULT 86400
+
+/** Maximum client secret lifetime in seconds (36 days per RFC 7873). */
+#define DNS_COOKIE_SECRET_LIFETIME_MAX 3110400
+
+/** Default cache size (number of server cookie entries). */
+#define DNS_COOKIE_CACHE_DEFAULT_SIZE 64
+
+/** Maximum cache size. */
+#define DNS_COOKIE_CACHE_MAX_SIZE 1024
+
+/** Server cookie expiry time in seconds (default: 1 hour). */
+#define DNS_COOKIE_SERVER_TTL_DEFAULT 3600
+
+/**
+ * @brief DNS Cookie operation failure exception.
+ * @ingroup dns_cookie
+ *
+ * Raised for cookie generation failures, invalid parameters,
+ * or resource exhaustion.
+ */
+extern const Except_T SocketDNSCookie_Failed;
+
+/**
+ * @brief Opaque handle for DNS Cookie cache.
+ * @ingroup dns_cookie
+ *
+ * Manages client secrets and cached server cookies per nameserver.
+ */
+#define T SocketDNSCookie_T
+typedef struct T *T;
+
+/**
+ * @brief Parsed DNS Cookie from EDNS0 option.
+ * @ingroup dns_cookie
+ *
+ * Contains client cookie and optional server cookie extracted
+ * from a DNS COOKIE EDNS0 option.
+ */
+typedef struct
+{
+  uint8_t client_cookie[DNS_CLIENT_COOKIE_SIZE]; /**< Client cookie (8 bytes) */
+  uint8_t server_cookie[DNS_SERVER_COOKIE_MAX_SIZE]; /**< Server cookie */
+  size_t server_cookie_len; /**< Server cookie length (0 if absent) */
+} SocketDNSCookie_Cookie;
+
+/**
+ * @brief Cached server cookie entry.
+ * @ingroup dns_cookie
+ *
+ * Stores a server cookie associated with a specific nameserver address.
+ */
+typedef struct
+{
+  struct sockaddr_storage server_addr; /**< Nameserver address */
+  socklen_t addr_len;                  /**< Address length */
+  uint8_t client_cookie[DNS_CLIENT_COOKIE_SIZE]; /**< Client cookie used */
+  uint8_t server_cookie[DNS_SERVER_COOKIE_MAX_SIZE]; /**< Cached server cookie */
+  size_t server_cookie_len;            /**< Server cookie length */
+  time_t received_at;                  /**< When cookie was received */
+  time_t expires_at;                   /**< Expiration time */
+} SocketDNSCookie_Entry;
+
+/**
+ * @brief Cookie cache statistics.
+ * @ingroup dns_cookie
+ */
+typedef struct
+{
+  uint64_t client_cookies_generated; /**< Total client cookies generated */
+  uint64_t server_cookies_cached;    /**< Server cookies added to cache */
+  uint64_t cache_hits;               /**< Successful cache lookups */
+  uint64_t cache_misses;             /**< Failed cache lookups */
+  uint64_t cache_evictions;          /**< LRU evictions */
+  uint64_t badcookie_responses;      /**< BADCOOKIE responses received */
+  uint64_t secret_rotations;         /**< Client secret rotations */
+  size_t current_entries;            /**< Current cached entries */
+  size_t max_entries;                /**< Maximum cache capacity */
+  time_t secret_expires_at;          /**< Current secret expiration */
+} SocketDNSCookie_Stats;
+
+/* Lifecycle functions */
+
+/**
+ * @brief Create a new DNS Cookie cache.
+ * @ingroup dns_cookie
+ *
+ * Creates a cookie cache with a randomly generated client secret.
+ * The secret is automatically rotated based on the configured lifetime.
+ *
+ * @param arena Arena for memory allocation (must outlive cache).
+ * @return New cookie cache instance.
+ * @throws SocketDNSCookie_Failed on allocation or entropy failure.
+ *
+ * @code{.c}
+ * Arena_T arena = Arena_new();
+ * SocketDNSCookie_T cache = SocketDNSCookie_new(arena);
+ * // Use cache with DNS queries...
+ * Arena_dispose(&arena);
+ * @endcode
+ */
+extern T SocketDNSCookie_new (Arena_T arena);
+
+/**
+ * @brief Dispose of a DNS Cookie cache.
+ * @ingroup dns_cookie
+ *
+ * Releases all resources and clears sensitive data (secrets).
+ * The cache pointer is set to NULL.
+ *
+ * @param cache Pointer to cache instance.
+ */
+extern void SocketDNSCookie_free (T *cache);
+
+/* Configuration functions */
+
+/**
+ * @brief Set the client secret lifetime.
+ * @ingroup dns_cookie
+ *
+ * Controls how often the client secret is rotated.
+ * Per RFC 7873, SHOULD NOT exceed 26 hours, MUST NOT exceed 36 days.
+ *
+ * @param cache           Cookie cache instance.
+ * @param lifetime_seconds Secret lifetime in seconds.
+ *                         Clamped to [60, DNS_COOKIE_SECRET_LIFETIME_MAX].
+ *
+ * @code{.c}
+ * // Rotate secret every 12 hours
+ * SocketDNSCookie_set_secret_lifetime(cache, 43200);
+ * @endcode
+ */
+extern void SocketDNSCookie_set_secret_lifetime (T cache, int lifetime_seconds);
+
+/**
+ * @brief Set maximum cache entries.
+ * @ingroup dns_cookie
+ *
+ * When the cache is full, least-recently-used entries are evicted.
+ *
+ * @param cache       Cookie cache instance.
+ * @param max_entries Maximum entries (clamped to [1, DNS_COOKIE_CACHE_MAX_SIZE]).
+ */
+extern void SocketDNSCookie_set_cache_size (T cache, size_t max_entries);
+
+/**
+ * @brief Set server cookie TTL.
+ * @ingroup dns_cookie
+ *
+ * Cached server cookies expire after this duration and must be refreshed.
+ *
+ * @param cache       Cookie cache instance.
+ * @param ttl_seconds TTL in seconds (default: 3600).
+ */
+extern void SocketDNSCookie_set_server_ttl (T cache, int ttl_seconds);
+
+/**
+ * @brief Force immediate rotation of the client secret.
+ * @ingroup dns_cookie
+ *
+ * Generates a new random client secret. Use after security events
+ * or when the secret may have been compromised.
+ *
+ * @param cache Cookie cache instance.
+ * @return 0 on success, -1 on entropy failure.
+ */
+extern int SocketDNSCookie_rotate_secret (T cache);
+
+/* Cookie generation and parsing */
+
+/**
+ * @brief Generate a client cookie for a server address.
+ * @ingroup dns_cookie
+ *
+ * Creates an 8-byte client cookie using HMAC-SHA256 over the
+ * client IP, server IP, and client secret, truncated to 64 bits.
+ *
+ * If a valid server cookie exists in the cache, it is also returned.
+ *
+ * @param cache       Cookie cache instance.
+ * @param server_addr Server address (IPv4 or IPv6).
+ * @param addr_len    Server address length.
+ * @param client_addr Client address (may be NULL for default).
+ * @param client_len  Client address length.
+ * @param[out] cookie Output cookie structure.
+ * @return 0 on success, -1 on error.
+ *
+ * @code{.c}
+ * struct sockaddr_in server;
+ * server.sin_family = AF_INET;
+ * inet_pton(AF_INET, "8.8.8.8", &server.sin_addr);
+ *
+ * SocketDNSCookie_Cookie cookie;
+ * if (SocketDNSCookie_generate(cache, (struct sockaddr*)&server,
+ *                               sizeof(server), NULL, 0, &cookie) == 0) {
+ *     // cookie.client_cookie is ready
+ *     // cookie.server_cookie_len > 0 if cached server cookie exists
+ * }
+ * @endcode
+ */
+extern int SocketDNSCookie_generate (T cache,
+                                     const struct sockaddr *server_addr,
+                                     socklen_t addr_len,
+                                     const struct sockaddr *client_addr,
+                                     socklen_t client_len,
+                                     SocketDNSCookie_Cookie *cookie);
+
+/**
+ * @brief Parse a cookie from EDNS0 option data.
+ * @ingroup dns_cookie
+ *
+ * Extracts client and server cookies from COOKIE option RDATA.
+ * Validates that the option length is valid per RFC 7873:
+ * - 8 bytes: client cookie only
+ * - 16-40 bytes: client + server cookie
+ * - Other lengths: FORMERR
+ *
+ * @param data     COOKIE option data (after OPTION-CODE and OPTION-LENGTH).
+ * @param len      Length of option data.
+ * @param[out] cookie Output cookie structure.
+ * @return 0 on success, -1 on invalid format.
+ *
+ * @code{.c}
+ * SocketDNS_EDNSOption opt;
+ * if (SocketDNS_edns_option_find(rdata, rdlen, DNS_EDNS_OPT_COOKIE, &opt)) {
+ *     SocketDNSCookie_Cookie cookie;
+ *     if (SocketDNSCookie_parse(opt.data, opt.length, &cookie) == 0) {
+ *         // Process cookie
+ *     }
+ * }
+ * @endcode
+ */
+extern int SocketDNSCookie_parse (const unsigned char *data, size_t len,
+                                  SocketDNSCookie_Cookie *cookie);
+
+/**
+ * @brief Encode a cookie to EDNS0 option format.
+ * @ingroup dns_cookie
+ *
+ * Serializes a cookie structure to wire format suitable for
+ * inclusion in an OPT record RDATA.
+ *
+ * @param cookie  Cookie to encode.
+ * @param[out] buf Output buffer.
+ * @param buflen  Buffer size.
+ * @return Number of bytes written on success, -1 on error.
+ *
+ * @code{.c}
+ * SocketDNSCookie_Cookie cookie;
+ * SocketDNSCookie_generate(cache, server, slen, NULL, 0, &cookie);
+ *
+ * unsigned char opt_data[DNS_COOKIE_OPTION_MAX_LEN];
+ * int opt_len = SocketDNSCookie_encode(&cookie, opt_data, sizeof(opt_data));
+ * if (opt_len > 0) {
+ *     SocketDNS_EDNSOption edns_opt = {
+ *         .code = DNS_EDNS_OPT_COOKIE,
+ *         .length = opt_len,
+ *         .data = opt_data
+ *     };
+ *     // Add to OPT record
+ * }
+ * @endcode
+ */
+extern int SocketDNSCookie_encode (const SocketDNSCookie_Cookie *cookie,
+                                   unsigned char *buf, size_t buflen);
+
+/* Cache operations */
+
+/**
+ * @brief Store a server cookie in the cache.
+ * @ingroup dns_cookie
+ *
+ * Caches a server cookie received in a DNS response. The cookie
+ * is associated with the server address and will be used in
+ * subsequent queries to the same server.
+ *
+ * @param cache         Cookie cache instance.
+ * @param server_addr   Server address.
+ * @param addr_len      Server address length.
+ * @param client_cookie Client cookie that was sent (for validation).
+ * @param server_cookie Server cookie received.
+ * @param server_len    Server cookie length.
+ * @return 0 on success, -1 on error.
+ *
+ * @note Server cookie length must be 8-32 bytes per RFC 7873.
+ */
+extern int SocketDNSCookie_cache_store (T cache,
+                                        const struct sockaddr *server_addr,
+                                        socklen_t addr_len,
+                                        const uint8_t *client_cookie,
+                                        const uint8_t *server_cookie,
+                                        size_t server_len);
+
+/**
+ * @brief Look up a cached server cookie.
+ * @ingroup dns_cookie
+ *
+ * Retrieves a previously cached server cookie for the given server.
+ * Returns the associated client cookie that should be used with it.
+ *
+ * @param cache       Cookie cache instance.
+ * @param server_addr Server address to look up.
+ * @param addr_len    Server address length.
+ * @param[out] entry  Output cache entry (may be NULL to just check existence).
+ * @return 1 if found and valid, 0 if not found or expired.
+ */
+extern int SocketDNSCookie_cache_lookup (T cache,
+                                         const struct sockaddr *server_addr,
+                                         socklen_t addr_len,
+                                         SocketDNSCookie_Entry *entry);
+
+/**
+ * @brief Invalidate cached cookie for a server.
+ * @ingroup dns_cookie
+ *
+ * Removes the cached server cookie for the given address.
+ * Use when receiving BADCOOKIE response to force cookie refresh.
+ *
+ * @param cache       Cookie cache instance.
+ * @param server_addr Server address to invalidate.
+ * @param addr_len    Server address length.
+ * @return 1 if entry was removed, 0 if not found.
+ */
+extern int SocketDNSCookie_cache_invalidate (T cache,
+                                             const struct sockaddr *server_addr,
+                                             socklen_t addr_len);
+
+/**
+ * @brief Clear all cached server cookies.
+ * @ingroup dns_cookie
+ *
+ * Removes all entries from the cache without rotating the client secret.
+ *
+ * @param cache Cookie cache instance.
+ */
+extern void SocketDNSCookie_cache_clear (T cache);
+
+/**
+ * @brief Remove expired entries from the cache.
+ * @ingroup dns_cookie
+ *
+ * Scans the cache and removes entries whose TTL has expired.
+ * Called automatically during cache operations.
+ *
+ * @param cache Cookie cache instance.
+ * @return Number of entries removed.
+ */
+extern int SocketDNSCookie_cache_expire (T cache);
+
+/* Validation */
+
+/**
+ * @brief Validate a response cookie against the request.
+ * @ingroup dns_cookie
+ *
+ * Verifies that the client cookie in the response matches what was sent.
+ * Per RFC 7873, responses with mismatched client cookies MUST be discarded.
+ *
+ * @param sent_cookie    Client cookie that was sent in the request.
+ * @param response       Cookie parsed from the response.
+ * @return 1 if valid, 0 if invalid (client cookie mismatch).
+ *
+ * @code{.c}
+ * SocketDNSCookie_Cookie sent, received;
+ * // ... generate sent, parse received ...
+ * if (!SocketDNSCookie_validate(&sent, &received)) {
+ *     // Discard response - possible spoofing attempt
+ *     return;
+ * }
+ * // Process valid response
+ * @endcode
+ */
+extern int SocketDNSCookie_validate (const SocketDNSCookie_Cookie *sent_cookie,
+                                     const SocketDNSCookie_Cookie *response);
+
+/**
+ * @brief Check if an RCODE indicates BADCOOKIE.
+ * @ingroup dns_cookie
+ *
+ * Convenience function to check for RCODE 23.
+ *
+ * @param rcode DNS response code (4-bit or extended 12-bit).
+ * @return 1 if BADCOOKIE, 0 otherwise.
+ */
+extern int SocketDNSCookie_is_badcookie (uint16_t rcode);
+
+/* Statistics */
+
+/**
+ * @brief Get cookie cache statistics.
+ * @ingroup dns_cookie
+ *
+ * @param cache  Cookie cache instance.
+ * @param[out] stats Output statistics structure.
+ */
+extern void SocketDNSCookie_stats (T cache, SocketDNSCookie_Stats *stats);
+
+/**
+ * @brief Reset statistics counters.
+ * @ingroup dns_cookie
+ *
+ * @param cache Cookie cache instance.
+ */
+extern void SocketDNSCookie_stats_reset (T cache);
+
+/* Utility functions */
+
+/**
+ * @brief Compare two cookies for equality.
+ * @ingroup dns_cookie
+ *
+ * Compares client and server cookies using constant-time comparison.
+ *
+ * @param a First cookie.
+ * @param b Second cookie.
+ * @return 1 if equal, 0 if different.
+ */
+extern int SocketDNSCookie_equal (const SocketDNSCookie_Cookie *a,
+                                  const SocketDNSCookie_Cookie *b);
+
+/**
+ * @brief Format a cookie as a hex string for debugging.
+ * @ingroup dns_cookie
+ *
+ * @param cookie Cookie to format.
+ * @param[out] buf Output buffer (must be at least 81 bytes for max cookie).
+ * @param buflen Buffer size.
+ * @return Length of formatted string, or -1 on error.
+ *
+ * @code{.c}
+ * char hex[81];
+ * SocketDNSCookie_to_hex(&cookie, hex, sizeof(hex));
+ * printf("Cookie: %s\n", hex);
+ * // Output: "0123456789abcdef:0011223344556677889900aabbccddeeff"
+ * @endcode
+ */
+extern int SocketDNSCookie_to_hex (const SocketDNSCookie_Cookie *cookie,
+                                   char *buf, size_t buflen);
+
+/** @} */ /* End of dns_cookie group */
+
+#undef T
+
+#endif /* SOCKETDNSCOOKIE_INCLUDED */

--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -71,7 +71,8 @@ typedef enum
   DNS_RCODE_YXRRSET = 7,  /**< RR set exists when it should not (RFC 2136) */
   DNS_RCODE_NXRRSET = 8,  /**< RR set does not exist (RFC 2136) */
   DNS_RCODE_NOTAUTH = 9,  /**< Server not authoritative (RFC 2136) */
-  DNS_RCODE_NOTZONE = 10  /**< Name not in zone (RFC 2136) */
+  DNS_RCODE_NOTZONE = 10,  /**< Name not in zone (RFC 2136) */
+  DNS_RCODE_BADCOOKIE = 23 /**< Bad/missing Server Cookie (RFC 7873) */
 } SocketDNS_Rcode;
 
 /**

--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -1,0 +1,881 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketDNSCookie.c
+ * @brief DNS Cookies implementation (RFC 7873).
+ */
+
+#include "dns/SocketDNSCookie.h"
+#include "dns/SocketDNSWire.h"
+#include "core/Arena.h"
+#include <arpa/inet.h>
+#include <string.h>
+#include <sys/random.h>
+
+#ifdef SOCKET_HAS_TLS
+#include <openssl/evp.h>
+#include <openssl/hmac.h>
+#include <openssl/rand.h>
+#endif
+
+#define T SocketDNSCookie_T
+
+/* Exception definition */
+const Except_T SocketDNSCookie_Failed
+    = {&SocketDNSCookie_Failed, "DNS Cookie operation failed"};
+
+/* Client secret size (256 bits for HMAC-SHA256) */
+#define SECRET_SIZE 32
+
+/* Internal cache entry with LRU tracking */
+typedef struct CacheNode
+{
+  SocketDNSCookie_Entry entry;
+  struct CacheNode *next;
+  struct CacheNode *prev;
+  time_t last_used;
+} CacheNode;
+
+/* Cookie cache structure */
+struct T
+{
+  Arena_T arena;
+
+  /* Client secret for cookie generation */
+  uint8_t secret[SECRET_SIZE];
+  time_t secret_created_at;
+  int secret_lifetime;
+
+  /* Previous secret for rollover period */
+  uint8_t prev_secret[SECRET_SIZE];
+  time_t prev_secret_valid_until;
+
+  /* Cache configuration */
+  size_t max_entries;
+  int server_ttl;
+
+  /* LRU cache implemented as doubly-linked list */
+  CacheNode *head; /* Most recently used */
+  CacheNode *tail; /* Least recently used */
+  size_t count;
+
+  /* Statistics */
+  SocketDNSCookie_Stats stats;
+};
+
+/* Forward declarations */
+static int generate_client_cookie (T cache, const struct sockaddr *server_addr,
+                                   socklen_t addr_len,
+                                   const struct sockaddr *client_addr,
+                                   socklen_t client_len, uint8_t *cookie);
+static int get_entropy (uint8_t *buf, size_t len);
+static int constant_time_compare (const uint8_t *a, const uint8_t *b,
+                                  size_t len);
+static CacheNode *find_node (T cache, const struct sockaddr *addr,
+                             socklen_t len);
+static void move_to_front (T cache, CacheNode *node);
+static void evict_lru (T cache);
+static int addr_equal (const struct sockaddr *a, socklen_t alen,
+                       const struct sockaddr *b, socklen_t blen);
+
+/*
+ * Create a new DNS Cookie cache
+ */
+T
+SocketDNSCookie_new (Arena_T arena)
+{
+  T cache;
+
+  if (arena == NULL)
+    RAISE (SocketDNSCookie_Failed);
+
+  cache = Arena_alloc (arena, sizeof (*cache), __FILE__, __LINE__);
+  memset (cache, 0, sizeof (*cache));
+
+  cache->arena = arena;
+  cache->max_entries = DNS_COOKIE_CACHE_DEFAULT_SIZE;
+  cache->server_ttl = DNS_COOKIE_SERVER_TTL_DEFAULT;
+  cache->secret_lifetime = DNS_COOKIE_SECRET_LIFETIME_DEFAULT;
+
+  /* Generate initial secret */
+  if (get_entropy (cache->secret, SECRET_SIZE) != 0)
+    RAISE (SocketDNSCookie_Failed);
+
+  cache->secret_created_at = time (NULL);
+
+  return cache;
+}
+
+/*
+ * Dispose of a DNS Cookie cache
+ */
+void
+SocketDNSCookie_free (T *cache)
+{
+  if (cache == NULL || *cache == NULL)
+    return;
+
+  /* Clear sensitive data */
+  memset ((*cache)->secret, 0, SECRET_SIZE);
+  memset ((*cache)->prev_secret, 0, SECRET_SIZE);
+
+  /* Clear cache entries */
+  CacheNode *node = (*cache)->head;
+  while (node)
+    {
+      CacheNode *next = node->next;
+      memset (&node->entry.server_cookie, 0, DNS_SERVER_COOKIE_MAX_SIZE);
+      node = next;
+    }
+
+  *cache = NULL;
+}
+
+/*
+ * Set client secret lifetime
+ */
+void
+SocketDNSCookie_set_secret_lifetime (T cache, int lifetime_seconds)
+{
+  if (cache == NULL)
+    return;
+
+  if (lifetime_seconds < 60)
+    lifetime_seconds = 60;
+  if (lifetime_seconds > DNS_COOKIE_SECRET_LIFETIME_MAX)
+    lifetime_seconds = DNS_COOKIE_SECRET_LIFETIME_MAX;
+
+  cache->secret_lifetime = lifetime_seconds;
+}
+
+/*
+ * Set maximum cache entries
+ */
+void
+SocketDNSCookie_set_cache_size (T cache, size_t max_entries)
+{
+  if (cache == NULL)
+    return;
+
+  if (max_entries < 1)
+    max_entries = 1;
+  if (max_entries > DNS_COOKIE_CACHE_MAX_SIZE)
+    max_entries = DNS_COOKIE_CACHE_MAX_SIZE;
+
+  cache->max_entries = max_entries;
+
+  /* Evict excess entries */
+  while (cache->count > cache->max_entries)
+    evict_lru (cache);
+}
+
+/*
+ * Set server cookie TTL
+ */
+void
+SocketDNSCookie_set_server_ttl (T cache, int ttl_seconds)
+{
+  if (cache == NULL)
+    return;
+
+  if (ttl_seconds < 60)
+    ttl_seconds = 60;
+  if (ttl_seconds > 86400)
+    ttl_seconds = 86400;
+
+  cache->server_ttl = ttl_seconds;
+}
+
+/*
+ * Force rotation of client secret
+ */
+int
+SocketDNSCookie_rotate_secret (T cache)
+{
+  if (cache == NULL)
+    return -1;
+
+  /* Save previous secret for rollover */
+  memcpy (cache->prev_secret, cache->secret, SECRET_SIZE);
+  cache->prev_secret_valid_until
+      = time (NULL) + 150; /* 150 seconds per RFC 7873 */
+
+  /* Generate new secret */
+  if (get_entropy (cache->secret, SECRET_SIZE) != 0)
+    return -1;
+
+  cache->secret_created_at = time (NULL);
+  cache->stats.secret_rotations++;
+
+  return 0;
+}
+
+/*
+ * Check and perform automatic secret rotation if needed
+ */
+static void
+check_secret_rotation (T cache)
+{
+  time_t now = time (NULL);
+
+  if (now - cache->secret_created_at >= cache->secret_lifetime)
+    SocketDNSCookie_rotate_secret (cache);
+}
+
+/*
+ * Generate a client cookie for a server
+ */
+int
+SocketDNSCookie_generate (T cache, const struct sockaddr *server_addr,
+                          socklen_t addr_len,
+                          const struct sockaddr *client_addr,
+                          socklen_t client_len, SocketDNSCookie_Cookie *cookie)
+{
+  if (cache == NULL || server_addr == NULL || cookie == NULL)
+    return -1;
+
+  check_secret_rotation (cache);
+
+  memset (cookie, 0, sizeof (*cookie));
+
+  /* Generate client cookie */
+  if (generate_client_cookie (cache, server_addr, addr_len, client_addr,
+                              client_len, cookie->client_cookie)
+      != 0)
+    return -1;
+
+  cache->stats.client_cookies_generated++;
+
+  /* Check for cached server cookie */
+  SocketDNSCookie_Entry entry;
+  if (SocketDNSCookie_cache_lookup (cache, server_addr, addr_len, &entry))
+    {
+      memcpy (cookie->server_cookie, entry.server_cookie,
+              entry.server_cookie_len);
+      cookie->server_cookie_len = entry.server_cookie_len;
+    }
+
+  return 0;
+}
+
+/*
+ * Parse cookie from EDNS0 option data
+ */
+int
+SocketDNSCookie_parse (const unsigned char *data, size_t len,
+                       SocketDNSCookie_Cookie *cookie)
+{
+  if (data == NULL || cookie == NULL)
+    return -1;
+
+  /* Validate length per RFC 7873:
+   * - 8 bytes: client cookie only
+   * - 16-40 bytes: client + server cookie
+   */
+  if (len < DNS_COOKIE_OPTION_MIN_LEN)
+    return -1;
+  if (len > DNS_COOKIE_OPTION_MAX_LEN)
+    return -1;
+  if (len > DNS_CLIENT_COOKIE_SIZE
+      && len < DNS_CLIENT_COOKIE_SIZE + DNS_SERVER_COOKIE_MIN_SIZE)
+    return -1;
+
+  memset (cookie, 0, sizeof (*cookie));
+
+  /* Copy client cookie */
+  memcpy (cookie->client_cookie, data, DNS_CLIENT_COOKIE_SIZE);
+
+  /* Copy server cookie if present */
+  if (len > DNS_CLIENT_COOKIE_SIZE)
+    {
+      cookie->server_cookie_len = len - DNS_CLIENT_COOKIE_SIZE;
+      memcpy (cookie->server_cookie, data + DNS_CLIENT_COOKIE_SIZE,
+              cookie->server_cookie_len);
+    }
+
+  return 0;
+}
+
+/*
+ * Encode cookie to EDNS0 option format
+ */
+int
+SocketDNSCookie_encode (const SocketDNSCookie_Cookie *cookie, unsigned char *buf,
+                        size_t buflen)
+{
+  if (cookie == NULL || buf == NULL)
+    return -1;
+
+  size_t total = DNS_CLIENT_COOKIE_SIZE + cookie->server_cookie_len;
+  if (buflen < total)
+    return -1;
+
+  /* Copy client cookie */
+  memcpy (buf, cookie->client_cookie, DNS_CLIENT_COOKIE_SIZE);
+
+  /* Copy server cookie if present */
+  if (cookie->server_cookie_len > 0)
+    memcpy (buf + DNS_CLIENT_COOKIE_SIZE, cookie->server_cookie,
+            cookie->server_cookie_len);
+
+  return (int)total;
+}
+
+/*
+ * Store a server cookie in the cache
+ */
+int
+SocketDNSCookie_cache_store (T cache, const struct sockaddr *server_addr,
+                             socklen_t addr_len, const uint8_t *client_cookie,
+                             const uint8_t *server_cookie, size_t server_len)
+{
+  if (cache == NULL || server_addr == NULL || client_cookie == NULL
+      || server_cookie == NULL)
+    return -1;
+
+  /* Validate server cookie length */
+  if (server_len < DNS_SERVER_COOKIE_MIN_SIZE
+      || server_len > DNS_SERVER_COOKIE_MAX_SIZE)
+    return -1;
+
+  time_t now = time (NULL);
+
+  /* Look for existing entry */
+  CacheNode *node = find_node (cache, server_addr, addr_len);
+
+  if (node)
+    {
+      /* Update existing entry */
+      memcpy (node->entry.client_cookie, client_cookie, DNS_CLIENT_COOKIE_SIZE);
+      memcpy (node->entry.server_cookie, server_cookie, server_len);
+      node->entry.server_cookie_len = server_len;
+      node->entry.received_at = now;
+      node->entry.expires_at = now + cache->server_ttl;
+      node->last_used = now;
+      move_to_front (cache, node);
+    }
+  else
+    {
+      /* Evict if at capacity */
+      if (cache->count >= cache->max_entries)
+        evict_lru (cache);
+
+      /* Create new entry */
+      node = Arena_alloc (cache->arena, sizeof (*node), __FILE__, __LINE__);
+      memset (node, 0, sizeof (*node));
+
+      memcpy (&node->entry.server_addr, server_addr, addr_len);
+      node->entry.addr_len = addr_len;
+      memcpy (node->entry.client_cookie, client_cookie, DNS_CLIENT_COOKIE_SIZE);
+      memcpy (node->entry.server_cookie, server_cookie, server_len);
+      node->entry.server_cookie_len = server_len;
+      node->entry.received_at = now;
+      node->entry.expires_at = now + cache->server_ttl;
+      node->last_used = now;
+
+      /* Add to front of list */
+      node->next = cache->head;
+      node->prev = NULL;
+      if (cache->head)
+        cache->head->prev = node;
+      cache->head = node;
+      if (!cache->tail)
+        cache->tail = node;
+
+      cache->count++;
+      cache->stats.server_cookies_cached++;
+    }
+
+  cache->stats.current_entries = cache->count;
+  return 0;
+}
+
+/*
+ * Look up a cached server cookie
+ */
+int
+SocketDNSCookie_cache_lookup (T cache, const struct sockaddr *server_addr,
+                              socklen_t addr_len, SocketDNSCookie_Entry *entry)
+{
+  if (cache == NULL || server_addr == NULL)
+    return 0;
+
+  CacheNode *node = find_node (cache, server_addr, addr_len);
+
+  if (!node)
+    {
+      cache->stats.cache_misses++;
+      return 0;
+    }
+
+  /* Check expiration */
+  time_t now = time (NULL);
+  if (now >= node->entry.expires_at)
+    {
+      /* Expired - remove from cache */
+      SocketDNSCookie_cache_invalidate (cache, server_addr, addr_len);
+      cache->stats.cache_misses++;
+      return 0;
+    }
+
+  /* Update LRU */
+  node->last_used = now;
+  move_to_front (cache, node);
+  cache->stats.cache_hits++;
+
+  if (entry)
+    memcpy (entry, &node->entry, sizeof (*entry));
+
+  return 1;
+}
+
+/*
+ * Invalidate cached cookie for a server
+ */
+int
+SocketDNSCookie_cache_invalidate (T cache, const struct sockaddr *server_addr,
+                                  socklen_t addr_len)
+{
+  if (cache == NULL || server_addr == NULL)
+    return 0;
+
+  CacheNode *node = find_node (cache, server_addr, addr_len);
+  if (!node)
+    return 0;
+
+  /* Remove from list */
+  if (node->prev)
+    node->prev->next = node->next;
+  else
+    cache->head = node->next;
+
+  if (node->next)
+    node->next->prev = node->prev;
+  else
+    cache->tail = node->prev;
+
+  /* Clear sensitive data */
+  memset (&node->entry.server_cookie, 0, DNS_SERVER_COOKIE_MAX_SIZE);
+
+  cache->count--;
+  cache->stats.current_entries = cache->count;
+
+  return 1;
+}
+
+/*
+ * Clear all cached server cookies
+ */
+void
+SocketDNSCookie_cache_clear (T cache)
+{
+  if (cache == NULL)
+    return;
+
+  CacheNode *node = cache->head;
+  while (node)
+    {
+      CacheNode *next = node->next;
+      memset (&node->entry.server_cookie, 0, DNS_SERVER_COOKIE_MAX_SIZE);
+      node = next;
+    }
+
+  cache->head = NULL;
+  cache->tail = NULL;
+  cache->count = 0;
+  cache->stats.current_entries = 0;
+}
+
+/*
+ * Remove expired entries
+ */
+int
+SocketDNSCookie_cache_expire (T cache)
+{
+  if (cache == NULL)
+    return 0;
+
+  time_t now = time (NULL);
+  int removed = 0;
+
+  CacheNode *node = cache->head;
+  while (node)
+    {
+      CacheNode *next = node->next;
+      if (now >= node->entry.expires_at)
+        {
+          if (SocketDNSCookie_cache_invalidate (
+                  cache, (struct sockaddr *)&node->entry.server_addr,
+                  node->entry.addr_len))
+            removed++;
+        }
+      node = next;
+    }
+
+  return removed;
+}
+
+/*
+ * Validate response cookie against request
+ */
+int
+SocketDNSCookie_validate (const SocketDNSCookie_Cookie *sent_cookie,
+                          const SocketDNSCookie_Cookie *response)
+{
+  if (sent_cookie == NULL || response == NULL)
+    return 0;
+
+  return constant_time_compare (sent_cookie->client_cookie,
+                                response->client_cookie,
+                                DNS_CLIENT_COOKIE_SIZE);
+}
+
+/*
+ * Check if RCODE is BADCOOKIE
+ */
+int
+SocketDNSCookie_is_badcookie (uint16_t rcode)
+{
+  return rcode == DNS_RCODE_BADCOOKIE;
+}
+
+/*
+ * Get statistics
+ */
+void
+SocketDNSCookie_stats (T cache, SocketDNSCookie_Stats *stats)
+{
+  if (cache == NULL || stats == NULL)
+    return;
+
+  memcpy (stats, &cache->stats, sizeof (*stats));
+  stats->max_entries = cache->max_entries;
+  stats->secret_expires_at = cache->secret_created_at + cache->secret_lifetime;
+}
+
+/*
+ * Reset statistics
+ */
+void
+SocketDNSCookie_stats_reset (T cache)
+{
+  if (cache == NULL)
+    return;
+
+  memset (&cache->stats, 0, sizeof (cache->stats));
+  cache->stats.current_entries = cache->count;
+}
+
+/*
+ * Compare two cookies for equality
+ */
+int
+SocketDNSCookie_equal (const SocketDNSCookie_Cookie *a,
+                       const SocketDNSCookie_Cookie *b)
+{
+  if (a == NULL || b == NULL)
+    return 0;
+
+  if (!constant_time_compare (a->client_cookie, b->client_cookie,
+                              DNS_CLIENT_COOKIE_SIZE))
+    return 0;
+
+  if (a->server_cookie_len != b->server_cookie_len)
+    return 0;
+
+  if (a->server_cookie_len > 0)
+    {
+      if (!constant_time_compare (a->server_cookie, b->server_cookie,
+                                  a->server_cookie_len))
+        return 0;
+    }
+
+  return 1;
+}
+
+/*
+ * Format cookie as hex string
+ */
+int
+SocketDNSCookie_to_hex (const SocketDNSCookie_Cookie *cookie, char *buf,
+                        size_t buflen)
+{
+  static const char hex[] = "0123456789abcdef";
+
+  if (cookie == NULL || buf == NULL)
+    return -1;
+
+  /* Calculate required size: client(16) + ':' + server(max 64) + '\0' */
+  size_t needed = DNS_CLIENT_COOKIE_SIZE * 2 + 1;
+  if (cookie->server_cookie_len > 0)
+    needed += 1 + cookie->server_cookie_len * 2;
+
+  if (buflen < needed)
+    return -1;
+
+  char *p = buf;
+
+  /* Format client cookie */
+  for (int i = 0; i < DNS_CLIENT_COOKIE_SIZE; i++)
+    {
+      *p++ = hex[(cookie->client_cookie[i] >> 4) & 0xF];
+      *p++ = hex[cookie->client_cookie[i] & 0xF];
+    }
+
+  /* Format server cookie if present */
+  if (cookie->server_cookie_len > 0)
+    {
+      *p++ = ':';
+      for (size_t i = 0; i < cookie->server_cookie_len; i++)
+        {
+          *p++ = hex[(cookie->server_cookie[i] >> 4) & 0xF];
+          *p++ = hex[cookie->server_cookie[i] & 0xF];
+        }
+    }
+
+  *p = '\0';
+  return (int)(p - buf);
+}
+
+/* ========== Internal helper functions ========== */
+
+/*
+ * Generate entropy for secrets/cookies
+ */
+static int
+get_entropy (uint8_t *buf, size_t len)
+{
+#ifdef SOCKET_HAS_TLS
+  if (RAND_bytes (buf, (int)len) == 1)
+    return 0;
+#endif
+
+  /* Fallback to getrandom() */
+  ssize_t ret = getrandom (buf, len, 0);
+  if (ret == (ssize_t)len)
+    return 0;
+
+  return -1;
+}
+
+/*
+ * Constant-time comparison to prevent timing attacks
+ */
+static int
+constant_time_compare (const uint8_t *a, const uint8_t *b, size_t len)
+{
+  uint8_t result = 0;
+  for (size_t i = 0; i < len; i++)
+    result |= a[i] ^ b[i];
+  return result == 0;
+}
+
+/*
+ * Generate client cookie using HMAC-SHA256
+ */
+static int
+generate_client_cookie (T cache, const struct sockaddr *server_addr,
+                        socklen_t addr_len __attribute__ ((unused)),
+                        const struct sockaddr *client_addr,
+                        socklen_t client_len, uint8_t *cookie)
+{
+#ifdef SOCKET_HAS_TLS
+  unsigned char data[256];
+  size_t data_len = 0;
+
+  /* Build input: server IP + client IP */
+  if (server_addr->sa_family == AF_INET)
+    {
+      const struct sockaddr_in *sin = (const struct sockaddr_in *)server_addr;
+      memcpy (data + data_len, &sin->sin_addr, sizeof (sin->sin_addr));
+      data_len += sizeof (sin->sin_addr);
+    }
+  else if (server_addr->sa_family == AF_INET6)
+    {
+      const struct sockaddr_in6 *sin6 = (const struct sockaddr_in6 *)server_addr;
+      memcpy (data + data_len, &sin6->sin6_addr, sizeof (sin6->sin6_addr));
+      data_len += sizeof (sin6->sin6_addr);
+    }
+  else
+    {
+      return -1;
+    }
+
+  if (client_addr && client_len > 0)
+    {
+      if (client_addr->sa_family == AF_INET)
+        {
+          const struct sockaddr_in *sin = (const struct sockaddr_in *)client_addr;
+          memcpy (data + data_len, &sin->sin_addr, sizeof (sin->sin_addr));
+          data_len += sizeof (sin->sin_addr);
+        }
+      else if (client_addr->sa_family == AF_INET6)
+        {
+          const struct sockaddr_in6 *sin6
+              = (const struct sockaddr_in6 *)client_addr;
+          memcpy (data + data_len, &sin6->sin6_addr, sizeof (sin6->sin6_addr));
+          data_len += sizeof (sin6->sin6_addr);
+        }
+    }
+
+  /* HMAC-SHA256 and truncate to 64 bits */
+  unsigned char hmac_out[32];
+  unsigned int hmac_len = 0;
+
+  HMAC (EVP_sha256 (), cache->secret, SECRET_SIZE, data, data_len, hmac_out,
+        &hmac_len);
+
+  memcpy (cookie, hmac_out, DNS_CLIENT_COOKIE_SIZE);
+  return 0;
+
+#else
+  /* Fallback: FNV-1a 64-bit (RFC 7873 Appendix A.1) */
+  uint64_t hash = 14695981039346656037ULL; /* FNV offset basis */
+  const uint64_t prime = 1099511628211ULL; /* FNV prime */
+
+  /* Hash server address */
+  const uint8_t *p = (const uint8_t *)server_addr;
+  for (socklen_t i = 0; i < addr_len; i++)
+    {
+      hash ^= p[i];
+      hash *= prime;
+    }
+
+  /* Hash client address if provided */
+  if (client_addr && client_len > 0)
+    {
+      p = (const uint8_t *)client_addr;
+      for (socklen_t i = 0; i < client_len; i++)
+        {
+          hash ^= p[i];
+          hash *= prime;
+        }
+    }
+
+  /* Hash secret */
+  for (int i = 0; i < SECRET_SIZE; i++)
+    {
+      hash ^= cache->secret[i];
+      hash *= prime;
+    }
+
+  /* Store as big-endian */
+  cookie[0] = (hash >> 56) & 0xFF;
+  cookie[1] = (hash >> 48) & 0xFF;
+  cookie[2] = (hash >> 40) & 0xFF;
+  cookie[3] = (hash >> 32) & 0xFF;
+  cookie[4] = (hash >> 24) & 0xFF;
+  cookie[5] = (hash >> 16) & 0xFF;
+  cookie[6] = (hash >> 8) & 0xFF;
+  cookie[7] = hash & 0xFF;
+
+  return 0;
+#endif
+}
+
+/*
+ * Find cache node by address
+ */
+static CacheNode *
+find_node (T cache, const struct sockaddr *addr, socklen_t len)
+{
+  CacheNode *node = cache->head;
+  while (node)
+    {
+      if (addr_equal ((struct sockaddr *)&node->entry.server_addr,
+                      node->entry.addr_len, addr, len))
+        return node;
+      node = node->next;
+    }
+  return NULL;
+}
+
+/*
+ * Move node to front of LRU list
+ */
+static void
+move_to_front (T cache, CacheNode *node)
+{
+  if (node == cache->head)
+    return; /* Already at front */
+
+  /* Remove from current position */
+  if (node->prev)
+    node->prev->next = node->next;
+  if (node->next)
+    node->next->prev = node->prev;
+  if (node == cache->tail)
+    cache->tail = node->prev;
+
+  /* Add to front */
+  node->prev = NULL;
+  node->next = cache->head;
+  if (cache->head)
+    cache->head->prev = node;
+  cache->head = node;
+}
+
+/*
+ * Evict least recently used entry
+ */
+static void
+evict_lru (T cache)
+{
+  if (!cache->tail)
+    return;
+
+  CacheNode *node = cache->tail;
+
+  /* Remove from list */
+  if (node->prev)
+    node->prev->next = NULL;
+  cache->tail = node->prev;
+
+  if (cache->head == node)
+    cache->head = NULL;
+
+  /* Clear sensitive data */
+  memset (&node->entry.server_cookie, 0, DNS_SERVER_COOKIE_MAX_SIZE);
+
+  cache->count--;
+  cache->stats.cache_evictions++;
+  cache->stats.current_entries = cache->count;
+}
+
+/*
+ * Compare socket addresses
+ */
+static int
+addr_equal (const struct sockaddr *a, socklen_t alen, const struct sockaddr *b,
+            socklen_t blen)
+{
+  if (a->sa_family != b->sa_family)
+    return 0;
+
+  if (a->sa_family == AF_INET)
+    {
+      const struct sockaddr_in *a4 = (const struct sockaddr_in *)a;
+      const struct sockaddr_in *b4 = (const struct sockaddr_in *)b;
+      return a4->sin_addr.s_addr == b4->sin_addr.s_addr
+             && a4->sin_port == b4->sin_port;
+    }
+  else if (a->sa_family == AF_INET6)
+    {
+      const struct sockaddr_in6 *a6 = (const struct sockaddr_in6 *)a;
+      const struct sockaddr_in6 *b6 = (const struct sockaddr_in6 *)b;
+      return memcmp (&a6->sin6_addr, &b6->sin6_addr, sizeof (a6->sin6_addr))
+                 == 0
+             && a6->sin6_port == b6->sin6_port;
+    }
+
+  /* Fallback: byte comparison */
+  if (alen != blen)
+    return 0;
+  return memcmp (a, b, alen) == 0;
+}
+
+#undef T

--- a/src/test/test_dnscookie.c
+++ b/src/test/test_dnscookie.c
@@ -1,0 +1,601 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_dnscookie.c
+ * @brief Unit tests for DNS Cookies (RFC 7873).
+ */
+
+#include "core/Arena.h"
+#include "dns/SocketDNSCookie.h"
+#include "dns/SocketDNSWire.h"
+#include "test/Test.h"
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <string.h>
+
+/*
+ * Test cookie cache creation
+ */
+TEST (cookie_cache_new)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+  ASSERT_NOT_NULL (cache);
+
+  SocketDNSCookie_free (&cache);
+  ASSERT_NULL (cache);
+
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test client cookie generation
+ */
+TEST (client_cookie_generation)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  SocketDNSCookie_Cookie cookie;
+  int ret = SocketDNSCookie_generate (cache, (struct sockaddr *)&server,
+                                      sizeof (server), NULL, 0, &cookie);
+
+  ASSERT (ret == 0);
+
+  /* Client cookie should be 8 bytes, non-zero */
+  int all_zero = 1;
+  for (int i = 0; i < DNS_CLIENT_COOKIE_SIZE; i++)
+    {
+      if (cookie.client_cookie[i] != 0)
+        all_zero = 0;
+    }
+  ASSERT (!all_zero);
+
+  /* No server cookie yet */
+  ASSERT (cookie.server_cookie_len == 0);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test that same server gets same cookie
+ */
+TEST (client_cookie_deterministic)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  SocketDNSCookie_Cookie cookie1, cookie2;
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server, sizeof (server),
+                            NULL, 0, &cookie1);
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server, sizeof (server),
+                            NULL, 0, &cookie2);
+
+  /* Same server should get same cookie */
+  ASSERT (memcmp (cookie1.client_cookie, cookie2.client_cookie,
+                  DNS_CLIENT_COOKIE_SIZE)
+          == 0);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test different servers get different cookies
+ */
+TEST (client_cookie_per_server)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server1, server2;
+  memset (&server1, 0, sizeof (server1));
+  memset (&server2, 0, sizeof (server2));
+
+  server1.sin_family = AF_INET;
+  server1.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server1.sin_addr);
+
+  server2.sin_family = AF_INET;
+  server2.sin_port = htons (53);
+  inet_pton (AF_INET, "1.1.1.1", &server2.sin_addr);
+
+  SocketDNSCookie_Cookie cookie1, cookie2;
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server1, sizeof (server1),
+                            NULL, 0, &cookie1);
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server2, sizeof (server2),
+                            NULL, 0, &cookie2);
+
+  /* Different servers should get different cookies */
+  ASSERT (memcmp (cookie1.client_cookie, cookie2.client_cookie,
+                  DNS_CLIENT_COOKIE_SIZE)
+          != 0);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test IPv6 cookie generation
+ */
+TEST (client_cookie_ipv6)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in6 server;
+  memset (&server, 0, sizeof (server));
+  server.sin6_family = AF_INET6;
+  server.sin6_port = htons (53);
+  inet_pton (AF_INET6, "2001:4860:4860::8888", &server.sin6_addr);
+
+  SocketDNSCookie_Cookie cookie;
+  int ret = SocketDNSCookie_generate (cache, (struct sockaddr *)&server,
+                                      sizeof (server), NULL, 0, &cookie);
+
+  ASSERT (ret == 0);
+
+  /* Client cookie should be non-zero */
+  int all_zero = 1;
+  for (int i = 0; i < DNS_CLIENT_COOKIE_SIZE; i++)
+    {
+      if (cookie.client_cookie[i] != 0)
+        all_zero = 0;
+    }
+  ASSERT (!all_zero);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test cookie parsing - client only
+ */
+TEST (cookie_parse_client_only)
+{
+  unsigned char data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+
+  SocketDNSCookie_Cookie cookie;
+  int ret = SocketDNSCookie_parse (data, sizeof (data), &cookie);
+
+  ASSERT (ret == 0);
+  ASSERT (memcmp (cookie.client_cookie, data, DNS_CLIENT_COOKIE_SIZE) == 0);
+  ASSERT (cookie.server_cookie_len == 0);
+}
+
+/*
+ * Test cookie parsing - client + server
+ */
+TEST (cookie_parse_with_server)
+{
+  unsigned char data[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, /* client */
+                          0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88}; /* server */
+
+  SocketDNSCookie_Cookie cookie;
+  int ret = SocketDNSCookie_parse (data, sizeof (data), &cookie);
+
+  ASSERT (ret == 0);
+  ASSERT (memcmp (cookie.client_cookie, data, DNS_CLIENT_COOKIE_SIZE) == 0);
+  ASSERT (cookie.server_cookie_len == 8);
+  ASSERT (memcmp (cookie.server_cookie, data + 8, 8) == 0);
+}
+
+/*
+ * Test cookie parsing - maximum server cookie
+ */
+TEST (cookie_parse_max_server)
+{
+  unsigned char data[40];
+  for (int i = 0; i < 40; i++)
+    data[i] = (unsigned char)i;
+
+  SocketDNSCookie_Cookie cookie;
+  int ret = SocketDNSCookie_parse (data, sizeof (data), &cookie);
+
+  ASSERT (ret == 0);
+  ASSERT (cookie.server_cookie_len == 32);
+}
+
+/*
+ * Test cookie parsing - invalid length
+ */
+TEST (cookie_parse_invalid_length)
+{
+  unsigned char short_data[] = {0x01, 0x02, 0x03}; /* Too short */
+  unsigned char gap_data[] = {0x01, 0x02, 0x03, 0x04, 0x05,
+                              0x06, 0x07, 0x08, 0x09, 0x0a}; /* 10 bytes - gap */
+
+  SocketDNSCookie_Cookie cookie;
+
+  /* Too short */
+  ASSERT (SocketDNSCookie_parse (short_data, sizeof (short_data), &cookie) == -1);
+
+  /* Invalid gap (9-15 bytes not allowed) */
+  ASSERT (SocketDNSCookie_parse (gap_data, sizeof (gap_data), &cookie) == -1);
+}
+
+/*
+ * Test cookie encoding
+ */
+TEST (cookie_encode)
+{
+  SocketDNSCookie_Cookie cookie;
+  memset (&cookie, 0, sizeof (cookie));
+
+  for (int i = 0; i < DNS_CLIENT_COOKIE_SIZE; i++)
+    cookie.client_cookie[i] = (uint8_t)(i + 1);
+
+  cookie.server_cookie_len = 8;
+  for (int i = 0; i < 8; i++)
+    cookie.server_cookie[i] = (uint8_t)(0x10 + i);
+
+  unsigned char buf[40];
+  int len = SocketDNSCookie_encode (&cookie, buf, sizeof (buf));
+
+  ASSERT (len == 16);
+  ASSERT (buf[0] == 0x01 && buf[7] == 0x08);
+  ASSERT (buf[8] == 0x10 && buf[15] == 0x17);
+}
+
+/*
+ * Test cookie encode - client only
+ */
+TEST (cookie_encode_client_only)
+{
+  SocketDNSCookie_Cookie cookie;
+  memset (&cookie, 0, sizeof (cookie));
+
+  for (int i = 0; i < DNS_CLIENT_COOKIE_SIZE; i++)
+    cookie.client_cookie[i] = (uint8_t)(i + 1);
+
+  unsigned char buf[8];
+  int len = SocketDNSCookie_encode (&cookie, buf, sizeof (buf));
+
+  ASSERT (len == 8);
+}
+
+/*
+ * Test server cookie caching
+ */
+TEST (cookie_cache_store_lookup)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  uint8_t client_cookie[8] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08};
+  uint8_t server_cookie[16] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88,
+                               0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF, 0x00};
+
+  int ret = SocketDNSCookie_cache_store (cache, (struct sockaddr *)&server,
+                                         sizeof (server), client_cookie,
+                                         server_cookie, 16);
+  ASSERT (ret == 0);
+
+  /* Look up the cached cookie */
+  SocketDNSCookie_Entry entry;
+  ret = SocketDNSCookie_cache_lookup (cache, (struct sockaddr *)&server,
+                                      sizeof (server), &entry);
+  ASSERT (ret == 1);
+  ASSERT (entry.server_cookie_len == 16);
+  ASSERT (memcmp (entry.server_cookie, server_cookie, 16) == 0);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test cache miss
+ */
+TEST (cookie_cache_miss)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  /* Look up without storing first */
+  SocketDNSCookie_Entry entry;
+  int ret = SocketDNSCookie_cache_lookup (cache, (struct sockaddr *)&server,
+                                          sizeof (server), &entry);
+  ASSERT (ret == 0); /* Miss */
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test cache invalidation
+ */
+TEST (cookie_cache_invalidate)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  uint8_t client_cookie[8] = {0};
+  uint8_t server_cookie[8] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+
+  SocketDNSCookie_cache_store (cache, (struct sockaddr *)&server, sizeof (server),
+                               client_cookie, server_cookie, 8);
+
+  /* Invalidate */
+  int ret = SocketDNSCookie_cache_invalidate (cache, (struct sockaddr *)&server,
+                                              sizeof (server));
+  ASSERT (ret == 1);
+
+  /* Should be gone */
+  ret = SocketDNSCookie_cache_lookup (cache, (struct sockaddr *)&server,
+                                      sizeof (server), NULL);
+  ASSERT (ret == 0);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test cookie validation
+ */
+TEST (cookie_validate)
+{
+  SocketDNSCookie_Cookie sent = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+                                 {0},
+                                 0};
+
+  SocketDNSCookie_Cookie response_good
+      = {{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08},
+         {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+         8};
+
+  SocketDNSCookie_Cookie response_bad
+      = {{0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8},
+         {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88},
+         8};
+
+  ASSERT (SocketDNSCookie_validate (&sent, &response_good) == 1);
+  ASSERT (SocketDNSCookie_validate (&sent, &response_bad) == 0);
+}
+
+/*
+ * Test BADCOOKIE check
+ */
+TEST (badcookie_check)
+{
+  ASSERT (SocketDNSCookie_is_badcookie (DNS_RCODE_BADCOOKIE) == 1);
+  ASSERT (SocketDNSCookie_is_badcookie (23) == 1);
+  ASSERT (SocketDNSCookie_is_badcookie (0) == 0);
+  ASSERT (SocketDNSCookie_is_badcookie (DNS_RCODE_NOERROR) == 0);
+  ASSERT (SocketDNSCookie_is_badcookie (DNS_RCODE_NXDOMAIN) == 0);
+}
+
+/*
+ * Test secret rotation
+ */
+TEST (secret_rotation)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  /* Get cookie before rotation */
+  SocketDNSCookie_Cookie cookie1;
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server, sizeof (server),
+                            NULL, 0, &cookie1);
+
+  /* Rotate secret */
+  int ret = SocketDNSCookie_rotate_secret (cache);
+  ASSERT (ret == 0);
+
+  /* Get cookie after rotation */
+  SocketDNSCookie_Cookie cookie2;
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server, sizeof (server),
+                            NULL, 0, &cookie2);
+
+  /* Cookies should be different after rotation */
+  ASSERT (memcmp (cookie1.client_cookie, cookie2.client_cookie,
+                  DNS_CLIENT_COOKIE_SIZE)
+          != 0);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test hex formatting
+ */
+TEST (cookie_to_hex)
+{
+  SocketDNSCookie_Cookie cookie;
+  memset (&cookie, 0, sizeof (cookie));
+
+  cookie.client_cookie[0] = 0x01;
+  cookie.client_cookie[1] = 0x23;
+  cookie.client_cookie[2] = 0x45;
+  cookie.client_cookie[3] = 0x67;
+  cookie.client_cookie[4] = 0x89;
+  cookie.client_cookie[5] = 0xab;
+  cookie.client_cookie[6] = 0xcd;
+  cookie.client_cookie[7] = 0xef;
+
+  char buf[80];
+  int len = SocketDNSCookie_to_hex (&cookie, buf, sizeof (buf));
+
+  ASSERT (len == 16);
+  ASSERT (strcmp (buf, "0123456789abcdef") == 0);
+}
+
+/*
+ * Test hex formatting with server cookie
+ */
+TEST (cookie_to_hex_with_server)
+{
+  SocketDNSCookie_Cookie cookie;
+  memset (&cookie, 0, sizeof (cookie));
+
+  for (int i = 0; i < 8; i++)
+    cookie.client_cookie[i] = (uint8_t)i;
+
+  cookie.server_cookie_len = 8;
+  for (int i = 0; i < 8; i++)
+    cookie.server_cookie[i] = (uint8_t)(0xA0 + i);
+
+  char buf[80];
+  int len = SocketDNSCookie_to_hex (&cookie, buf, sizeof (buf));
+
+  ASSERT (len == 33); /* 16 + 1 + 16 */
+  ASSERT (strstr (buf, ":") != NULL);
+}
+
+/*
+ * Test cookie equality
+ */
+TEST (cookie_equality)
+{
+  SocketDNSCookie_Cookie a, b;
+  memset (&a, 0, sizeof (a));
+  memset (&b, 0, sizeof (b));
+
+  for (int i = 0; i < 8; i++)
+    {
+      a.client_cookie[i] = (uint8_t)i;
+      b.client_cookie[i] = (uint8_t)i;
+    }
+
+  ASSERT (SocketDNSCookie_equal (&a, &b) == 1);
+
+  /* Differ in one byte */
+  b.client_cookie[0] = 0xFF;
+  ASSERT (SocketDNSCookie_equal (&a, &b) == 0);
+}
+
+/*
+ * Test statistics
+ */
+TEST (cookie_stats)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  struct sockaddr_in server;
+  memset (&server, 0, sizeof (server));
+  server.sin_family = AF_INET;
+  server.sin_port = htons (53);
+  inet_pton (AF_INET, "8.8.8.8", &server.sin_addr);
+
+  /* Generate some cookies */
+  SocketDNSCookie_Cookie cookie;
+  SocketDNSCookie_generate (cache, (struct sockaddr *)&server, sizeof (server),
+                            NULL, 0, &cookie);
+
+  SocketDNSCookie_Stats stats;
+  SocketDNSCookie_stats (cache, &stats);
+
+  ASSERT (stats.client_cookies_generated >= 1);
+  ASSERT (stats.max_entries == DNS_COOKIE_CACHE_DEFAULT_SIZE);
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Test cache LRU eviction
+ */
+TEST (cookie_cache_lru_eviction)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSCookie_T cache = SocketDNSCookie_new (arena);
+
+  /* Set small cache size */
+  SocketDNSCookie_set_cache_size (cache, 3);
+
+  /* Add 4 entries (should evict first) */
+  for (int i = 0; i < 4; i++)
+    {
+      struct sockaddr_in server;
+      memset (&server, 0, sizeof (server));
+      server.sin_family = AF_INET;
+      server.sin_port = htons (53);
+      server.sin_addr.s_addr = htonl (0x08080800 + i);
+
+      uint8_t client_cookie[8] = {0};
+      uint8_t server_cookie[8] = {0};
+
+      SocketDNSCookie_cache_store (cache, (struct sockaddr *)&server,
+                                   sizeof (server), client_cookie, server_cookie,
+                                   8);
+    }
+
+  /* First entry should be evicted */
+  struct sockaddr_in first;
+  memset (&first, 0, sizeof (first));
+  first.sin_family = AF_INET;
+  first.sin_port = htons (53);
+  first.sin_addr.s_addr = htonl (0x08080800);
+
+  int ret = SocketDNSCookie_cache_lookup (cache, (struct sockaddr *)&first,
+                                          sizeof (first), NULL);
+  ASSERT (ret == 0); /* Should be evicted */
+
+  /* Last entry should still be there */
+  struct sockaddr_in last;
+  memset (&last, 0, sizeof (last));
+  last.sin_family = AF_INET;
+  last.sin_port = htons (53);
+  last.sin_addr.s_addr = htonl (0x08080803);
+
+  ret = SocketDNSCookie_cache_lookup (cache, (struct sockaddr *)&last,
+                                      sizeof (last), NULL);
+  ASSERT (ret == 1); /* Should still be there */
+
+  SocketDNSCookie_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/*
+ * Main test entry point
+ */
+int
+main (void)
+{
+  printf ("Running DNS Cookie tests...\n");
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Implement DNS Cookies (RFC 7873) for protection against off-path spoofing and amplification attacks
- Add client cookie generation using HMAC-SHA256 (with FNV-1a fallback when TLS disabled)
- Implement per-server cookie caching with LRU eviction policy
- Add BADCOOKIE RCODE (23) handling for invalid server cookies

Fixes #150

## Implementation Details
- `SocketDNSCookie_T` - Opaque cache handle with client secret and server cookie storage
- `SocketDNSCookie_generate()` - Generates 8-byte client cookie per server IP
- `SocketDNSCookie_cache_store/lookup/invalidate()` - Server cookie cache operations
- `SocketDNSCookie_validate()` - Constant-time cookie validation to prevent timing attacks
- Automatic secret rotation (configurable, default 24 hours per RFC 7873)

## Files Changed
- `include/dns/SocketDNSCookie.h` - Public API header
- `src/dns/SocketDNSCookie.c` - Implementation
- `include/dns/SocketDNSWire.h` - Added BADCOOKIE RCODE
- `src/test/test_dnscookie.c` - 22 unit tests
- `CMakeLists.txt` - Build integration

## Test plan
- [x] All 22 unit tests pass
- [x] Tests pass with ASan + UBSan sanitizers
- [x] All DNS-related tests continue to pass
- [ ] Manual testing with public DNS servers (8.8.8.8, 1.1.1.1)