### PR TITLE
feat(dns): implement RFC 2308 negative cache key tuples

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -325,6 +325,7 @@ set(LIB_SOURCES
     src/dns/SocketDNSSEC.c
     src/dns/SocketDNSCookie.c
     src/dns/SocketDNSError.c
+    src/dns/SocketDNSNegCache.c
 
     # Poll module (consolidated)
     src/poll/SocketPoll.c
@@ -558,6 +559,7 @@ set(DNS_HEADERS
     include/dns/SocketDNSSEC.h
     include/dns/SocketDNSCookie.h
     include/dns/SocketDNSError.h
+    include/dns/SocketDNSNegCache.h
 )
 
 set(POLL_HEADERS
@@ -695,6 +697,7 @@ set(TEST_SOURCES
     test_dnssec
     test_dnscookie
     test_dnserror
+    test_dns_negcache
     test_integration
     test_threadsafety
     test_happy_eyeballs

--- a/include/dns/SocketDNSNegCache.h
+++ b/include/dns/SocketDNSNegCache.h
@@ -1,0 +1,378 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETDNSNEGCACHE_INCLUDED
+#define SOCKETDNSNEGCACHE_INCLUDED
+
+/**
+ * @file SocketDNSNegCache.h
+ * @brief DNS Negative Response Cache (RFC 2308).
+ * @ingroup dns
+ *
+ * Implements RFC 2308 compliant negative caching for DNS responses.
+ * Caches NXDOMAIN and NODATA responses with proper cache key tuples
+ * as specified in RFC 2308 Section 5.
+ *
+ * ## RFC References
+ *
+ * - RFC 2308 Section 5: Caching Negative Answers
+ * - RFC 2308 Section 3: Negative Answers from Authoritative Servers
+ *
+ * ## Cache Key Tuples
+ *
+ * Per RFC 2308 Section 5:
+ *
+ * - **NXDOMAIN**: Cached against `<QNAME, QCLASS>` tuple.
+ *   The domain does not exist at all, so any query type for that name
+ *   should return the cached NXDOMAIN.
+ *
+ * - **NODATA**: Cached against `<QNAME, QTYPE, QCLASS>` tuple.
+ *   The name exists but has no records of the requested type.
+ *   Other record types for the same name may still exist.
+ *
+ * ## TTL Handling
+ *
+ * Per RFC 2308 Section 5, negative response TTL comes from the SOA
+ * MINIMUM field in the authority section. Responses without SOA
+ * records should not be cached.
+ *
+ * ## Features
+ *
+ * - RFC 2308 compliant cache key tuples
+ * - Separate handling for NXDOMAIN vs NODATA
+ * - LRU eviction when cache is full
+ * - TTL-based expiration
+ * - Thread-safe operations
+ *
+ * @see SocketDNSResolver.h for the async resolver API.
+ * @see SocketDNSWire.h for DNS record types and classes.
+ */
+
+#include "core/Arena.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup dns_negcache DNS Negative Cache
+ * @brief RFC 2308 compliant negative response caching.
+ * @ingroup dns
+ * @{
+ */
+
+/** Maximum hostname length in cache key. */
+#define DNS_NEGCACHE_MAX_NAME 255
+
+/** Default maximum cache entries. */
+#define DNS_NEGCACHE_DEFAULT_MAX 1000
+
+/** Default maximum TTL in seconds (1 hour per RFC 2308 recommendation). */
+#define DNS_NEGCACHE_DEFAULT_MAX_TTL 3600
+
+/** Minimum TTL in seconds (prevent excessive caching). */
+#define DNS_NEGCACHE_MIN_TTL 0
+
+/** QTYPE value used for NXDOMAIN entries (matches any type). */
+#define DNS_NEGCACHE_QTYPE_ANY 0
+
+/** Default QCLASS for Internet class. */
+#define DNS_NEGCACHE_QCLASS_IN 1
+
+#define T SocketDNSNegCache_T
+typedef struct T *T;
+
+/**
+ * @brief Type of negative cache entry.
+ * @ingroup dns_negcache
+ *
+ * Distinguishes between NXDOMAIN (name does not exist) and
+ * NODATA (name exists but has no records of requested type).
+ */
+typedef enum
+{
+  /** Name Error - domain does not exist (RCODE 3). */
+  DNS_NEG_NXDOMAIN = 0,
+
+  /** No Data - name exists but has no records of requested type. */
+  DNS_NEG_NODATA = 1
+} SocketDNS_NegCacheType;
+
+/**
+ * @brief Negative cache lookup result.
+ * @ingroup dns_negcache
+ */
+typedef enum
+{
+  /** No cached entry found. */
+  DNS_NEG_MISS = 0,
+
+  /** Cached NXDOMAIN entry found. */
+  DNS_NEG_HIT_NXDOMAIN = 1,
+
+  /** Cached NODATA entry found. */
+  DNS_NEG_HIT_NODATA = 2
+} SocketDNS_NegCacheResult;
+
+/**
+ * @brief Negative cache entry information.
+ * @ingroup dns_negcache
+ *
+ * Returned by lookup functions to provide details about cached entries.
+ */
+typedef struct
+{
+  /** Type of negative response (NXDOMAIN or NODATA). */
+  SocketDNS_NegCacheType type;
+
+  /** TTL remaining in seconds. */
+  uint32_t ttl_remaining;
+
+  /** Original TTL from SOA MINIMUM. */
+  uint32_t original_ttl;
+
+  /** Timestamp when entry was inserted (monotonic ms). */
+  int64_t insert_time_ms;
+} SocketDNS_NegCacheEntry;
+
+/**
+ * @brief Negative cache statistics.
+ * @ingroup dns_negcache
+ */
+typedef struct
+{
+  uint64_t hits;             /**< Total cache hits */
+  uint64_t misses;           /**< Total cache misses */
+  uint64_t nxdomain_hits;    /**< NXDOMAIN-specific hits */
+  uint64_t nodata_hits;      /**< NODATA-specific hits */
+  uint64_t insertions;       /**< Total insertions */
+  uint64_t evictions;        /**< LRU evictions */
+  uint64_t expirations;      /**< TTL expirations */
+  size_t current_size;       /**< Current entry count */
+  size_t max_entries;        /**< Maximum capacity */
+  uint32_t max_ttl;          /**< Maximum allowed TTL */
+  double hit_rate;           /**< Calculated hit rate */
+} SocketDNS_NegCacheStats;
+
+/* Lifecycle functions */
+
+/**
+ * @brief Create a new negative cache instance.
+ * @ingroup dns_negcache
+ *
+ * Creates a cache with default settings:
+ * - max_entries: 1000
+ * - max_ttl: 3600 seconds (1 hour)
+ *
+ * @param arena Arena for memory allocation (must outlive cache).
+ * @return New cache instance, or NULL on allocation failure.
+ *
+ * @code{.c}
+ * Arena_T arena = Arena_new();
+ * SocketDNSNegCache_T cache = SocketDNSNegCache_new(arena);
+ * SocketDNSNegCache_set_max_entries(cache, 500);
+ * @endcode
+ */
+extern T SocketDNSNegCache_new (Arena_T arena);
+
+/**
+ * @brief Dispose of a negative cache instance.
+ * @ingroup dns_negcache
+ *
+ * Clears all entries and releases resources.
+ * The cache pointer is set to NULL.
+ *
+ * @param cache Pointer to cache instance.
+ */
+extern void SocketDNSNegCache_free (T *cache);
+
+/* Cache operations */
+
+/**
+ * @brief Look up a negative cache entry.
+ * @ingroup dns_negcache
+ *
+ * Checks for cached NXDOMAIN or NODATA responses. Per RFC 2308:
+ * - First checks for NXDOMAIN (qtype=0 matches any type)
+ * - Then checks for type-specific NODATA
+ *
+ * @param cache   Cache instance.
+ * @param qname   Query name (case-insensitive lookup).
+ * @param qtype   Query type (e.g., DNS_TYPE_A, DNS_TYPE_AAAA).
+ * @param qclass  Query class (typically DNS_CLASS_IN = 1).
+ * @param entry   Output entry details (may be NULL if not needed).
+ * @return Lookup result (MISS, HIT_NXDOMAIN, or HIT_NODATA).
+ *
+ * @code{.c}
+ * SocketDNS_NegCacheEntry info;
+ * SocketDNS_NegCacheResult result = SocketDNSNegCache_lookup(
+ *     cache, "nonexistent.example.com", DNS_TYPE_A, DNS_CLASS_IN, &info);
+ *
+ * switch (result) {
+ * case DNS_NEG_HIT_NXDOMAIN:
+ *     printf("Cached NXDOMAIN, TTL=%u\n", info.ttl_remaining);
+ *     break;
+ * case DNS_NEG_HIT_NODATA:
+ *     printf("Cached NODATA for type, TTL=%u\n", info.ttl_remaining);
+ *     break;
+ * case DNS_NEG_MISS:
+ *     printf("Not cached, need to query DNS\n");
+ *     break;
+ * }
+ * @endcode
+ */
+extern SocketDNS_NegCacheResult SocketDNSNegCache_lookup (
+    T cache, const char *qname, uint16_t qtype, uint16_t qclass,
+    SocketDNS_NegCacheEntry *entry);
+
+/**
+ * @brief Insert an NXDOMAIN entry into the cache.
+ * @ingroup dns_negcache
+ *
+ * Caches an NXDOMAIN response with key `<QNAME, QCLASS>`.
+ * This entry will match lookups for ANY query type.
+ *
+ * @param cache    Cache instance.
+ * @param qname    Query name (normalized to lowercase internally).
+ * @param qclass   Query class (typically DNS_CLASS_IN = 1).
+ * @param ttl      TTL from SOA MINIMUM field.
+ * @return 0 on success, -1 on error.
+ *
+ * @code{.c}
+ * // Cache NXDOMAIN for nonexistent.example.com
+ * SocketDNSNegCache_insert_nxdomain(cache, "nonexistent.example.com",
+ *                                    DNS_CLASS_IN, 300);
+ *
+ * // Subsequent lookups for ANY type will hit:
+ * // - nonexistent.example.com A
+ * // - nonexistent.example.com AAAA
+ * // - nonexistent.example.com MX
+ * // etc.
+ * @endcode
+ */
+extern int SocketDNSNegCache_insert_nxdomain (T cache, const char *qname,
+                                               uint16_t qclass, uint32_t ttl);
+
+/**
+ * @brief Insert a NODATA entry into the cache.
+ * @ingroup dns_negcache
+ *
+ * Caches a NODATA response with key `<QNAME, QTYPE, QCLASS>`.
+ * This entry only matches lookups for the specific query type.
+ *
+ * @param cache    Cache instance.
+ * @param qname    Query name (normalized to lowercase internally).
+ * @param qtype    Query type that returned NODATA.
+ * @param qclass   Query class (typically DNS_CLASS_IN = 1).
+ * @param ttl      TTL from SOA MINIMUM field.
+ * @return 0 on success, -1 on error.
+ *
+ * @code{.c}
+ * // Cache NODATA for example.com AAAA (name exists, but no AAAA records)
+ * SocketDNSNegCache_insert_nodata(cache, "example.com",
+ *                                  DNS_TYPE_AAAA, DNS_CLASS_IN, 300);
+ *
+ * // Only example.com AAAA lookups will hit cache
+ * // example.com A lookups will miss (and may succeed)
+ * @endcode
+ */
+extern int SocketDNSNegCache_insert_nodata (T cache, const char *qname,
+                                             uint16_t qtype, uint16_t qclass,
+                                             uint32_t ttl);
+
+/**
+ * @brief Remove all entries for a specific name.
+ * @ingroup dns_negcache
+ *
+ * Removes both NXDOMAIN and all NODATA entries for the given name.
+ *
+ * @param cache  Cache instance.
+ * @param qname  Query name to remove.
+ * @return Number of entries removed.
+ */
+extern int SocketDNSNegCache_remove (T cache, const char *qname);
+
+/**
+ * @brief Remove a specific NODATA entry.
+ * @ingroup dns_negcache
+ *
+ * Removes only the NODATA entry for the specific name/type/class tuple.
+ *
+ * @param cache   Cache instance.
+ * @param qname   Query name.
+ * @param qtype   Query type.
+ * @param qclass  Query class.
+ * @return 1 if entry was found and removed, 0 if not found.
+ */
+extern int SocketDNSNegCache_remove_nodata (T cache, const char *qname,
+                                             uint16_t qtype, uint16_t qclass);
+
+/**
+ * @brief Clear all entries from the cache.
+ * @ingroup dns_negcache
+ *
+ * Removes all cached negative responses.
+ *
+ * @param cache Cache instance.
+ */
+extern void SocketDNSNegCache_clear (T cache);
+
+/* Configuration */
+
+/**
+ * @brief Set maximum cache entries.
+ * @ingroup dns_negcache
+ *
+ * @param cache       Cache instance.
+ * @param max_entries Maximum entries (0 = unlimited).
+ */
+extern void SocketDNSNegCache_set_max_entries (T cache, size_t max_entries);
+
+/**
+ * @brief Set maximum TTL for cached entries.
+ * @ingroup dns_negcache
+ *
+ * Per RFC 2308, one to three hours is recommended.
+ * Values exceeding one day are problematic.
+ *
+ * @param cache   Cache instance.
+ * @param max_ttl Maximum TTL in seconds.
+ */
+extern void SocketDNSNegCache_set_max_ttl (T cache, uint32_t max_ttl);
+
+/**
+ * @brief Get cache statistics.
+ * @ingroup dns_negcache
+ *
+ * @param cache Cache instance.
+ * @param stats Output statistics structure.
+ */
+extern void SocketDNSNegCache_stats (T cache, SocketDNS_NegCacheStats *stats);
+
+/* Utility functions */
+
+/**
+ * @brief Get type name as string.
+ * @ingroup dns_negcache
+ *
+ * @param type Cache entry type.
+ * @return "NXDOMAIN" or "NODATA".
+ */
+extern const char *SocketDNSNegCache_type_name (SocketDNS_NegCacheType type);
+
+/**
+ * @brief Get result name as string.
+ * @ingroup dns_negcache
+ *
+ * @param result Lookup result.
+ * @return "MISS", "HIT_NXDOMAIN", or "HIT_NODATA".
+ */
+extern const char *SocketDNSNegCache_result_name (SocketDNS_NegCacheResult result);
+
+/** @} */ /* End of dns_negcache group */
+
+#undef T
+
+#endif /* SOCKETDNSNEGCACHE_INCLUDED */

--- a/src/dns/SocketDNSNegCache.c
+++ b/src/dns/SocketDNSNegCache.c
@@ -1,0 +1,682 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketDNSNegCache.c
+ * @brief DNS Negative Response Cache implementation (RFC 2308).
+ */
+
+#include "dns/SocketDNSNegCache.h"
+#include "core/Arena.h"
+#include "core/SocketUtil.h"
+
+#include <ctype.h>
+#include <pthread.h>
+#include <string.h>
+#include <strings.h>
+
+#define T SocketDNSNegCache_T
+
+/** Hash table size (prime for better distribution). */
+#define NEGCACHE_HASH_SIZE 257
+
+/**
+ * @brief Internal cache entry structure.
+ */
+struct NegCacheEntry
+{
+  char name[DNS_NEGCACHE_MAX_NAME + 1]; /**< Normalized (lowercase) QNAME */
+  uint16_t qtype;    /**< QTYPE (0 for NXDOMAIN, specific for NODATA) */
+  uint16_t qclass;   /**< QCLASS */
+  SocketDNS_NegCacheType type; /**< Entry type */
+  uint32_t ttl;      /**< Original TTL */
+  int64_t insert_time_ms; /**< Monotonic insertion time */
+  struct NegCacheEntry *hash_next; /**< Hash chain pointer */
+  struct NegCacheEntry *lru_prev;  /**< LRU list prev */
+  struct NegCacheEntry *lru_next;  /**< LRU list next */
+};
+
+/**
+ * @brief Negative cache structure.
+ */
+struct T
+{
+  Arena_T arena; /**< Memory arena */
+  pthread_mutex_t mutex; /**< Thread safety */
+
+  struct NegCacheEntry *hash_table[NEGCACHE_HASH_SIZE]; /**< Hash buckets */
+  struct NegCacheEntry *lru_head; /**< LRU head (most recent) */
+  struct NegCacheEntry *lru_tail; /**< LRU tail (oldest) */
+
+  size_t size;         /**< Current entry count */
+  size_t max_entries;  /**< Maximum capacity */
+  uint32_t max_ttl;    /**< Maximum TTL allowed */
+
+  /* Statistics */
+  uint64_t hits;
+  uint64_t misses;
+  uint64_t nxdomain_hits;
+  uint64_t nodata_hits;
+  uint64_t insertions;
+  uint64_t evictions;
+  uint64_t expirations;
+};
+
+/**
+ * @brief Normalize name to lowercase for case-insensitive lookup.
+ */
+static void
+normalize_name (char *dest, const char *src, size_t max_len)
+{
+  size_t i;
+  for (i = 0; src[i] && i < max_len; i++)
+    dest[i] = (char)tolower ((unsigned char)src[i]);
+  dest[i] = '\0';
+}
+
+/**
+ * @brief Compute hash for cache key tuple.
+ *
+ * For NXDOMAIN: hash(name, 0, class)
+ * For NODATA: hash(name, type, class)
+ */
+static unsigned
+compute_hash (const char *name, uint16_t qtype, uint16_t qclass)
+{
+  unsigned hash = 5381; /* djb2 initial value */
+
+  /* Hash the normalized name */
+  for (const char *p = name; *p; p++)
+    hash = ((hash << 5) + hash) ^ (unsigned char)tolower ((unsigned char)*p);
+
+  /* Include qtype and qclass */
+  hash = ((hash << 5) + hash) ^ qtype;
+  hash = ((hash << 5) + hash) ^ qclass;
+
+  return hash % NEGCACHE_HASH_SIZE;
+}
+
+/**
+ * @brief Check if an entry has expired.
+ */
+static bool
+entry_expired (const struct NegCacheEntry *entry, int64_t now_ms)
+{
+  int64_t age_ms = now_ms - entry->insert_time_ms;
+  int64_t ttl_ms = (int64_t)entry->ttl * 1000;
+  return age_ms >= ttl_ms;
+}
+
+/**
+ * @brief Calculate remaining TTL.
+ */
+static uint32_t
+entry_ttl_remaining (const struct NegCacheEntry *entry, int64_t now_ms)
+{
+  int64_t age_ms = now_ms - entry->insert_time_ms;
+  int64_t ttl_ms = (int64_t)entry->ttl * 1000;
+  int64_t remaining_ms = ttl_ms - age_ms;
+
+  if (remaining_ms <= 0)
+    return 0;
+
+  return (uint32_t)(remaining_ms / 1000);
+}
+
+/**
+ * @brief Remove entry from LRU list.
+ */
+static void
+lru_remove (T cache, struct NegCacheEntry *entry)
+{
+  if (entry->lru_prev)
+    entry->lru_prev->lru_next = entry->lru_next;
+  else
+    cache->lru_head = entry->lru_next;
+
+  if (entry->lru_next)
+    entry->lru_next->lru_prev = entry->lru_prev;
+  else
+    cache->lru_tail = entry->lru_prev;
+
+  entry->lru_prev = NULL;
+  entry->lru_next = NULL;
+}
+
+/**
+ * @brief Add entry to LRU head (most recently used).
+ */
+static void
+lru_add_head (T cache, struct NegCacheEntry *entry)
+{
+  entry->lru_prev = NULL;
+  entry->lru_next = cache->lru_head;
+
+  if (cache->lru_head)
+    cache->lru_head->lru_prev = entry;
+  else
+    cache->lru_tail = entry;
+
+  cache->lru_head = entry;
+}
+
+/**
+ * @brief Move entry to LRU head (accessed).
+ */
+static void
+lru_touch (T cache, struct NegCacheEntry *entry)
+{
+  if (entry != cache->lru_head)
+    {
+      lru_remove (cache, entry);
+      lru_add_head (cache, entry);
+    }
+}
+
+/**
+ * @brief Remove entry from hash table.
+ */
+static void
+hash_remove (T cache, struct NegCacheEntry *entry, unsigned bucket)
+{
+  struct NegCacheEntry **pp = &cache->hash_table[bucket];
+  while (*pp)
+    {
+      if (*pp == entry)
+        {
+          *pp = entry->hash_next;
+          entry->hash_next = NULL;
+          return;
+        }
+      pp = &(*pp)->hash_next;
+    }
+}
+
+/**
+ * @brief Free an entry (remove from all lists).
+ */
+static void
+entry_free (T cache, struct NegCacheEntry *entry)
+{
+  /* Compute bucket for hash removal */
+  unsigned bucket = compute_hash (entry->name, entry->qtype, entry->qclass);
+
+  hash_remove (cache, entry, bucket);
+  lru_remove (cache, entry);
+  cache->size--;
+
+  /* Entry memory is arena-managed, no explicit free needed */
+}
+
+/**
+ * @brief Evict LRU entry when cache is full.
+ */
+static void
+evict_lru (T cache)
+{
+  if (cache->lru_tail)
+    {
+      entry_free (cache, cache->lru_tail);
+      cache->evictions++;
+    }
+}
+
+/**
+ * @brief Find entry by exact key tuple.
+ */
+static struct NegCacheEntry *
+find_entry (T cache, const char *normalized_name, uint16_t qtype,
+            uint16_t qclass)
+{
+  unsigned bucket = compute_hash (normalized_name, qtype, qclass);
+  struct NegCacheEntry *entry = cache->hash_table[bucket];
+
+  while (entry)
+    {
+      if (entry->qtype == qtype && entry->qclass == qclass
+          && strcasecmp (entry->name, normalized_name) == 0)
+        return entry;
+      entry = entry->hash_next;
+    }
+
+  return NULL;
+}
+
+/**
+ * @brief Insert entry into hash table.
+ */
+static void
+hash_insert (T cache, struct NegCacheEntry *entry)
+{
+  unsigned bucket = compute_hash (entry->name, entry->qtype, entry->qclass);
+  entry->hash_next = cache->hash_table[bucket];
+  cache->hash_table[bucket] = entry;
+}
+
+/**
+ * @brief Allocate new entry from arena.
+ */
+static struct NegCacheEntry *
+entry_alloc (T cache)
+{
+  return Arena_alloc (cache->arena, sizeof (struct NegCacheEntry), __FILE__,
+                      __LINE__);
+}
+
+/* Public API */
+
+T
+SocketDNSNegCache_new (Arena_T arena)
+{
+  if (arena == NULL)
+    return NULL;
+
+  T cache = Arena_alloc (arena, sizeof (*cache), __FILE__, __LINE__);
+  if (cache == NULL)
+    return NULL;
+
+  memset (cache, 0, sizeof (*cache));
+  cache->arena = arena;
+  cache->max_entries = DNS_NEGCACHE_DEFAULT_MAX;
+  cache->max_ttl = DNS_NEGCACHE_DEFAULT_MAX_TTL;
+
+  if (pthread_mutex_init (&cache->mutex, NULL) != 0)
+    return NULL;
+
+  return cache;
+}
+
+void
+SocketDNSNegCache_free (T *cache)
+{
+  if (cache == NULL || *cache == NULL)
+    return;
+
+  pthread_mutex_destroy (&(*cache)->mutex);
+
+  /* Arena handles memory, just clear pointer */
+  *cache = NULL;
+}
+
+SocketDNS_NegCacheResult
+SocketDNSNegCache_lookup (T cache, const char *qname, uint16_t qtype,
+                          uint16_t qclass, SocketDNS_NegCacheEntry *entry)
+{
+  if (cache == NULL || qname == NULL)
+    return DNS_NEG_MISS;
+
+  char normalized[DNS_NEGCACHE_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_NEGCACHE_MAX_NAME);
+
+  int64_t now_ms = Socket_get_monotonic_ms ();
+  SocketDNS_NegCacheResult result = DNS_NEG_MISS;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* First check for NXDOMAIN (qtype=0 matches any type) */
+  struct NegCacheEntry *found = find_entry (cache, normalized, 0, qclass);
+  if (found)
+    {
+      if (entry_expired (found, now_ms))
+        {
+          entry_free (cache, found);
+          cache->expirations++;
+          found = NULL;
+        }
+      else
+        {
+          result = DNS_NEG_HIT_NXDOMAIN;
+          cache->hits++;
+          cache->nxdomain_hits++;
+          lru_touch (cache, found);
+        }
+    }
+
+  /* If no NXDOMAIN, check for type-specific NODATA */
+  if (result == DNS_NEG_MISS)
+    {
+      found = find_entry (cache, normalized, qtype, qclass);
+      if (found)
+        {
+          if (entry_expired (found, now_ms))
+            {
+              entry_free (cache, found);
+              cache->expirations++;
+              found = NULL;
+            }
+          else
+            {
+              result = DNS_NEG_HIT_NODATA;
+              cache->hits++;
+              cache->nodata_hits++;
+              lru_touch (cache, found);
+            }
+        }
+    }
+
+  /* Fill in entry details if requested and found */
+  if (entry != NULL && found != NULL)
+    {
+      entry->type = found->type;
+      entry->original_ttl = found->ttl;
+      entry->ttl_remaining = entry_ttl_remaining (found, now_ms);
+      entry->insert_time_ms = found->insert_time_ms;
+    }
+
+  if (result == DNS_NEG_MISS)
+    cache->misses++;
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return result;
+}
+
+int
+SocketDNSNegCache_insert_nxdomain (T cache, const char *qname, uint16_t qclass,
+                                    uint32_t ttl)
+{
+  if (cache == NULL || qname == NULL)
+    return -1;
+
+  /* Reject if cache is disabled */
+  if (cache->max_entries == 0)
+    return -1;
+
+  /* Validate name length before normalizing */
+  size_t qname_len = strlen (qname);
+  if (qname_len > DNS_NEGCACHE_MAX_NAME)
+    return -1;
+
+  char normalized[DNS_NEGCACHE_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_NEGCACHE_MAX_NAME);
+
+  /* Cap TTL */
+  if (ttl > cache->max_ttl)
+    ttl = cache->max_ttl;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Check if already exists and update */
+  struct NegCacheEntry *existing = find_entry (cache, normalized, 0, qclass);
+  if (existing)
+    {
+      existing->ttl = ttl;
+      existing->insert_time_ms = Socket_get_monotonic_ms ();
+      lru_touch (cache, existing);
+      pthread_mutex_unlock (&cache->mutex);
+      return 0;
+    }
+
+  /* Evict if at capacity */
+  if (cache->max_entries > 0 && cache->size >= cache->max_entries)
+    evict_lru (cache);
+
+  /* Allocate new entry */
+  struct NegCacheEntry *entry = entry_alloc (cache);
+  if (entry == NULL)
+    {
+      pthread_mutex_unlock (&cache->mutex);
+      return -1;
+    }
+
+  memset (entry, 0, sizeof (*entry));
+  strncpy (entry->name, normalized, DNS_NEGCACHE_MAX_NAME);
+  entry->name[DNS_NEGCACHE_MAX_NAME] = '\0';
+  entry->qtype = 0; /* NXDOMAIN uses qtype=0 */
+  entry->qclass = qclass;
+  entry->type = DNS_NEG_NXDOMAIN;
+  entry->ttl = ttl;
+  entry->insert_time_ms = Socket_get_monotonic_ms ();
+
+  hash_insert (cache, entry);
+  lru_add_head (cache, entry);
+  cache->size++;
+  cache->insertions++;
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return 0;
+}
+
+int
+SocketDNSNegCache_insert_nodata (T cache, const char *qname, uint16_t qtype,
+                                  uint16_t qclass, uint32_t ttl)
+{
+  if (cache == NULL || qname == NULL)
+    return -1;
+
+  /* qtype=0 is reserved for NXDOMAIN */
+  if (qtype == 0)
+    return -1;
+
+  /* Reject if cache is disabled */
+  if (cache->max_entries == 0)
+    return -1;
+
+  /* Validate name length before normalizing */
+  size_t qname_len = strlen (qname);
+  if (qname_len > DNS_NEGCACHE_MAX_NAME)
+    return -1;
+
+  char normalized[DNS_NEGCACHE_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_NEGCACHE_MAX_NAME);
+
+  /* Cap TTL */
+  if (ttl > cache->max_ttl)
+    ttl = cache->max_ttl;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Check if already exists and update */
+  struct NegCacheEntry *existing
+      = find_entry (cache, normalized, qtype, qclass);
+  if (existing)
+    {
+      existing->ttl = ttl;
+      existing->insert_time_ms = Socket_get_monotonic_ms ();
+      lru_touch (cache, existing);
+      pthread_mutex_unlock (&cache->mutex);
+      return 0;
+    }
+
+  /* Evict if at capacity */
+  if (cache->max_entries > 0 && cache->size >= cache->max_entries)
+    evict_lru (cache);
+
+  /* Allocate new entry */
+  struct NegCacheEntry *entry = entry_alloc (cache);
+  if (entry == NULL)
+    {
+      pthread_mutex_unlock (&cache->mutex);
+      return -1;
+    }
+
+  memset (entry, 0, sizeof (*entry));
+  strncpy (entry->name, normalized, DNS_NEGCACHE_MAX_NAME);
+  entry->name[DNS_NEGCACHE_MAX_NAME] = '\0';
+  entry->qtype = qtype;
+  entry->qclass = qclass;
+  entry->type = DNS_NEG_NODATA;
+  entry->ttl = ttl;
+  entry->insert_time_ms = Socket_get_monotonic_ms ();
+
+  hash_insert (cache, entry);
+  lru_add_head (cache, entry);
+  cache->size++;
+  cache->insertions++;
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return 0;
+}
+
+int
+SocketDNSNegCache_remove (T cache, const char *qname)
+{
+  if (cache == NULL || qname == NULL)
+    return 0;
+
+  char normalized[DNS_NEGCACHE_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_NEGCACHE_MAX_NAME);
+
+  int removed = 0;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Scan all buckets for entries with this name */
+  for (unsigned i = 0; i < NEGCACHE_HASH_SIZE; i++)
+    {
+      struct NegCacheEntry **pp = &cache->hash_table[i];
+      while (*pp)
+        {
+          struct NegCacheEntry *entry = *pp;
+          if (strcasecmp (entry->name, normalized) == 0)
+            {
+              *pp = entry->hash_next;
+              lru_remove (cache, entry);
+              cache->size--;
+              removed++;
+            }
+          else
+            {
+              pp = &entry->hash_next;
+            }
+        }
+    }
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return removed;
+}
+
+int
+SocketDNSNegCache_remove_nodata (T cache, const char *qname, uint16_t qtype,
+                                  uint16_t qclass)
+{
+  if (cache == NULL || qname == NULL || qtype == 0)
+    return 0;
+
+  char normalized[DNS_NEGCACHE_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_NEGCACHE_MAX_NAME);
+
+  pthread_mutex_lock (&cache->mutex);
+
+  struct NegCacheEntry *entry = find_entry (cache, normalized, qtype, qclass);
+  if (entry)
+    {
+      entry_free (cache, entry);
+      pthread_mutex_unlock (&cache->mutex);
+      return 1;
+    }
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return 0;
+}
+
+void
+SocketDNSNegCache_clear (T cache)
+{
+  if (cache == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Clear hash table */
+  for (unsigned i = 0; i < NEGCACHE_HASH_SIZE; i++)
+    cache->hash_table[i] = NULL;
+
+  /* Clear LRU list */
+  cache->lru_head = NULL;
+  cache->lru_tail = NULL;
+  cache->size = 0;
+
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+void
+SocketDNSNegCache_set_max_entries (T cache, size_t max_entries)
+{
+  if (cache == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+  cache->max_entries = max_entries;
+
+  /* Evict excess entries */
+  while (max_entries > 0 && cache->size > max_entries)
+    evict_lru (cache);
+
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+void
+SocketDNSNegCache_set_max_ttl (T cache, uint32_t max_ttl)
+{
+  if (cache == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+  cache->max_ttl = max_ttl;
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+void
+SocketDNSNegCache_stats (T cache, SocketDNS_NegCacheStats *stats)
+{
+  if (cache == NULL || stats == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  stats->hits = cache->hits;
+  stats->misses = cache->misses;
+  stats->nxdomain_hits = cache->nxdomain_hits;
+  stats->nodata_hits = cache->nodata_hits;
+  stats->insertions = cache->insertions;
+  stats->evictions = cache->evictions;
+  stats->expirations = cache->expirations;
+  stats->current_size = cache->size;
+  stats->max_entries = cache->max_entries;
+  stats->max_ttl = cache->max_ttl;
+
+  uint64_t total = stats->hits + stats->misses;
+  stats->hit_rate = (total > 0) ? ((double)stats->hits / total) : 0.0;
+
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+const char *
+SocketDNSNegCache_type_name (SocketDNS_NegCacheType type)
+{
+  switch (type)
+    {
+    case DNS_NEG_NXDOMAIN:
+      return "NXDOMAIN";
+    case DNS_NEG_NODATA:
+      return "NODATA";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+const char *
+SocketDNSNegCache_result_name (SocketDNS_NegCacheResult result)
+{
+  switch (result)
+    {
+    case DNS_NEG_MISS:
+      return "MISS";
+    case DNS_NEG_HIT_NXDOMAIN:
+      return "HIT_NXDOMAIN";
+    case DNS_NEG_HIT_NODATA:
+      return "HIT_NODATA";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+#undef T

--- a/src/test/test_dns_negcache.c
+++ b/src/test/test_dns_negcache.c
@@ -1,0 +1,615 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/*
+ * test_dns_negcache.c - Unit tests for DNS Negative Response Cache (RFC 2308)
+ *
+ * Tests RFC 2308 compliant negative caching with proper cache key tuples:
+ * - NXDOMAIN: <QNAME, QCLASS> tuple (matches any QTYPE)
+ * - NODATA: <QNAME, QTYPE, QCLASS> tuple (type-specific)
+ */
+
+#include "core/Arena.h"
+#include "dns/SocketDNSNegCache.h"
+#include "test/Test.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* DNS type constants for testing */
+#define DNS_TYPE_A 1
+#define DNS_TYPE_AAAA 28
+#define DNS_TYPE_MX 15
+#define DNS_TYPE_TXT 16
+#define DNS_CLASS_IN 1
+
+/* Test basic cache creation and disposal */
+TEST (negcache_new_free)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+  ASSERT_NOT_NULL (cache);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 0);
+  ASSERT_EQ (stats.max_entries, DNS_NEGCACHE_DEFAULT_MAX);
+  ASSERT_EQ (stats.max_ttl, DNS_NEGCACHE_DEFAULT_MAX_TTL);
+
+  SocketDNSNegCache_free (&cache);
+  ASSERT_NULL (cache);
+  Arena_dispose (&arena);
+}
+
+/* Test NXDOMAIN insertion and lookup */
+TEST (negcache_nxdomain_insert_lookup)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert NXDOMAIN for nonexistent.example.com */
+  int ret
+      = SocketDNSNegCache_insert_nxdomain (cache, "nonexistent.example.com",
+                                           DNS_CLASS_IN, 300);
+  ASSERT_EQ (ret, 0);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.insertions, 1);
+  ASSERT_EQ (stats.current_size, 1);
+
+  /* Lookup should hit for ANY query type (RFC 2308 Section 5) */
+  SocketDNS_NegCacheEntry entry;
+  SocketDNS_NegCacheResult result;
+
+  result = SocketDNSNegCache_lookup (cache, "nonexistent.example.com",
+                                     DNS_TYPE_A, DNS_CLASS_IN, &entry);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+  ASSERT_EQ (entry.type, DNS_NEG_NXDOMAIN);
+  ASSERT (entry.ttl_remaining > 0);
+  ASSERT (entry.ttl_remaining <= 300);
+
+  /* AAAA lookup should also hit the NXDOMAIN */
+  result = SocketDNSNegCache_lookup (cache, "nonexistent.example.com",
+                                     DNS_TYPE_AAAA, DNS_CLASS_IN, &entry);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  /* MX lookup should also hit */
+  result = SocketDNSNegCache_lookup (cache, "nonexistent.example.com",
+                                     DNS_TYPE_MX, DNS_CLASS_IN, &entry);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.hits, 3);
+  ASSERT_EQ (stats.nxdomain_hits, 3);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test NODATA insertion and lookup */
+TEST (negcache_nodata_insert_lookup)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert NODATA for example.com AAAA (name exists but no AAAA records) */
+  int ret = SocketDNSNegCache_insert_nodata (cache, "example.com",
+                                             DNS_TYPE_AAAA, DNS_CLASS_IN, 300);
+  ASSERT_EQ (ret, 0);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.insertions, 1);
+
+  /* Lookup AAAA should hit */
+  SocketDNS_NegCacheEntry entry;
+  SocketDNS_NegCacheResult result;
+
+  result = SocketDNSNegCache_lookup (cache, "example.com", DNS_TYPE_AAAA,
+                                     DNS_CLASS_IN, &entry);
+  ASSERT_EQ (result, DNS_NEG_HIT_NODATA);
+  ASSERT_EQ (entry.type, DNS_NEG_NODATA);
+
+  /* Lookup A should MISS (NODATA is type-specific per RFC 2308) */
+  result = SocketDNSNegCache_lookup (cache, "example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  /* Lookup MX should also MISS */
+  result = SocketDNSNegCache_lookup (cache, "example.com", DNS_TYPE_MX,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.hits, 1);
+  ASSERT_EQ (stats.nodata_hits, 1);
+  ASSERT_EQ (stats.misses, 2);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test NXDOMAIN takes precedence over NODATA */
+TEST (negcache_nxdomain_precedence)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert NODATA for specific type first */
+  SocketDNSNegCache_insert_nodata (cache, "test.example.com", DNS_TYPE_A,
+                                   DNS_CLASS_IN, 300);
+
+  /* Then insert NXDOMAIN for same name (should replace/override) */
+  SocketDNSNegCache_insert_nxdomain (cache, "test.example.com", DNS_CLASS_IN,
+                                     600);
+
+  /* Lookup should return NXDOMAIN (takes precedence) */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "test.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  /* Other types should also return NXDOMAIN */
+  result = SocketDNSNegCache_lookup (cache, "test.example.com", DNS_TYPE_AAAA,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test case-insensitive lookup */
+TEST (negcache_case_insensitive)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert with lowercase */
+  SocketDNSNegCache_insert_nxdomain (cache, "test.example.com", DNS_CLASS_IN,
+                                     300);
+
+  /* Lookup with different cases should all hit */
+  SocketDNS_NegCacheResult result;
+
+  result = SocketDNSNegCache_lookup (cache, "TEST.EXAMPLE.COM", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  result = SocketDNSNegCache_lookup (cache, "Test.Example.Com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  result = SocketDNSNegCache_lookup (cache, "tEsT.eXaMpLe.CoM", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test TTL expiration */
+TEST (negcache_ttl_expiration)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert with 1 second TTL */
+  SocketDNSNegCache_insert_nxdomain (cache, "expiring.example.com",
+                                     DNS_CLASS_IN, 1);
+
+  /* Should hit immediately */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "expiring.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  /* Wait for TTL to expire */
+  sleep (2);
+
+  /* Should now miss due to expiration */
+  result = SocketDNSNegCache_lookup (cache, "expiring.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT (stats.expirations > 0);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test max TTL clamping */
+TEST (negcache_max_ttl_clamp)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Set low max TTL */
+  SocketDNSNegCache_set_max_ttl (cache, 60);
+
+  /* Insert with high TTL - should be clamped */
+  SocketDNSNegCache_insert_nxdomain (cache, "clamped.example.com", DNS_CLASS_IN,
+                                     3600);
+
+  /* Lookup and verify TTL was clamped */
+  SocketDNS_NegCacheEntry entry;
+  SocketDNSNegCache_lookup (cache, "clamped.example.com", DNS_TYPE_A,
+                            DNS_CLASS_IN, &entry);
+  ASSERT (entry.original_ttl <= 60);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test LRU eviction when cache is full */
+TEST (negcache_lru_eviction)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Set very small cache size */
+  SocketDNSNegCache_set_max_entries (cache, 3);
+
+  /* Insert 3 entries */
+  SocketDNSNegCache_insert_nxdomain (cache, "first.example.com", DNS_CLASS_IN,
+                                     300);
+  SocketDNSNegCache_insert_nxdomain (cache, "second.example.com", DNS_CLASS_IN,
+                                     300);
+  SocketDNSNegCache_insert_nxdomain (cache, "third.example.com", DNS_CLASS_IN,
+                                     300);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Access first entry to make it recently used */
+  SocketDNSNegCache_lookup (cache, "first.example.com", DNS_TYPE_A,
+                            DNS_CLASS_IN, NULL);
+
+  /* Insert 4th entry - should evict LRU (second) */
+  SocketDNSNegCache_insert_nxdomain (cache, "fourth.example.com", DNS_CLASS_IN,
+                                     300);
+
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+  ASSERT (stats.evictions > 0);
+
+  /* First should still be present (was accessed) */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "first.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  /* Second should have been evicted */
+  result = SocketDNSNegCache_lookup (cache, "second.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test remove by name */
+TEST (negcache_remove)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert NXDOMAIN */
+  SocketDNSNegCache_insert_nxdomain (cache, "remove.example.com", DNS_CLASS_IN,
+                                     300);
+
+  /* Insert multiple NODATA for same name */
+  SocketDNSNegCache_insert_nodata (cache, "partial.example.com", DNS_TYPE_A,
+                                   DNS_CLASS_IN, 300);
+  SocketDNSNegCache_insert_nodata (cache, "partial.example.com", DNS_TYPE_AAAA,
+                                   DNS_CLASS_IN, 300);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Remove all entries for partial.example.com */
+  int removed = SocketDNSNegCache_remove (cache, "partial.example.com");
+  ASSERT_EQ (removed, 2);
+
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 1);
+
+  /* Lookups should miss */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "partial.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  /* Original entry should still exist */
+  result = SocketDNSNegCache_lookup (cache, "remove.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test remove specific NODATA */
+TEST (negcache_remove_nodata)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert multiple NODATA for same name */
+  SocketDNSNegCache_insert_nodata (cache, "multi.example.com", DNS_TYPE_A,
+                                   DNS_CLASS_IN, 300);
+  SocketDNSNegCache_insert_nodata (cache, "multi.example.com", DNS_TYPE_AAAA,
+                                   DNS_CLASS_IN, 300);
+  SocketDNSNegCache_insert_nodata (cache, "multi.example.com", DNS_TYPE_MX,
+                                   DNS_CLASS_IN, 300);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Remove only AAAA NODATA */
+  int removed = SocketDNSNegCache_remove_nodata (cache, "multi.example.com",
+                                                 DNS_TYPE_AAAA, DNS_CLASS_IN);
+  ASSERT_EQ (removed, 1);
+
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 2);
+
+  /* AAAA should miss */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "multi.example.com", DNS_TYPE_AAAA,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  /* A and MX should still hit */
+  result = SocketDNSNegCache_lookup (cache, "multi.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NODATA);
+
+  result = SocketDNSNegCache_lookup (cache, "multi.example.com", DNS_TYPE_MX,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NODATA);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test cache clear */
+TEST (negcache_clear)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert several entries */
+  SocketDNSNegCache_insert_nxdomain (cache, "a.example.com", DNS_CLASS_IN, 300);
+  SocketDNSNegCache_insert_nxdomain (cache, "b.example.com", DNS_CLASS_IN, 300);
+  SocketDNSNegCache_insert_nodata (cache, "c.example.com", DNS_TYPE_A,
+                                   DNS_CLASS_IN, 300);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Clear cache */
+  SocketDNSNegCache_clear (cache);
+
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 0);
+
+  /* All lookups should miss */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "a.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test statistics accuracy */
+TEST (negcache_stats_accuracy)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+
+  /* Initial stats should be zero */
+  ASSERT_EQ (stats.hits, 0);
+  ASSERT_EQ (stats.misses, 0);
+  ASSERT_EQ (stats.insertions, 0);
+
+  /* Insert and lookup */
+  SocketDNSNegCache_insert_nxdomain (cache, "stat.example.com", DNS_CLASS_IN,
+                                     300);
+  SocketDNSNegCache_insert_nodata (cache, "nodata.example.com", DNS_TYPE_A,
+                                   DNS_CLASS_IN, 300);
+
+  SocketDNSNegCache_lookup (cache, "stat.example.com", DNS_TYPE_A, DNS_CLASS_IN,
+                            NULL);
+  SocketDNSNegCache_lookup (cache, "stat.example.com", DNS_TYPE_AAAA,
+                            DNS_CLASS_IN, NULL);
+  SocketDNSNegCache_lookup (cache, "nodata.example.com", DNS_TYPE_A,
+                            DNS_CLASS_IN, NULL);
+  SocketDNSNegCache_lookup (cache, "miss.example.com", DNS_TYPE_A, DNS_CLASS_IN,
+                            NULL);
+
+  SocketDNSNegCache_stats (cache, &stats);
+
+  ASSERT_EQ (stats.insertions, 2);
+  ASSERT_EQ (stats.hits, 3);       /* 2 NXDOMAIN + 1 NODATA */
+  ASSERT_EQ (stats.nxdomain_hits, 2);
+  ASSERT_EQ (stats.nodata_hits, 1);
+  ASSERT_EQ (stats.misses, 1);
+
+  /* Verify hit rate calculation */
+  double expected_hit_rate = 3.0 / 4.0; /* 3 hits out of 4 lookups */
+  ASSERT (stats.hit_rate > 0.7);
+  ASSERT (stats.hit_rate < 0.8);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test type name and result name functions */
+TEST (negcache_name_functions)
+{
+  const char *type_name;
+  const char *result_name;
+
+  type_name = SocketDNSNegCache_type_name (DNS_NEG_NXDOMAIN);
+  ASSERT (strcmp (type_name, "NXDOMAIN") == 0);
+
+  type_name = SocketDNSNegCache_type_name (DNS_NEG_NODATA);
+  ASSERT (strcmp (type_name, "NODATA") == 0);
+
+  result_name = SocketDNSNegCache_result_name (DNS_NEG_MISS);
+  ASSERT (strcmp (result_name, "MISS") == 0);
+
+  result_name = SocketDNSNegCache_result_name (DNS_NEG_HIT_NXDOMAIN);
+  ASSERT (strcmp (result_name, "HIT_NXDOMAIN") == 0);
+
+  result_name = SocketDNSNegCache_result_name (DNS_NEG_HIT_NODATA);
+  ASSERT (strcmp (result_name, "HIT_NODATA") == 0);
+}
+
+/* Test different query classes (RFC 2308 compliance) */
+TEST (negcache_different_classes)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert NXDOMAIN for class IN */
+  SocketDNSNegCache_insert_nxdomain (cache, "class.example.com", DNS_CLASS_IN,
+                                     300);
+
+  /* Lookup with same class should hit */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "class.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  /* Lookup with different class should miss (per RFC 2308) */
+  uint16_t DNS_CLASS_CH = 3; /* Chaos class */
+  result = SocketDNSNegCache_lookup (cache, "class.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_CH, NULL);
+  ASSERT_EQ (result, DNS_NEG_MISS);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test name length limits */
+TEST (negcache_name_limits)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Create a name at the max length (255 characters) */
+  char long_name[256];
+  memset (long_name, 'a', 255);
+  long_name[255] = '\0';
+
+  /* Should succeed */
+  int ret
+      = SocketDNSNegCache_insert_nxdomain (cache, long_name, DNS_CLASS_IN, 300);
+  ASSERT_EQ (ret, 0);
+
+  /* Lookup should work */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, long_name, DNS_TYPE_A, DNS_CLASS_IN,
+                                     NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  /* Create a name exceeding max length (256 characters) */
+  char too_long_name[257];
+  memset (too_long_name, 'b', 256);
+  too_long_name[256] = '\0';
+
+  /* Should fail */
+  ret = SocketDNSNegCache_insert_nxdomain (cache, too_long_name, DNS_CLASS_IN,
+                                           300);
+  ASSERT_EQ (ret, -1);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test cache disabled (max_entries = 0) */
+TEST (negcache_disabled)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Disable cache */
+  SocketDNSNegCache_set_max_entries (cache, 0);
+
+  /* Insertions should fail */
+  int ret = SocketDNSNegCache_insert_nxdomain (cache, "disabled.example.com",
+                                               DNS_CLASS_IN, 300);
+  ASSERT_EQ (ret, -1);
+
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 0);
+  ASSERT_EQ (stats.insertions, 0);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test zero TTL entries */
+TEST (negcache_zero_ttl)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  /* Insert with zero TTL - should still be cached momentarily */
+  int ret = SocketDNSNegCache_insert_nxdomain (cache, "zero.example.com",
+                                               DNS_CLASS_IN, 0);
+  ASSERT_EQ (ret, 0);
+
+  /* Immediate lookup might hit or miss depending on timing */
+  SocketDNS_NegCacheStats stats;
+  SocketDNSNegCache_stats (cache, &stats);
+  ASSERT_EQ (stats.insertions, 1);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test NULL entry pointer in lookup */
+TEST (negcache_null_entry)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSNegCache_T cache = SocketDNSNegCache_new (arena);
+
+  SocketDNSNegCache_insert_nxdomain (cache, "null.example.com", DNS_CLASS_IN,
+                                     300);
+
+  /* Lookup with NULL entry should still work */
+  SocketDNS_NegCacheResult result;
+  result = SocketDNSNegCache_lookup (cache, "null.example.com", DNS_TYPE_A,
+                                     DNS_CLASS_IN, NULL);
+  ASSERT_EQ (result, DNS_NEG_HIT_NXDOMAIN);
+
+  SocketDNSNegCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Main function - run all tests */
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary
- Implements RFC 2308 Section 5 compliant negative caching
- NXDOMAIN cached against `<QNAME, QCLASS>` - matches any query type
- NODATA cached against `<QNAME, QTYPE, QCLASS>` - type-specific
- Thread-safe with pthread mutex
- LRU eviction and TTL-based expiration
- 18 comprehensive unit tests

Fixes #171

## Test plan
- [x] Tests pass with AddressSanitizer
- [x] Tests pass with UBSan
- [x] No memory leaks detected
- [x] RFC 2308 Section 5 compliance verified