### PR TITLE
feat(quic): implement Error Codes (RFC 9000 §20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ set(LIB_SOURCES
 
     # QUIC foundational module (RFC 9000)
     src/quic/SocketQUICVarInt.c
+    src/quic/SocketQUICError.c
 
     # Simple convenience API
     src/simple/SocketSimple.c
@@ -611,6 +612,7 @@ set(TEST_HEADERS
 
 set(QUIC_HEADERS
     include/quic/SocketQUICVarInt.h
+    include/quic/SocketQUICError.h
 )
 
 set(SIMPLE_HEADERS
@@ -750,6 +752,7 @@ set(TEST_SOURCES
     test_httpserver
     # QUIC tests (RFC 9000)
     test_quic_varint
+    test_quic_error
 )
 
 # TLS tests (only built when TLS is enabled)
@@ -1074,6 +1077,7 @@ if(ENABLE_FUZZING)
         fuzz_synprotect_list
         # QUIC fuzzers (RFC 9000)
         fuzz_quic_varint
+        fuzz_quic_error
     )
     
     # TLS fuzz harnesses (require SOCKET_HAS_TLS)

--- a/include/quic/SocketQUICError.h
+++ b/include/quic/SocketQUICError.h
@@ -1,0 +1,324 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICError.h
+ * @brief QUIC Transport and Application Error Codes (RFC 9000 Section 20).
+ *
+ * Defines error codes used in QUIC CONNECTION_CLOSE and RESET_STREAM frames.
+ * Error codes are 62-bit unsigned integers (encoded as VarInt).
+ *
+ * Error code spaces:
+ *   - 0x00-0x10:     Transport error codes (defined in RFC 9000)
+ *   - 0x0100-0x01ff: Crypto/TLS error codes (TLS alerts)
+ *   - 0x0200+:       Reserved for application protocols (e.g., HTTP/3)
+ *
+ * Thread Safety: All functions are thread-safe (pure computation, no state).
+ *
+ * @defgroup quic_error QUIC Error Codes Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9000#section-20
+ */
+
+#ifndef SOCKETQUICERROR_INCLUDED
+#define SOCKETQUICERROR_INCLUDED
+
+#include <stdint.h>
+
+/* ============================================================================
+ * Transport Error Codes (RFC 9000 Section 20.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief QUIC transport error codes for CONNECTION_CLOSE frames.
+ *
+ * These errors apply to the entire connection and are sent in
+ * CONNECTION_CLOSE frames with type 0x1c.
+ */
+typedef enum
+{
+  /**
+   * No error. Used to signal that the connection is being closed
+   * abruptly in the absence of any error.
+   */
+  QUIC_NO_ERROR = 0x00,
+
+  /**
+   * Internal error. The endpoint encountered an internal error
+   * and cannot continue with the connection.
+   */
+  QUIC_INTERNAL_ERROR = 0x01,
+
+  /**
+   * Connection refused. The server refused to accept a new connection.
+   */
+  QUIC_CONNECTION_REFUSED = 0x02,
+
+  /**
+   * Flow control error. An endpoint received more data than it
+   * permitted in its advertised data limits (Section 4).
+   */
+  QUIC_FLOW_CONTROL_ERROR = 0x03,
+
+  /**
+   * Stream limit error. An endpoint received a frame for a stream
+   * identifier that exceeded its advertised stream limit.
+   */
+  QUIC_STREAM_LIMIT_ERROR = 0x04,
+
+  /**
+   * Stream state error. An endpoint received a frame for a stream
+   * that was not in a state that permitted that frame (Section 3).
+   */
+  QUIC_STREAM_STATE_ERROR = 0x05,
+
+  /**
+   * Final size error. An endpoint received a STREAM frame containing
+   * data that exceeded the previously established final size, or
+   * conflicting final size values.
+   */
+  QUIC_FINAL_SIZE_ERROR = 0x06,
+
+  /**
+   * Frame encoding error. An endpoint received a frame that was
+   * badly formatted (e.g., unknown type, invalid ACK ranges).
+   */
+  QUIC_FRAME_ENCODING_ERROR = 0x07,
+
+  /**
+   * Transport parameter error. An endpoint received transport
+   * parameters that were badly formatted, invalid, or in error.
+   */
+  QUIC_TRANSPORT_PARAMETER_ERROR = 0x08,
+
+  /**
+   * Connection ID limit error. The number of connection IDs provided
+   * by the peer exceeds the advertised active_connection_id_limit.
+   */
+  QUIC_CONNECTION_ID_LIMIT_ERROR = 0x09,
+
+  /**
+   * Protocol violation. An endpoint detected an error with protocol
+   * compliance that was not covered by more specific error codes.
+   */
+  QUIC_PROTOCOL_VIOLATION = 0x0a,
+
+  /**
+   * Invalid token. A server received a client Initial that contained
+   * an invalid Token field.
+   */
+  QUIC_INVALID_TOKEN = 0x0b,
+
+  /**
+   * Application error. The application or application protocol
+   * caused the connection to be closed.
+   */
+  QUIC_APPLICATION_ERROR = 0x0c,
+
+  /**
+   * Crypto buffer exceeded. An endpoint has received more data in
+   * CRYPTO frames than it can buffer.
+   */
+  QUIC_CRYPTO_BUFFER_EXCEEDED = 0x0d,
+
+  /**
+   * Key update error. An endpoint detected errors in performing
+   * key updates (Section 6 of [QUIC-TLS]).
+   */
+  QUIC_KEY_UPDATE_ERROR = 0x0e,
+
+  /**
+   * AEAD limit reached. An endpoint has reached the confidentiality
+   * or integrity limit for the AEAD algorithm used by the connection.
+   */
+  QUIC_AEAD_LIMIT_REACHED = 0x0f,
+
+  /**
+   * No viable path. An endpoint has determined that the network path
+   * is incapable of supporting QUIC (e.g., MTU too small).
+   */
+  QUIC_NO_VIABLE_PATH = 0x10
+
+} SocketQUIC_TransportError;
+
+/* ============================================================================
+ * Crypto Error Codes (RFC 9000 Section 20.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Base value for crypto (TLS) error codes.
+ *
+ * Crypto errors are in the range 0x0100-0x01ff.
+ * The low 8 bits contain the TLS AlertDescription value.
+ */
+#define QUIC_CRYPTO_ERROR_BASE 0x0100
+
+/**
+ * @brief Maximum crypto error code value.
+ */
+#define QUIC_CRYPTO_ERROR_MAX 0x01ff
+
+/**
+ * @brief Convert TLS AlertDescription to QUIC crypto error code.
+ *
+ * @param alert TLS AlertDescription value (0-255).
+ * @return QUIC crypto error code (0x0100-0x01ff).
+ */
+#define QUIC_CRYPTO_ERROR(alert) (QUIC_CRYPTO_ERROR_BASE | ((alert) & 0xff))
+
+/**
+ * @brief Check if an error code is a crypto error.
+ *
+ * @param code QUIC error code to check.
+ * @return Non-zero if code is in crypto error range, zero otherwise.
+ */
+#define QUIC_IS_CRYPTO_ERROR(code)                                            \
+  (((code) >= QUIC_CRYPTO_ERROR_BASE) && ((code) <= QUIC_CRYPTO_ERROR_MAX))
+
+/**
+ * @brief Extract TLS AlertDescription from crypto error code.
+ *
+ * @param code QUIC crypto error code.
+ * @return TLS AlertDescription value (0-255).
+ */
+#define QUIC_CRYPTO_ALERT(code) ((code) & 0xff)
+
+/* ============================================================================
+ * Application Error Codes (RFC 9000 Section 20.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Base value for application protocol error codes.
+ *
+ * Application protocol error codes (e.g., HTTP/3) are defined
+ * by the respective application protocol specifications.
+ * They are used in RESET_STREAM, STOP_SENDING, and CONNECTION_CLOSE
+ * frames with type 0x1d.
+ */
+#define QUIC_APPLICATION_ERROR_BASE 0x0200
+
+/* ============================================================================
+ * Error Code Limits
+ * ============================================================================
+ */
+
+/**
+ * @brief Maximum transport error code defined in RFC 9000.
+ */
+#define QUIC_TRANSPORT_ERROR_MAX QUIC_NO_VIABLE_PATH
+
+/**
+ * @brief Maximum value for any QUIC error code (62 bits).
+ *
+ * Error codes are VarInt encoded, so the maximum is 2^62-1.
+ */
+#define QUIC_ERROR_CODE_MAX ((uint64_t)0x3FFFFFFFFFFFFFFFULL)
+
+/* ============================================================================
+ * Error Code Classification
+ * ============================================================================
+ */
+
+/**
+ * @brief Error code category.
+ */
+typedef enum
+{
+  QUIC_ERROR_CATEGORY_TRANSPORT,   /**< Transport layer error (0x00-0x10) */
+  QUIC_ERROR_CATEGORY_CRYPTO,      /**< Crypto/TLS error (0x0100-0x01ff) */
+  QUIC_ERROR_CATEGORY_APPLICATION, /**< Application protocol error */
+  QUIC_ERROR_CATEGORY_UNKNOWN      /**< Reserved/unknown error code */
+} SocketQUIC_ErrorCategory;
+
+/**
+ * @brief Classify a QUIC error code.
+ *
+ * @param code Error code to classify.
+ * @return Category of the error code.
+ */
+static inline SocketQUIC_ErrorCategory
+SocketQUIC_error_category (uint64_t code)
+{
+  if (code <= QUIC_TRANSPORT_ERROR_MAX)
+    return QUIC_ERROR_CATEGORY_TRANSPORT;
+
+  if (QUIC_IS_CRYPTO_ERROR (code))
+    return QUIC_ERROR_CATEGORY_CRYPTO;
+
+  if (code >= QUIC_APPLICATION_ERROR_BASE)
+    return QUIC_ERROR_CATEGORY_APPLICATION;
+
+  return QUIC_ERROR_CATEGORY_UNKNOWN;
+}
+
+/**
+ * @brief Check if an error code is valid (within 62-bit range).
+ *
+ * @param code Error code to validate.
+ * @return 1 if valid, 0 if exceeds maximum.
+ */
+static inline int
+SocketQUIC_error_is_valid (uint64_t code)
+{
+  return code <= QUIC_ERROR_CODE_MAX;
+}
+
+/**
+ * @brief Check if an error code is a known transport error.
+ *
+ * @param code Error code to check.
+ * @return 1 if known transport error, 0 otherwise.
+ */
+static inline int
+SocketQUIC_is_transport_error (uint64_t code)
+{
+  return code <= QUIC_TRANSPORT_ERROR_MAX;
+}
+
+/* ============================================================================
+ * String Conversion
+ * ============================================================================
+ */
+
+/**
+ * @brief Get human-readable string for a QUIC error code.
+ *
+ * Returns the RFC-defined name for transport errors, a formatted
+ * string for crypto errors, or "APPLICATION_ERROR" for application
+ * protocol errors.
+ *
+ * @param code Error code to convert.
+ * @return Static string describing the error. Never returns NULL.
+ *
+ * @note For crypto errors, a static buffer is used. Not thread-safe
+ *       for crypto errors if called concurrently with different codes.
+ */
+extern const char *SocketQUIC_error_string (uint64_t code);
+
+/**
+ * @brief Get category name string.
+ *
+ * @param category Error category.
+ * @return Static string for the category name.
+ */
+static inline const char *
+SocketQUIC_error_category_string (SocketQUIC_ErrorCategory category)
+{
+  static const char *names[] = { "TRANSPORT", "CRYPTO", "APPLICATION",
+                                 "UNKNOWN" };
+
+  if (category > QUIC_ERROR_CATEGORY_UNKNOWN)
+    return "UNKNOWN";
+
+  return names[category];
+}
+
+/** @} */
+
+#endif /* SOCKETQUICERROR_INCLUDED */

--- a/src/fuzz/fuzz_quic_error.c
+++ b/src/fuzz/fuzz_quic_error.c
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_error.c - libFuzzer harness for QUIC Error Codes
+ *
+ * Part of the Socket Library Fuzzing Suite
+ *
+ * Targets:
+ * - Error code classification with arbitrary values
+ * - Error code validation boundary conditions
+ * - String conversion with all possible error codes
+ * - Category string functions
+ *
+ * Build: CC=clang cmake .. -DENABLE_FUZZING=ON && make fuzz_quic_error
+ * Run:   ./fuzz_quic_error -fork=16 -max_len=16
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "quic/SocketQUICError.h"
+
+/**
+ * parse_u64 - Parse uint64_t from fuzz input (little-endian)
+ */
+static uint64_t
+parse_u64 (const uint8_t *data, size_t len)
+{
+  uint64_t value = 0;
+
+  for (size_t i = 0; i < len && i < 8; i++)
+    value |= ((uint64_t)data[i]) << (i * 8);
+
+  return value;
+}
+
+/**
+ * LLVMFuzzerTestOneInput - libFuzzer entry point
+ */
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 1)
+    return 0;
+
+  /* Extract operation and error code from fuzz input */
+  uint8_t op = data[0] % 6;
+  uint64_t code = (size > 1) ? parse_u64 (data + 1, size - 1) : 0;
+
+  switch (op)
+    {
+    case 0:
+      {
+        /* Test error category classification */
+        SocketQUIC_ErrorCategory cat = SocketQUIC_error_category (code);
+
+        /* Verify category is valid enum value */
+        assert (cat >= QUIC_ERROR_CATEGORY_TRANSPORT
+                && cat <= QUIC_ERROR_CATEGORY_UNKNOWN);
+
+        /* Verify category string returns valid string */
+        const char *cat_str = SocketQUIC_error_category_string (cat);
+        assert (cat_str != NULL);
+        assert (strlen (cat_str) > 0);
+      }
+      break;
+
+    case 1:
+      {
+        /* Test error validation */
+        int valid = SocketQUIC_error_is_valid (code);
+
+        /* Verify consistency: if code > max, must be invalid */
+        if (code > QUIC_ERROR_CODE_MAX)
+          assert (valid == 0);
+        else
+          assert (valid == 1);
+      }
+      break;
+
+    case 2:
+      {
+        /* Test transport error detection */
+        int is_transport = SocketQUIC_is_transport_error (code);
+
+        /* Verify consistency with known transport errors */
+        if (code <= QUIC_TRANSPORT_ERROR_MAX)
+          assert (is_transport == 1);
+        else
+          assert (is_transport == 0);
+      }
+      break;
+
+    case 3:
+      {
+        /* Test crypto error macros */
+        int is_crypto = QUIC_IS_CRYPTO_ERROR (code);
+
+        if (code >= QUIC_CRYPTO_ERROR_BASE && code <= QUIC_CRYPTO_ERROR_MAX)
+          {
+            assert (is_crypto != 0);
+
+            /* Verify alert extraction */
+            uint8_t alert = QUIC_CRYPTO_ALERT (code);
+            assert (alert == (code & 0xff));
+          }
+        else
+          {
+            assert (is_crypto == 0);
+          }
+      }
+      break;
+
+    case 4:
+      {
+        /* Test error string conversion */
+        const char *str = SocketQUIC_error_string (code);
+
+        /* Must never return NULL */
+        assert (str != NULL);
+        assert (strlen (str) > 0);
+
+        /* Known transport errors should have specific names */
+        if (code == QUIC_NO_ERROR)
+          assert (strcmp (str, "NO_ERROR") == 0);
+        if (code == QUIC_PROTOCOL_VIOLATION)
+          assert (strcmp (str, "PROTOCOL_VIOLATION") == 0);
+      }
+      break;
+
+    case 5:
+      {
+        /* Test CRYPTO_ERROR macro round-trip */
+        if (size > 1)
+          {
+            uint8_t alert = data[1];
+            uint64_t crypto_code = QUIC_CRYPTO_ERROR (alert);
+
+            /* Verify it's in crypto range */
+            assert (QUIC_IS_CRYPTO_ERROR (crypto_code));
+
+            /* Verify alert extraction */
+            assert (QUIC_CRYPTO_ALERT (crypto_code) == alert);
+
+            /* Verify it's categorized as crypto */
+            assert (SocketQUIC_error_category (crypto_code)
+                    == QUIC_ERROR_CATEGORY_CRYPTO);
+          }
+      }
+      break;
+    }
+
+  /* Exercise all transport error codes */
+  for (uint64_t i = 0; i <= QUIC_TRANSPORT_ERROR_MAX; i++)
+    {
+      const char *s = SocketQUIC_error_string (i);
+      assert (s != NULL);
+      assert (SocketQUIC_is_transport_error (i));
+      assert (SocketQUIC_error_category (i) == QUIC_ERROR_CATEGORY_TRANSPORT);
+    }
+
+  /* Exercise category string with invalid values */
+  SocketQUIC_error_category_string ((SocketQUIC_ErrorCategory)255);
+
+  return 0;
+}

--- a/src/quic/SocketQUICError.c
+++ b/src/quic/SocketQUICError.c
@@ -1,0 +1,74 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQUICError.c - QUIC Error Code String Conversion (RFC 9000 §20)
+ *
+ * Provides human-readable string representation of QUIC error codes.
+ */
+
+#include "quic/SocketQUICError.h"
+
+#include <stdio.h>
+
+/* ============================================================================
+ * Transport Error Code Names (RFC 9000 Section 20.1)
+ * ============================================================================
+ */
+
+static const char *transport_error_names[] = {
+  "NO_ERROR",                  /* 0x00 */
+  "INTERNAL_ERROR",            /* 0x01 */
+  "CONNECTION_REFUSED",        /* 0x02 */
+  "FLOW_CONTROL_ERROR",        /* 0x03 */
+  "STREAM_LIMIT_ERROR",        /* 0x04 */
+  "STREAM_STATE_ERROR",        /* 0x05 */
+  "FINAL_SIZE_ERROR",          /* 0x06 */
+  "FRAME_ENCODING_ERROR",      /* 0x07 */
+  "TRANSPORT_PARAMETER_ERROR", /* 0x08 */
+  "CONNECTION_ID_LIMIT_ERROR", /* 0x09 */
+  "PROTOCOL_VIOLATION",        /* 0x0a */
+  "INVALID_TOKEN",             /* 0x0b */
+  "APPLICATION_ERROR",         /* 0x0c */
+  "CRYPTO_BUFFER_EXCEEDED",    /* 0x0d */
+  "KEY_UPDATE_ERROR",          /* 0x0e */
+  "AEAD_LIMIT_REACHED",        /* 0x0f */
+  "NO_VIABLE_PATH"             /* 0x10 */
+};
+
+#define TRANSPORT_ERROR_COUNT                                                 \
+  (sizeof (transport_error_names) / sizeof (transport_error_names[0]))
+
+/* ============================================================================
+ * String Conversion
+ * ============================================================================
+ */
+
+const char *
+SocketQUIC_error_string (uint64_t code)
+{
+  /* Thread-local buffer for crypto error formatting */
+  static __thread char crypto_buf[32];
+
+  /* Transport errors: 0x00-0x10 */
+  if (code < TRANSPORT_ERROR_COUNT)
+    return transport_error_names[code];
+
+  /* Crypto errors: 0x0100-0x01ff */
+  if (QUIC_IS_CRYPTO_ERROR (code))
+    {
+      snprintf (crypto_buf, sizeof (crypto_buf), "CRYPTO_ERROR(0x%02x)",
+                (unsigned int)QUIC_CRYPTO_ALERT (code));
+      return crypto_buf;
+    }
+
+  /* Application errors */
+  if (code >= QUIC_APPLICATION_ERROR_BASE)
+    return "APPLICATION_PROTOCOL_ERROR";
+
+  /* Unknown/reserved range (0x11-0xff) */
+  return "UNKNOWN_ERROR";
+}

--- a/src/test/test_quic_error.c
+++ b/src/test/test_quic_error.c
@@ -1,0 +1,323 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_quic_error.c - QUIC Error Code unit tests (RFC 9000 §20)
+ *
+ * Tests error code definitions, classification, validation, and string
+ * conversion for QUIC transport and crypto errors.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "quic/SocketQUICError.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Transport Error Code Value Tests
+ * ============================================================================
+ */
+
+TEST (quic_error_no_error_value)
+{
+  ASSERT_EQ (QUIC_NO_ERROR, 0x00);
+}
+
+TEST (quic_error_internal_error_value)
+{
+  ASSERT_EQ (QUIC_INTERNAL_ERROR, 0x01);
+}
+
+TEST (quic_error_connection_refused_value)
+{
+  ASSERT_EQ (QUIC_CONNECTION_REFUSED, 0x02);
+}
+
+TEST (quic_error_flow_control_error_value)
+{
+  ASSERT_EQ (QUIC_FLOW_CONTROL_ERROR, 0x03);
+}
+
+TEST (quic_error_stream_limit_error_value)
+{
+  ASSERT_EQ (QUIC_STREAM_LIMIT_ERROR, 0x04);
+}
+
+TEST (quic_error_stream_state_error_value)
+{
+  ASSERT_EQ (QUIC_STREAM_STATE_ERROR, 0x05);
+}
+
+TEST (quic_error_final_size_error_value)
+{
+  ASSERT_EQ (QUIC_FINAL_SIZE_ERROR, 0x06);
+}
+
+TEST (quic_error_frame_encoding_error_value)
+{
+  ASSERT_EQ (QUIC_FRAME_ENCODING_ERROR, 0x07);
+}
+
+TEST (quic_error_transport_parameter_error_value)
+{
+  ASSERT_EQ (QUIC_TRANSPORT_PARAMETER_ERROR, 0x08);
+}
+
+TEST (quic_error_connection_id_limit_error_value)
+{
+  ASSERT_EQ (QUIC_CONNECTION_ID_LIMIT_ERROR, 0x09);
+}
+
+TEST (quic_error_protocol_violation_value)
+{
+  ASSERT_EQ (QUIC_PROTOCOL_VIOLATION, 0x0a);
+}
+
+TEST (quic_error_invalid_token_value)
+{
+  ASSERT_EQ (QUIC_INVALID_TOKEN, 0x0b);
+}
+
+TEST (quic_error_application_error_value)
+{
+  ASSERT_EQ (QUIC_APPLICATION_ERROR, 0x0c);
+}
+
+TEST (quic_error_crypto_buffer_exceeded_value)
+{
+  ASSERT_EQ (QUIC_CRYPTO_BUFFER_EXCEEDED, 0x0d);
+}
+
+TEST (quic_error_key_update_error_value)
+{
+  ASSERT_EQ (QUIC_KEY_UPDATE_ERROR, 0x0e);
+}
+
+TEST (quic_error_aead_limit_reached_value)
+{
+  ASSERT_EQ (QUIC_AEAD_LIMIT_REACHED, 0x0f);
+}
+
+TEST (quic_error_no_viable_path_value)
+{
+  ASSERT_EQ (QUIC_NO_VIABLE_PATH, 0x10);
+}
+
+/* ============================================================================
+ * Crypto Error Macro Tests
+ * ============================================================================
+ */
+
+TEST (quic_error_crypto_base_value)
+{
+  ASSERT_EQ (QUIC_CRYPTO_ERROR_BASE, 0x0100);
+}
+
+TEST (quic_error_crypto_max_value)
+{
+  ASSERT_EQ (QUIC_CRYPTO_ERROR_MAX, 0x01ff);
+}
+
+TEST (quic_error_crypto_error_macro)
+{
+  /* TLS alert 0 -> QUIC crypto error 0x0100 */
+  ASSERT_EQ (QUIC_CRYPTO_ERROR (0), 0x0100);
+
+  /* TLS alert 40 (handshake_failure) -> QUIC crypto error 0x0128 */
+  ASSERT_EQ (QUIC_CRYPTO_ERROR (40), 0x0128);
+
+  /* TLS alert 255 -> QUIC crypto error 0x01ff */
+  ASSERT_EQ (QUIC_CRYPTO_ERROR (255), 0x01ff);
+}
+
+TEST (quic_error_is_crypto_error_true)
+{
+  ASSERT (QUIC_IS_CRYPTO_ERROR (0x0100));
+  ASSERT (QUIC_IS_CRYPTO_ERROR (0x0128));
+  ASSERT (QUIC_IS_CRYPTO_ERROR (0x01ff));
+}
+
+TEST (quic_error_is_crypto_error_false)
+{
+  ASSERT (!QUIC_IS_CRYPTO_ERROR (0x00));
+  ASSERT (!QUIC_IS_CRYPTO_ERROR (0x10));
+  ASSERT (!QUIC_IS_CRYPTO_ERROR (0xff));
+  ASSERT (!QUIC_IS_CRYPTO_ERROR (0x0200));
+}
+
+TEST (quic_error_crypto_alert_macro)
+{
+  ASSERT_EQ (QUIC_CRYPTO_ALERT (0x0100), 0);
+  ASSERT_EQ (QUIC_CRYPTO_ALERT (0x0128), 40);
+  ASSERT_EQ (QUIC_CRYPTO_ALERT (0x01ff), 255);
+}
+
+/* ============================================================================
+ * Error Category Tests
+ * ============================================================================
+ */
+
+TEST (quic_error_category_transport)
+{
+  ASSERT_EQ (SocketQUIC_error_category (QUIC_NO_ERROR),
+             QUIC_ERROR_CATEGORY_TRANSPORT);
+  ASSERT_EQ (SocketQUIC_error_category (QUIC_INTERNAL_ERROR),
+             QUIC_ERROR_CATEGORY_TRANSPORT);
+  ASSERT_EQ (SocketQUIC_error_category (QUIC_NO_VIABLE_PATH),
+             QUIC_ERROR_CATEGORY_TRANSPORT);
+}
+
+TEST (quic_error_category_crypto)
+{
+  ASSERT_EQ (SocketQUIC_error_category (0x0100), QUIC_ERROR_CATEGORY_CRYPTO);
+  ASSERT_EQ (SocketQUIC_error_category (0x0128), QUIC_ERROR_CATEGORY_CRYPTO);
+  ASSERT_EQ (SocketQUIC_error_category (0x01ff), QUIC_ERROR_CATEGORY_CRYPTO);
+}
+
+TEST (quic_error_category_application)
+{
+  ASSERT_EQ (SocketQUIC_error_category (0x0200),
+             QUIC_ERROR_CATEGORY_APPLICATION);
+  ASSERT_EQ (SocketQUIC_error_category (0x1000),
+             QUIC_ERROR_CATEGORY_APPLICATION);
+}
+
+TEST (quic_error_category_unknown)
+{
+  /* Reserved range 0x11-0xff */
+  ASSERT_EQ (SocketQUIC_error_category (0x11), QUIC_ERROR_CATEGORY_UNKNOWN);
+  ASSERT_EQ (SocketQUIC_error_category (0xff), QUIC_ERROR_CATEGORY_UNKNOWN);
+}
+
+/* ============================================================================
+ * Error Validation Tests
+ * ============================================================================
+ */
+
+TEST (quic_error_is_valid_true)
+{
+  ASSERT (SocketQUIC_error_is_valid (0));
+  ASSERT (SocketQUIC_error_is_valid (QUIC_NO_VIABLE_PATH));
+  ASSERT (SocketQUIC_error_is_valid (0x0100));
+  ASSERT (SocketQUIC_error_is_valid (QUIC_ERROR_CODE_MAX));
+}
+
+TEST (quic_error_is_valid_false)
+{
+  /* 62-bit max is 0x3FFFFFFFFFFFFFFF, anything larger is invalid */
+  ASSERT (!SocketQUIC_error_is_valid (QUIC_ERROR_CODE_MAX + 1));
+  ASSERT (!SocketQUIC_error_is_valid (UINT64_MAX));
+}
+
+TEST (quic_error_is_transport_error)
+{
+  ASSERT (SocketQUIC_is_transport_error (QUIC_NO_ERROR));
+  ASSERT (SocketQUIC_is_transport_error (QUIC_NO_VIABLE_PATH));
+  ASSERT (!SocketQUIC_is_transport_error (0x11));
+  ASSERT (!SocketQUIC_is_transport_error (0x0100));
+}
+
+/* ============================================================================
+ * Error String Tests
+ * ============================================================================
+ */
+
+TEST (quic_error_string_transport_errors)
+{
+  ASSERT (strcmp (SocketQUIC_error_string (QUIC_NO_ERROR), "NO_ERROR") == 0);
+  ASSERT (strcmp (SocketQUIC_error_string (QUIC_INTERNAL_ERROR),
+                  "INTERNAL_ERROR")
+          == 0);
+  ASSERT (strcmp (SocketQUIC_error_string (QUIC_CONNECTION_REFUSED),
+                  "CONNECTION_REFUSED")
+          == 0);
+  ASSERT (strcmp (SocketQUIC_error_string (QUIC_FLOW_CONTROL_ERROR),
+                  "FLOW_CONTROL_ERROR")
+          == 0);
+  ASSERT (strcmp (SocketQUIC_error_string (QUIC_PROTOCOL_VIOLATION),
+                  "PROTOCOL_VIOLATION")
+          == 0);
+  ASSERT (strcmp (SocketQUIC_error_string (QUIC_NO_VIABLE_PATH), "NO_VIABLE_PATH")
+          == 0);
+}
+
+TEST (quic_error_string_crypto_errors)
+{
+  const char *str;
+
+  str = SocketQUIC_error_string (0x0100);
+  ASSERT (strstr (str, "CRYPTO_ERROR") != NULL);
+  ASSERT (strstr (str, "0x00") != NULL);
+
+  str = SocketQUIC_error_string (0x0128);
+  ASSERT (strstr (str, "CRYPTO_ERROR") != NULL);
+  ASSERT (strstr (str, "0x28") != NULL);
+}
+
+TEST (quic_error_string_application_error)
+{
+  const char *str = SocketQUIC_error_string (0x0200);
+  ASSERT (strstr (str, "APPLICATION") != NULL);
+}
+
+TEST (quic_error_string_unknown)
+{
+  const char *str = SocketQUIC_error_string (0x50);
+  ASSERT (strstr (str, "UNKNOWN") != NULL);
+}
+
+TEST (quic_error_string_not_null)
+{
+  /* Ensure we never return NULL for any input */
+  ASSERT_NOT_NULL (SocketQUIC_error_string (0));
+  ASSERT_NOT_NULL (SocketQUIC_error_string (0x10));
+  ASSERT_NOT_NULL (SocketQUIC_error_string (0x50));
+  ASSERT_NOT_NULL (SocketQUIC_error_string (0x0100));
+  ASSERT_NOT_NULL (SocketQUIC_error_string (0x0200));
+  ASSERT_NOT_NULL (SocketQUIC_error_string (UINT64_MAX));
+}
+
+/* ============================================================================
+ * Category String Tests
+ * ============================================================================
+ */
+
+TEST (quic_error_category_string)
+{
+  ASSERT (strcmp (SocketQUIC_error_category_string (QUIC_ERROR_CATEGORY_TRANSPORT),
+                  "TRANSPORT")
+          == 0);
+  ASSERT (strcmp (SocketQUIC_error_category_string (QUIC_ERROR_CATEGORY_CRYPTO),
+                  "CRYPTO")
+          == 0);
+  ASSERT (
+      strcmp (SocketQUIC_error_category_string (QUIC_ERROR_CATEGORY_APPLICATION),
+              "APPLICATION")
+      == 0);
+  ASSERT (strcmp (SocketQUIC_error_category_string (QUIC_ERROR_CATEGORY_UNKNOWN),
+                  "UNKNOWN")
+          == 0);
+}
+
+TEST (quic_error_category_string_invalid)
+{
+  /* Invalid category should return "UNKNOWN" */
+  const char *str = SocketQUIC_error_category_string (99);
+  ASSERT (strcmp (str, "UNKNOWN") == 0);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

- Implement QUIC transport and application error code definitions (RFC 9000 §20)
- Add error code constants for CONNECTION_CLOSE and RESET_STREAM frames
- Provide error classification and string conversion helpers

## Changes

| File | Description |
|------|-------------|
| `include/quic/SocketQUICError.h` | Error code enum, macros, and inline helpers |
| `src/quic/SocketQUICError.c` | Error string conversion function |
| `src/test/test_quic_error.c` | 37 unit tests |
| `src/fuzz/fuzz_quic_error.c` | libFuzzer harness |
| `CMakeLists.txt` | Build system integration |

## Error Codes (RFC 9000 §20.1)

| Code | Name | Description |
|------|------|-------------|
| 0x00 | NO_ERROR | Connection closed without error |
| 0x01 | INTERNAL_ERROR | Internal error |
| 0x02 | CONNECTION_REFUSED | Server refused connection |
| 0x03 | FLOW_CONTROL_ERROR | Flow control violation |
| 0x04 | STREAM_LIMIT_ERROR | Stream limit exceeded |
| 0x05 | STREAM_STATE_ERROR | Invalid stream state |
| 0x06 | FINAL_SIZE_ERROR | Final size mismatch |
| 0x07 | FRAME_ENCODING_ERROR | Invalid frame format |
| 0x08 | TRANSPORT_PARAMETER_ERROR | Bad transport params |
| 0x09 | CONNECTION_ID_LIMIT_ERROR | Too many connection IDs |
| 0x0a | PROTOCOL_VIOLATION | Protocol error |
| 0x0b | INVALID_TOKEN | Invalid token |
| 0x0c | APPLICATION_ERROR | Application caused close |
| 0x0d | CRYPTO_BUFFER_EXCEEDED | Crypto buffer full |
| 0x0e | KEY_UPDATE_ERROR | Key update failed |
| 0x0f | AEAD_LIMIT_REACHED | AEAD limit reached |
| 0x10 | NO_VIABLE_PATH | Path not viable |

## API

```c
// Error code classification
SocketQUIC_ErrorCategory SocketQUIC_error_category(uint64_t code);
int SocketQUIC_error_is_valid(uint64_t code);
int SocketQUIC_is_transport_error(uint64_t code);

// Crypto error helpers
QUIC_CRYPTO_ERROR(alert)     // Convert TLS alert to QUIC code
QUIC_IS_CRYPTO_ERROR(code)   // Check if crypto error
QUIC_CRYPTO_ALERT(code)      // Extract TLS alert

// String conversion
const char *SocketQUIC_error_string(uint64_t code);
```

## Test plan

- [x] All 37 unit tests pass
- [x] Tests pass with AddressSanitizer
- [x] Tests pass with UndefinedBehaviorSanitizer
- [x] Full test suite (89 tests) passes
- [x] Fuzz harness compiles correctly

Fixes #378