### PR TITLE
fix(fuzz): correct reference counting in fuzz_dtls_enable_config

### DIFF
--- a/src/fuzz/fuzz_dtls_enable_config.c
+++ b/src/fuzz/fuzz_dtls_enable_config.c
@@ -119,7 +119,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         /* Verify enabled state */
         if (SocketDTLS_is_enabled (socket) != 1)
@@ -135,10 +134,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-
-        /* Context is now owned by socket - don't free it separately */
-        /* Socket cleanup will handle context cleanup */
-        ctx = NULL; /* Prevent double-free */
         break;
 
       case OP_SET_PEER_IP:
@@ -149,7 +144,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
         /* Set peer with localhost IP - should succeed without DNS */
         SocketDTLS_set_peer (socket, "127.0.0.1", 4433);
-        ctx = NULL; /* Owned by socket */
         break;
 
       case OP_SET_PEER_HOSTNAME:
@@ -160,7 +154,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
         /* set_peer with "localhost" - will do DNS resolution */
         SocketDTLS_set_peer (socket, "localhost", 4433);
-        ctx = NULL;
         break;
 
       case OP_SET_HOSTNAME_VALID:
@@ -168,7 +161,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         SocketDTLS_set_hostname (socket, "example.com");
         break;
@@ -178,7 +170,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         if (size > 2)
           {
@@ -194,7 +185,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         SocketDTLS_set_mtu (socket, SOCKET_DTLS_MIN_MTU);
 
@@ -209,7 +199,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         SocketDTLS_set_mtu (socket, SOCKET_DTLS_MAX_MTU);
 
@@ -224,7 +213,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         /* This should raise SocketDTLS_Failed */
         SocketDTLS_set_mtu (socket, SOCKET_DTLS_MIN_MTU - 1);
@@ -237,7 +225,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
 
         /* This should raise SocketDTLS_Failed */
         SocketDTLS_set_mtu (socket, SOCKET_DTLS_MAX_MTU + 1);
@@ -254,7 +241,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         size_t ctx_mtu = SocketDTLSContext_get_mtu (ctx);
 
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket now */
 
         /* Socket should inherit context MTU */
         size_t socket_mtu = SocketDTLS_get_mtu (socket);
@@ -274,7 +260,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL;
 
         /* Second enable should fail */
         ctx2 = SocketDTLSContext_new_client (NULL);
@@ -297,7 +282,6 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         (void)SocketDTLS_get_mtu (socket);
         (void)SocketDTLS_get_last_state (socket);
 
-        ctx = NULL;
         break;
 
       default:


### PR DESCRIPTION
## Summary
- Fixes memory leak in fuzz_dtls_enable_config by properly handling DTLS context reference counting
- Removes all `ctx = NULL` assignments after `SocketDTLS_enable()` calls
- Allows cleanup code to properly decrement reference counts through `SocketDTLSContext_free(&ctx)`

## Root Cause
After PR #312 introduced reference counting to SocketDTLSContext:
1. `SocketDTLS_enable()` now calls `SocketDTLSContext_ref(ctx)` to increment refcount (from 1 to 2)
2. The fuzzer needs to call `SocketDTLSContext_free(&ctx)` to decrement refcount (back to 1)
3. When socket is freed, `SocketDgram_free()` decrements refcount again (to 0), freeing memory

Previously, setting `ctx = NULL` after `SocketDTLS_enable()` prevented the cleanup section from calling `SocketDTLSContext_free(&ctx)`, leaving refcount=2 and leaking SSL_CTX allocations.

## Changes
Removed 13 instances of `ctx = NULL` assignments in all test cases:
- OP_ENABLE_BASIC
- OP_ENABLE_OWNERSHIP
- OP_SET_PEER_IP
- OP_SET_PEER_HOSTNAME
- OP_SET_HOSTNAME_VALID
- OP_SET_HOSTNAME_FUZZ
- OP_SET_MTU_VALID_MIN
- OP_SET_MTU_VALID_MAX
- OP_SET_MTU_INVALID_LOW
- OP_SET_MTU_INVALID_HIGH
- OP_GET_MTU
- OP_ENABLE_DOUBLE
- OP_COMBINED_CONFIG

The cleanup code (lines 310-314) now properly handles reference counting for all code paths, including exception paths.

## Test Plan
- [x] Built with fuzzing and sanitizers: `CC=clang cmake -B build -DENABLE_FUZZING=ON -DENABLE_SANITIZERS=ON`
- [x] Ran fuzzer for 10 seconds: `./build/fuzz_dtls_enable_config /tmp/corpus -max_total_time=10`
- [x] Verified no memory leaks detected (previously leaked 8861 bytes in 177 allocations)
- [x] Fuzzer completed 11867 runs successfully without errors

Fixes #314
Fixes #313