### PR TITLE
fix(fuzz): resolve heap-buffer-overflow in DTLS replay fuzzer

### DIFF
--- a/src/fuzz/fuzz_dtls_replay.c
+++ b/src/fuzz/fuzz_dtls_replay.c
@@ -151,6 +151,9 @@ test_sequence_out_of_order (SocketDgram_T socket, const uint8_t *data,
   for (size_t i = 0; i < count && offset < size; i++)
     {
       size_t idx = pkt_order[i];
+      /* Bounds check: ensure offset + idx is within valid range */
+      if (offset + idx >= size)
+        break;
       size_t pkt_len = (data[offset + idx] % 64) + 1;
 
       TRY


### PR DESCRIPTION
## Summary
- Fixed heap-buffer-overflow in `test_sequence_out_of_order` function in fuzz_dtls_replay.c
- Added bounds check before accessing `data[offset + idx]` to prevent out-of-bounds reads

Fixes #288

## Root Cause
The fuzzer was reading `data[offset + idx]` without checking if `offset + idx < size`, causing reads up to 6 bytes past the allocated buffer when `idx` was close to its maximum value (7).

## Fix
Added a bounds check: `if (offset + idx >= size) break;` before accessing the array to ensure we never read past the buffer bounds.

## Test Plan
- [x] Built fuzzer with ASan/UBSan enabled
- [x] Tested with the crash input from issue #288 - no longer crashes
- [x] Ran fuzzer successfully for extended period  
- [x] All sanitizer tests pass