### PR TITLE
fix: add empty statement after label for C11 compatibility

### DIFF
--- a/src/pool/SocketPool-ops.c
+++ b/src/pool/SocketPool-ops.c
@@ -1198,7 +1198,7 @@ async_connect_dns_callback (Request_T req, struct addrinfo *result,
 
   SocketCommon_free_addrinfo (result);
 
-invoke_callback:
+invoke_callback:;
   /* Save callback and data before removing context (removal clears them) */
   SocketPool_ConnectCallback user_cb = ctx->cb;
   void *user_data = ctx->user_data;


### PR DESCRIPTION
## Summary
- Fixes Clang build failure with `-DENABLE_FUZZING=ON`
- Adds empty statement (`;`) after `invoke_callback:` label in SocketPool-ops.c
- In C11, labels must be followed by statements, not declarations

Fixes #239

## Test plan
- [x] Verified fuzzing build succeeds with Clang
- [x] One-line fix with no behavior change