### PR TITLE
fix(fuzz): null-terminate string and fix context leak

### DIFF
--- a/src/fuzz/fuzz_dns_cache.c
+++ b/src/fuzz/fuzz_dns_cache.c
@@ -93,7 +93,11 @@ extract_string (const uint8_t *data, size_t size, size_t *offset, char *out,
                 size_t max_len)
 {
   if (*offset >= size)
-    return 0;
+    {
+      if (max_len > 0)
+        out[0] = '\0';
+      return 0;
+    }
 
   uint8_t len = data[(*offset)++];
   if (len == 0 || len > max_len - 1)

--- a/src/fuzz/fuzz_dtls_enable_config.c
+++ b/src/fuzz/fuzz_dtls_enable_config.c
@@ -275,7 +275,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
         socket = SocketDgram_new (AF_INET, 0);
         ctx = SocketDTLSContext_new_client (NULL);
         SocketDTLS_enable (socket, ctx);
-        ctx = NULL; /* Owned by socket */
+        /* Note: socket takes its own ref, we still need to free ours in cleanup */
 
         /* Set various configurations */
         SocketDTLS_set_mtu (socket, 1400);


### PR DESCRIPTION
## Summary
- Fix stack-buffer-overflow in `fuzz_dns_cache` by null-terminating string in `extract_string()` early return path
- Fix memory leak in `fuzz_dtls_enable_config` by removing erroneous `ctx = NULL` assignment

Fixes #334

## Details

### fuzz_dns_cache (stack-buffer-overflow)
The `extract_string()` function returned 0 without null-terminating the output buffer when `offset >= size`. This left the buffer uninitialized, and when passed to `compute_hash()`, it would iterate past the buffer bounds looking for a null terminator.

### fuzz_dtls_enable_config (memory leak)
The `OP_COMBINED_CONFIG` case was incorrectly setting `ctx = NULL` after calling `SocketDTLS_enable()`. This was based on a misunderstanding that the socket "owns" the context. In reality, `SocketDTLS_enable()` takes its own reference (via `SocketDTLSContext_ref()`), so the caller must still free their reference.

## Test plan
- [x] `fuzz_dns_cache_crash-404fdb5b...` no longer crashes
- [x] `fuzz_dtls_enable_config_leak-579c8cd6...` no longer leaks
- [x] `fuzz_dtls_enable_config_leak-8f4daf3c...` no longer leaks
- [x] All 87 tests pass with ASan/UBSan enabled