### PR TITLE
perf(async): batch multiple io_uring submissions

### DIFF
--- a/include/socket/SocketAsync-private.h
+++ b/include/socket/SocketAsync-private.h
@@ -449,6 +449,19 @@ struct SocketAsync_T
    * @see eventfd(2)
    */
   int io_uring_fd; /* Eventfd for completion notifications */
+
+  /**
+   * @brief Count of pending SQEs not yet submitted to kernel.
+   *
+   * Tracks operations submitted with ASYNC_FLAG_NOSYNC that have been
+   * prepared in the SQ but not yet submitted via io_uring_submit().
+   * Reset to 0 after SocketAsync_flush() or auto-flush.
+   *
+   * @see SocketAsync_flush()
+   * @see SocketAsync_pending_count()
+   * @see ASYNC_FLAG_NOSYNC
+   */
+  unsigned pending_sqe_count;
 #elif defined(__APPLE__) || defined(__FreeBSD__)
   /**
    * @brief kqueue file descriptor for AIO events.


### PR DESCRIPTION
## Summary

- Add `ASYNC_FLAG_NOSYNC` flag to defer io_uring_submit() calls
- Track `pending_sqe_count` in SocketAsync_T for pending SQE tracking
- Implement `SocketAsync_flush()` to submit all pending SQEs in one syscall
- Add `SocketAsync_pending_count()` to query unflushed operation count
- Auto-flush when SQ reaches 75% capacity to prevent blocking
- Update `SocketAsync_submit_batch()` to use deferred submission internally

This reduces syscall overhead when submitting multiple operations, improving throughput for high-concurrency scenarios.

Fixes #202

## Test plan

- [x] All 83 tests pass with sanitizers enabled
- [x] io_uring batching tested via SocketAsync_submit_batch()
- [x] Auto-flush threshold prevents SQ overflow