### PR TITLE
fix(fuzz): add missing stdio.h and stdlib.h includes

### DIFF
--- a/src/fuzz/fuzz_cert_pinning.c
+++ b/src/fuzz/fuzz_cert_pinning.c
@@ -23,6 +23,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_certificate_parsing.c
+++ b/src/fuzz/fuzz_certificate_parsing.c
@@ -21,6 +21,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdio.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/fuzz/fuzz_cidr_parse.c
+++ b/src/fuzz/fuzz_cidr_parse.c
@@ -18,6 +18,7 @@
  * Run:   ./fuzz_cidr_parse corpus/cidr_parse/ -fork=16 -max_len=512
  */
 
+#include <stdio.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_dns_cache.c
+++ b/src/fuzz/fuzz_dns_cache.c
@@ -42,6 +42,8 @@
  * Run:   ./fuzz_dns_cache corpus/dns_cache/ -fork=16 -max_len=4096
  */
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_dns_config.c
+++ b/src/fuzz/fuzz_dns_config.c
@@ -47,6 +47,7 @@
  * Run:   ./fuzz_dns_config corpus/dns_config/ -fork=16 -max_len=8192
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_dns_cookie_client.c
+++ b/src/fuzz/fuzz_dns_cookie_client.c
@@ -38,6 +38,7 @@
  * Run:   ./fuzz_dns_cookie_client corpus/dns_cookie_client/ -fork=16 -max_len=1024
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_dns_deadserver.c
+++ b/src/fuzz/fuzz_dns_deadserver.c
@@ -41,6 +41,8 @@
  * Run:   ./fuzz_dns_deadserver -fork=16 -max_len=4096
  */
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_dns_dot.c
+++ b/src/fuzz/fuzz_dns_dot.c
@@ -66,6 +66,8 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <arpa/inet.h>
 

--- a/src/fuzz/fuzz_dns_resolver.c
+++ b/src/fuzz/fuzz_dns_resolver.c
@@ -40,6 +40,8 @@
  * Run:   ./fuzz_dns_resolver corpus/dns_resolver/ -fork=16 -max_len=4096
  */
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_dns_transport.c
+++ b/src/fuzz/fuzz_dns_transport.c
@@ -32,6 +32,7 @@
  * Run:   ./fuzz_dns_transport corpus/dns_transport/ -fork=16 -max_len=8192
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_dtls_cookie.c
+++ b/src/fuzz/fuzz_dtls_cookie.c
@@ -26,6 +26,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdio.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/fuzz/fuzz_dtls_replay.c
+++ b/src/fuzz/fuzz_dtls_replay.c
@@ -31,6 +31,7 @@ S packet sequencing and reordering
 
 #if SOCKET_HAS_TLS
 
+#include <stdio.h>
 #include <assert.h>
 #include <errno.h>
 #include <signal.h>

--- a/src/fuzz/fuzz_except_unwind.c
+++ b/src/fuzz/fuzz_except_unwind.c
@@ -32,6 +32,7 @@
  * Run:   ./fuzz_except_unwind corpus/except_unwind/ -fork=16 -max_len=512
  */
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_hpack.c
+++ b/src/fuzz/fuzz_hpack.c
@@ -24,6 +24,7 @@
  * ./fuzz_hpack corpus/hpack/ -fork=16 -max_len=32768
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_http1_chunked.c
+++ b/src/fuzz/fuzz_http1_chunked.c
@@ -34,6 +34,7 @@
  * ./fuzz_http1_chunked corpus/http1_chunked/ -fork=16 -max_len=65536
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTP.h"

--- a/src/fuzz/fuzz_http1_request.c
+++ b/src/fuzz/fuzz_http1_request.c
@@ -34,6 +34,7 @@
  * ./fuzz_http1_request corpus/http1_request/ -fork=16 -max_len=65536
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "core/SocketSecurity.h"

--- a/src/fuzz/fuzz_http1_response.c
+++ b/src/fuzz/fuzz_http1_response.c
@@ -37,6 +37,7 @@
  * ./fuzz_http1_response corpus/http1_response/ -fork=16 -max_len=65536
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTP.h"

