### PR TITLE
feat(quic): implement Variable-Length Integer encoding (RFC 9000 §16)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,9 @@ set(LIB_SOURCES
     src/http/SocketHTTPServer.c
     src/http/SocketHTTPServer-connections.c
 
+    # QUIC foundational module (RFC 9000)
+    src/quic/SocketQUICVarInt.c
+
     # Simple convenience API
     src/simple/SocketSimple.c
     src/simple/SocketSimple-tcp.c
@@ -606,6 +609,10 @@ set(TEST_HEADERS
     include/test/Test.h
 )
 
+set(QUIC_HEADERS
+    include/quic/SocketQUICVarInt.h
+)
+
 set(SIMPLE_HEADERS
     include/simple/SocketSimple.h
     include/simple/SocketSimple-tcp.h
@@ -638,6 +645,7 @@ install(FILES ${POOL_HEADERS} DESTINATION include/pool)
 install(FILES ${TLS_HEADERS} DESTINATION include/tls)
 install(FILES ${HTTP_HEADERS} DESTINATION include/http)
 install(FILES ${TEST_HEADERS} DESTINATION include/test)
+install(FILES ${QUIC_HEADERS} DESTINATION include/quic)
 install(FILES ${SIMPLE_HEADERS} DESTINATION include/simple)
 
 # Print build configuration
@@ -740,6 +748,8 @@ set(TEST_SOURCES
     test_timer
     test_metrics
     test_httpserver
+    # QUIC tests (RFC 9000)
+    test_quic_varint
 )
 
 # TLS tests (only built when TLS is enabled)
@@ -1062,6 +1072,8 @@ if(ENABLE_FUZZING)
         # SYN protection fuzzers
         fuzz_synprotect_ip
         fuzz_synprotect_list
+        # QUIC fuzzers (RFC 9000)
+        fuzz_quic_varint
     )
     
     # TLS fuzz harnesses (require SOCKET_HAS_TLS)

--- a/include/quic/SocketQUICVarInt.h
+++ b/include/quic/SocketQUICVarInt.h
@@ -1,0 +1,148 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICVarInt.h
+ * @brief QUIC Variable-Length Integer encoding/decoding (RFC 9000 Section 16).
+ *
+ * Implements the QUIC variable-length integer encoding scheme. The 2 most
+ * significant bits of the first byte encode the length of the integer:
+ *   - 00: 1 byte  (6-bit value, max 63)
+ *   - 01: 2 bytes (14-bit value, max 16383)
+ *   - 10: 4 bytes (30-bit value, max 1073741823)
+ *   - 11: 8 bytes (62-bit value, max 4611686018427387903)
+ *
+ * All multi-byte values are stored in network byte order (big-endian).
+ *
+ * Thread Safety: All functions are thread-safe (no shared state).
+ *
+ * @defgroup quic_varint QUIC Variable-Length Integer Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9000#section-16
+ */
+
+#ifndef SOCKETQUICVARINT_INCLUDED
+#define SOCKETQUICVARINT_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Except.h"
+
+/**
+ * @brief Maximum value representable in QUIC variable-length integer.
+ *
+ * QUIC varints can represent values up to 2^62-1 (4611686018427387903).
+ */
+#define SOCKETQUICVARINT_MAX ((uint64_t)4611686018427387903ULL)
+
+/**
+ * @brief Maximum encoded size in bytes.
+ */
+#define SOCKETQUICVARINT_MAX_SIZE 8
+
+/**
+ * @brief Exception raised on encoding/decoding errors.
+ *
+ * Raised when:
+ * - Decoding truncated input
+ * - Encoding value exceeds maximum
+ * - Output buffer too small
+ */
+extern const Except_T SocketQUICVarInt_Error;
+
+/**
+ * @brief Result codes for QUIC variable-length integer operations.
+ */
+typedef enum
+{
+  QUIC_VARINT_OK = 0,         /**< Operation succeeded */
+  QUIC_VARINT_INCOMPLETE,     /**< Need more input data */
+  QUIC_VARINT_ERROR_OVERFLOW, /**< Value exceeds maximum (2^62-1) */
+  QUIC_VARINT_ERROR_BUFFER,   /**< Output buffer too small */
+  QUIC_VARINT_ERROR_NULL      /**< NULL pointer argument */
+} SocketQUICVarInt_Result;
+
+/**
+ * @brief Decode a QUIC variable-length integer.
+ *
+ * Decodes a variable-length integer from the given buffer according to
+ * RFC 9000 Section 16. The 2 most significant bits of the first byte
+ * determine the total length.
+ *
+ * @param data     Input buffer containing encoded integer.
+ * @param len      Size of input buffer in bytes.
+ * @param value    Output: decoded integer value.
+ * @param consumed Output: number of bytes consumed from input.
+ *
+ * @return QUIC_VARINT_OK on success, error code otherwise.
+ *
+ * @retval QUIC_VARINT_OK         Successfully decoded.
+ * @retval QUIC_VARINT_INCOMPLETE Input truncated (need more bytes).
+ * @retval QUIC_VARINT_ERROR_NULL NULL pointer argument.
+ *
+ * Example:
+ * @code
+ * const uint8_t data[] = {0x40, 0x25}; // Encodes 37
+ * uint64_t value;
+ * size_t consumed;
+ * SocketQUICVarInt_Result res = SocketQUICVarInt_decode(data, 2, &value, &consumed);
+ * // value = 37, consumed = 2
+ * @endcode
+ */
+extern SocketQUICVarInt_Result SocketQUICVarInt_decode (const uint8_t *data,
+                                                        size_t len,
+                                                        uint64_t *value,
+                                                        size_t *consumed);
+
+/**
+ * @brief Encode a value as QUIC variable-length integer.
+ *
+ * Encodes the given value using the minimum number of bytes required.
+ * Values 0-63 use 1 byte, 64-16383 use 2 bytes, etc.
+ *
+ * @param value       Value to encode (must be <= SOCKETQUICVARINT_MAX).
+ * @param output      Output buffer for encoded bytes.
+ * @param output_size Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, 0 on error.
+ *
+ * Example:
+ * @code
+ * uint8_t buf[8];
+ * size_t len = SocketQUICVarInt_encode(16384, buf, sizeof(buf));
+ * // len = 4, buf = {0x80, 0x00, 0x40, 0x00}
+ * @endcode
+ */
+extern size_t SocketQUICVarInt_encode (uint64_t value, uint8_t *output,
+                                       size_t output_size);
+
+/**
+ * @brief Calculate encoded size for a value.
+ *
+ * Returns the number of bytes needed to encode the given value.
+ *
+ * @param value Value to calculate size for.
+ *
+ * @return 1, 2, 4, or 8 for valid values; 0 if value > SOCKETQUICVARINT_MAX.
+ *
+ * @note This is useful for pre-allocating buffers or calculating packet sizes.
+ */
+extern size_t SocketQUICVarInt_size (uint64_t value);
+
+/**
+ * @brief Get string representation of result code.
+ *
+ * @param result Result code to convert.
+ *
+ * @return Human-readable string describing the result.
+ */
+extern const char *
+SocketQUICVarInt_result_string (SocketQUICVarInt_Result result);
+
+/** @} */
+
+#endif /* SOCKETQUICVARINT_INCLUDED */

--- a/src/fuzz/fuzz_quic_varint.c
+++ b/src/fuzz/fuzz_quic_varint.c
@@ -1,0 +1,189 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_varint.c - libFuzzer harness for QUIC Variable-Length Integer
+ *
+ * Part of the Socket Library Fuzzing Suite
+ *
+ * Targets:
+ * - Decode with malformed input (truncated, invalid prefix patterns)
+ * - Round-trip encode/decode consistency
+ * - Integer overflow in decoded values
+ * - Buffer boundary conditions
+ *
+ * Build: CC=clang cmake .. -DENABLE_FUZZING=ON && make fuzz_quic_varint
+ * Run:   ./fuzz_quic_varint corpus/quic_varint/ -fork=16 -max_len=64
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "quic/SocketQUICVarInt.h"
+
+/* Fuzz operation opcodes */
+enum FuzzOp
+{
+  OP_DECODE = 0,
+  OP_ENCODE,
+  OP_ROUNDTRIP,
+  OP_MULTIPLE_DECODE,
+  OP_MAX
+};
+
+/**
+ * parse_u64 - Parse uint64_t from fuzz input
+ * @data: Input bytes
+ * @len: Number of bytes available
+ *
+ * Returns: Parsed value
+ */
+static uint64_t
+parse_u64 (const uint8_t *data, size_t len)
+{
+  uint64_t value = 0;
+  size_t i;
+
+  for (i = 0; i < len && i < 8; i++)
+    value |= ((uint64_t)data[i]) << (i * 8);
+
+  return value;
+}
+
+/**
+ * LLVMFuzzerTestOneInput - libFuzzer entry point
+ * @data: Fuzz input data
+ * @size: Size of fuzz input
+ *
+ * Returns: 0 (required by libFuzzer)
+ */
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 1)
+    return 0;
+
+  uint8_t op = data[0] % OP_MAX;
+  const uint8_t *payload = data + 1;
+  size_t payload_size = size - 1;
+
+  switch (op)
+    {
+    case OP_DECODE:
+      {
+        /* Attempt to decode arbitrary input */
+        uint64_t value;
+        size_t consumed;
+
+        SocketQUICVarInt_Result res
+            = SocketQUICVarInt_decode (payload, payload_size, &value,
+                                       &consumed);
+
+        if (res == QUIC_VARINT_OK)
+          {
+            /* Verify consumed is valid */
+            assert (consumed > 0 && consumed <= payload_size);
+            assert (consumed <= 8);
+
+            /* Verify value is within range */
+            assert (value <= SOCKETQUICVARINT_MAX);
+          }
+      }
+      break;
+
+    case OP_ENCODE:
+      {
+        /* Encode a fuzz-derived value */
+        if (payload_size >= 8)
+          {
+            uint64_t value = parse_u64 (payload, 8);
+
+            /* Cap to valid range to test normal encoding */
+            if (value > SOCKETQUICVARINT_MAX)
+              value = value % (SOCKETQUICVARINT_MAX + 1);
+
+            uint8_t buf[8];
+            size_t len = SocketQUICVarInt_encode (value, buf, sizeof (buf));
+
+            /* Should always succeed for valid values */
+            assert (len > 0);
+            assert (len == SocketQUICVarInt_size (value));
+          }
+      }
+      break;
+
+    case OP_ROUNDTRIP:
+      {
+        /* Encode then decode - must produce same value */
+        if (payload_size >= 8)
+          {
+            uint64_t original = parse_u64 (payload, 8);
+
+            /* Cap to valid range */
+            if (original > SOCKETQUICVARINT_MAX)
+              original = original % (SOCKETQUICVARINT_MAX + 1);
+
+            uint8_t buf[8];
+            size_t encoded_len
+                = SocketQUICVarInt_encode (original, buf, sizeof (buf));
+
+            if (encoded_len > 0)
+              {
+                uint64_t decoded;
+                size_t consumed;
+
+                SocketQUICVarInt_Result res
+                    = SocketQUICVarInt_decode (buf, encoded_len, &decoded,
+                                               &consumed);
+
+                /* Must succeed and produce same value */
+                assert (res == QUIC_VARINT_OK);
+                assert (decoded == original);
+                assert (consumed == encoded_len);
+              }
+          }
+      }
+      break;
+
+    case OP_MULTIPLE_DECODE:
+      {
+        /* Parse multiple consecutive varints from input */
+        size_t offset = 0;
+        int count = 0;
+
+        while (offset < payload_size && count < 100)
+          {
+            uint64_t value;
+            size_t consumed;
+
+            SocketQUICVarInt_Result res
+                = SocketQUICVarInt_decode (payload + offset,
+                                           payload_size - offset, &value,
+                                           &consumed);
+
+            if (res != QUIC_VARINT_OK)
+              break;
+
+            /* Verify consumed is valid */
+            assert (consumed > 0);
+            assert (offset + consumed <= payload_size);
+
+            offset += consumed;
+            count++;
+          }
+      }
+      break;
+    }
+
+  /* Test with all NULL parameters to verify null safety */
+  SocketQUICVarInt_decode (NULL, 0, NULL, NULL);
+  SocketQUICVarInt_encode (0, NULL, 0);
+  SocketQUICVarInt_size (0);
+
+  return 0;
+}

