### PR TITLE
feat(dns): implement Extended DNS Errors (RFC 8914)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -324,6 +324,7 @@ set(LIB_SOURCES
     src/dns/SocketDNSResolver.c
     src/dns/SocketDNSSEC.c
     src/dns/SocketDNSCookie.c
+    src/dns/SocketDNSError.c
 
     # Poll module (consolidated)
     src/poll/SocketPoll.c
@@ -556,6 +557,7 @@ set(DNS_HEADERS
     include/dns/SocketDNSoverHTTPS.h
     include/dns/SocketDNSSEC.h
     include/dns/SocketDNSCookie.h
+    include/dns/SocketDNSError.h
 )
 
 set(POLL_HEADERS
@@ -692,6 +694,7 @@ set(TEST_SOURCES
     test_dns_resolver
     test_dnssec
     test_dnscookie
+    test_dnserror
     test_integration
     test_threadsafety
     test_happy_eyeballs

--- a/include/dns/SocketDNSError.h
+++ b/include/dns/SocketDNSError.h
@@ -1,0 +1,444 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETDNSERROR_INCLUDED
+#define SOCKETDNSERROR_INCLUDED
+
+/**
+ * @file SocketDNSError.h
+ * @brief Extended DNS Errors (RFC 8914).
+ * @ingroup dns
+ *
+ * Implements Extended DNS Errors (EDE) as specified in RFC 8914.
+ * EDE provides detailed error information beyond the traditional 4-bit
+ * RCODE, transported via EDNS0 option code 15.
+ *
+ * ## RFC References
+ *
+ * - RFC 8914: Extended DNS Errors
+ * - RFC 6891: EDNS0 (transport mechanism)
+ *
+ * ## Features
+ *
+ * - Parse EDE options from DNS responses
+ * - Extract INFO-CODE and EXTRA-TEXT
+ * - Support all 25 defined error codes (0-24)
+ * - Human-readable error descriptions
+ * - Integration with existing EDNS0 infrastructure
+ *
+ * @see SocketDNSWire.h for EDNS0 option parsing.
+ */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup dns_ede Extended DNS Errors
+ * @brief RFC 8914 Extended DNS Error parsing and handling.
+ * @ingroup dns
+ * @{
+ */
+
+/** EDNS0 option code for Extended DNS Errors (RFC 8914). */
+#define DNS_EDE_OPTION_CODE 15
+
+/** Minimum EDE option size (INFO-CODE only, no EXTRA-TEXT). */
+#define DNS_EDE_MIN_SIZE 2
+
+/** Maximum EXTRA-TEXT length (practical limit). */
+#define DNS_EDE_MAX_EXTRA_TEXT 256
+
+/**
+ * @brief Extended DNS Error INFO-CODE values (RFC 8914 Section 4).
+ *
+ * These codes provide detailed error information beyond RCODE.
+ * Values 0-24 are defined by RFC 8914. Higher values are reserved
+ * for future use and should be treated as "Other Error" (0).
+ */
+typedef enum
+{
+  /** Catchall for errors not matching other codes (INFO-CODE 0). */
+  DNS_EDE_OTHER = 0,
+
+  /** DNSKEY algorithm not supported by validator (INFO-CODE 1). */
+  DNS_EDE_UNSUPPORTED_DNSKEY_ALGORITHM = 1,
+
+  /** DS digest type not supported by validator (INFO-CODE 2). */
+  DNS_EDE_UNSUPPORTED_DS_DIGEST_TYPE = 2,
+
+  /** Answer served from stale cache (timeout, INFO-CODE 3). */
+  DNS_EDE_STALE_ANSWER = 3,
+
+  /** Answer was forged/modified by policy (INFO-CODE 4). */
+  DNS_EDE_FORGED_ANSWER = 4,
+
+  /** DNSSEC validation state indeterminate (INFO-CODE 5). */
+  DNS_EDE_DNSSEC_INDETERMINATE = 5,
+
+  /** DNSSEC validation failed (bogus) (INFO-CODE 6). */
+  DNS_EDE_DNSSEC_BOGUS = 6,
+
+  /** RRSIG validity period expired (INFO-CODE 7). */
+  DNS_EDE_SIGNATURE_EXPIRED = 7,
+
+  /** RRSIG not yet valid (INFO-CODE 8). */
+  DNS_EDE_SIGNATURE_NOT_YET_VALID = 8,
+
+  /** No matching DNSKEY for RRSIG (INFO-CODE 9). */
+  DNS_EDE_DNSKEY_MISSING = 9,
+
+  /** No RRSIGs found for RRset (INFO-CODE 10). */
+  DNS_EDE_RRSIGS_MISSING = 10,
+
+  /** DNSKEY has no zone flag set (INFO-CODE 11). */
+  DNS_EDE_NO_ZONE_KEY_BIT_SET = 11,
+
+  /** NSEC/NSEC3 missing for denial of existence (INFO-CODE 12). */
+  DNS_EDE_NSEC_MISSING = 12,
+
+  /** Previous SERVFAIL cached and returned (INFO-CODE 13). */
+  DNS_EDE_CACHED_ERROR = 13,
+
+  /** Server not ready to serve queries (INFO-CODE 14). */
+  DNS_EDE_NOT_READY = 14,
+
+  /** Query blocked by server policy (INFO-CODE 15). */
+  DNS_EDE_BLOCKED = 15,
+
+  /** Answer censored by external requirement (INFO-CODE 16). */
+  DNS_EDE_CENSORED = 16,
+
+  /** Answer filtered per client request (INFO-CODE 17). */
+  DNS_EDE_FILTERED = 17,
+
+  /** Client not authorized (INFO-CODE 18). */
+  DNS_EDE_PROHIBITED = 18,
+
+  /** Stale NXDOMAIN served (INFO-CODE 19). */
+  DNS_EDE_STALE_NXDOMAIN_ANSWER = 19,
+
+  /** Server not authoritative and recursion disabled (INFO-CODE 20). */
+  DNS_EDE_NOT_AUTHORITATIVE = 20,
+
+  /** Query type/operation not supported (INFO-CODE 21). */
+  DNS_EDE_NOT_SUPPORTED = 21,
+
+  /** Cannot reach authoritative servers (INFO-CODE 22). */
+  DNS_EDE_NO_REACHABLE_AUTHORITY = 22,
+
+  /** Network error reaching remote server (INFO-CODE 23). */
+  DNS_EDE_NETWORK_ERROR = 23,
+
+  /** Zone data too old or expired (INFO-CODE 24). */
+  DNS_EDE_INVALID_DATA = 24,
+
+  /** Maximum defined INFO-CODE value. */
+  DNS_EDE_MAX_DEFINED = 24
+} SocketDNS_EDECode;
+
+/**
+ * @brief Categorization of EDE codes.
+ *
+ * Groups related error codes for easier handling.
+ */
+typedef enum
+{
+  /** General/unspecified errors. */
+  DNS_EDE_CATEGORY_GENERAL = 0,
+
+  /** DNSSEC validation-related errors (codes 1-2, 5-12). */
+  DNS_EDE_CATEGORY_DNSSEC = 1,
+
+  /** Stale cache responses (codes 3, 19). */
+  DNS_EDE_CATEGORY_STALE = 2,
+
+  /** Policy/filtering errors (codes 4, 15-18). */
+  DNS_EDE_CATEGORY_POLICY = 3,
+
+  /** Server state errors (codes 13, 14, 20, 21). */
+  DNS_EDE_CATEGORY_SERVER = 4,
+
+  /** Network/reachability errors (codes 22, 23, 24). */
+  DNS_EDE_CATEGORY_NETWORK = 5
+} SocketDNS_EDECategory;
+
+/**
+ * @brief Extended DNS Error structure.
+ *
+ * Represents a parsed EDE option from a DNS response.
+ * May contain optional UTF-8 EXTRA-TEXT for human consumption.
+ */
+typedef struct
+{
+  /** INFO-CODE from RFC 8914. */
+  uint16_t info_code;
+
+  /** Whether an EDE option was present in the response. */
+  bool present;
+
+  /** Length of extra_text in bytes (0 if none). */
+  size_t extra_text_len;
+
+  /** Optional UTF-8 extra text (NOT null-terminated in wire format). */
+  char extra_text[DNS_EDE_MAX_EXTRA_TEXT + 1];
+} SocketDNS_ExtendedError;
+
+/**
+ * @brief Initialize an Extended Error structure.
+ * @ingroup dns_ede
+ *
+ * Sets all fields to default/empty values.
+ *
+ * @param[out] ede Structure to initialize.
+ *
+ * @code{.c}
+ * SocketDNS_ExtendedError ede;
+ * SocketDNS_ede_init(&ede);
+ * // ede.present = false, ede.info_code = 0, ede.extra_text_len = 0
+ * @endcode
+ */
+extern void SocketDNS_ede_init (SocketDNS_ExtendedError *ede);
+
+/**
+ * @brief Parse an EDE option from EDNS0 option data.
+ * @ingroup dns_ede
+ *
+ * Extracts INFO-CODE and optional EXTRA-TEXT from an EDE option.
+ * The EXTRA-TEXT is validated as UTF-8 and null-terminated in the output.
+ *
+ * @param[in]  data    EDE option data (after OPTION-CODE and OPTION-LENGTH).
+ * @param[in]  len     Length of option data.
+ * @param[out] ede     Output Extended Error structure.
+ * @return 0 on success, -1 on error (NULL params, len < 2, or invalid UTF-8).
+ *
+ * @code{.c}
+ * // Assuming we found EDE option in EDNS0 RDATA:
+ * SocketDNS_EDNSOption opt;
+ * if (SocketDNS_edns_option_find(rdata, rdlen, DNS_EDE_OPTION_CODE, &opt)) {
+ *     SocketDNS_ExtendedError ede;
+ *     if (SocketDNS_ede_parse(opt.data, opt.length, &ede) == 0) {
+ *         printf("EDE: %s\n", SocketDNS_ede_code_name(ede.info_code));
+ *         if (ede.extra_text_len > 0) {
+ *             printf("  Extra: %s\n", ede.extra_text);
+ *         }
+ *     }
+ * }
+ * @endcode
+ */
+extern int SocketDNS_ede_parse (const unsigned char *data, size_t len,
+                                SocketDNS_ExtendedError *ede);
+
+/**
+ * @brief Encode an EDE option to wire format.
+ * @ingroup dns_ede
+ *
+ * Serializes an Extended Error to wire format suitable for inclusion
+ * in an EDNS0 OPT record RDATA section.
+ *
+ * @param[in]  ede     Extended Error to encode.
+ * @param[out] buf     Output buffer.
+ * @param[in]  buflen  Size of output buffer.
+ * @return Bytes written on success, -1 on error (buffer too small).
+ *
+ * @code{.c}
+ * SocketDNS_ExtendedError ede;
+ * SocketDNS_ede_init(&ede);
+ * ede.info_code = DNS_EDE_NETWORK_ERROR;
+ * ede.present = true;
+ * snprintf(ede.extra_text, sizeof(ede.extra_text), "Connection refused");
+ * ede.extra_text_len = strlen(ede.extra_text);
+ *
+ * unsigned char buf[64];
+ * int len = SocketDNS_ede_encode(&ede, buf, sizeof(buf));
+ * // len = 2 + strlen("Connection refused")
+ * @endcode
+ */
+extern int SocketDNS_ede_encode (const SocketDNS_ExtendedError *ede,
+                                 unsigned char *buf, size_t buflen);
+
+/**
+ * @brief Get human-readable name for an EDE INFO-CODE.
+ * @ingroup dns_ede
+ *
+ * Returns a static string describing the error code.
+ * Unknown codes return "Unknown Error".
+ *
+ * @param[in] code INFO-CODE value.
+ * @return Static string name (never NULL).
+ *
+ * @code{.c}
+ * printf("Error: %s\n", SocketDNS_ede_code_name(DNS_EDE_DNSSEC_BOGUS));
+ * // Output: "Error: DNSSEC Bogus"
+ * @endcode
+ */
+extern const char *SocketDNS_ede_code_name (uint16_t code);
+
+/**
+ * @brief Get detailed description for an EDE INFO-CODE.
+ * @ingroup dns_ede
+ *
+ * Returns a static string with detailed explanation of the error code.
+ * Unknown codes return a generic message.
+ *
+ * @param[in] code INFO-CODE value.
+ * @return Static description string (never NULL).
+ *
+ * @code{.c}
+ * printf("Description: %s\n",
+ *        SocketDNS_ede_code_description(DNS_EDE_DNSSEC_BOGUS));
+ * // Output: "Description: DNSSEC validation failed (signature invalid, chain broken, etc.)"
+ * @endcode
+ */
+extern const char *SocketDNS_ede_code_description (uint16_t code);
+
+/**
+ * @brief Get category for an EDE INFO-CODE.
+ * @ingroup dns_ede
+ *
+ * Categorizes the error code for easier handling/display.
+ *
+ * @param[in] code INFO-CODE value.
+ * @return Error category.
+ *
+ * @code{.c}
+ * if (SocketDNS_ede_category(ede.info_code) == DNS_EDE_CATEGORY_DNSSEC) {
+ *     printf("DNSSEC validation issue\n");
+ * }
+ * @endcode
+ */
+extern SocketDNS_EDECategory SocketDNS_ede_category (uint16_t code);
+
+/**
+ * @brief Get category name as string.
+ * @ingroup dns_ede
+ *
+ * @param[in] category Error category.
+ * @return Static category name string.
+ */
+extern const char *SocketDNS_ede_category_name (SocketDNS_EDECategory category);
+
+/**
+ * @brief Check if EDE indicates a DNSSEC-related error.
+ * @ingroup dns_ede
+ *
+ * Returns true for INFO-CODEs 1, 2, and 5-12.
+ *
+ * @param[in] code INFO-CODE value.
+ * @return true if DNSSEC-related, false otherwise.
+ */
+extern bool SocketDNS_ede_is_dnssec_error (uint16_t code);
+
+/**
+ * @brief Check if EDE indicates a stale response.
+ * @ingroup dns_ede
+ *
+ * Returns true for INFO-CODEs 3 and 19.
+ *
+ * @param[in] code INFO-CODE value.
+ * @return true if stale response, false otherwise.
+ */
+extern bool SocketDNS_ede_is_stale (uint16_t code);
+
+/**
+ * @brief Check if EDE indicates a policy/filtering action.
+ * @ingroup dns_ede
+ *
+ * Returns true for INFO-CODEs 4, 15, 16, 17, 18.
+ *
+ * @param[in] code INFO-CODE value.
+ * @return true if policy/filter action, false otherwise.
+ */
+extern bool SocketDNS_ede_is_filtered (uint16_t code);
+
+/**
+ * @brief Check if EDE indicates the response may be retried.
+ * @ingroup dns_ede
+ *
+ * Some errors are transient (network issues, server not ready).
+ * Returns true if retrying the query might succeed.
+ *
+ * @param[in] code INFO-CODE value.
+ * @return true if retry may help, false if permanent error.
+ *
+ * @code{.c}
+ * if (SocketDNS_ede_is_retriable(ede.info_code)) {
+ *     // Retry with exponential backoff
+ * } else {
+ *     // Don't retry - error is permanent
+ * }
+ * @endcode
+ */
+extern bool SocketDNS_ede_is_retriable (uint16_t code);
+
+/**
+ * @brief Format an EDE for logging/display.
+ * @ingroup dns_ede
+ *
+ * Creates a formatted string representation of the Extended Error
+ * suitable for logging or user display.
+ *
+ * @param[in]  ede     Extended Error to format.
+ * @param[out] buf     Output buffer.
+ * @param[in]  buflen  Size of output buffer.
+ * @return Length of formatted string (excluding null terminator),
+ *         or -1 on error.
+ *
+ * @code{.c}
+ * char msg[256];
+ * SocketDNS_ede_format(&ede, msg, sizeof(msg));
+ * printf("DNS Error: %s\n", msg);
+ * // Output: "DNS Error: DNSSEC Bogus (6): Signature verification failed"
+ * @endcode
+ */
+extern int SocketDNS_ede_format (const SocketDNS_ExtendedError *ede, char *buf,
+                                 size_t buflen);
+
+/**
+ * @brief Parse all EDE options from EDNS0 RDATA.
+ * @ingroup dns_ede
+ *
+ * RFC 8914 allows multiple EDE options in a single response.
+ * This function extracts all EDE options into an array.
+ *
+ * @param[in]  rdata     EDNS0 OPT RDATA.
+ * @param[in]  rdlen     Length of RDATA.
+ * @param[out] ede_array Array to fill with parsed EDE options.
+ * @param[in]  max_count Maximum number of entries in array.
+ * @return Number of EDE options found, or -1 on error.
+ *
+ * @code{.c}
+ * SocketDNS_ExtendedError errors[4];
+ * int count = SocketDNS_ede_parse_all(rdata, rdlen, errors, 4);
+ * for (int i = 0; i < count; i++) {
+ *     printf("EDE[%d]: %s\n", i, SocketDNS_ede_code_name(errors[i].info_code));
+ * }
+ * @endcode
+ */
+extern int SocketDNS_ede_parse_all (const unsigned char *rdata, size_t rdlen,
+                                    SocketDNS_ExtendedError *ede_array,
+                                    size_t max_count);
+
+/**
+ * @brief Create an EDNS0 option structure from an EDE.
+ * @ingroup dns_ede
+ *
+ * Convenience function to create an EDNS0 option for transmission.
+ * The caller must provide a buffer for the option data.
+ *
+ * @param[in]  ede        Extended Error to convert.
+ * @param[out] opt        Output EDNS0 option structure.
+ * @param[out] opt_data   Buffer for option data.
+ * @param[in]  data_len   Size of opt_data buffer.
+ * @return 0 on success, -1 on error.
+ */
+extern int SocketDNS_ede_to_edns_option (const SocketDNS_ExtendedError *ede,
+                                         void *opt, unsigned char *opt_data,
+                                         size_t data_len);
+
+/** @} */ /* End of dns_ede group */
+
+#endif /* SOCKETDNSERROR_INCLUDED */

--- a/src/dns/SocketDNSError.c
+++ b/src/dns/SocketDNSError.c
@@ -1,0 +1,467 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketDNSError.c
+ * @brief Extended DNS Errors implementation (RFC 8914).
+ */
+
+#include "dns/SocketDNSError.h"
+#include "dns/SocketDNSWire.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/**
+ * @brief Error code name table.
+ */
+static const char *ede_code_names[] = {
+  "Other Error",                   /* 0 */
+  "Unsupported DNSKEY Algorithm",  /* 1 */
+  "Unsupported DS Digest Type",    /* 2 */
+  "Stale Answer",                  /* 3 */
+  "Forged Answer",                 /* 4 */
+  "DNSSEC Indeterminate",          /* 5 */
+  "DNSSEC Bogus",                  /* 6 */
+  "Signature Expired",             /* 7 */
+  "Signature Not Yet Valid",       /* 8 */
+  "DNSKEY Missing",                /* 9 */
+  "RRSIGs Missing",                /* 10 */
+  "No Zone Key Bit Set",           /* 11 */
+  "NSEC Missing",                  /* 12 */
+  "Cached Error",                  /* 13 */
+  "Not Ready",                     /* 14 */
+  "Blocked",                       /* 15 */
+  "Censored",                      /* 16 */
+  "Filtered",                      /* 17 */
+  "Prohibited",                    /* 18 */
+  "Stale NXDOMAIN Answer",         /* 19 */
+  "Not Authoritative",             /* 20 */
+  "Not Supported",                 /* 21 */
+  "No Reachable Authority",        /* 22 */
+  "Network Error",                 /* 23 */
+  "Invalid Data"                   /* 24 */
+};
+
+/**
+ * @brief Error code description table.
+ */
+static const char *ede_code_descriptions[] = {
+  /* 0 */ "Catchall for errors not matching other defined codes",
+  /* 1 */ "DNSKEY algorithm not supported by the validator",
+  /* 2 */ "DS digest type not supported by the validator",
+  /* 3 */ "Answer served from stale cache due to timeout",
+  /* 4 */ "Answer was forged or modified by policy",
+  /* 5 */ "DNSSEC validation state could not be determined",
+  /* 6 */ "DNSSEC validation failed (signature invalid, chain broken, etc.)",
+  /* 7 */ "RRSIG validity period has expired",
+  /* 8 */ "RRSIG inception time is in the future",
+  /* 9 */ "No matching DNSKEY found for RRSIG verification",
+  /* 10 */ "No RRSIGs found for the RRset requiring validation",
+  /* 11 */ "DNSKEY record has no zone flag set (bit 7)",
+  /* 12 */ "NSEC/NSEC3 record missing for denial of existence proof",
+  /* 13 */ "Previous SERVFAIL response cached and returned",
+  /* 14 */ "Server is not ready to serve queries",
+  /* 15 */ "Query blocked by server operator policy",
+  /* 16 */ "Answer censored due to external requirement",
+  /* 17 */ "Answer filtered per client-requested policy",
+  /* 18 */ "Client is not authorized for this query",
+  /* 19 */ "Stale NXDOMAIN answer served from cache",
+  /* 20 */ "Server is not authoritative and recursion is disabled",
+  /* 21 */ "Requested query type or operation not supported",
+  /* 22 */ "Cannot reach any authoritative nameservers",
+  /* 23 */ "Network error communicating with remote server",
+  /* 24 */ "Zone data is too old or has expired"
+};
+
+/**
+ * @brief Category name table.
+ */
+static const char *ede_category_names[] = {
+  "General",
+  "DNSSEC",
+  "Stale Cache",
+  "Policy/Filter",
+  "Server State",
+  "Network"
+};
+
+/**
+ * @brief Validate UTF-8 byte sequence.
+ *
+ * Simple UTF-8 validation - checks for valid byte sequences.
+ *
+ * @param data Data to validate.
+ * @param len  Length of data.
+ * @return true if valid UTF-8, false otherwise.
+ */
+static bool
+validate_utf8 (const unsigned char *data, size_t len)
+{
+  size_t i = 0;
+
+  while (i < len)
+    {
+      unsigned char c = data[i];
+
+      if (c < 0x80)
+        {
+          /* ASCII character */
+          i++;
+        }
+      else if ((c & 0xE0) == 0xC0)
+        {
+          /* 2-byte sequence */
+          if (i + 1 >= len)
+            return false;
+          if ((data[i + 1] & 0xC0) != 0x80)
+            return false;
+          /* Check for overlong encoding */
+          if (c < 0xC2)
+            return false;
+          i += 2;
+        }
+      else if ((c & 0xF0) == 0xE0)
+        {
+          /* 3-byte sequence */
+          if (i + 2 >= len)
+            return false;
+          if ((data[i + 1] & 0xC0) != 0x80)
+            return false;
+          if ((data[i + 2] & 0xC0) != 0x80)
+            return false;
+          /* Check for overlong encoding and surrogates */
+          if (c == 0xE0 && data[i + 1] < 0xA0)
+            return false;
+          if (c == 0xED && data[i + 1] >= 0xA0)
+            return false; /* Surrogates */
+          i += 3;
+        }
+      else if ((c & 0xF8) == 0xF0)
+        {
+          /* 4-byte sequence */
+          if (i + 3 >= len)
+            return false;
+          if ((data[i + 1] & 0xC0) != 0x80)
+            return false;
+          if ((data[i + 2] & 0xC0) != 0x80)
+            return false;
+          if ((data[i + 3] & 0xC0) != 0x80)
+            return false;
+          /* Check for overlong encoding and valid range */
+          if (c == 0xF0 && data[i + 1] < 0x90)
+            return false;
+          if (c == 0xF4 && data[i + 1] >= 0x90)
+            return false;
+          if (c > 0xF4)
+            return false;
+          i += 4;
+        }
+      else
+        {
+          /* Invalid leading byte */
+          return false;
+        }
+    }
+
+  return true;
+}
+
+void
+SocketDNS_ede_init (SocketDNS_ExtendedError *ede)
+{
+  if (ede == NULL)
+    return;
+
+  ede->info_code = 0;
+  ede->present = false;
+  ede->extra_text_len = 0;
+  ede->extra_text[0] = '\0';
+}
+
+int
+SocketDNS_ede_parse (const unsigned char *data, size_t len,
+                     SocketDNS_ExtendedError *ede)
+{
+  if (data == NULL || ede == NULL)
+    return -1;
+
+  /* Minimum size is 2 bytes (INFO-CODE only) */
+  if (len < DNS_EDE_MIN_SIZE)
+    return -1;
+
+  SocketDNS_ede_init (ede);
+
+  /* Parse INFO-CODE (network byte order) */
+  ede->info_code = ((uint16_t)data[0] << 8) | data[1];
+  ede->present = true;
+
+  /* Parse optional EXTRA-TEXT */
+  if (len > DNS_EDE_MIN_SIZE)
+    {
+      size_t text_len = len - DNS_EDE_MIN_SIZE;
+      const unsigned char *text_data = data + DNS_EDE_MIN_SIZE;
+
+      /* Validate UTF-8 */
+      if (!validate_utf8 (text_data, text_len))
+        {
+          /* RFC 8914: EXTRA-TEXT must be valid UTF-8 */
+          /* We'll accept the EDE but truncate invalid text */
+          ede->extra_text_len = 0;
+          ede->extra_text[0] = '\0';
+        }
+      else
+        {
+          /* Truncate if too long */
+          if (text_len > DNS_EDE_MAX_EXTRA_TEXT)
+            text_len = DNS_EDE_MAX_EXTRA_TEXT;
+
+          memcpy (ede->extra_text, text_data, text_len);
+          ede->extra_text[text_len] = '\0';
+          ede->extra_text_len = text_len;
+        }
+    }
+
+  return 0;
+}
+
+int
+SocketDNS_ede_encode (const SocketDNS_ExtendedError *ede, unsigned char *buf,
+                      size_t buflen)
+{
+  if (ede == NULL || buf == NULL)
+    return -1;
+
+  size_t required = DNS_EDE_MIN_SIZE + ede->extra_text_len;
+  if (buflen < required)
+    return -1;
+
+  /* Encode INFO-CODE (network byte order) */
+  buf[0] = (ede->info_code >> 8) & 0xFF;
+  buf[1] = ede->info_code & 0xFF;
+
+  /* Encode EXTRA-TEXT if present */
+  if (ede->extra_text_len > 0)
+    memcpy (buf + DNS_EDE_MIN_SIZE, ede->extra_text, ede->extra_text_len);
+
+  return (int)required;
+}
+
+const char *
+SocketDNS_ede_code_name (uint16_t code)
+{
+  if (code <= DNS_EDE_MAX_DEFINED)
+    return ede_code_names[code];
+  return "Unknown Error";
+}
+
+const char *
+SocketDNS_ede_code_description (uint16_t code)
+{
+  if (code <= DNS_EDE_MAX_DEFINED)
+    return ede_code_descriptions[code];
+  return "Unknown extended DNS error code";
+}
+
+SocketDNS_EDECategory
+SocketDNS_ede_category (uint16_t code)
+{
+  switch (code)
+    {
+    case DNS_EDE_OTHER:
+      return DNS_EDE_CATEGORY_GENERAL;
+
+    case DNS_EDE_UNSUPPORTED_DNSKEY_ALGORITHM:
+    case DNS_EDE_UNSUPPORTED_DS_DIGEST_TYPE:
+    case DNS_EDE_DNSSEC_INDETERMINATE:
+    case DNS_EDE_DNSSEC_BOGUS:
+    case DNS_EDE_SIGNATURE_EXPIRED:
+    case DNS_EDE_SIGNATURE_NOT_YET_VALID:
+    case DNS_EDE_DNSKEY_MISSING:
+    case DNS_EDE_RRSIGS_MISSING:
+    case DNS_EDE_NO_ZONE_KEY_BIT_SET:
+    case DNS_EDE_NSEC_MISSING:
+      return DNS_EDE_CATEGORY_DNSSEC;
+
+    case DNS_EDE_STALE_ANSWER:
+    case DNS_EDE_STALE_NXDOMAIN_ANSWER:
+      return DNS_EDE_CATEGORY_STALE;
+
+    case DNS_EDE_FORGED_ANSWER:
+    case DNS_EDE_BLOCKED:
+    case DNS_EDE_CENSORED:
+    case DNS_EDE_FILTERED:
+    case DNS_EDE_PROHIBITED:
+      return DNS_EDE_CATEGORY_POLICY;
+
+    case DNS_EDE_CACHED_ERROR:
+    case DNS_EDE_NOT_READY:
+    case DNS_EDE_NOT_AUTHORITATIVE:
+    case DNS_EDE_NOT_SUPPORTED:
+      return DNS_EDE_CATEGORY_SERVER;
+
+    case DNS_EDE_NO_REACHABLE_AUTHORITY:
+    case DNS_EDE_NETWORK_ERROR:
+    case DNS_EDE_INVALID_DATA:
+      return DNS_EDE_CATEGORY_NETWORK;
+
+    default:
+      return DNS_EDE_CATEGORY_GENERAL;
+    }
+}
+
+const char *
+SocketDNS_ede_category_name (SocketDNS_EDECategory category)
+{
+  if (category <= DNS_EDE_CATEGORY_NETWORK)
+    return ede_category_names[category];
+  return "Unknown";
+}
+
+bool
+SocketDNS_ede_is_dnssec_error (uint16_t code)
+{
+  switch (code)
+    {
+    case DNS_EDE_UNSUPPORTED_DNSKEY_ALGORITHM:
+    case DNS_EDE_UNSUPPORTED_DS_DIGEST_TYPE:
+    case DNS_EDE_DNSSEC_INDETERMINATE:
+    case DNS_EDE_DNSSEC_BOGUS:
+    case DNS_EDE_SIGNATURE_EXPIRED:
+    case DNS_EDE_SIGNATURE_NOT_YET_VALID:
+    case DNS_EDE_DNSKEY_MISSING:
+    case DNS_EDE_RRSIGS_MISSING:
+    case DNS_EDE_NO_ZONE_KEY_BIT_SET:
+    case DNS_EDE_NSEC_MISSING:
+      return true;
+    default:
+      return false;
+    }
+}
+
+bool
+SocketDNS_ede_is_stale (uint16_t code)
+{
+  return code == DNS_EDE_STALE_ANSWER || code == DNS_EDE_STALE_NXDOMAIN_ANSWER;
+}
+
+bool
+SocketDNS_ede_is_filtered (uint16_t code)
+{
+  switch (code)
+    {
+    case DNS_EDE_FORGED_ANSWER:
+    case DNS_EDE_BLOCKED:
+    case DNS_EDE_CENSORED:
+    case DNS_EDE_FILTERED:
+    case DNS_EDE_PROHIBITED:
+      return true;
+    default:
+      return false;
+    }
+}
+
+bool
+SocketDNS_ede_is_retriable (uint16_t code)
+{
+  switch (code)
+    {
+    /* Transient errors - retry may help */
+    case DNS_EDE_NOT_READY:
+    case DNS_EDE_NO_REACHABLE_AUTHORITY:
+    case DNS_EDE_NETWORK_ERROR:
+    case DNS_EDE_CACHED_ERROR:
+      return true;
+
+    /* Stale answers - server might have fresher data on retry */
+    case DNS_EDE_STALE_ANSWER:
+    case DNS_EDE_STALE_NXDOMAIN_ANSWER:
+      return true;
+
+    /* DNSSEC errors - signature may become valid */
+    case DNS_EDE_SIGNATURE_NOT_YET_VALID:
+      return true;
+
+    /* All other errors are likely permanent */
+    default:
+      return false;
+    }
+}
+
+int
+SocketDNS_ede_format (const SocketDNS_ExtendedError *ede, char *buf,
+                      size_t buflen)
+{
+  if (ede == NULL || buf == NULL || buflen == 0)
+    return -1;
+
+  if (!ede->present)
+    {
+      int ret = snprintf (buf, buflen, "(no extended error)");
+      return (ret < 0 || (size_t)ret >= buflen) ? -1 : ret;
+    }
+
+  const char *name = SocketDNS_ede_code_name (ede->info_code);
+  int ret;
+
+  if (ede->extra_text_len > 0)
+    ret = snprintf (buf, buflen, "%s (%u): %s", name, ede->info_code,
+                    ede->extra_text);
+  else
+    ret = snprintf (buf, buflen, "%s (%u)", name, ede->info_code);
+
+  return (ret < 0 || (size_t)ret >= buflen) ? -1 : ret;
+}
+
+int
+SocketDNS_ede_parse_all (const unsigned char *rdata, size_t rdlen,
+                         SocketDNS_ExtendedError *ede_array, size_t max_count)
+{
+  if (rdata == NULL || ede_array == NULL || max_count == 0)
+    return -1;
+
+  SocketDNS_EDNSOptionIter iter;
+  SocketDNS_EDNSOption opt;
+  int count = 0;
+
+  SocketDNS_edns_option_iter_init (&iter, rdata, rdlen);
+
+  while (SocketDNS_edns_option_iter_next (&iter, &opt))
+    {
+      if (opt.code == DNS_EDE_OPTION_CODE)
+        {
+          if ((size_t)count >= max_count)
+            break;
+
+          if (SocketDNS_ede_parse (opt.data, opt.length,
+                                   &ede_array[count]) == 0)
+            count++;
+        }
+    }
+
+  return count;
+}
+
+int
+SocketDNS_ede_to_edns_option (const SocketDNS_ExtendedError *ede, void *opt,
+                              unsigned char *opt_data, size_t data_len)
+{
+  if (ede == NULL || opt == NULL || opt_data == NULL)
+    return -1;
+
+  /* Encode the EDE into the data buffer */
+  int encoded_len = SocketDNS_ede_encode (ede, opt_data, data_len);
+  if (encoded_len < 0)
+    return -1;
+
+  /* Fill in the EDNS option structure */
+  SocketDNS_EDNSOption *edns_opt = (SocketDNS_EDNSOption *)opt;
+  edns_opt->code = DNS_EDE_OPTION_CODE;
+  edns_opt->length = (uint16_t)encoded_len;
+  edns_opt->data = opt_data;
+
+  return 0;
+}

--- a/src/test/test_dnserror.c
+++ b/src/test/test_dnserror.c
@@ -1,0 +1,455 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/*
+ * test_dnserror.c - Unit tests for Extended DNS Errors (RFC 8914)
+ *
+ * Tests EDE parsing, encoding, and helper functions.
+ */
+
+#include "dns/SocketDNSError.h"
+#include "dns/SocketDNSWire.h"
+#include "test/Test.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/* Test EDE initialization */
+TEST (ede_init)
+{
+  SocketDNS_ExtendedError ede;
+
+  /* Fill with garbage first */
+  memset (&ede, 0xFF, sizeof (ede));
+
+  SocketDNS_ede_init (&ede);
+
+  ASSERT_EQ (ede.info_code, 0);
+  ASSERT_EQ (ede.present, false);
+  ASSERT_EQ (ede.extra_text_len, 0);
+  ASSERT_EQ (ede.extra_text[0], '\0');
+}
+
+/* Test EDE init with NULL parameter */
+TEST (ede_init_null)
+{
+  /* Should not crash */
+  SocketDNS_ede_init (NULL);
+}
+
+/* Test basic EDE parsing without EXTRA-TEXT */
+TEST (ede_parse_basic)
+{
+  /* INFO-CODE only: DNSSEC Bogus (6) */
+  unsigned char data[] = { 0x00, 0x06 };
+  SocketDNS_ExtendedError ede;
+
+  int ret = SocketDNS_ede_parse (data, sizeof (data), &ede);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (ede.info_code, DNS_EDE_DNSSEC_BOGUS);
+  ASSERT_EQ (ede.present, true);
+  ASSERT_EQ (ede.extra_text_len, 0);
+}
+
+/* Test EDE parsing with EXTRA-TEXT */
+TEST (ede_parse_with_text)
+{
+  /* INFO-CODE: Network Error (23) + EXTRA-TEXT */
+  unsigned char data[] = {
+    0x00, 0x17,                               /* INFO-CODE = 23 */
+    'C', 'o', 'n', 'n', 'e', 'c', 't', 'i',   /* EXTRA-TEXT */
+    'o', 'n', ' ', 'r', 'e', 'f', 'u', 's',
+    'e', 'd'
+  };
+  SocketDNS_ExtendedError ede;
+
+  int ret = SocketDNS_ede_parse (data, sizeof (data), &ede);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (ede.info_code, DNS_EDE_NETWORK_ERROR);
+  ASSERT_EQ (ede.present, true);
+  ASSERT_EQ (ede.extra_text_len, 18);
+  ASSERT (strcmp (ede.extra_text, "Connection refused") == 0);
+}
+
+/* Test EDE parsing with UTF-8 EXTRA-TEXT */
+TEST (ede_parse_utf8_text)
+{
+  /* INFO-CODE: Blocked (15) + UTF-8 EXTRA-TEXT with Euro sign */
+  unsigned char data[] = {
+    0x00, 0x0F,                     /* INFO-CODE = 15 */
+    'C', 'o', 's', 't', ':', ' ',
+    0xE2, 0x82, 0xAC,               /* Euro sign (U+20AC) */
+    '1', '0'
+  };
+  SocketDNS_ExtendedError ede;
+
+  int ret = SocketDNS_ede_parse (data, sizeof (data), &ede);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (ede.info_code, DNS_EDE_BLOCKED);
+  ASSERT_EQ (ede.extra_text_len, 11);
+}
+
+/* Test EDE parsing with all defined codes */
+TEST (ede_parse_all_codes)
+{
+  for (uint16_t code = 0; code <= DNS_EDE_MAX_DEFINED; code++)
+    {
+      unsigned char data[2] = { (code >> 8) & 0xFF, code & 0xFF };
+      SocketDNS_ExtendedError ede;
+
+      int ret = SocketDNS_ede_parse (data, sizeof (data), &ede);
+      ASSERT_EQ (ret, 0);
+      ASSERT_EQ (ede.info_code, code);
+      ASSERT_EQ (ede.present, true);
+    }
+}
+
+/* Test EDE parsing with high info codes (undefined) */
+TEST (ede_parse_high_code)
+{
+  /* INFO-CODE 65535 (undefined) */
+  unsigned char data[] = { 0xFF, 0xFF };
+  SocketDNS_ExtendedError ede;
+
+  int ret = SocketDNS_ede_parse (data, sizeof (data), &ede);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (ede.info_code, 65535);
+  ASSERT_EQ (ede.present, true);
+}
+
+/* Test EDE parse with too short data */
+TEST (ede_parse_too_short)
+{
+  unsigned char data[] = { 0x00 };
+  SocketDNS_ExtendedError ede;
+
+  int ret = SocketDNS_ede_parse (data, sizeof (data), &ede);
+  ASSERT_EQ (ret, -1);
+}
+
+/* Test EDE parse with NULL parameters */
+TEST (ede_parse_null)
+{
+  unsigned char data[] = { 0x00, 0x00 };
+  SocketDNS_ExtendedError ede;
+
+  ASSERT_EQ (SocketDNS_ede_parse (NULL, 2, &ede), -1);
+  ASSERT_EQ (SocketDNS_ede_parse (data, 2, NULL), -1);
+}
+
+/* Test EDE encoding without EXTRA-TEXT */
+TEST (ede_encode_basic)
+{
+  SocketDNS_ExtendedError ede;
+  SocketDNS_ede_init (&ede);
+  ede.info_code = DNS_EDE_DNSSEC_BOGUS;
+  ede.present = true;
+
+  unsigned char buf[64];
+  int ret = SocketDNS_ede_encode (&ede, buf, sizeof (buf));
+  ASSERT_EQ (ret, 2);
+  ASSERT_EQ (buf[0], 0x00);
+  ASSERT_EQ (buf[1], 0x06);
+}
+
+/* Test EDE encoding with EXTRA-TEXT */
+TEST (ede_encode_with_text)
+{
+  SocketDNS_ExtendedError ede;
+  SocketDNS_ede_init (&ede);
+  ede.info_code = DNS_EDE_NETWORK_ERROR;
+  ede.present = true;
+  strcpy (ede.extra_text, "timeout");
+  ede.extra_text_len = 7;
+
+  unsigned char buf[64];
+  int ret = SocketDNS_ede_encode (&ede, buf, sizeof (buf));
+  ASSERT_EQ (ret, 9);  /* 2 + 7 */
+  ASSERT_EQ (buf[0], 0x00);
+  ASSERT_EQ (buf[1], 0x17);  /* 23 = Network Error */
+  ASSERT (memcmp (buf + 2, "timeout", 7) == 0);
+}
+
+/* Test EDE encoding roundtrip */
+TEST (ede_encode_roundtrip)
+{
+  SocketDNS_ExtendedError orig, decoded;
+  SocketDNS_ede_init (&orig);
+  orig.info_code = DNS_EDE_NO_REACHABLE_AUTHORITY;
+  orig.present = true;
+  strcpy (orig.extra_text, "All nameservers failed");
+  orig.extra_text_len = strlen (orig.extra_text);
+
+  unsigned char buf[256];
+  int len = SocketDNS_ede_encode (&orig, buf, sizeof (buf));
+  ASSERT (len > 0);
+
+  int ret = SocketDNS_ede_parse (buf, (size_t)len, &decoded);
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (decoded.info_code, orig.info_code);
+  ASSERT_EQ (decoded.extra_text_len, orig.extra_text_len);
+  ASSERT (strcmp (decoded.extra_text, orig.extra_text) == 0);
+}
+
+/* Test EDE encode with buffer too small */
+TEST (ede_encode_buffer_too_small)
+{
+  SocketDNS_ExtendedError ede;
+  SocketDNS_ede_init (&ede);
+  ede.info_code = DNS_EDE_OTHER;
+  ede.present = true;
+  strcpy (ede.extra_text, "test");
+  ede.extra_text_len = 4;
+
+  unsigned char buf[4];  /* Too small for 2 + 4 = 6 bytes */
+  int ret = SocketDNS_ede_encode (&ede, buf, sizeof (buf));
+  ASSERT_EQ (ret, -1);
+}
+
+/* Test EDE code names */
+TEST (ede_code_name)
+{
+  ASSERT (strcmp (SocketDNS_ede_code_name (DNS_EDE_OTHER), "Other Error") == 0);
+  ASSERT (strcmp (SocketDNS_ede_code_name (DNS_EDE_DNSSEC_BOGUS), "DNSSEC Bogus") == 0);
+  ASSERT (strcmp (SocketDNS_ede_code_name (DNS_EDE_NETWORK_ERROR), "Network Error") == 0);
+  ASSERT (strcmp (SocketDNS_ede_code_name (DNS_EDE_INVALID_DATA), "Invalid Data") == 0);
+
+  /* Unknown code */
+  ASSERT (strcmp (SocketDNS_ede_code_name (100), "Unknown Error") == 0);
+  ASSERT (strcmp (SocketDNS_ede_code_name (65535), "Unknown Error") == 0);
+}
+
+/* Test EDE code descriptions */
+TEST (ede_code_description)
+{
+  const char *desc = SocketDNS_ede_code_description (DNS_EDE_DNSSEC_BOGUS);
+  ASSERT_NOT_NULL (desc);
+  ASSERT (strlen (desc) > 0);
+
+  /* Unknown code */
+  desc = SocketDNS_ede_code_description (999);
+  ASSERT_NOT_NULL (desc);
+  ASSERT (strstr (desc, "Unknown") != NULL || strstr (desc, "unknown") != NULL);
+}
+
+/* Test EDE categories */
+TEST (ede_category)
+{
+  /* DNSSEC category */
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_DNSSEC_BOGUS), DNS_EDE_CATEGORY_DNSSEC);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_SIGNATURE_EXPIRED), DNS_EDE_CATEGORY_DNSSEC);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_DNSKEY_MISSING), DNS_EDE_CATEGORY_DNSSEC);
+
+  /* Stale category */
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_STALE_ANSWER), DNS_EDE_CATEGORY_STALE);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_STALE_NXDOMAIN_ANSWER), DNS_EDE_CATEGORY_STALE);
+
+  /* Policy category */
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_BLOCKED), DNS_EDE_CATEGORY_POLICY);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_CENSORED), DNS_EDE_CATEGORY_POLICY);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_FILTERED), DNS_EDE_CATEGORY_POLICY);
+
+  /* Server category */
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_NOT_READY), DNS_EDE_CATEGORY_SERVER);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_NOT_SUPPORTED), DNS_EDE_CATEGORY_SERVER);
+
+  /* Network category */
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_NETWORK_ERROR), DNS_EDE_CATEGORY_NETWORK);
+  ASSERT_EQ (SocketDNS_ede_category (DNS_EDE_NO_REACHABLE_AUTHORITY), DNS_EDE_CATEGORY_NETWORK);
+}
+
+/* Test EDE category names */
+TEST (ede_category_name)
+{
+  ASSERT (strcmp (SocketDNS_ede_category_name (DNS_EDE_CATEGORY_GENERAL), "General") == 0);
+  ASSERT (strcmp (SocketDNS_ede_category_name (DNS_EDE_CATEGORY_DNSSEC), "DNSSEC") == 0);
+  ASSERT (strcmp (SocketDNS_ede_category_name (DNS_EDE_CATEGORY_STALE), "Stale Cache") == 0);
+  ASSERT (strcmp (SocketDNS_ede_category_name (DNS_EDE_CATEGORY_POLICY), "Policy/Filter") == 0);
+  ASSERT (strcmp (SocketDNS_ede_category_name (DNS_EDE_CATEGORY_SERVER), "Server State") == 0);
+  ASSERT (strcmp (SocketDNS_ede_category_name (DNS_EDE_CATEGORY_NETWORK), "Network") == 0);
+}
+
+/* Test is_dnssec_error helper */
+TEST (ede_is_dnssec_error)
+{
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_DNSSEC_BOGUS), true);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_SIGNATURE_EXPIRED), true);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_DNSKEY_MISSING), true);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_RRSIGS_MISSING), true);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_NSEC_MISSING), true);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_UNSUPPORTED_DNSKEY_ALGORITHM), true);
+
+  /* Non-DNSSEC codes */
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_OTHER), false);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_NETWORK_ERROR), false);
+  ASSERT_EQ (SocketDNS_ede_is_dnssec_error (DNS_EDE_BLOCKED), false);
+}
+
+/* Test is_stale helper */
+TEST (ede_is_stale)
+{
+  ASSERT_EQ (SocketDNS_ede_is_stale (DNS_EDE_STALE_ANSWER), true);
+  ASSERT_EQ (SocketDNS_ede_is_stale (DNS_EDE_STALE_NXDOMAIN_ANSWER), true);
+
+  ASSERT_EQ (SocketDNS_ede_is_stale (DNS_EDE_OTHER), false);
+  ASSERT_EQ (SocketDNS_ede_is_stale (DNS_EDE_DNSSEC_BOGUS), false);
+}
+
+/* Test is_filtered helper */
+TEST (ede_is_filtered)
+{
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_FORGED_ANSWER), true);
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_BLOCKED), true);
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_CENSORED), true);
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_FILTERED), true);
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_PROHIBITED), true);
+
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_OTHER), false);
+  ASSERT_EQ (SocketDNS_ede_is_filtered (DNS_EDE_NETWORK_ERROR), false);
+}
+
+/* Test is_retriable helper */
+TEST (ede_is_retriable)
+{
+  /* Retriable errors */
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_NOT_READY), true);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_NETWORK_ERROR), true);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_NO_REACHABLE_AUTHORITY), true);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_CACHED_ERROR), true);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_SIGNATURE_NOT_YET_VALID), true);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_STALE_ANSWER), true);
+
+  /* Non-retriable errors */
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_DNSSEC_BOGUS), false);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_BLOCKED), false);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_PROHIBITED), false);
+  ASSERT_EQ (SocketDNS_ede_is_retriable (DNS_EDE_SIGNATURE_EXPIRED), false);
+}
+
+/* Test EDE format */
+TEST (ede_format)
+{
+  SocketDNS_ExtendedError ede;
+  char buf[256];
+
+  /* Test with EXTRA-TEXT */
+  SocketDNS_ede_init (&ede);
+  ede.info_code = DNS_EDE_NETWORK_ERROR;
+  ede.present = true;
+  strcpy (ede.extra_text, "Connection timed out");
+  ede.extra_text_len = strlen (ede.extra_text);
+
+  int ret = SocketDNS_ede_format (&ede, buf, sizeof (buf));
+  ASSERT (ret > 0);
+  ASSERT (strstr (buf, "Network Error") != NULL);
+  ASSERT (strstr (buf, "23") != NULL);
+  ASSERT (strstr (buf, "Connection timed out") != NULL);
+
+  /* Test without EXTRA-TEXT */
+  SocketDNS_ede_init (&ede);
+  ede.info_code = DNS_EDE_BLOCKED;
+  ede.present = true;
+
+  ret = SocketDNS_ede_format (&ede, buf, sizeof (buf));
+  ASSERT (ret > 0);
+  ASSERT (strstr (buf, "Blocked") != NULL);
+  ASSERT (strstr (buf, "15") != NULL);
+
+  /* Test with not present */
+  SocketDNS_ede_init (&ede);
+  ret = SocketDNS_ede_format (&ede, buf, sizeof (buf));
+  ASSERT (ret > 0);
+  ASSERT (strstr (buf, "no extended error") != NULL);
+}
+
+/* Test EDE format with NULL params */
+TEST (ede_format_null)
+{
+  SocketDNS_ExtendedError ede;
+  char buf[64];
+
+  ASSERT_EQ (SocketDNS_ede_format (NULL, buf, sizeof (buf)), -1);
+  ASSERT_EQ (SocketDNS_ede_format (&ede, NULL, sizeof (buf)), -1);
+  ASSERT_EQ (SocketDNS_ede_format (&ede, buf, 0), -1);
+}
+
+/* Test EDE parse_all with multiple EDEs */
+TEST (ede_parse_all_multiple)
+{
+  /* Construct RDATA with two EDE options */
+  unsigned char rdata[64];
+  size_t pos = 0;
+
+  /* First EDE: DNSSEC Bogus (6) */
+  rdata[pos++] = 0x00; rdata[pos++] = 0x0F;  /* Option code 15 */
+  rdata[pos++] = 0x00; rdata[pos++] = 0x02;  /* Length 2 */
+  rdata[pos++] = 0x00; rdata[pos++] = 0x06;  /* INFO-CODE 6 */
+
+  /* Second EDE: Network Error (23) with text */
+  rdata[pos++] = 0x00; rdata[pos++] = 0x0F;  /* Option code 15 */
+  rdata[pos++] = 0x00; rdata[pos++] = 0x09;  /* Length 9 */
+  rdata[pos++] = 0x00; rdata[pos++] = 0x17;  /* INFO-CODE 23 */
+  memcpy (rdata + pos, "timeout", 7);
+  pos += 7;
+
+  SocketDNS_ExtendedError errors[4];
+  int count = SocketDNS_ede_parse_all (rdata, pos, errors, 4);
+  ASSERT_EQ (count, 2);
+  ASSERT_EQ (errors[0].info_code, DNS_EDE_DNSSEC_BOGUS);
+  ASSERT_EQ (errors[1].info_code, DNS_EDE_NETWORK_ERROR);
+  ASSERT (strcmp (errors[1].extra_text, "timeout") == 0);
+}
+
+/* Test EDE parse_all with no EDEs */
+TEST (ede_parse_all_empty)
+{
+  /* RDATA with only non-EDE options */
+  unsigned char rdata[] = {
+    0x00, 0x03,  /* Option code 3 (NSID) */
+    0x00, 0x04,  /* Length 4 */
+    't', 'e', 's', 't'
+  };
+
+  SocketDNS_ExtendedError errors[4];
+  int count = SocketDNS_ede_parse_all (rdata, sizeof (rdata), errors, 4);
+  ASSERT_EQ (count, 0);
+}
+
+/* Test EDE to EDNS option */
+TEST (ede_to_edns_option)
+{
+  SocketDNS_ExtendedError ede;
+  SocketDNS_ede_init (&ede);
+  ede.info_code = DNS_EDE_BLOCKED;
+  ede.present = true;
+  strcpy (ede.extra_text, "policy");
+  ede.extra_text_len = 6;
+
+  SocketDNS_EDNSOption opt;
+  unsigned char data[64];
+
+  int ret = SocketDNS_ede_to_edns_option (&ede, &opt, data, sizeof (data));
+  ASSERT_EQ (ret, 0);
+  ASSERT_EQ (opt.code, DNS_EDE_OPTION_CODE);
+  ASSERT_EQ (opt.length, 8);  /* 2 + 6 */
+  ASSERT_NOT_NULL (opt.data);
+}
+
+/* Test EDE option code constant */
+TEST (ede_option_code)
+{
+  /* Verify option code matches RFC 8914 */
+  ASSERT_EQ (DNS_EDE_OPTION_CODE, 15);
+  ASSERT_EQ (DNS_EDE_OPTION_CODE, DNS_EDNS_OPT_EXTENDED_ERROR);
+}
+
+/* Main function */
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary
- Implement Extended DNS Errors (EDE) per RFC 8914
- Parse EDE from EDNS0 option code 15 in DNS responses
- Support all 25 defined INFO-CODEs (0-24)
- Extract and validate UTF-8 EXTRA-TEXT for detailed error messages
- Add helper functions for error categorization and retry logic

Fixes #151

## Changes
| File | Description |
|------|-------------|
| `include/dns/SocketDNSError.h` | Public API header with types and functions |
| `src/dns/SocketDNSError.c` | Full implementation |
| `src/test/test_dnserror.c` | 27 unit tests |
| `CMakeLists.txt` | Build integration |

## Features
- `SocketDNS_ede_parse()` - Parse EDE from option data
- `SocketDNS_ede_encode()` - Encode EDE for server responses
- `SocketDNS_ede_code_name()` - Human-readable error names
- `SocketDNS_ede_code_description()` - Detailed descriptions
- `SocketDNS_ede_category()` - Categorize errors (DNSSEC, Network, Policy, etc.)
- `SocketDNS_ede_is_retriable()` - Check if retry may help
- `SocketDNS_ede_is_dnssec_error()` - Check for DNSSEC-related errors
- `SocketDNS_ede_parse_all()` - Handle multiple EDEs in response

## Test plan
- [x] All 27 unit tests pass
- [x] Tests pass with ASan + UBSan sanitizers
- [x] All DNS module tests pass (12 tests)
- [x] UTF-8 validation for EXTRA-TEXT
- [x] Roundtrip encode/parse verification