### PR TITLE
feat(async): add advanced io_uring features

### DIFF
--- a/include/socket/SocketAsync-private.h
+++ b/include/socket/SocketAsync-private.h
@@ -462,6 +462,54 @@ struct SocketAsync_T
    * @see ASYNC_FLAG_NOSYNC
    */
   unsigned pending_sqe_count;
+
+  /**
+   * @brief SQPOLL mode active flag.
+   *
+   * Non-zero if SQPOLL kernel thread polling is active.
+   * When active, io_uring_submit() is not needed - kernel polls SQ.
+   *
+   * @see SocketAsync_Config::enable_sqpoll
+   * @see SocketAsync_is_sqpoll_active()
+   */
+  int sqpoll_active;
+
+  /**
+   * @brief Ring size used for this io_uring instance.
+   *
+   * Number of SQ entries, used for flush threshold calculation.
+   */
+  unsigned ring_size;
+
+  /* === Registered Buffers === */
+
+  /**
+   * @brief Array of registered buffer iovecs.
+   *
+   * Points to iovec array registered with IORING_REGISTER_BUFFERS.
+   * NULL if no buffers registered.
+   */
+  struct iovec *registered_bufs;
+
+  /**
+   * @brief Number of registered buffers.
+   */
+  unsigned registered_buf_count;
+
+  /* === Fixed Files === */
+
+  /**
+   * @brief Array of registered file descriptors.
+   *
+   * Copy of fds registered with IORING_REGISTER_FILES.
+   * Used for fd-to-index lookup.
+   */
+  int *registered_fds;
+
+  /**
+   * @brief Number of registered file descriptors.
+   */
+  unsigned registered_fd_count;
 #elif defined(__APPLE__) || defined(__FreeBSD__)
   /**
    * @brief kqueue file descriptor for AIO events.


### PR DESCRIPTION
## Summary

Add support for advanced io_uring performance features:

### SQPOLL Mode
- `SocketAsync_Config` struct for advanced configuration options
- `SocketAsync_new_with_config()` creates context with custom settings
- SQPOLL kernel polling thread eliminates io_uring_submit() syscalls entirely
- `SocketAsync_is_sqpoll_active()` to verify activation
- Graceful fallback when privileges insufficient (requires CAP_SYS_ADMIN or kernel 5.12+)

### Registered Buffers
- `SocketAsync_register_buffers()` pre-registers buffer pool with kernel
- `SocketAsync_send_fixed()` / `SocketAsync_recv_fixed()` use registered buffers
- Eliminates per-operation buffer mapping overhead (10-20% improvement for small I/O)
- `ASYNC_FLAG_FIXED_BUFFER` flag for fixed buffer operations
- `SocketAsync_registered_buffer_count()` to query registration state

### Fixed Files (fd registration)
- `SocketAsync_register_files()` pre-registers fd table with io_uring
- `SocketAsync_update_registered_fd()` for dynamic fd updates (pool recycling)
- `SocketAsync_get_fixed_fd_index()` for fd-to-index lookup
- `SocketAsync_registered_file_count()` to query registration state
- 5-10% kernel fd lookup improvement for stable connection pools

All features are io_uring-only with graceful no-op fallback on other platforms.

Fixes #203

## Test plan

- [x] All 84 tests pass with sanitizers (ASan + UBSan)
- [x] SQPOLL initialization with fallback tested
- [x] Buffer registration and unregistration tested
- [x] Fixed files registration and update tested
- [x] No memory leaks detected with ASan