--- a/src/quic/SocketQUICVarInt.c
+++ b/src/quic/SocketQUICVarInt.c
@@ -1,0 +1,215 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQUICVarInt.c - QUIC Variable-Length Integer Encoding (RFC 9000 §16)
+ *
+ * Implements encoding/decoding of QUIC variable-length integers with
+ * 2-bit prefix length encoding in network byte order.
+ */
+
+#include <assert.h>
+
+#include "quic/SocketQUICVarInt.h"
+
+/* ============================================================================
+ * Constants - RFC 9000 Section 16
+ * ============================================================================
+ */
+
+/* 2-bit prefix values (in top 2 bits of first byte) */
+#define VARINT_PREFIX_MASK 0xC0
+#define VARINT_PREFIX_1BYTE 0x00 /* 00xxxxxx */
+#define VARINT_PREFIX_2BYTE 0x40 /* 01xxxxxx */
+#define VARINT_PREFIX_4BYTE 0x80 /* 10xxxxxx */
+#define VARINT_PREFIX_8BYTE 0xC0 /* 11xxxxxx */
+
+/* Value masks for extracting data bits from first byte */
+#define VARINT_VALUE_MASK_1BYTE 0x3F /* 6 bits */
+#define VARINT_VALUE_MASK_2BYTE 0x3F /* 14 bits total */
+#define VARINT_VALUE_MASK_4BYTE 0x3F /* 30 bits total */
+#define VARINT_VALUE_MASK_8BYTE 0x3F /* 62 bits total */
+
+/* Maximum values per encoding length */
+#define VARINT_MAX_1BYTE 63ULL
+#define VARINT_MAX_2BYTE 16383ULL
+#define VARINT_MAX_4BYTE 1073741823ULL
+#define VARINT_MAX_8BYTE SOCKETQUICVARINT_MAX
+
+/* ============================================================================
+ * Exception Definition
+ * ============================================================================
+ */
+
+const Except_T SocketQUICVarInt_Error
+    = { &SocketQUICVarInt_Error, "QUIC VarInt encoding error" };
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QUIC_VARINT_OK] = "OK",
+  [QUIC_VARINT_INCOMPLETE] = "Incomplete - need more data",
+  [QUIC_VARINT_ERROR_OVERFLOW] = "Value exceeds maximum (2^62-1)",
+  [QUIC_VARINT_ERROR_BUFFER] = "Output buffer too small",
+  [QUIC_VARINT_ERROR_NULL] = "NULL pointer argument",
+};
+
+const char *
+SocketQUICVarInt_result_string (SocketQUICVarInt_Result result)
+{
+  if (result < 0 || result > QUIC_VARINT_ERROR_NULL)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Decoding - RFC 9000 Section 16
+ * ============================================================================
+ */
+
+SocketQUICVarInt_Result
+SocketQUICVarInt_decode (const uint8_t *data, size_t len, uint64_t *value,
+                         size_t *consumed)
+{
+  uint8_t prefix;
+  size_t required_len;
+
+  if (data == NULL || value == NULL || consumed == NULL)
+    return QUIC_VARINT_ERROR_NULL;
+
+  if (len == 0)
+    return QUIC_VARINT_INCOMPLETE;
+
+  prefix = data[0] & VARINT_PREFIX_MASK;
+
+  switch (prefix)
+    {
+    case VARINT_PREFIX_1BYTE:
+      required_len = 1;
+      break;
+    case VARINT_PREFIX_2BYTE:
+      required_len = 2;
+      break;
+    case VARINT_PREFIX_4BYTE:
+      required_len = 4;
+      break;
+    case VARINT_PREFIX_8BYTE:
+      required_len = 8;
+      break;
+    default:
+      /* Should not reach here - prefix is masked to 2 bits */
+      return QUIC_VARINT_ERROR_NULL;
+    }
+
+  if (len < required_len)
+    return QUIC_VARINT_INCOMPLETE;
+
+  switch (prefix)
+    {
+    case VARINT_PREFIX_1BYTE:
+      *value = (uint64_t)(data[0] & VARINT_VALUE_MASK_1BYTE);
+      break;
+
+    case VARINT_PREFIX_2BYTE:
+      *value = ((uint64_t)(data[0] & VARINT_VALUE_MASK_2BYTE) << 8)
+               | (uint64_t)data[1];
+      break;
+
+    case VARINT_PREFIX_4BYTE:
+      *value = ((uint64_t)(data[0] & VARINT_VALUE_MASK_4BYTE) << 24)
+               | ((uint64_t)data[1] << 16) | ((uint64_t)data[2] << 8)
+               | (uint64_t)data[3];
+      break;
+
+    case VARINT_PREFIX_8BYTE:
+      *value = ((uint64_t)(data[0] & VARINT_VALUE_MASK_8BYTE) << 56)
+               | ((uint64_t)data[1] << 48) | ((uint64_t)data[2] << 40)
+               | ((uint64_t)data[3] << 32) | ((uint64_t)data[4] << 24)
+               | ((uint64_t)data[5] << 16) | ((uint64_t)data[6] << 8)
+               | (uint64_t)data[7];
+      break;
+    }
+
+  *consumed = required_len;
+  return QUIC_VARINT_OK;
+}
+
+/* ============================================================================
+ * Size Calculation
+ * ============================================================================
+ */
+
+size_t
+SocketQUICVarInt_size (uint64_t value)
+{
+  if (value <= VARINT_MAX_1BYTE)
+    return 1;
+  if (value <= VARINT_MAX_2BYTE)
+    return 2;
+  if (value <= VARINT_MAX_4BYTE)
+    return 4;
+  if (value <= VARINT_MAX_8BYTE)
+    return 8;
+
+  /* Value exceeds maximum representable value */
+  return 0;
+}
+
+/* ============================================================================
+ * Encoding - RFC 9000 Section 16
+ * ============================================================================
+ */
+
+size_t
+SocketQUICVarInt_encode (uint64_t value, uint8_t *output, size_t output_size)
+{
+  size_t required_size;
+
+  if (output == NULL)
+    return 0;
+
+  required_size = SocketQUICVarInt_size (value);
+  if (required_size == 0)
+    return 0; /* Value too large */
+
+  if (output_size < required_size)
+    return 0; /* Buffer too small */
+
+  switch (required_size)
+    {
+    case 1:
+      output[0] = (uint8_t)(VARINT_PREFIX_1BYTE | (value & 0x3F));
+      break;
+
+    case 2:
+      output[0] = (uint8_t)(VARINT_PREFIX_2BYTE | ((value >> 8) & 0x3F));
+      output[1] = (uint8_t)(value & 0xFF);
+      break;
+
+    case 4:
+      output[0] = (uint8_t)(VARINT_PREFIX_4BYTE | ((value >> 24) & 0x3F));
+      output[1] = (uint8_t)((value >> 16) & 0xFF);
+      output[2] = (uint8_t)((value >> 8) & 0xFF);
+      output[3] = (uint8_t)(value & 0xFF);
+      break;
+
+    case 8:
+      output[0] = (uint8_t)(VARINT_PREFIX_8BYTE | ((value >> 56) & 0x3F));
+      output[1] = (uint8_t)((value >> 48) & 0xFF);
+      output[2] = (uint8_t)((value >> 40) & 0xFF);
+      output[3] = (uint8_t)((value >> 32) & 0xFF);
+      output[4] = (uint8_t)((value >> 24) & 0xFF);
+      output[5] = (uint8_t)((value >> 16) & 0xFF);
+      output[6] = (uint8_t)((value >> 8) & 0xFF);
+      output[7] = (uint8_t)(value & 0xFF);
+      break;
+    }
+
+  return required_size;
+}

--- a/src/test/test_quic_varint.c
+++ b/src/test/test_quic_varint.c
@@ -1,0 +1,531 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_quic_varint.c - QUIC Variable-Length Integer unit tests
+ *
+ * Tests encoding/decoding of QUIC variable-length integers (RFC 9000 §16).
+ * Covers boundary values, round-trip encoding, error conditions, and
+ * RFC test vectors.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "quic/SocketQUICVarInt.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * RFC 9000 Section 16 Test Vectors
+ * ============================================================================
+ */
+
+TEST (quic_varint_decode_1byte_zero)
+{
+  const uint8_t data[] = { 0x00 };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 0);
+  ASSERT_EQ (consumed, 1);
+}
+
+TEST (quic_varint_decode_1byte_max)
+{
+  const uint8_t data[] = { 0x3F }; /* 63 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 63);
+  ASSERT_EQ (consumed, 1);
+}
+
+TEST (quic_varint_decode_2byte_min)
+{
+  const uint8_t data[] = { 0x40, 0x40 }; /* 64 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 64);
+  ASSERT_EQ (consumed, 2);
+}
+
+TEST (quic_varint_decode_2byte_max)
+{
+  const uint8_t data[] = { 0x7F, 0xFF }; /* 16383 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 16383);
+  ASSERT_EQ (consumed, 2);
+}
+
+TEST (quic_varint_decode_4byte_min)
+{
+  const uint8_t data[] = { 0x80, 0x00, 0x40, 0x00 }; /* 16384 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 16384);
+  ASSERT_EQ (consumed, 4);
+}
+
+TEST (quic_varint_decode_4byte_max)
+{
+  const uint8_t data[] = { 0xBF, 0xFF, 0xFF, 0xFF }; /* 1073741823 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 1073741823);
+  ASSERT_EQ (consumed, 4);
+}
+
+TEST (quic_varint_decode_8byte_min)
+{
+  const uint8_t data[]
+      = { 0xC0, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00 }; /* 1073741824 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 1073741824);
+  ASSERT_EQ (consumed, 8);
+}
+
+TEST (quic_varint_decode_8byte_max)
+{
+  /* 2^62-1 = 4611686018427387903 */
+  const uint8_t data[] = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, SOCKETQUICVARINT_MAX);
+  ASSERT_EQ (consumed, 8);
+}
+
+/* RFC 9000 Appendix A.1 sample values */
+TEST (quic_varint_decode_rfc_sample_37)
+{
+  const uint8_t data[] = { 0x25 }; /* 37 in 1-byte form */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 37);
+  ASSERT_EQ (consumed, 1);
+}
+
+TEST (quic_varint_decode_rfc_sample_15293)
+{
+  const uint8_t data[] = { 0x7B, 0xBD }; /* 15293 in 2-byte form */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 15293);
+  ASSERT_EQ (consumed, 2);
+}
+
+TEST (quic_varint_decode_rfc_sample_494878333)
+{
+  const uint8_t data[] = { 0x9D, 0x7F, 0x3E, 0x7D }; /* 494878333 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 494878333);
+  ASSERT_EQ (consumed, 4);
+}
+
+TEST (quic_varint_decode_rfc_sample_151288809941952652)
+{
+  const uint8_t data[] = { 0xC2, 0x19, 0x7C, 0x5E,
+                           0xFF, 0x14, 0xE8, 0x8C }; /* 151288809941952652 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 151288809941952652ULL);
+  ASSERT_EQ (consumed, 8);
+}
+
+/* ============================================================================
+ * Encoding Tests
+ * ============================================================================
+ */
+
+TEST (quic_varint_encode_zero)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (0, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 1);
+  ASSERT_EQ (buf[0], 0x00);
+}
+
+TEST (quic_varint_encode_1byte_max)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (63, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 1);
+  ASSERT_EQ (buf[0], 0x3F);
+}
+
+TEST (quic_varint_encode_2byte_min)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (64, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 2);
+  ASSERT_EQ (buf[0], 0x40);
+  ASSERT_EQ (buf[1], 0x40);
+}
+
+TEST (quic_varint_encode_2byte_max)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (16383, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 2);
+  ASSERT_EQ (buf[0], 0x7F);
+  ASSERT_EQ (buf[1], 0xFF);
+}
+
+TEST (quic_varint_encode_4byte_min)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (16384, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 4);
+  ASSERT_EQ (buf[0], 0x80);
+  ASSERT_EQ (buf[1], 0x00);
+  ASSERT_EQ (buf[2], 0x40);
+  ASSERT_EQ (buf[3], 0x00);
+}
+
+TEST (quic_varint_encode_4byte_max)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (1073741823, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 4);
+  ASSERT_EQ (buf[0], 0xBF);
+  ASSERT_EQ (buf[1], 0xFF);
+  ASSERT_EQ (buf[2], 0xFF);
+  ASSERT_EQ (buf[3], 0xFF);
+}
+
+TEST (quic_varint_encode_8byte_min)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (1073741824, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 8);
+  ASSERT_EQ (buf[0], 0xC0);
+  ASSERT_EQ (buf[1], 0x00);
+  ASSERT_EQ (buf[2], 0x00);
+  ASSERT_EQ (buf[3], 0x00);
+  ASSERT_EQ (buf[4], 0x40);
+  ASSERT_EQ (buf[5], 0x00);
+  ASSERT_EQ (buf[6], 0x00);
+  ASSERT_EQ (buf[7], 0x00);
+}
+
+TEST (quic_varint_encode_8byte_max)
+{
+  uint8_t buf[8];
+  size_t len = SocketQUICVarInt_encode (SOCKETQUICVARINT_MAX, buf, sizeof (buf));
+
+  ASSERT_EQ (len, 8);
+  ASSERT_EQ (buf[0], 0xFF);
+  ASSERT_EQ (buf[1], 0xFF);
+  ASSERT_EQ (buf[2], 0xFF);
+  ASSERT_EQ (buf[3], 0xFF);
+  ASSERT_EQ (buf[4], 0xFF);
+  ASSERT_EQ (buf[5], 0xFF);
+  ASSERT_EQ (buf[6], 0xFF);
+  ASSERT_EQ (buf[7], 0xFF);
+}
+
+/* ============================================================================
+ * Round-Trip Tests
+ * ============================================================================
+ */
+
+TEST (quic_varint_roundtrip_boundary_values)
+{
+  uint64_t test_values[] = { 0,
+                             1,
+                             62,
+                             63,
+                             64,
+                             65,
+                             16382,
+                             16383,
+                             16384,
+                             16385,
+                             1073741822,
+                             1073741823,
+                             1073741824,
+                             1073741825,
+                             SOCKETQUICVARINT_MAX - 1,
+                             SOCKETQUICVARINT_MAX };
+
+  for (size_t i = 0; i < sizeof (test_values) / sizeof (test_values[0]); i++)
+    {
+      uint8_t buf[8];
+      uint64_t decoded;
+      size_t consumed;
+
+      size_t encoded_len
+          = SocketQUICVarInt_encode (test_values[i], buf, sizeof (buf));
+      ASSERT (encoded_len > 0);
+
+      SocketQUICVarInt_Result res
+          = SocketQUICVarInt_decode (buf, encoded_len, &decoded, &consumed);
+      ASSERT_EQ (res, QUIC_VARINT_OK);
+      ASSERT_EQ (decoded, test_values[i]);
+      ASSERT_EQ (consumed, encoded_len);
+    }
+}
+
+/* ============================================================================
+ * Size Calculation Tests
+ * ============================================================================
+ */
+
+TEST (quic_varint_size_1byte)
+{
+  ASSERT_EQ (SocketQUICVarInt_size (0), 1);
+  ASSERT_EQ (SocketQUICVarInt_size (63), 1);
+}
+
+TEST (quic_varint_size_2byte)
+{
+  ASSERT_EQ (SocketQUICVarInt_size (64), 2);
+  ASSERT_EQ (SocketQUICVarInt_size (16383), 2);
+}
+
+TEST (quic_varint_size_4byte)
+{
+  ASSERT_EQ (SocketQUICVarInt_size (16384), 4);
+  ASSERT_EQ (SocketQUICVarInt_size (1073741823), 4);
+}
+
+TEST (quic_varint_size_8byte)
+{
+  ASSERT_EQ (SocketQUICVarInt_size (1073741824), 8);
+  ASSERT_EQ (SocketQUICVarInt_size (SOCKETQUICVARINT_MAX), 8);
+}
+
+TEST (quic_varint_size_overflow)
+{
+  /* Value larger than maximum should return 0 */
+  ASSERT_EQ (SocketQUICVarInt_size (SOCKETQUICVARINT_MAX + 1), 0);
+  ASSERT_EQ (SocketQUICVarInt_size (UINT64_MAX), 0);
+}
+
+/* ============================================================================
+ * Error Condition Tests
+ * ============================================================================
+ */
+
+TEST (quic_varint_decode_null_data)
+{
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (NULL, 10, &value, &consumed);
+  ASSERT_EQ (res, QUIC_VARINT_ERROR_NULL);
+}
+
+TEST (quic_varint_decode_null_value)
+{
+  const uint8_t data[] = { 0x00 };
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), NULL, &consumed);
+  ASSERT_EQ (res, QUIC_VARINT_ERROR_NULL);
+}
+
+TEST (quic_varint_decode_null_consumed)
+{
+  const uint8_t data[] = { 0x00 };
+  uint64_t value;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, NULL);
+  ASSERT_EQ (res, QUIC_VARINT_ERROR_NULL);
+}
+
+TEST (quic_varint_decode_empty_input)
+{
+  const uint8_t data[] = { 0x00 };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, 0, &value, &consumed);
+  ASSERT_EQ (res, QUIC_VARINT_INCOMPLETE);
+}
+
+TEST (quic_varint_decode_truncated_2byte)
+{
+  const uint8_t data[] = { 0x40 }; /* 2-byte prefix but only 1 byte */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+  ASSERT_EQ (res, QUIC_VARINT_INCOMPLETE);
+}
+
+TEST (quic_varint_decode_truncated_4byte)
+{
+  const uint8_t data[] = { 0x80, 0x00, 0x00 }; /* 4-byte prefix but only 3 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+  ASSERT_EQ (res, QUIC_VARINT_INCOMPLETE);
+}
+
+TEST (quic_varint_decode_truncated_8byte)
+{
+  const uint8_t data[]
+      = { 0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }; /* 8-byte prefix but 7 */
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+  ASSERT_EQ (res, QUIC_VARINT_INCOMPLETE);
+}
+
+TEST (quic_varint_encode_null_output)
+{
+  size_t len = SocketQUICVarInt_encode (100, NULL, 8);
+  ASSERT_EQ (len, 0);
+}
+
+TEST (quic_varint_encode_buffer_too_small)
+{
+  uint8_t buf[1];
+  size_t len = SocketQUICVarInt_encode (64, buf, sizeof (buf)); /* needs 2 */
+  ASSERT_EQ (len, 0);
+}
+
+TEST (quic_varint_encode_overflow)
+{
+  uint8_t buf[8];
+  size_t len
+      = SocketQUICVarInt_encode (SOCKETQUICVARINT_MAX + 1, buf, sizeof (buf));
+  ASSERT_EQ (len, 0);
+}
+
+/* ============================================================================
+ * Result String Tests
+ * ============================================================================
+ */
+
+TEST (quic_varint_result_string)
+{
+  ASSERT_NOT_NULL (SocketQUICVarInt_result_string (QUIC_VARINT_OK));
+  ASSERT_NOT_NULL (SocketQUICVarInt_result_string (QUIC_VARINT_INCOMPLETE));
+  ASSERT_NOT_NULL (SocketQUICVarInt_result_string (QUIC_VARINT_ERROR_OVERFLOW));
+  ASSERT_NOT_NULL (SocketQUICVarInt_result_string (QUIC_VARINT_ERROR_BUFFER));
+  ASSERT_NOT_NULL (SocketQUICVarInt_result_string (QUIC_VARINT_ERROR_NULL));
+  ASSERT_NOT_NULL (SocketQUICVarInt_result_string ((SocketQUICVarInt_Result)99));
+}
+
+/* ============================================================================
+ * Extra bytes in buffer test (ensure we only consume what we need)
+ * ============================================================================
+ */
+
+TEST (quic_varint_decode_extra_bytes)
+{
+  /* 1-byte varint followed by extra data */
+  const uint8_t data[] = { 0x25, 0xAA, 0xBB, 0xCC };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 37);
+  ASSERT_EQ (consumed, 1);
+}
+
+TEST (quic_varint_decode_2byte_extra_bytes)
+{
+  /* 2-byte varint followed by extra data */
+  const uint8_t data[] = { 0x7B, 0xBD, 0xAA, 0xBB, 0xCC };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (data, sizeof (data), &value, &consumed);
+
+  ASSERT_EQ (res, QUIC_VARINT_OK);
+  ASSERT_EQ (value, 15293);
+  ASSERT_EQ (consumed, 2);
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Implement QUIC Variable-Length Integer encoding/decoding (RFC 9000 §16)
- Add foundational primitive for all QUIC packet parsing
- 2-bit prefix determines length: 1, 2, 4, or 8 bytes
- Maximum value: 2^62-1 (4611686018427387903)

## Changes

| File | Description |
|------|-------------|
| `include/quic/SocketQUICVarInt.h` | Public API with detailed documentation |
| `src/quic/SocketQUICVarInt.c` | Encode/decode/size functions |
| `src/test/test_quic_varint.c` | 39 unit tests including RFC test vectors |
| `src/fuzz/fuzz_quic_varint.c` | libFuzzer harness for robustness testing |
| `CMakeLists.txt` | Build system integration |

## API

```c
// Decode variable-length integer from buffer
SocketQUICVarInt_Result SocketQUICVarInt_decode(
    const uint8_t *data, size_t len, 
    uint64_t *value, size_t *consumed);

// Encode value as variable-length integer
size_t SocketQUICVarInt_encode(
    uint64_t value, uint8_t *output, size_t output_size);

// Get encoded size for value
size_t SocketQUICVarInt_size(uint64_t value);
```

## Test plan

- [x] All 39 unit tests pass including RFC test vectors
- [x] Tests pass with AddressSanitizer enabled
- [x] Tests pass with UndefinedBehaviorSanitizer enabled
- [x] Fuzz harness compiles and links correctly
- [x] Full test suite (88 tests) passes with sanitizers

Fixes #377