### PR TITLE
fix(fuzz): resolve assertion failure in fuzz_http_client_async

### DIFF
--- a/src/fuzz/fuzz_http_client_async.c
+++ b/src/fuzz/fuzz_http_client_async.c
@@ -104,8 +104,7 @@ test_async_init_cleanup(Arena_T arena, const FuzzInput *input)
         /* Test cleanup with NULL (should be safe) */
         httpclient_async_cleanup(NULL);
 
-        /* Test init with NULL (should be safe) */
-        (void)httpclient_async_init(NULL);
+        /* Note: httpclient_async_init(NULL) is not safe - has assertion */
 
         SocketHTTPClient_free(&client);
     }


### PR DESCRIPTION
## Summary
Fix assertion failure by validating client is not NULL before calling httpclient_async_init.

The fuzzer was testing NULL safety by calling `httpclient_async_init(NULL)` at line 108, but the function has an assertion at line 89 in `SocketHTTPClient-async.c` that requires `client != NULL`. The fix removes this unsafe test case.

## Test plan
- Build with sanitizers enabled
- Run fuzzer to verify crash is fixed

Fixes #287