### PR TITLE
fix: resolve fuzz build errors with incorrect API usage

### DIFF
--- a/src/fuzz/fuzz_dns_cookie_client.c
+++ b/src/fuzz/fuzz_dns_cookie_client.c
@@ -348,7 +348,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         (void)is_bad;
 
         /* Specifically test RCODE 23 (BADCOOKIE) */
-        is_bad = SocketDNSCookie_is_badcookie (DNS_RCODE_BADCOOKIE);
+        is_bad = SocketDNSCookie_is_badcookie (23);
         (void)is_bad;
       }
 

--- a/src/fuzz/fuzz_dns_doh.c
+++ b/src/fuzz/fuzz_dns_doh.c
@@ -409,8 +409,8 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
                       {
                         /* OPT record (EDNS0) */
                         SocketDNS_OPT opt;
-                        (void)SocketDNS_opt_decode (body, body_len, offset,
-                                                    &opt, &consumed);
+                        (void)SocketDNS_opt_decode (body + offset,
+                                                    body_len - offset, &opt);
                         break;
                       }
                     default:

--- a/src/fuzz/fuzz_dns_dot.c
+++ b/src/fuzz/fuzz_dns_dot.c
@@ -385,7 +385,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
                                         DOT_MODE_OPPORTUNISTIC);
 
             /* Submit multiple queries */
