### PR TITLE
fix(dtls): add reference counting to prevent use-after-free on shared contexts

### DIFF
--- a/include/tls/SocketDTLS-private.h
+++ b/include/tls/SocketDTLS-private.h
@@ -26,6 +26,7 @@
 #if SOCKET_HAS_TLS
 
 #include <pthread.h>
+#include <stdatomic.h>
 #include <string.h>
 
 #include "core/Arena.h"
@@ -805,6 +806,7 @@ struct T
 {
   SSL_CTX *ssl_ctx;            /**< OpenSSL context */
   Arena_T arena;               /**< Arena for allocations */
+  atomic_int refcount;         /**< Reference count for shared ownership */
   int is_server;               /**< 1 for server, 0 for client */
   size_t mtu;                  /**< Configured MTU */
   int session_cache_enabled;   /**< Session cache flag */

--- a/include/tls/SocketDTLSContext.h
+++ b/include/tls/SocketDTLSContext.h
@@ -424,6 +424,28 @@ extern T SocketDTLSContext_new_client (const char *ca_file);
  */
 extern void SocketDTLSContext_free (T *ctx_p);
 
+/**
+ * @brief Increment the reference count on a DTLS context.
+ * @ingroup dtls_context
+ *
+ * Increments the internal reference count, allowing the context to be shared
+ * safely across multiple sockets. Each call to SocketDTLSContext_ref() must be
+ * balanced by a call to SocketDTLSContext_free() when the socket no longer
+ * needs the context.
+ *
+ * This function is called automatically by SocketDTLS_enable() when a context
+ * is attached to a socket. Manual calls are typically not needed unless
+ * implementing custom context sharing patterns.
+ *
+ * @param[in] ctx The context to retain. If NULL, this is a no-op.
+ *
+ * @threadsafe Yes - Uses atomic operations for the reference count.
+ *
+ * @see SocketDTLSContext_free() to release a reference.
+ * @see SocketDTLS_enable() which automatically retains the context.
+ */
+extern void SocketDTLSContext_ref (T ctx);
+
 /* ============================================================================
  * Certificate Management
  * ============================================================================

--- a/src/test/test_dtls_basic.c
+++ b/src/test/test_dtls_basic.c
@@ -82,7 +82,8 @@ TEST (dtls_enable_on_dgram_socket)
     ASSERT_NOT_NULL (ctx);
 
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is now reference-counted; socket holds a reference,
+       we still hold ours - both must call free */
     ASSERT_EQ (SocketDTLS_is_enabled (socket), 1);
     ASSERT_EQ (SocketDTLS_is_handshake_done (socket), 0);
   }
@@ -164,7 +165,7 @@ TEST (dtls_state_queries_before_handshake)
 
     /* After enable */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
     ASSERT_EQ (SocketDTLS_is_enabled (socket), 1);
     ASSERT_EQ (SocketDTLS_is_handshake_done (socket), 0);
     ASSERT_EQ (SocketDTLS_is_shutdown (socket), 0);
@@ -191,7 +192,7 @@ TEST (dtls_info_queries_before_handshake)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Info before handshake */
     const char *cipher = SocketDTLS_get_cipher (socket);
@@ -229,7 +230,7 @@ TEST (dtls_set_hostname)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Set hostname for SNI */
     SocketDTLS_set_hostname (socket, "example.com");
@@ -254,7 +255,7 @@ TEST (dtls_set_peer)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Set peer address */
     SocketDTLS_set_peer (socket, "127.0.0.1", 4433);
@@ -281,7 +282,7 @@ TEST (dtls_handshake_single_step)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Single handshake step on unconnected socket */
     TRY
@@ -317,7 +318,7 @@ TEST (dtls_handshake_loop_zero_timeout)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Zero timeout = non-blocking */
     TRY
@@ -353,7 +354,7 @@ TEST (dtls_send_before_handshake_fails)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     char buf[] = "test";
     TRY { SocketDTLS_send (socket, buf, sizeof (buf)); }
@@ -383,7 +384,7 @@ TEST (dtls_recv_before_handshake_fails)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     char buf[64];
     TRY { SocketDTLS_recv (socket, buf, sizeof (buf)); }
