### PR TITLE
fix(dtls): resolve memory leaks in DTLS fuzzers

### DIFF
--- a/src/fuzz/fuzz_dtls_context.c
+++ b/src/fuzz/fuzz_dtls_context.c
@@ -201,7 +201,8 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
     return 0;
 
   volatile uint8_t op = get_op (data, size);
-  SocketDTLSContext_T ctx = NULL;
+  /* volatile required: modified in TRY, accessed after END_TRY (longjmp safety) */
+  SocketDTLSContext_T volatile ctx = NULL;
 
   /* Single TRY block - no nesting */
   TRY
@@ -215,7 +216,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
           {
             /* Verify DTLS 1.2 enforcement even on client */
             (void)verify_dtls12_enforcement (ctx);
-            SocketDTLSContext_free (&ctx);
+            SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
           }
         break;
 
@@ -227,7 +228,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
             if (ctx)
               {
                 (void)verify_dtls12_enforcement (ctx);
-                SocketDTLSContext_free (&ctx);
+                SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
               }
           }
         break;
@@ -245,7 +246,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
                   {
                     /* Server flag should be set */
                   }
-                SocketDTLSContext_free (&ctx);
+                SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
               }
           }
         break;
@@ -263,7 +264,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
                   {
                     /* DTLS 1.2 enforcement should always be set */
                   }
-                SocketDTLSContext_free (&ctx);
+                SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
               }
           }
         break;
@@ -345,7 +346,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
               {
                 test_cookie_secret_cleanup (ctx);
                 /* Cookie secrets should be cleared on free */
-                SocketDTLSContext_free (&ctx);
+                SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
               }
           }
         break;
@@ -379,7 +380,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
                  * - Cookie secrets (securely cleared)
                  * - Mutexes
                  */
-                SocketDTLSContext_free (&ctx);
+                SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
 
                 /* Verify ctx is NULL after free */
                 if (ctx != NULL)
@@ -405,7 +406,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
   /* Cleanup */
   if (ctx)
-    SocketDTLSContext_free (&ctx);
+    SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
 
   return 0;
 }

--- a/src/fuzz/fuzz_dtls_cookie.c
+++ b/src/fuzz/fuzz_dtls_cookie.c
@@ -194,7 +194,8 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
     return 0; /* Skip if certs not available */
 
   volatile uint8_t op = get_op (data, size);
-  SocketDTLSContext_T ctx = NULL;
+  /* volatile required: modified in TRY, accessed after END_TRY (longjmp safety) */
+  SocketDTLSContext_T volatile ctx = NULL;
   volatile int exception_caught = 0;
 
   /* Single TRY block - no nesting */
@@ -366,7 +367,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
   /* Cleanup */
   if (ctx)
-    SocketDTLSContext_free (&ctx);
+    SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
 
   return 0;
 }


### PR DESCRIPTION
## Summary
- Add volatile qualifiers to variables modified in TRY blocks that are accessed in FINALLY/post-exception cleanup
- Fix reference counting issue in fuzz_dtls_enable_config.c where context refs weren't properly freed

Fixes #332

## Root Cause Analysis

Two issues were causing memory leaks:

1. **Missing volatile qualifiers**: Variables modified inside TRY blocks but accessed in FINALLY blocks or after END_TRY need to be volatile. Without volatile, these variables may have indeterminate values after `longjmp`, causing cleanup code to skip freeing resources.

2. **Incorrect ownership model in fuzz harness**: `fuzz_dtls_enable_config.c` was setting `ctx = NULL` after `SocketDTLS_enable()`, thinking ownership transferred. However, the context uses reference counting - the socket takes its own reference via `SocketDTLSContext_ref()`, and the caller still needs to free their reference.

## Changes

### Library Code
- `SocketDTLSContext_load_certificate()`: Make `cert_data`, `key_data`, `cert_bio`, `key_bio` volatile
- Add necessary casts where volatile pointers are passed to functions expecting non-volatile

### Fuzz Harnesses
- `fuzz_dtls_context.c`: Make `ctx` volatile
- `fuzz_dtls_cookie.c`: Make `ctx` volatile  
- `fuzz_dtls_enable_config.c`: Make `socket`, `ctx`, `ctx2` volatile; remove incorrect `ctx = NULL` assignments

## Test plan
- [x] All DTLS tests pass with sanitizers enabled
- [x] All leak-triggering inputs now pass without leaks
- [x] Verified with `ASAN_OPTIONS=detect_leaks=1` on each leak input