--- a/src/fuzz/fuzz_http2_connection.c
+++ b/src/fuzz/fuzz_http2_connection.c
@@ -24,6 +24,7 @@
  * Run: ./fuzz_http2_connection corpus/http2_conn/ -fork=16 -max_len=65536
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHPACK.h"

--- a/src/fuzz/fuzz_http2_headers.c
+++ b/src/fuzz/fuzz_http2_headers.c
@@ -15,6 +15,7 @@
  * - Creates new decoder per invocation (HPACK has state that can't be reset)
  */
 
+#include <stdlib.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHPACK.h"

--- a/src/fuzz/fuzz_http_client_async.c
+++ b/src/fuzz/fuzz_http_client_async.c
@@ -42,6 +42,7 @@
  * Run: ./build/fuzz_http_client_async corpus/http_client_async/ -fork=8 -max_len=4096
  */
 
+#include <stdlib.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTPClient.h"

--- a/src/fuzz/fuzz_http_client_pool.c
+++ b/src/fuzz/fuzz_http_client_pool.c
@@ -48,6 +48,8 @@
  * Run: ./build/fuzz_http_client_pool corpus/http_client_pool/ -fork=8 -max_len=2048
  */
 
+#include <stdlib.h>
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTPClient.h"

--- a/src/fuzz/fuzz_http_client_retry.c
+++ b/src/fuzz/fuzz_http_client_retry.c
@@ -35,6 +35,7 @@
  * Run: ./build/fuzz_http_client_retry corpus/http_client_retry/ -fork=8 -max_len=256
  */
 
+#include <stdlib.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTPClient.h"

--- a/src/fuzz/fuzz_http_cookies_simple.c
+++ b/src/fuzz/fuzz_http_cookies_simple.c
@@ -33,6 +33,7 @@
  * ./fuzz_http_cookies_simple corpus/http_cookies/ -fork=16 -max_len=8192
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTP.h"

--- a/src/fuzz/fuzz_http_server.c
+++ b/src/fuzz/fuzz_http_server.c
@@ -53,6 +53,7 @@
  * ./fuzz_http_server corpus/http_server/ -fork=16 -max_len=65536
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "core/SocketRateLimit.h"

--- a/src/fuzz/fuzz_http_smuggling.c
+++ b/src/fuzz/fuzz_http_smuggling.c
@@ -56,6 +56,7 @@
  * ./fuzz_http_smuggling corpus/http_smug/ -fork=16 -max_len=65536
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTP.h"

--- a/src/fuzz/fuzz_iptracker.c
+++ b/src/fuzz/fuzz_iptracker.c
@@ -19,6 +19,7 @@
  * Run:   ./fuzz_iptracker corpus/iptracker/ -fork=16 -max_len=8192
  */
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_new_features.c
+++ b/src/fuzz/fuzz_new_features.c
@@ -29,6 +29,7 @@
  * Run:   ./fuzz_new_features corpus/new_features/ -fork=16 -max_len=4096
  */
 
+#include <stdio.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_pool_dos.c
+++ b/src/fuzz/fuzz_pool_dos.c
@@ -58,6 +58,7 @@
  * ./fuzz_pool_dos corpus/pool_dos/ -fork=16 -max_len=4096
  */
 
+#include <stdio.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <stdlib.h>

--- a/src/fuzz/fuzz_ratelimit.c
+++ b/src/fuzz/fuzz_ratelimit.c
@@ -19,6 +19,7 @@
  * Run:   ./fuzz_ratelimit corpus/ratelimit/ -fork=16 -max_len=4096
  */
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_reconnect.c
+++ b/src/fuzz/fuzz_reconnect.c
@@ -23,6 +23,7 @@
  * Run:   ./fuzz_reconnect corpus/reconnect/ -fork=16 -max_len=4096
  */
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_synprotect.c
+++ b/src/fuzz/fuzz_synprotect.c
@@ -16,6 +16,7 @@
  * - Operation sequences
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "core/SocketSYNProtect.h"

--- a/src/fuzz/fuzz_synprotect_ip.c
+++ b/src/fuzz/fuzz_synprotect_ip.c
@@ -25,6 +25,8 @@
  * Run:   ./fuzz_synprotect_ip corpus/synprotect_ip/ -fork=16 -max_len=1024
  */
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_synprotect_list.c
+++ b/src/fuzz/fuzz_synprotect_list.c
@@ -26,6 +26,8 @@
  * Run:   ./fuzz_synprotect_list corpus/synprotect_list/ -fork=16 -max_len=2048
  */
 
+#include <stdlib.h>
+#include <stdio.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_timer.c
+++ b/src/fuzz/fuzz_timer.c
@@ -22,6 +22,7 @@
  * Run:   ./fuzz_timer corpus/timer/ -fork=16 -max_len=4096
  */
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_cert_lookup.c
+++ b/src/fuzz/fuzz_tls_cert_lookup.c
@@ -21,6 +21,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_certs.c
+++ b/src/fuzz/fuzz_tls_certs.c
@@ -22,6 +22,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_context.c
+++ b/src/fuzz/fuzz_tls_context.c
@@ -25,6 +25,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_ct.c
+++ b/src/fuzz/fuzz_tls_ct.c
@@ -24,6 +24,7 @@
  * - Requires OpenSSL 1.1.0+ without OPENSSL_NO_CT
  */
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_key_update.c
+++ b/src/fuzz/fuzz_tls_key_update.c
@@ -20,6 +20,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/fuzz/fuzz_tls_ocsp.c
+++ b/src/fuzz/fuzz_tls_ocsp.c
@@ -24,6 +24,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_protocol_version.c
+++ b/src/fuzz/fuzz_tls_protocol_version.c
@@ -28,6 +28,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_session.c
+++ b/src/fuzz/fuzz_tls_session.c
@@ -20,6 +20,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_shutdown.c
+++ b/src/fuzz/fuzz_tls_shutdown.c
@@ -22,6 +22,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <errno.h>
 #include <stddef.h>

--- a/src/fuzz/fuzz_tls_verify.c
+++ b/src/fuzz/fuzz_tls_verify.c
@@ -22,6 +22,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_tls_verify_callback.c
+++ b/src/fuzz/fuzz_tls_verify_callback.c
@@ -22,6 +22,7 @@
 
 #if SOCKET_HAS_TLS
 
+#include <stdlib.h>
 #include <assert.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/fuzz/fuzz_websocket_handshake.c
+++ b/src/fuzz/fuzz_websocket_handshake.c
@@ -25,6 +25,7 @@
  * ./fuzz_websocket_handshake corpus/websocket_handshake/ -fork=16 -max_len=8192
  */
 
+#include <stdio.h>
 #include "core/Arena.h"
 #include "core/Except.h"
 #include "http/SocketHTTP.h"

--- a/src/fuzz/fuzz_ws_deflate.c
+++ b/src/fuzz/fuzz_ws_deflate.c
@@ -11,6 +11,7 @@
  * Only compiled when SOCKETWS_HAS_DEFLATE is defined.
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>

--- a/src/fuzz/fuzz_ws_handshake.c
+++ b/src/fuzz/fuzz_ws_handshake.c
@@ -10,6 +10,7 @@
  * Tests handshake validation with random HTTP responses.
  */
 
+#include <stdlib.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>


### PR DESCRIPTION
## Summary
- Add missing `<stdio.h>` includes for `snprintf`, `printf`, `fprintf` calls
- Add missing `<stdlib.h>` includes for `abort`, `malloc`, `free`, `exit` calls
- Fixes 48 fuzz harnesses that failed to build with Clang after removing `-Wno-implicit-function-declaration`

This is a follow-up to PR #330 which removed the implicit function declaration warning suppression.

Fixes #324

## Test plan
- [x] All 125 fuzz harnesses build successfully with `./scripts/build_fuzz.sh`