### PR TITLE
fix(arena): resolve heap-use-after-free in TLSBufferPool_free

### DIFF
--- a/include/tls/SocketTLS.h
+++ b/include/tls/SocketTLS.h
@@ -2443,6 +2443,12 @@ typedef struct TLSBufferPool *TLSBufferPool_T;
  * Creates a pool of reusable TLS buffers to reduce per-connection
  * allocation overhead.
  *
+ * Arena ownership:
+ * - If @p arena is NULL, pool creates and owns its own arena; TLSBufferPool_free()
+ *   will dispose it.
+ * - If @p arena is provided, caller retains ownership; TLSBufferPool_free() will
+ *   NOT dispose it, and caller must ensure arena outlives the pool.
+ *
  * @return New buffer pool, or NULL on error
  *
  * @threadsafe Yes - fully thread-safe once created
@@ -2491,6 +2497,10 @@ extern void TLSBufferPool_stats (TLSBufferPool_T pool, size_t *total,
  * @brief Destroy a buffer pool
  * @ingroup security
  * @param[in,out] pool Pointer to pool (set to NULL on success)
+ *
+ * Frees pool resources. If pool was created with arena=NULL, the internal
+ * arena is disposed. If pool was created with a caller-provided arena,
+ * the arena is NOT disposed (caller must manage arena lifecycle).
  *
  * @threadsafe No - ensure all buffers are released first
  */


### PR DESCRIPTION
## Summary

Fixes the heap-use-after-free vulnerability in `Arena_dispose()` when the arena pointer (`ap`) points into arena-allocated memory. This was found by fuzzing `fuzz_tls_buffer_pool`.

### Root Cause
When `TLSBufferPool_new()` created its own arena (arena=NULL), the pool struct itself was allocated from that arena. When `TLSBufferPool_free()` called `Arena_dispose(&p->arena)`, the pointer `&p->arena` pointed into arena-allocated memory that was freed during `Arena_clear()`, causing use-after-free when `Arena_dispose()` wrote `*ap = NULL`.

### Solution (Option 3 from issue)
Implements the architectural fix that separates arena ownership from pool struct allocation:

- **When pool creates its own arena**: Use `malloc()` for the pool struct, keeping it separate from arena memory
- **When caller provides arena**: Pool struct is arena-allocated, but pool does NOT dispose the arena (caller manages lifecycle)

### Changes
- Add `owns_arena` flag to `TLSBufferPool` struct
- Use `malloc()` for pool struct when `owns_arena` is true
- `TLSBufferPool_free()` properly frees malloc'd struct before disposing arena
- Updated documentation in `SocketTLS.h` to clarify arena ownership semantics

Fixes #309

## Test plan
- [x] All 87 tests pass with AddressSanitizer + UBSan enabled
- [x] TLS performance tests pass (buffer pool lifecycle, concurrent access, NULL handling)
- [x] Original crash input no longer reproduces the bug
- [x] Extended fuzzing session (282K+ runs) with no crashes