-            for (int i = 0; i < 3 && op_size >= (i + 1) * 12; i++)
+            for (size_t i = 0; i < 3 && op_size >= (i + 1) * 12; i++)
               {
                 query_len = build_dns_query (op_data + i * 12,
                                             op_size - i * 12,
@@ -621,14 +621,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   EXCEPT (SocketDNSoverTLS_Failed)
   {
     /* Expected for some malformed inputs */
-    if (transport)
-      SocketDNSoverTLS_free (&transport);
-    if (arena)
-      Arena_dispose (&arena);
-  }
-  EXCEPT (Socket_Failed)
-  {
-    /* Socket operations may fail */
     if (transport)
       SocketDNSoverTLS_free (&transport);
     if (arena)

--- a/src/fuzz/fuzz_dns_transport.c
+++ b/src/fuzz/fuzz_dns_transport.c
@@ -121,6 +121,8 @@ build_query (const struct fuzz_input *input, size_t input_size,
   SocketDNS_Header hdr;
   size_t offset = 0;
 
+  (void)input_size; /* Used for struct size, not runtime validation */
+
   if (query_buf_size < DNS_HEADER_SIZE)
     return -1;
 
@@ -358,21 +360,16 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   /* Enable dead server tracking if requested */
   if (input->flags & FLAG_ENABLE_DEAD_TRACKER)
     {
-      TRY
-      {
-        SocketDNSDeadServer_T tracker = SocketDNSDeadServer_new (arena);
-        SocketDNSTransport_set_dead_server_tracker (transport, tracker);
+      SocketDNSDeadServer_T tracker = SocketDNSDeadServer_new (arena);
+      if (tracker)
+        {
+          SocketDNSTransport_set_dead_server_tracker (transport, tracker);
 
-        /* Verify getter */
-        SocketDNSDeadServer_T retrieved
-            = SocketDNSTransport_get_dead_server_tracker (transport);
-        (void)(retrieved == tracker);
-      }
-      EXCEPT (SocketDNSDeadServer_Failed)
-      {
-        /* Continue without tracker */
-      }
-      END_TRY;
+          /* Verify getter */
+          SocketDNSDeadServer_T retrieved
+              = SocketDNSTransport_get_dead_server_tracker (transport);
+          (void)(retrieved == tracker);
+        }
     }
 
   /* Build query message */

--- a/src/fuzz/fuzz_dnssec.c
+++ b/src/fuzz/fuzz_dnssec.c
@@ -299,8 +299,8 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
           int opt_out = (nsec3.flags & NSEC3_FLAG_OPT_OUT) != 0;
           (void)opt_out;
 
-          /* Test iterations count (should be reasonable) */
-          (void)(nsec3.iterations < 65536);
+          /* Test iterations count (should be reasonable, RFC 5155 recommends <= 100) */
+          (void)(nsec3.iterations <= 2500);
 
           /* Test salt length */
           (void)(nsec3.salt_len <= 255);

--- a/src/fuzz/fuzz_http_client_async.c
+++ b/src/fuzz/fuzz_http_client_async.c
@@ -48,6 +48,7 @@
 #include "http/SocketHTTPClient-private.h"
 #include "socket/Socket.h"
 
+#include <assert.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -81,6 +82,8 @@ test_async_init_cleanup(Arena_T arena, const FuzzInput *input)
 {
     SocketHTTPClient_Config config;
     SocketHTTPClient_T client;
+
+    (void)arena; /* Not used in this test */
 
     SocketHTTPClient_config_defaults(&config);
     config.enable_async_io = input->enable_async_io;
@@ -122,12 +125,14 @@ create_socketpair(Socket_T *sock1_out, Socket_T *sock2_out, Arena_T arena)
     Socket_T sock1 = NULL;
     Socket_T sock2 = NULL;
 
+    (void)arena; /* Not used with Socket_new_from_fd */
+
     if (socketpair(AF_UNIX, SOCK_STREAM, 0, fds) < 0)
         return -1;
 
     TRY {
-        sock1 = Socket_wrap(fds[0], SOCKET_TYPE_STREAM, arena);
-        sock2 = Socket_wrap(fds[1], SOCKET_TYPE_STREAM, arena);
+        sock1 = Socket_new_from_fd(fds[0]);
+        sock2 = Socket_new_from_fd(fds[1]);
 
         *sock1_out = sock1;
         *sock2_out = sock2;
@@ -334,6 +339,8 @@ test_cleanup_during_operations(Arena_T arena, const FuzzInput *input)
     SocketHTTPClient_Config config;
     SocketHTTPClient_T client;
 
+    (void)arena; /* Not used in this test */
+
     SocketHTTPClient_config_defaults(&config);
     config.enable_async_io = input->enable_async_io;
 
@@ -456,10 +463,6 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         Arena_dispose((Arena_T *)&arena);
     }
     EXCEPT(Arena_Failed) {
-        if (arena)
-            Arena_dispose((Arena_T *)&arena);
-    }
-    EXCEPT(Except_T) {
         if (arena)
             Arena_dispose((Arena_T *)&arena);
     }

--- a/src/fuzz/fuzz_http_client_pool.c
+++ b/src/fuzz/fuzz_http_client_pool.c
@@ -111,6 +111,8 @@ test_pool_creation_limits(Arena_T arena, const FuzzInput *input)
     SocketHTTPClient_Config config;
     SocketHTTPClient_T client;
 
+    (void)arena; /* Not used in this test */
+
     SocketHTTPClient_config_defaults(&config);
     config.enable_connection_pool = input->enable_pool;
     config.max_connections_per_host = input->max_per_host;
@@ -410,6 +412,8 @@ test_pool_free(Arena_T arena, const FuzzInput *input)
     SocketHTTPClient_Config config;
     HTTPPool *pool;
 
+    (void)input; /* Not used in this test */
+
     SocketHTTPClient_config_defaults(&config);
     config.enable_connection_pool = 1;
     config.max_connections_per_host = 5;
@@ -540,10 +544,6 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         Arena_dispose((Arena_T *)&arena);
     }
     EXCEPT(Arena_Failed) {
-        if (arena)
-            Arena_dispose((Arena_T *)&arena);
-    }
-    EXCEPT(Except_T) {
         if (arena)
             Arena_dispose((Arena_T *)&arena);
     }

--- a/src/fuzz/fuzz_http_client_retry.c
+++ b/src/fuzz/fuzz_http_client_retry.c
@@ -77,6 +77,8 @@ test_retry_delay_calculation(Arena_T arena, const FuzzInput *input)
     SocketHTTPClient_T client;
     volatile int delay = 0;
 
+    (void)arena; /* Not used in this test */
+
     /* Initialize config with fuzzer input */
     SocketHTTPClient_config_defaults(&config);
     config.enable_retry = input->enable_retry;
@@ -128,6 +130,8 @@ test_retry_error_decision(Arena_T arena, const FuzzInput *input)
     SocketHTTPClient_Config config;
     SocketHTTPClient_T client;
     volatile int should_retry = 0;
+
+    (void)arena; /* Not used in this test */
 
     SocketHTTPClient_config_defaults(&config);
     config.enable_retry = input->enable_retry;
@@ -182,6 +186,8 @@ test_retry_status_with_method(Arena_T arena, const FuzzInput *input)
     SocketHTTPClient_Config config;
     SocketHTTPClient_T client;
     volatile int should_retry = 0;
+
+    (void)arena; /* Not used in this test */
 
     SocketHTTPClient_config_defaults(&config);
     config.enable_retry = input->enable_retry;
@@ -253,6 +259,8 @@ test_retry_combinations(Arena_T arena, const FuzzInput *input)
 {
     SocketHTTPClient_Config config;
     SocketHTTPClient_T client;
+
+    (void)arena; /* Not used in this test */
 
     SocketHTTPClient_config_defaults(&config);
     config.enable_retry = input->enable_retry;
@@ -328,11 +336,6 @@ LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
         Arena_dispose((Arena_T *)&arena);
     }
     EXCEPT(Arena_Failed) {
-        if (arena)
-            Arena_dispose((Arena_T *)&arena);
-    }
-    EXCEPT(Except_T) {
-        /* Catch any other exceptions */
         if (arena)
             Arena_dispose((Arena_T *)&arena);
     }


### PR DESCRIPTION
## Summary
- Fix multiple fuzz harness build errors caused by incorrect API usage
- 9 files fixed with API corrections and unused parameter fixes

## Changes
- `fuzz_dns_dot.c`: Remove non-existent `Socket_Failed` exception, fix `size_t` comparison
- `fuzz_dns_config.c`: Use correct `SocketDNS_ExtendedError` API instead of non-existent `SocketDNSError_Info`
- `fuzz_dns_cookie_client.c`: Use literal BADCOOKIE RCODE value (23) instead of undefined constant
- `fuzz_dns_transport.c`: Remove non-existent `SocketDNSDeadServer_Failed` exception
- `fuzz_dnssec.c`: Fix tautological uint16_t < 65536 comparison
- `fuzz_http_client_async.c`: Add missing `assert.h` include, replace `Socket_wrap` with `Socket_new_from_fd`
- `fuzz_http_client_retry.c`: Add `(void)` casts for unused parameters, remove invalid `EXCEPT(Except_T)`
- `fuzz_http_client_pool.c`: Add `(void)` casts for unused parameters, remove invalid `EXCEPT(Except_T)`
- `fuzz_dns_doh.c`: Fix `SocketDNS_opt_decode` argument count (3, not 5)

Fixes #283

## Test plan
- [x] All fuzzers compile successfully with `./scripts/build_fuzz.sh`