### PR TITLE
fix(dns): resolve stack-buffer-overflow in SocketDNSSEC_name_canonical_compare

### DIFF
--- a/src/dns/SocketDNSSEC.c
+++ b/src/dns/SocketDNSSEC.c
@@ -418,7 +418,7 @@ SocketDNSSEC_name_canonical_compare (const char *name1, const char *name2)
         }
       labels1++;
     }
-  if (*p)
+  if (*p && labels1 < 128)
     labels1++;
 
   p = name2;
@@ -438,7 +438,7 @@ SocketDNSSEC_name_canonical_compare (const char *name1, const char *name2)
         }
       labels2++;
     }
-  if (*p)
+  if (*p && labels2 < 128)
     labels2++;
 
   /* Compare from rightmost label */


### PR DESCRIPTION
## Summary
Fix stack-buffer-overflow at line 448 by adding bounds checking for labellen arrays.

## Test plan
- Build with sanitizers enabled
- Run fuzzer to verify crash is fixed

Fixes #292