### PR TITLE
fix(http): resolve assertion failure with NULL buffer in async I/O

### DIFF
--- a/src/http/SocketHTTPClient-async.c
+++ b/src/http/SocketHTTPClient-async.c
@@ -157,9 +157,23 @@ httpclient_io_send (SocketHTTPClient_T client, Socket_T socket,
   unsigned req_id;
   volatile ssize_t result = 0;
 
-  assert (client != NULL);
-  assert (socket != NULL);
-  assert (data != NULL || len == 0);
+  /* Validate required inputs */
+  if (client == NULL || socket == NULL)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* NULL data with non-zero length is invalid */
+  if (data == NULL && len > 0)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* Zero-length send is a no-op */
+  if (len == 0)
+    return 0;
 
   /* Fast path: use sync I/O if async not available */
   if (!client->async_available || client->async == NULL)
@@ -226,9 +240,23 @@ httpclient_io_recv (SocketHTTPClient_T client, Socket_T socket,
   unsigned req_id;
   volatile ssize_t result = 0;
 
-  assert (client != NULL);
-  assert (socket != NULL);
-  assert (buf != NULL || len == 0);
+  /* Validate required inputs */
+  if (client == NULL || socket == NULL)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* NULL buffer with non-zero length is invalid */
+  if (buf == NULL && len > 0)
+    {
+      errno = EINVAL;
+      return -1;
+    }
+
+  /* Zero-length recv is a no-op */
+  if (len == 0)
+    return 0;
 
   /* Fast path: use sync I/O if async not available */
   if (!client->async_available || client->async == NULL)


### PR DESCRIPTION
## Summary
- Replace assertions with runtime validation in `httpclient_io_send()` and `httpclient_io_recv()`
- Handle NULL client/socket/buffer gracefully by returning `-1` with `errno = EINVAL`
- Return `0` immediately for zero-length operations (no-op)

Fixes #308

## Test plan
- [x] All 87 tests pass with sanitizers (`ENABLE_SANITIZERS=ON`)
- [x] All 13 HTTP-related tests pass
- [x] Original crash input no longer triggers assertion failure
- [x] Fuzzer runs without crashes on edge cases

## Changes
**src/http/SocketHTTPClient-async.c:**
- `httpclient_io_send()`: Replace `assert(client/socket/data)` with runtime checks
- `httpclient_io_recv()`: Replace `assert(client/socket/buf)` with runtime checks

This is the recommended fix (Option 1) from the issue: validation at the API boundary before passing to lower layers.