### PR TITLE
feat(dns): implement RFC 2308 Section 7.1 SERVFAIL caching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -326,6 +326,7 @@ set(LIB_SOURCES
     src/dns/SocketDNSCookie.c
     src/dns/SocketDNSError.c
     src/dns/SocketDNSNegCache.c
+    src/dns/SocketDNSServfailCache.c
 
     # Poll module (consolidated)
     src/poll/SocketPoll.c
@@ -560,6 +561,7 @@ set(DNS_HEADERS
     include/dns/SocketDNSCookie.h
     include/dns/SocketDNSError.h
     include/dns/SocketDNSNegCache.h
+    include/dns/SocketDNSServfailCache.h
 )
 
 set(POLL_HEADERS
@@ -698,6 +700,7 @@ set(TEST_SOURCES
     test_dnscookie
     test_dnserror
     test_dns_negcache
+    test_dns_servfailcache
     test_integration
     test_threadsafety
     test_happy_eyeballs

--- a/include/dns/SocketDNSServfailCache.h
+++ b/include/dns/SocketDNSServfailCache.h
@@ -1,0 +1,290 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#ifndef SOCKETDNSSERVFAILCACHE_INCLUDED
+#define SOCKETDNSSERVFAILCACHE_INCLUDED
+
+/**
+ * @file SocketDNSServfailCache.h
+ * @brief DNS Server Failure Cache (RFC 2308 Section 7.1).
+ * @ingroup dns
+ *
+ * Implements RFC 2308 Section 7.1 compliant SERVFAIL caching.
+ * Server failures are cached for a maximum of 5 minutes to reduce
+ * query storms against failing servers while ensuring timely recovery.
+ *
+ * ## RFC Reference
+ *
+ * RFC 2308 Section 7.1:
+ * > "A server MAY cache a server failure response... However, this
+ * > cached indication MUST NOT be retained longer than five (5) minutes."
+ *
+ * ## Cache Key Tuple
+ *
+ * SERVFAIL is server-specific, so the cache key includes the nameserver:
+ * - `<QNAME, QTYPE, QCLASS, nameserver>` (4-tuple)
+ *
+ * This allows the resolver to try alternate nameservers when one fails.
+ *
+ * ## Features
+ *
+ * - RFC 2308 compliant 5-minute maximum TTL
+ * - Server-specific caching (same query can succeed on different NS)
+ * - LRU eviction when cache is full
+ * - Thread-safe operations
+ *
+ * @see SocketDNSNegCache.h for NXDOMAIN/NODATA caching.
+ * @see SocketDNSResolver.h for the async resolver API.
+ */
+
+#include "core/Arena.h"
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @defgroup dns_servfail_cache DNS SERVFAIL Cache
+ * @brief RFC 2308 Section 7.1 compliant server failure caching.
+ * @ingroup dns
+ * @{
+ */
+
+/** Maximum hostname length in cache key. */
+#define DNS_SERVFAIL_MAX_NAME 255
+
+/** Maximum nameserver address length (IPv6 + port). */
+#define DNS_SERVFAIL_MAX_NS 64
+
+/** Default maximum cache entries. */
+#define DNS_SERVFAIL_DEFAULT_MAX 500
+
+/**
+ * RFC 2308 Section 7.1: SERVFAIL MUST NOT be cached longer than 5 minutes.
+ */
+#define DNS_SERVFAIL_MAX_TTL 300
+
+/** Default QCLASS for Internet class. */
+#define DNS_SERVFAIL_QCLASS_IN 1
+
+#define T SocketDNSServfailCache_T
+typedef struct T *T;
+
+/**
+ * @brief SERVFAIL cache lookup result.
+ * @ingroup dns_servfail_cache
+ */
+typedef enum
+{
+  /** No cached SERVFAIL entry found. */
+  DNS_SERVFAIL_MISS = 0,
+
+  /** Cached SERVFAIL entry found - this nameserver is known to fail. */
+  DNS_SERVFAIL_HIT = 1
+} SocketDNS_ServfailCacheResult;
+
+/**
+ * @brief SERVFAIL cache entry information.
+ * @ingroup dns_servfail_cache
+ *
+ * Returned by lookup functions to provide details about cached entries.
+ */
+typedef struct
+{
+  /** TTL remaining in seconds. */
+  uint32_t ttl_remaining;
+
+  /** Original TTL when inserted. */
+  uint32_t original_ttl;
+
+  /** Timestamp when entry was inserted (monotonic ms). */
+  int64_t insert_time_ms;
+} SocketDNS_ServfailCacheEntry;
+
+/**
+ * @brief SERVFAIL cache statistics.
+ * @ingroup dns_servfail_cache
+ */
+typedef struct
+{
+  uint64_t hits;           /**< Cache hits (known failing server) */
+  uint64_t misses;         /**< Cache misses */
+  uint64_t insertions;     /**< Total insertions */
+  uint64_t evictions;      /**< LRU evictions */
+  uint64_t expirations;    /**< TTL expirations */
+  size_t current_size;     /**< Current entry count */
+  size_t max_entries;      /**< Maximum capacity */
+  double hit_rate;         /**< Calculated hit rate */
+} SocketDNS_ServfailCacheStats;
+
+/* Lifecycle functions */
+
+/**
+ * @brief Create a new SERVFAIL cache instance.
+ * @ingroup dns_servfail_cache
+ *
+ * Creates a cache with default settings:
+ * - max_entries: 500
+ * - max_ttl: 300 seconds (5 minutes, RFC 2308 mandated)
+ *
+ * @param arena Arena for memory allocation (must outlive cache).
+ * @return New cache instance, or NULL on allocation failure.
+ *
+ * @code{.c}
+ * Arena_T arena = Arena_new();
+ * SocketDNSServfailCache_T cache = SocketDNSServfailCache_new(arena);
+ * @endcode
+ */
+extern T SocketDNSServfailCache_new (Arena_T arena);
+
+/**
+ * @brief Dispose of a SERVFAIL cache instance.
+ * @ingroup dns_servfail_cache
+ *
+ * Clears all entries and releases resources.
+ * The cache pointer is set to NULL.
+ *
+ * @param cache Pointer to cache instance.
+ */
+extern void SocketDNSServfailCache_free (T *cache);
+
+/* Cache operations */
+
+/**
+ * @brief Look up a SERVFAIL cache entry.
+ * @ingroup dns_servfail_cache
+ *
+ * Checks if a query to a specific nameserver has recently failed.
+ * Uses the 4-tuple key: `<QNAME, QTYPE, QCLASS, nameserver>`.
+ *
+ * @param cache      Cache instance.
+ * @param qname      Query name (case-insensitive lookup).
+ * @param qtype      Query type (e.g., DNS_TYPE_A, DNS_TYPE_AAAA).
+ * @param qclass     Query class (typically DNS_CLASS_IN = 1).
+ * @param nameserver Nameserver address (e.g., "8.8.8.8" or "2001:4860:4860::8888").
+ * @param entry      Output entry details (may be NULL if not needed).
+ * @return DNS_SERVFAIL_HIT if cached failure, DNS_SERVFAIL_MISS otherwise.
+ *
+ * @code{.c}
+ * SocketDNS_ServfailCacheEntry info;
+ * SocketDNS_ServfailCacheResult result = SocketDNSServfailCache_lookup(
+ *     cache, "example.com", DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8", &info);
+ *
+ * if (result == DNS_SERVFAIL_HIT) {
+ *     printf("Nameserver 8.8.8.8 failed for this query, TTL=%u\n",
+ *            info.ttl_remaining);
+ *     // Try a different nameserver
+ * }
+ * @endcode
+ */
+extern SocketDNS_ServfailCacheResult SocketDNSServfailCache_lookup (
+    T cache, const char *qname, uint16_t qtype, uint16_t qclass,
+    const char *nameserver, SocketDNS_ServfailCacheEntry *entry);
+
+/**
+ * @brief Insert a SERVFAIL entry into the cache.
+ * @ingroup dns_servfail_cache
+ *
+ * Caches a SERVFAIL response with key `<QNAME, QTYPE, QCLASS, nameserver>`.
+ * The TTL is capped at DNS_SERVFAIL_MAX_TTL (5 minutes) per RFC 2308.
+ *
+ * @param cache      Cache instance.
+ * @param qname      Query name (normalized to lowercase internally).
+ * @param qtype      Query type.
+ * @param qclass     Query class (typically DNS_CLASS_IN = 1).
+ * @param nameserver Nameserver address that returned SERVFAIL.
+ * @param ttl        Desired TTL (capped at 300 seconds).
+ * @return 0 on success, -1 on error.
+ *
+ * @code{.c}
+ * // Cache SERVFAIL from 8.8.8.8 for example.com A query
+ * SocketDNSServfailCache_insert(cache, "example.com", DNS_TYPE_A,
+ *                                DNS_CLASS_IN, "8.8.8.8", 300);
+ *
+ * // Future lookups for this query to 8.8.8.8 will hit cache
+ * // But queries to 8.8.4.4 will miss (try alternate nameserver)
+ * @endcode
+ */
+extern int SocketDNSServfailCache_insert (T cache, const char *qname,
+                                           uint16_t qtype, uint16_t qclass,
+                                           const char *nameserver, uint32_t ttl);
+
+/**
+ * @brief Remove a specific SERVFAIL entry.
+ * @ingroup dns_servfail_cache
+ *
+ * Removes the entry for the exact 4-tuple.
+ *
+ * @param cache      Cache instance.
+ * @param qname      Query name.
+ * @param qtype      Query type.
+ * @param qclass     Query class.
+ * @param nameserver Nameserver address.
+ * @return 1 if entry was found and removed, 0 if not found.
+ */
+extern int SocketDNSServfailCache_remove (T cache, const char *qname,
+                                           uint16_t qtype, uint16_t qclass,
+                                           const char *nameserver);
+
+/**
+ * @brief Remove all SERVFAIL entries for a nameserver.
+ * @ingroup dns_servfail_cache
+ *
+ * Useful when a nameserver comes back online and all cached
+ * failures should be cleared.
+ *
+ * @param cache      Cache instance.
+ * @param nameserver Nameserver address to clear.
+ * @return Number of entries removed.
+ */
+extern int SocketDNSServfailCache_remove_nameserver (T cache,
+                                                      const char *nameserver);
+
+/**
+ * @brief Clear all entries from the cache.
+ * @ingroup dns_servfail_cache
+ *
+ * @param cache Cache instance.
+ */
+extern void SocketDNSServfailCache_clear (T cache);
+
+/* Configuration */
+
+/**
+ * @brief Set maximum cache entries.
+ * @ingroup dns_servfail_cache
+ *
+ * @param cache       Cache instance.
+ * @param max_entries Maximum entries (0 = unlimited).
+ */
+extern void SocketDNSServfailCache_set_max_entries (T cache, size_t max_entries);
+
+/**
+ * @brief Get cache statistics.
+ * @ingroup dns_servfail_cache
+ *
+ * @param cache Cache instance.
+ * @param stats Output statistics structure.
+ */
+extern void SocketDNSServfailCache_stats (T cache,
+                                           SocketDNS_ServfailCacheStats *stats);
+
+/* Utility functions */
+
+/**
+ * @brief Get result name as string.
+ * @ingroup dns_servfail_cache
+ *
+ * @param result Lookup result.
+ * @return "MISS" or "HIT".
+ */
+extern const char *SocketDNSServfailCache_result_name (
+    SocketDNS_ServfailCacheResult result);
+
+/** @} */ /* End of dns_servfail_cache group */
+
+#undef T
+
+#endif /* SOCKETDNSSERVFAILCACHE_INCLUDED */

--- a/src/dns/SocketDNSServfailCache.c
+++ b/src/dns/SocketDNSServfailCache.c
@@ -1,0 +1,570 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketDNSServfailCache.c
+ * @brief DNS Server Failure Cache implementation (RFC 2308 Section 7.1).
+ */
+
+#include "dns/SocketDNSServfailCache.h"
+#include "core/Arena.h"
+#include "core/SocketUtil.h"
+
+#include <ctype.h>
+#include <pthread.h>
+#include <string.h>
+#include <strings.h>
+
+#define T SocketDNSServfailCache_T
+
+/** Hash table size (prime for better distribution). */
+#define SERVFAIL_HASH_SIZE 127
+
+/**
+ * @brief Internal cache entry structure.
+ *
+ * Stores the 4-tuple key: <QNAME, QTYPE, QCLASS, nameserver>
+ */
+struct ServfailCacheEntry
+{
+  char name[DNS_SERVFAIL_MAX_NAME + 1]; /**< Normalized (lowercase) QNAME */
+  char nameserver[DNS_SERVFAIL_MAX_NS + 1]; /**< Nameserver address */
+  uint16_t qtype;    /**< QTYPE */
+  uint16_t qclass;   /**< QCLASS */
+  uint32_t ttl;      /**< Original TTL (capped at DNS_SERVFAIL_MAX_TTL) */
+  int64_t insert_time_ms; /**< Monotonic insertion time */
+  struct ServfailCacheEntry *hash_next; /**< Hash chain pointer */
+  struct ServfailCacheEntry *lru_prev;  /**< LRU list prev */
+  struct ServfailCacheEntry *lru_next;  /**< LRU list next */
+};
+
+/**
+ * @brief SERVFAIL cache structure.
+ */
+struct T
+{
+  Arena_T arena; /**< Memory arena */
+  pthread_mutex_t mutex; /**< Thread safety */
+
+  struct ServfailCacheEntry *hash_table[SERVFAIL_HASH_SIZE]; /**< Hash buckets */
+  struct ServfailCacheEntry *lru_head; /**< LRU head (most recent) */
+  struct ServfailCacheEntry *lru_tail; /**< LRU tail (oldest) */
+
+  size_t size;         /**< Current entry count */
+  size_t max_entries;  /**< Maximum capacity */
+
+  /* Statistics */
+  uint64_t hits;
+  uint64_t misses;
+  uint64_t insertions;
+  uint64_t evictions;
+  uint64_t expirations;
+};
+
+/**
+ * @brief Normalize name to lowercase for case-insensitive lookup.
+ */
+static void
+normalize_name (char *dest, const char *src, size_t max_len)
+{
+  size_t i;
+  for (i = 0; src[i] && i < max_len; i++)
+    dest[i] = (char)tolower ((unsigned char)src[i]);
+  dest[i] = '\0';
+}
+
+/**
+ * @brief Compute hash for cache key 4-tuple.
+ *
+ * Includes name, qtype, qclass, and nameserver in hash calculation.
+ */
+static unsigned
+compute_hash (const char *name, uint16_t qtype, uint16_t qclass,
+              const char *nameserver)
+{
+  unsigned hash = 5381; /* djb2 initial value */
+
+  /* Hash the normalized name */
+  for (const char *p = name; *p; p++)
+    hash = ((hash << 5) + hash) ^ (unsigned char)tolower ((unsigned char)*p);
+
+  /* Include qtype and qclass */
+  hash = ((hash << 5) + hash) ^ qtype;
+  hash = ((hash << 5) + hash) ^ qclass;
+
+  /* Include nameserver */
+  for (const char *p = nameserver; *p; p++)
+    hash = ((hash << 5) + hash) ^ (unsigned char)*p;
+
+  return hash % SERVFAIL_HASH_SIZE;
+}
+
+/**
+ * @brief Check if an entry has expired.
+ */
+static bool
+entry_expired (const struct ServfailCacheEntry *entry, int64_t now_ms)
+{
+  int64_t age_ms = now_ms - entry->insert_time_ms;
+  int64_t ttl_ms = (int64_t)entry->ttl * 1000;
+  return age_ms >= ttl_ms;
+}
+
+/**
+ * @brief Calculate remaining TTL.
+ */
+static uint32_t
+entry_ttl_remaining (const struct ServfailCacheEntry *entry, int64_t now_ms)
+{
+  int64_t age_ms = now_ms - entry->insert_time_ms;
+  int64_t ttl_ms = (int64_t)entry->ttl * 1000;
+  int64_t remaining_ms = ttl_ms - age_ms;
+
+  if (remaining_ms <= 0)
+    return 0;
+
+  return (uint32_t)(remaining_ms / 1000);
+}
+
+/**
+ * @brief Remove entry from LRU list.
+ */
+static void
+lru_remove (T cache, struct ServfailCacheEntry *entry)
+{
+  if (entry->lru_prev)
+    entry->lru_prev->lru_next = entry->lru_next;
+  else
+    cache->lru_head = entry->lru_next;
+
+  if (entry->lru_next)
+    entry->lru_next->lru_prev = entry->lru_prev;
+  else
+    cache->lru_tail = entry->lru_prev;
+
+  entry->lru_prev = NULL;
+  entry->lru_next = NULL;
+}
+
+/**
+ * @brief Add entry to LRU head (most recently used).
+ */
+static void
+lru_add_head (T cache, struct ServfailCacheEntry *entry)
+{
+  entry->lru_prev = NULL;
+  entry->lru_next = cache->lru_head;
+
+  if (cache->lru_head)
+    cache->lru_head->lru_prev = entry;
+  else
+    cache->lru_tail = entry;
+
+  cache->lru_head = entry;
+}
+
+/**
+ * @brief Move entry to LRU head (accessed).
+ */
+static void
+lru_touch (T cache, struct ServfailCacheEntry *entry)
+{
+  if (entry != cache->lru_head)
+    {
+      lru_remove (cache, entry);
+      lru_add_head (cache, entry);
+    }
+}
+
+/**
+ * @brief Remove entry from hash table.
+ */
+static void
+hash_remove (T cache, struct ServfailCacheEntry *entry, unsigned bucket)
+{
+  struct ServfailCacheEntry **pp = &cache->hash_table[bucket];
+  while (*pp)
+    {
+      if (*pp == entry)
+        {
+          *pp = entry->hash_next;
+          entry->hash_next = NULL;
+          return;
+        }
+      pp = &(*pp)->hash_next;
+    }
+}
+
+/**
+ * @brief Free an entry (remove from all lists).
+ */
+static void
+entry_free (T cache, struct ServfailCacheEntry *entry)
+{
+  /* Compute bucket for hash removal */
+  unsigned bucket
+      = compute_hash (entry->name, entry->qtype, entry->qclass,
+                      entry->nameserver);
+
+  hash_remove (cache, entry, bucket);
+  lru_remove (cache, entry);
+  cache->size--;
+
+  /* Entry memory is arena-managed, no explicit free needed */
+}
+
+/**
+ * @brief Evict LRU entry when cache is full.
+ */
+static void
+evict_lru (T cache)
+{
+  if (cache->lru_tail)
+    {
+      entry_free (cache, cache->lru_tail);
+      cache->evictions++;
+    }
+}
+
+/**
+ * @brief Find entry by exact key 4-tuple.
+ */
+static struct ServfailCacheEntry *
+find_entry (T cache, const char *normalized_name, uint16_t qtype,
+            uint16_t qclass, const char *nameserver)
+{
+  unsigned bucket = compute_hash (normalized_name, qtype, qclass, nameserver);
+  struct ServfailCacheEntry *entry = cache->hash_table[bucket];
+
+  while (entry)
+    {
+      if (entry->qtype == qtype && entry->qclass == qclass
+          && strcasecmp (entry->name, normalized_name) == 0
+          && strcmp (entry->nameserver, nameserver) == 0)
+        return entry;
+      entry = entry->hash_next;
+    }
+
+  return NULL;
+}
+
+/**
+ * @brief Insert entry into hash table.
+ */
+static void
+hash_insert (T cache, struct ServfailCacheEntry *entry)
+{
+  unsigned bucket
+      = compute_hash (entry->name, entry->qtype, entry->qclass,
+                      entry->nameserver);
+  entry->hash_next = cache->hash_table[bucket];
+  cache->hash_table[bucket] = entry;
+}
+
+/**
+ * @brief Allocate new entry from arena.
+ */
+static struct ServfailCacheEntry *
+entry_alloc (T cache)
+{
+  return Arena_alloc (cache->arena, sizeof (struct ServfailCacheEntry),
+                      __FILE__, __LINE__);
+}
+
+/* Public API */
+
+T
+SocketDNSServfailCache_new (Arena_T arena)
+{
+  if (arena == NULL)
+    return NULL;
+
+  T cache = Arena_alloc (arena, sizeof (*cache), __FILE__, __LINE__);
+  if (cache == NULL)
+    return NULL;
+
+  memset (cache, 0, sizeof (*cache));
+  cache->arena = arena;
+  cache->max_entries = DNS_SERVFAIL_DEFAULT_MAX;
+
+  if (pthread_mutex_init (&cache->mutex, NULL) != 0)
+    return NULL;
+
+  return cache;
+}
+
+void
+SocketDNSServfailCache_free (T *cache)
+{
+  if (cache == NULL || *cache == NULL)
+    return;
+
+  pthread_mutex_destroy (&(*cache)->mutex);
+
+  /* Arena handles memory, just clear pointer */
+  *cache = NULL;
+}
+
+SocketDNS_ServfailCacheResult
+SocketDNSServfailCache_lookup (T cache, const char *qname, uint16_t qtype,
+                                uint16_t qclass, const char *nameserver,
+                                SocketDNS_ServfailCacheEntry *entry)
+{
+  if (cache == NULL || qname == NULL || nameserver == NULL)
+    return DNS_SERVFAIL_MISS;
+
+  char normalized[DNS_SERVFAIL_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_SERVFAIL_MAX_NAME);
+
+  int64_t now_ms = Socket_get_monotonic_ms ();
+  SocketDNS_ServfailCacheResult result = DNS_SERVFAIL_MISS;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  struct ServfailCacheEntry *found
+      = find_entry (cache, normalized, qtype, qclass, nameserver);
+
+  if (found)
+    {
+      if (entry_expired (found, now_ms))
+        {
+          entry_free (cache, found);
+          cache->expirations++;
+          found = NULL;
+        }
+      else
+        {
+          result = DNS_SERVFAIL_HIT;
+          cache->hits++;
+          lru_touch (cache, found);
+        }
+    }
+
+  /* Fill in entry details if requested and found */
+  if (entry != NULL && found != NULL)
+    {
+      entry->original_ttl = found->ttl;
+      entry->ttl_remaining = entry_ttl_remaining (found, now_ms);
+      entry->insert_time_ms = found->insert_time_ms;
+    }
+
+  if (result == DNS_SERVFAIL_MISS)
+    cache->misses++;
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return result;
+}
+
+int
+SocketDNSServfailCache_insert (T cache, const char *qname, uint16_t qtype,
+                                uint16_t qclass, const char *nameserver,
+                                uint32_t ttl)
+{
+  if (cache == NULL || qname == NULL || nameserver == NULL)
+    return -1;
+
+  /* Reject if cache is disabled */
+  if (cache->max_entries == 0)
+    return -1;
+
+  /* Validate name and nameserver length */
+  size_t qname_len = strlen (qname);
+  if (qname_len > DNS_SERVFAIL_MAX_NAME)
+    return -1;
+
+  size_t ns_len = strlen (nameserver);
+  if (ns_len > DNS_SERVFAIL_MAX_NS)
+    return -1;
+
+  char normalized[DNS_SERVFAIL_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_SERVFAIL_MAX_NAME);
+
+  /* Cap TTL at RFC 2308 mandated maximum of 5 minutes */
+  if (ttl > DNS_SERVFAIL_MAX_TTL)
+    ttl = DNS_SERVFAIL_MAX_TTL;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Check if already exists and update */
+  struct ServfailCacheEntry *existing
+      = find_entry (cache, normalized, qtype, qclass, nameserver);
+  if (existing)
+    {
+      existing->ttl = ttl;
+      existing->insert_time_ms = Socket_get_monotonic_ms ();
+      lru_touch (cache, existing);
+      pthread_mutex_unlock (&cache->mutex);
+      return 0;
+    }
+
+  /* Evict if at capacity */
+  if (cache->max_entries > 0 && cache->size >= cache->max_entries)
+    evict_lru (cache);
+
+  /* Allocate new entry */
+  struct ServfailCacheEntry *entry = entry_alloc (cache);
+  if (entry == NULL)
+    {
+      pthread_mutex_unlock (&cache->mutex);
+      return -1;
+    }
+
+  memset (entry, 0, sizeof (*entry));
+  strncpy (entry->name, normalized, DNS_SERVFAIL_MAX_NAME);
+  entry->name[DNS_SERVFAIL_MAX_NAME] = '\0';
+  strncpy (entry->nameserver, nameserver, DNS_SERVFAIL_MAX_NS);
+  entry->nameserver[DNS_SERVFAIL_MAX_NS] = '\0';
+  entry->qtype = qtype;
+  entry->qclass = qclass;
+  entry->ttl = ttl;
+  entry->insert_time_ms = Socket_get_monotonic_ms ();
+
+  hash_insert (cache, entry);
+  lru_add_head (cache, entry);
+  cache->size++;
+  cache->insertions++;
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return 0;
+}
+
+int
+SocketDNSServfailCache_remove (T cache, const char *qname, uint16_t qtype,
+                                uint16_t qclass, const char *nameserver)
+{
+  if (cache == NULL || qname == NULL || nameserver == NULL)
+    return 0;
+
+  char normalized[DNS_SERVFAIL_MAX_NAME + 1];
+  normalize_name (normalized, qname, DNS_SERVFAIL_MAX_NAME);
+
+  pthread_mutex_lock (&cache->mutex);
+
+  struct ServfailCacheEntry *entry
+      = find_entry (cache, normalized, qtype, qclass, nameserver);
+  if (entry)
+    {
+      entry_free (cache, entry);
+      pthread_mutex_unlock (&cache->mutex);
+      return 1;
+    }
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return 0;
+}
+
+int
+SocketDNSServfailCache_remove_nameserver (T cache, const char *nameserver)
+{
+  if (cache == NULL || nameserver == NULL)
+    return 0;
+
+  int removed = 0;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Scan all buckets for entries with this nameserver */
+  for (unsigned i = 0; i < SERVFAIL_HASH_SIZE; i++)
+    {
+      struct ServfailCacheEntry **pp = &cache->hash_table[i];
+      while (*pp)
+        {
+          struct ServfailCacheEntry *entry = *pp;
+          if (strcmp (entry->nameserver, nameserver) == 0)
+            {
+              *pp = entry->hash_next;
+              lru_remove (cache, entry);
+              cache->size--;
+              removed++;
+            }
+          else
+            {
+              pp = &entry->hash_next;
+            }
+        }
+    }
+
+  pthread_mutex_unlock (&cache->mutex);
+
+  return removed;
+}
+
+void
+SocketDNSServfailCache_clear (T cache)
+{
+  if (cache == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  /* Clear hash table */
+  for (unsigned i = 0; i < SERVFAIL_HASH_SIZE; i++)
+    cache->hash_table[i] = NULL;
+
+  /* Clear LRU list */
+  cache->lru_head = NULL;
+  cache->lru_tail = NULL;
+  cache->size = 0;
+
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+void
+SocketDNSServfailCache_set_max_entries (T cache, size_t max_entries)
+{
+  if (cache == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+  cache->max_entries = max_entries;
+
+  /* Evict excess entries */
+  while (max_entries > 0 && cache->size > max_entries)
+    evict_lru (cache);
+
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+void
+SocketDNSServfailCache_stats (T cache, SocketDNS_ServfailCacheStats *stats)
+{
+  if (cache == NULL || stats == NULL)
+    return;
+
+  pthread_mutex_lock (&cache->mutex);
+
+  stats->hits = cache->hits;
+  stats->misses = cache->misses;
+  stats->insertions = cache->insertions;
+  stats->evictions = cache->evictions;
+  stats->expirations = cache->expirations;
+  stats->current_size = cache->size;
+  stats->max_entries = cache->max_entries;
+
+  uint64_t total = stats->hits + stats->misses;
+  stats->hit_rate = (total > 0) ? ((double)stats->hits / total) : 0.0;
+
+  pthread_mutex_unlock (&cache->mutex);
+}
+
+const char *
+SocketDNSServfailCache_result_name (SocketDNS_ServfailCacheResult result)
+{
+  switch (result)
+    {
+    case DNS_SERVFAIL_MISS:
+      return "MISS";
+    case DNS_SERVFAIL_HIT:
+      return "HIT";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+#undef T

--- a/src/test/test_dns_servfailcache.c
+++ b/src/test/test_dns_servfailcache.c
@@ -1,0 +1,617 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/*
+ * test_dns_servfailcache.c - Unit tests for DNS SERVFAIL Cache (RFC 2308 Section 7.1)
+ *
+ * Tests RFC 2308 Section 7.1 compliant SERVFAIL caching with:
+ * - 4-tuple cache key: <QNAME, QTYPE, QCLASS, nameserver>
+ * - 5-minute maximum TTL
+ * - Server-specific failure tracking
+ */
+
+#include "core/Arena.h"
+#include "dns/SocketDNSServfailCache.h"
+#include "test/Test.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+/* DNS type constants for testing */
+#define DNS_TYPE_A 1
+#define DNS_TYPE_AAAA 28
+#define DNS_TYPE_MX 15
+#define DNS_CLASS_IN 1
+
+/* Test basic cache creation and disposal */
+TEST (servfailcache_new_free)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+  ASSERT_NOT_NULL (cache);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 0);
+  ASSERT_EQ (stats.max_entries, DNS_SERVFAIL_DEFAULT_MAX);
+
+  SocketDNSServfailCache_free (&cache);
+  ASSERT_NULL (cache);
+  Arena_dispose (&arena);
+}
+
+/* Test SERVFAIL insertion and lookup */
+TEST (servfailcache_insert_lookup)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert SERVFAIL for example.com A query to 8.8.8.8 */
+  int ret = SocketDNSServfailCache_insert (cache, "example.com", DNS_TYPE_A,
+                                            DNS_CLASS_IN, "8.8.8.8", 300);
+  ASSERT_EQ (ret, 0);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.insertions, 1);
+  ASSERT_EQ (stats.current_size, 1);
+
+  /* Lookup should hit for same 4-tuple */
+  SocketDNS_ServfailCacheEntry entry;
+  SocketDNS_ServfailCacheResult result;
+
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", &entry);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+  ASSERT (entry.ttl_remaining > 0);
+  ASSERT (entry.ttl_remaining <= 300);
+
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.hits, 1);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test server-specific caching: different nameserver should miss */
+TEST (servfailcache_server_specific)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert SERVFAIL for 8.8.8.8 */
+  SocketDNSServfailCache_insert (cache, "example.com", DNS_TYPE_A, DNS_CLASS_IN,
+                                  "8.8.8.8", 300);
+
+  /* Lookup with same nameserver should hit */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  /* Lookup with different nameserver should MISS */
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.4.4", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  /* Lookup with IPv6 nameserver should MISS */
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "2001:4860:4860::8888",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.hits, 1);
+  ASSERT_EQ (stats.misses, 2);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test type-specific caching: different QTYPE should miss */
+TEST (servfailcache_type_specific)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert SERVFAIL for A query */
+  SocketDNSServfailCache_insert (cache, "example.com", DNS_TYPE_A, DNS_CLASS_IN,
+                                  "8.8.8.8", 300);
+
+  /* Lookup A should hit */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  /* Lookup AAAA should MISS (type-specific) */
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_AAAA,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  /* Lookup MX should also MISS */
+  result = SocketDNSServfailCache_lookup (cache, "example.com", DNS_TYPE_MX,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test case-insensitive name lookup */
+TEST (servfailcache_case_insensitive)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert with lowercase */
+  SocketDNSServfailCache_insert (cache, "test.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  /* Lookup with different cases should all hit */
+  SocketDNS_ServfailCacheResult result;
+
+  result = SocketDNSServfailCache_lookup (cache, "TEST.EXAMPLE.COM", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  result = SocketDNSServfailCache_lookup (cache, "Test.Example.Com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  result = SocketDNSServfailCache_lookup (cache, "tEsT.eXaMpLe.CoM", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test RFC 2308 Section 7.1: 5-minute max TTL */
+TEST (servfailcache_max_ttl_5min)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert with TTL higher than 5 minutes - should be capped */
+  SocketDNSServfailCache_insert (cache, "clamped.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 3600);
+
+  /* Lookup and verify TTL was capped at 300 seconds */
+  SocketDNS_ServfailCacheEntry entry;
+  SocketDNSServfailCache_lookup (cache, "clamped.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", &entry);
+  ASSERT (entry.original_ttl <= DNS_SERVFAIL_MAX_TTL);
+  ASSERT_EQ (entry.original_ttl, 300);
+
+  /* Insert with TTL less than 5 minutes - should be kept as-is */
+  SocketDNSServfailCache_insert (cache, "short.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 60);
+
+  SocketDNSServfailCache_lookup (cache, "short.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", &entry);
+  ASSERT_EQ (entry.original_ttl, 60);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test TTL expiration */
+TEST (servfailcache_ttl_expiration)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert with 1 second TTL */
+  SocketDNSServfailCache_insert (cache, "expiring.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 1);
+
+  /* Should hit immediately */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "expiring.example.com",
+                                           DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  /* Wait for TTL to expire */
+  sleep (2);
+
+  /* Should now miss due to expiration */
+  result = SocketDNSServfailCache_lookup (cache, "expiring.example.com",
+                                           DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT (stats.expirations > 0);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test LRU eviction when cache is full */
+TEST (servfailcache_lru_eviction)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Set very small cache size */
+  SocketDNSServfailCache_set_max_entries (cache, 3);
+
+  /* Insert 3 entries */
+  SocketDNSServfailCache_insert (cache, "first.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "second.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "third.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Access first entry to make it recently used */
+  SocketDNSServfailCache_lookup (cache, "first.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", NULL);
+
+  /* Insert 4th entry - should evict LRU (second) */
+  SocketDNSServfailCache_insert (cache, "fourth.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+  ASSERT (stats.evictions > 0);
+
+  /* First should still be present (was accessed) */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "first.example.com",
+                                           DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  /* Second should have been evicted */
+  result = SocketDNSServfailCache_lookup (cache, "second.example.com",
+                                           DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test remove specific entry */
+TEST (servfailcache_remove)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert two entries */
+  SocketDNSServfailCache_insert (cache, "remove.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "keep.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 2);
+
+  /* Remove one entry */
+  int removed = SocketDNSServfailCache_remove (cache, "remove.example.com",
+                                                DNS_TYPE_A, DNS_CLASS_IN,
+                                                "8.8.8.8");
+  ASSERT_EQ (removed, 1);
+
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 1);
+
+  /* Removed entry should miss */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "remove.example.com",
+                                           DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  /* Other entry should still hit */
+  result = SocketDNSServfailCache_lookup (cache, "keep.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test remove all entries for a nameserver */
+TEST (servfailcache_remove_nameserver)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert entries for two different nameservers */
+  SocketDNSServfailCache_insert (cache, "a.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "b.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "c.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.4.4", 300);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Remove all entries for 8.8.8.8 */
+  int removed = SocketDNSServfailCache_remove_nameserver (cache, "8.8.8.8");
+  ASSERT_EQ (removed, 2);
+
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 1);
+
+  /* 8.8.8.8 entries should miss */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "a.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  /* 8.8.4.4 entry should still hit */
+  result = SocketDNSServfailCache_lookup (cache, "c.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.4.4", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test cache clear */
+TEST (servfailcache_clear)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert several entries */
+  SocketDNSServfailCache_insert (cache, "a.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "b.example.com", DNS_TYPE_AAAA,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+  SocketDNSServfailCache_insert (cache, "c.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.4.4", 300);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 3);
+
+  /* Clear cache */
+  SocketDNSServfailCache_clear (cache);
+
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 0);
+
+  /* All lookups should miss */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "a.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test statistics accuracy */
+TEST (servfailcache_stats_accuracy)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+
+  /* Initial stats should be zero */
+  ASSERT_EQ (stats.hits, 0);
+  ASSERT_EQ (stats.misses, 0);
+  ASSERT_EQ (stats.insertions, 0);
+
+  /* Insert and lookup */
+  SocketDNSServfailCache_insert (cache, "stat.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  SocketDNSServfailCache_lookup (cache, "stat.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", NULL);
+  SocketDNSServfailCache_lookup (cache, "stat.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", NULL);
+  SocketDNSServfailCache_lookup (cache, "miss.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", NULL);
+
+  SocketDNSServfailCache_stats (cache, &stats);
+
+  ASSERT_EQ (stats.insertions, 1);
+  ASSERT_EQ (stats.hits, 2);
+  ASSERT_EQ (stats.misses, 1);
+
+  /* Verify hit rate calculation */
+  double expected_hit_rate = 2.0 / 3.0; /* 2 hits out of 3 lookups */
+  ASSERT (stats.hit_rate > 0.6);
+  ASSERT (stats.hit_rate < 0.7);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test result name function */
+TEST (servfailcache_result_name)
+{
+  const char *result_name;
+
+  result_name = SocketDNSServfailCache_result_name (DNS_SERVFAIL_MISS);
+  ASSERT (strcmp (result_name, "MISS") == 0);
+
+  result_name = SocketDNSServfailCache_result_name (DNS_SERVFAIL_HIT);
+  ASSERT (strcmp (result_name, "HIT") == 0);
+}
+
+/* Test name and nameserver length limits */
+TEST (servfailcache_length_limits)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Create a name at the max length (255 characters) */
+  char long_name[256];
+  memset (long_name, 'a', 255);
+  long_name[255] = '\0';
+
+  /* Should succeed */
+  int ret = SocketDNSServfailCache_insert (cache, long_name, DNS_TYPE_A,
+                                            DNS_CLASS_IN, "8.8.8.8", 300);
+  ASSERT_EQ (ret, 0);
+
+  /* Lookup should work */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, long_name, DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  /* Create a name exceeding max length (256 characters) */
+  char too_long_name[257];
+  memset (too_long_name, 'b', 256);
+  too_long_name[256] = '\0';
+
+  /* Should fail */
+  ret = SocketDNSServfailCache_insert (cache, too_long_name, DNS_TYPE_A,
+                                        DNS_CLASS_IN, "8.8.8.8", 300);
+  ASSERT_EQ (ret, -1);
+
+  /* Create a nameserver at max length (64 characters) */
+  char long_ns[65];
+  memset (long_ns, '1', 64);
+  long_ns[64] = '\0';
+
+  ret = SocketDNSServfailCache_insert (cache, "test.example.com", DNS_TYPE_A,
+                                        DNS_CLASS_IN, long_ns, 300);
+  ASSERT_EQ (ret, 0);
+
+  /* Create a nameserver exceeding max length (65 characters) */
+  char too_long_ns[66];
+  memset (too_long_ns, '2', 65);
+  too_long_ns[65] = '\0';
+
+  ret = SocketDNSServfailCache_insert (cache, "test2.example.com", DNS_TYPE_A,
+                                        DNS_CLASS_IN, too_long_ns, 300);
+  ASSERT_EQ (ret, -1);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test cache disabled (max_entries = 0) */
+TEST (servfailcache_disabled)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Disable cache */
+  SocketDNSServfailCache_set_max_entries (cache, 0);
+
+  /* Insertions should fail */
+  int ret = SocketDNSServfailCache_insert (cache, "disabled.example.com",
+                                            DNS_TYPE_A, DNS_CLASS_IN, "8.8.8.8",
+                                            300);
+  ASSERT_EQ (ret, -1);
+
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 0);
+  ASSERT_EQ (stats.insertions, 0);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test NULL entry pointer in lookup */
+TEST (servfailcache_null_entry)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  SocketDNSServfailCache_insert (cache, "null.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  /* Lookup with NULL entry should still work */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "null.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "8.8.8.8", NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test update existing entry */
+TEST (servfailcache_update_existing)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert entry with short TTL */
+  SocketDNSServfailCache_insert (cache, "update.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 60);
+
+  SocketDNS_ServfailCacheEntry entry;
+  SocketDNSServfailCache_lookup (cache, "update.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", &entry);
+  ASSERT_EQ (entry.original_ttl, 60);
+
+  /* Update with longer TTL (capped at 300) */
+  SocketDNSServfailCache_insert (cache, "update.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", 300);
+
+  SocketDNSServfailCache_lookup (cache, "update.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "8.8.8.8", &entry);
+  ASSERT_EQ (entry.original_ttl, 300);
+
+  /* Size should still be 1 */
+  SocketDNS_ServfailCacheStats stats;
+  SocketDNSServfailCache_stats (cache, &stats);
+  ASSERT_EQ (stats.current_size, 1);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Test IPv6 nameserver addresses */
+TEST (servfailcache_ipv6_nameserver)
+{
+  Arena_T arena = Arena_new ();
+  SocketDNSServfailCache_T cache = SocketDNSServfailCache_new (arena);
+
+  /* Insert with IPv6 nameserver */
+  SocketDNSServfailCache_insert (cache, "ipv6.example.com", DNS_TYPE_A,
+                                  DNS_CLASS_IN, "2001:4860:4860::8888", 300);
+
+  /* Lookup should hit */
+  SocketDNS_ServfailCacheResult result;
+  result = SocketDNSServfailCache_lookup (cache, "ipv6.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "2001:4860:4860::8888",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_HIT);
+
+  /* Different IPv6 should miss */
+  result = SocketDNSServfailCache_lookup (cache, "ipv6.example.com", DNS_TYPE_A,
+                                           DNS_CLASS_IN, "2001:4860:4860::8844",
+                                           NULL);
+  ASSERT_EQ (result, DNS_SERVFAIL_MISS);
+
+  SocketDNSServfailCache_free (&cache);
+  Arena_dispose (&arena);
+}
+
+/* Main function - run all tests */
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

- Implements RFC 2308 Section 7.1 compliant SERVFAIL response caching
- Uses 4-tuple cache key `<QNAME, QTYPE, QCLASS, nameserver>` for server-specific failure tracking
- Enforces RFC-mandated 5-minute maximum TTL (DNS_SERVFAIL_MAX_TTL = 300 seconds)
- Provides thread-safe operations with LRU eviction and full statistics tracking

## Implementation Details

This PR adds a new module `SocketDNSServfailCache` that caches SERVFAIL responses from DNS servers. Unlike NXDOMAIN/NODATA caching (which uses 2/3-tuple keys), SERVFAIL caching requires a 4-tuple key that includes the nameserver address. This allows the resolver to:

1. Skip known-failing nameservers for specific queries
2. Still try alternate nameservers for the same query
3. Automatically recover when the 5-minute TTL expires

### RFC 2308 Section 7.1 Compliance

> "A server MAY cache a server failure response... However, this cached indication MUST NOT be retained longer than five (5) minutes."

The implementation strictly enforces the 5-minute maximum TTL and provides the infrastructure for resolver integration.

## Files Changed

| File | Description |
|------|-------------|
| `include/dns/SocketDNSServfailCache.h` | Public API with comprehensive documentation |
| `src/dns/SocketDNSServfailCache.c` | Thread-safe implementation with LRU eviction |
| `src/test/test_dns_servfailcache.c` | 18 unit tests covering all functionality |
| `CMakeLists.txt` | Build integration |

## Test Plan

- [x] All 18 new tests pass with sanitizers enabled
- [x] Full test suite (86 tests) passes with ASan/UBSan
- [x] Memory leak detection enabled and passing
- [x] Tests cover: insert/lookup, TTL expiration, LRU eviction, server-specific behavior, case-insensitivity, IPv6 nameservers

```bash
cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ./test_dns_servfailcache
# Results: 18 passed, 0 failed

ctest -j16 --output-on-failure
# 100% tests passed, 0 tests failed out of 86
```

Fixes #174