@@ -414,7 +415,7 @@ TEST (dtls_shutdown_before_handshake)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Shutdown before handshake */
     TRY { SocketDTLS_shutdown (socket); }
@@ -443,7 +444,7 @@ TEST (dtls_socket_free_with_dtls_enabled)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Free should cleanup properly */
     SocketDgram_free (&socket);

--- a/src/test/test_dtls_cookie.c
+++ b/src/test/test_dtls_cookie.c
@@ -363,7 +363,7 @@ TEST (dtls_listen_with_cookie)
 
     /* Enable DTLS */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Listen - returns immediately without client */
     TRY

--- a/src/test/test_dtls_integration.c
+++ b/src/test/test_dtls_integration.c
@@ -314,7 +314,7 @@ TEST (dtls_enable_on_dgram_socket)
 
     /* Enable DTLS */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
     ASSERT_EQ (SocketDTLS_is_enabled (socket), 1);
     ASSERT_EQ (SocketDTLS_is_handshake_done (socket), 0);
   }
@@ -350,7 +350,7 @@ TEST (dtls_state_queries)
 
     /* After enable */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
     ASSERT_EQ (SocketDTLS_is_enabled (socket), 1);
     ASSERT_EQ (SocketDTLS_is_handshake_done (socket), 0);
     ASSERT_EQ (SocketDTLS_is_shutdown (socket), 0);
@@ -379,7 +379,7 @@ TEST (dtls_mtu_configuration)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Test default MTU */
     ASSERT_EQ (SocketDTLS_get_mtu (socket), (size_t)SOCKET_DTLS_DEFAULT_MTU);
@@ -414,7 +414,7 @@ TEST (dtls_connection_info_before_handshake)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Info queries before handshake:
      * - cipher is NULL (not negotiated yet)
@@ -461,7 +461,7 @@ TEST (dtls_double_enable_error)
 
     /* First enable should succeed */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
     ASSERT_EQ (SocketDTLS_is_enabled (socket), 1);
 
     /* Verify metrics: total incremented on successful enable */
@@ -509,7 +509,7 @@ TEST (dtls_io_before_handshake_error)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Send before handshake should fail */
     char buf[] = "test";
@@ -628,7 +628,7 @@ TEST (dtls_shutdown_before_handshake)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Shutdown before handshake - should not crash */
     TRY { SocketDTLS_shutdown (socket); }
