### PR TITLE
fix(fuzz): resolve heap-buffer-overflow in fuzz_dns_dot

### DIFF
--- a/src/fuzz/fuzz_dns_dot.c
+++ b/src/fuzz/fuzz_dns_dot.c
@@ -288,7 +288,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
             SocketDNSoverTLS_Config config = {
               .server_address = addr_buf,
-              .port = op_size > 4 ? ((op_data[4] << 8) | op_data[5]) : DOT_PORT,
+              .port = op_size > 5 ? ((op_data[4] << 8) | op_data[5]) : DOT_PORT,
               .server_name = name_buf,
               .mode = (op_size > 6 && (op_data[6] & 1)) ? DOT_MODE_STRICT
                                                          : DOT_MODE_OPPORTUNISTIC,


### PR DESCRIPTION
## Summary
Fix heap-buffer-overflow at line 291 by adding bounds checking.

The bug occurred when accessing op_data[4] and op_data[5] to construct the port number. The condition checked op_size > 4, which allowed access to op_data[5] when only 5 bytes were available (indices 0-4), causing a read past the allocation.

Changed the bounds check from op_size > 4 to op_size > 5 to ensure both bytes are available before reading.

## Test plan
- Build with sanitizers enabled: PASS
- Fuzzer compiles without errors: PASS

Fixes #285