### PR TITLE
fix: remove -Wno-implicit-function-declaration compiler flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)  # Enable GNU extensions (_GNU_SOURCE)
 
 # Compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-variable -Wno-comment -Wno-implicit-int -Wno-implicit-function-declaration -Wno-ignored-qualifiers -Wno-return-type -Wno-error=return-type -D_GNU_SOURCE -pthread -fno-strict-aliasing -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-variable -Wno-comment -Wno-implicit-int -Wno-ignored-qualifiers -Wno-return-type -Wno-error=return-type -D_GNU_SOURCE -pthread -fno-strict-aliasing -fPIC")
 
 # Executable stack warning is expected and harmless:
 # - Caused by setjmp/longjmp in TRY/EXCEPT/FINALLY exception handling

--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -295,6 +295,8 @@ extern void initialize_synchronization (struct SocketDNS_T *dns);
 extern void create_completion_pipe (struct SocketDNS_T *dns);
 extern void set_pipe_nonblocking (struct SocketDNS_T *dns);
 extern void initialize_pipe (struct SocketDNS_T *dns);
+extern void initialize_dns_fields (struct SocketDNS_T *dns);
+extern void initialize_dns_components (struct SocketDNS_T *dns);
 
 /* Cleanup and shutdown */
 extern void cleanup_mutex_cond (struct SocketDNS_T *dns);

--- a/include/socket/SocketWS-private.h
+++ b/include/socket/SocketWS-private.h
@@ -1008,6 +1008,21 @@ SocketWS_Error ws_frame_parse_header (SocketWS_FrameParse *frame,
                                       size_t *consumed);
 
 /**
+ * @brief Receives and processes a complete WebSocket frame.
+ * @internal
+ * @ingroup websocket
+ * @param ws The WebSocket context.
+ * @param[out] frame_out Frame parse structure to populate.
+ * @return 1 if data message completed, 0 if control frame handled,
+ *         -1 on error, -2 if would block / need more data.
+ * @note Handles incremental frame reception for non-blocking I/O.
+ * @note Processes control frames internally (PING/PONG/CLOSE).
+ * @see ws_frame_parse_header() for header parsing details.
+ * @see ws_process_frames() caller loop.
+ */
+int ws_recv_frame (SocketWS_T ws, SocketWS_FrameParse *frame_out);
+
+/**
  * @brief Builds the binary WebSocket frame header into output buffer.
  * @internal
  * @ingroup websocket

--- a/src/poll/SocketPoll_epoll.c
+++ b/src/poll/SocketPoll_epoll.c
@@ -24,8 +24,9 @@
 
 #include "core/Arena.h"
 #include "core/SocketConfig.h"
+#include "core/SocketUtil.h" /* For Socket_get_monotonic_ms */
 #include "poll/SocketPoll_backend.h"
-#include "socket/Socket.h" /* For Socket_get_monotonic_ms */
+#include "socket/Socket.h"
 
 /* Backend instance structure */
 #define T PollBackend_T

--- a/src/simple/SocketSimple-internal.h
+++ b/src/simple/SocketSimple-internal.h
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "core/Except.h"
+#include "core/SocketUtil.h"
 #include "dns/SocketDNS.h"
 #include "http/SocketHTTPClient.h"
 #include "socket/Socket.h"

--- a/src/test/test_async.c
+++ b/src/test/test_async.c
@@ -30,6 +30,7 @@
 #include "core/Except.h"
 #include "core/SocketConfig.h"
 #include "core/SocketTimer.h"
+#include "core/SocketUtil.h"
 #include "poll/SocketPoll.h"
 #include "socket/Socket.h"
 #include "socket/SocketAsync.h"


### PR DESCRIPTION
## Summary
- Remove `-Wno-implicit-function-declaration` from CMakeLists.txt compiler flags
- Add missing forward declarations for `ws_recv_frame()` in SocketWS-private.h
- Add missing forward declarations for `initialize_dns_fields()` and `initialize_dns_components()` in SocketDNS-private.h
- Add `SocketUtil.h` includes where `Socket_get_monotonic_ms()` and `Socket_geterrno()` are used without proper declaration

This allows the compiler to catch implicit function declaration issues, improving code quality and preventing potential bugs from function signature mismatches.

Fixes #324

## Test plan
- [x] Build with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All 87 tests pass with ASan/UBSan enabled
- [x] No implicit function declaration warnings in build output