@@ -729,7 +729,7 @@ TEST (dtls_handshake_initial_state)
 
     /* After enable: state may remain NOT_STARTED */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
     DTLSHandshakeState state = SocketDTLS_get_last_state (socket);
     /* State should be NOT_STARTED (no handshake attempted yet) */
     ASSERT (state == DTLS_HANDSHAKE_NOT_STARTED
@@ -760,7 +760,7 @@ TEST (dtls_handshake_loop_zero_timeout)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Zero timeout = non-blocking, returns current state immediately */
     state = SocketDTLS_handshake_loop (socket, 0);
@@ -803,7 +803,7 @@ TEST (dtls_handshake_loop_short_timeout)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Short timeout - should fail or timeout quickly */
     TRY { SocketDTLS_handshake_loop (socket, 10); }
@@ -839,7 +839,7 @@ TEST (dtls_handshake_single_step)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Single handshake step */
     state = SocketDTLS_handshake (socket);
@@ -874,7 +874,7 @@ TEST (dtls_listen_without_connection)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Listen on client context (no cookies) */
     state = SocketDTLS_listen (socket);
@@ -915,7 +915,7 @@ TEST (dtls_handshake_metrics)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Enabling DTLS should increment handshakes total */
     uint64_t after_total
@@ -1080,7 +1080,7 @@ TEST (dtls_handshake_state_transitions)
 
     /* Enable DTLS */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* State after enable but before handshake attempt */
     DTLSHandshakeState post_enable = SocketDTLS_get_last_state (socket);
@@ -1214,7 +1214,7 @@ TEST (dtls_socket_mtu_inheritance)
 
     /* Enable DTLS - socket should inherit MTU from context */
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
+    /* Context is reference-counted - we still hold our reference */
 
     /* Socket should have inherited MTU */
     ASSERT_EQ (SocketDTLS_get_mtu (socket), 1200);

--- a/src/test/test_dtls_mtu.c
+++ b/src/test/test_dtls_mtu.c
@@ -200,7 +200,6 @@ TEST (dtls_mtu_socket_default)
     ASSERT_NOT_NULL (ctx);
 
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
 
     /* Socket MTU should inherit from context default */
     size_t mtu = SocketDTLS_get_mtu (socket);
@@ -226,7 +225,6 @@ TEST (dtls_mtu_socket_set_custom)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
 
     /* Set custom MTU on socket */
     SocketDTLS_set_mtu (socket, 1200);
@@ -256,7 +254,6 @@ TEST (dtls_mtu_socket_inherits_context)
     SocketDTLSContext_set_mtu (ctx, 1500);
 
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
 
     /* Socket should have context's MTU */
     ASSERT_EQ (SocketDTLS_get_mtu (socket), 1500);
@@ -337,7 +334,6 @@ TEST (dtls_mtu_update_after_enable)
     socket = SocketDgram_new (AF_INET, 0);
     ctx = SocketDTLSContext_new_client (NULL);
     SocketDTLS_enable (socket, ctx);
-    ctx = NULL; /* Ownership transferred to socket */
 
     /* Update MTU multiple times */
     SocketDTLS_set_mtu (socket, 1000);

--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -225,12 +225,16 @@ create_dgram_bio (int fd)
  * @socket: Socket to configure
  * @ssl: SSL object to associate
  * @ctx: DTLS context
+ *
+ * Increments the context refcount so the context remains valid while the
+ * socket is in use. The refcount is decremented when the socket is freed.
  */
 static void
 finalize_dtls_state (SocketDgram_T socket, SSL *ssl, SocketDTLSContext_T ctx)
 {
   socket->dtls_ssl = (void *)ssl;
   socket->dtls_ctx = (void *)ctx;
+  SocketDTLSContext_ref (ctx); /* Retain context for this socket */
   SSL_set_app_data (ssl, socket);
   allocate_dtls_buffers (socket);
 


### PR DESCRIPTION
## Summary

Fixes the heap-use-after-free vulnerability when a `SocketDTLSContext` is reused across multiple sockets. Found by fuzzers `fuzz_dtls_io`, `fuzz_dtls_handshake`, and `fuzz_dtls_replay`.

### Root Cause
When a DTLS context was shared across multiple sockets (common in servers and fuzzers), freeing one socket would incorrectly free the entire context via `SocketDTLSContext_free()`, leaving subsequent sockets with dangling pointers.

### Solution (Option 1 from issue - Reference Counting)
Added atomic reference counting to `SocketDTLSContext`:

- **Struct changes**: Added `atomic_int refcount` field
- **Creation**: Initialize refcount to 1
- **SocketDTLS_enable()**: Increments refcount when context is attached to a socket
- **SocketDTLSContext_free()**: Decrements refcount atomically, only frees when reaching 0
- **New API**: Added `SocketDTLSContext_ref()` for explicit reference management

### API Semantics Change
| Aspect | Old Behavior | New Behavior |
|--------|-------------|--------------|
| Ownership | `SocketDTLS_enable()` transfers ownership | Both caller and socket hold references |
| Caller cleanup | Must NOT call `free()` after enable | MUST call `free()` after socket is done |
| Context sharing | Not safe | Fully safe with refcounting |

### Files Changed
- `include/tls/SocketDTLS-private.h` - Added `atomic_int refcount` to struct
- `include/tls/SocketDTLSContext.h` - Added `SocketDTLSContext_ref()` declaration
- `src/tls/SocketDTLSContext.c` - Refcount init/increment/decrement logic
- `src/tls/SocketDTLS.c` - Call `ref()` when attaching context to socket
- `src/test/test_dtls_*.c` - Updated tests to new ownership semantics

Fixes #307

## Test plan
- [x] All 4 DTLS tests pass with ASan + UBSan
- [x] `fuzz_dtls_io` runs 18K+ iterations without crashes
- [x] `fuzz_dtls_handshake` runs without crashes
- [x] `fuzz_dtls_replay` runs without crashes
- [x] Context can be safely shared across multiple sockets