### PR TITLE
feat(quic): implement Connection ID structure (RFC 9000 §5.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ set(LIB_SOURCES
     # QUIC foundational module (RFC 9000)
     src/quic/SocketQUICVarInt.c
     src/quic/SocketQUICError.c
+    src/quic/SocketQUICConnectionID.c
 
     # Simple convenience API
     src/simple/SocketSimple.c
@@ -614,6 +615,7 @@ set(QUIC_HEADERS
     include/quic/SocketQUICVarInt.h
     include/quic/SocketQUICError.h
     include/quic/SocketQUICVersion.h
+    include/quic/SocketQUICConnectionID.h
 )
 
 set(SIMPLE_HEADERS
@@ -755,6 +757,7 @@ set(TEST_SOURCES
     test_quic_varint
     test_quic_error
     test_quic_version
+    test_quic_connid
 )
 
 # TLS tests (only built when TLS is enabled)
@@ -1081,6 +1084,7 @@ if(ENABLE_FUZZING)
         fuzz_quic_varint
         fuzz_quic_error
         fuzz_quic_version
+        fuzz_quic_connid
     )
     
     # TLS fuzz harnesses (require SOCKET_HAS_TLS)

--- a/include/quic/SocketQUICConnectionID.h
+++ b/include/quic/SocketQUICConnectionID.h
@@ -1,0 +1,380 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICConnectionID.h
+ * @brief QUIC Connection ID Management (RFC 9000 Section 5.1).
+ *
+ * Connection IDs are used to route QUIC packets to the correct endpoint
+ * and to allow connections to survive address changes (migration).
+ *
+ * Key properties:
+ *   - Connection IDs are 0-20 bytes in length
+ *   - Each CID has a sequence number (starting from 0 for initial)
+ *   - CIDs include a 16-byte stateless reset token
+ *   - Multiple CIDs can be active for a single connection
+ *
+ * Thread Safety: Individual CID structures are not thread-safe.
+ * Use external synchronization when sharing across threads.
+ *
+ * @defgroup quic_connid QUIC Connection ID Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9000#section-5.1
+ */
+
+#ifndef SOCKETQUICCONNECTIONID_INCLUDED
+#define SOCKETQUICCONNECTIONID_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Constants (RFC 9000 Section 5.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Maximum length of a QUIC Connection ID in bytes.
+ *
+ * Connection IDs can be 0-20 bytes. Zero-length CIDs are valid but
+ * limit connection migration capabilities.
+ */
+#define QUIC_CONNID_MAX_LEN 20
+
+/**
+ * @brief Minimum length of a non-zero Connection ID.
+ *
+ * When a non-zero-length CID is used, it must be at least 1 byte.
+ * NEW_CONNECTION_ID frame requires length 1-20.
+ */
+#define QUIC_CONNID_MIN_LEN 1
+
+/**
+ * @brief Size of the Stateless Reset Token in bytes.
+ *
+ * Each Connection ID has an associated 16-byte (128-bit) stateless
+ * reset token used to identify Stateless Reset packets.
+ */
+#define QUIC_STATELESS_RESET_TOKEN_LEN 16
+
+/**
+ * @brief Sequence number for the initial Connection ID.
+ *
+ * The initial CID exchanged during handshake has sequence 0.
+ */
+#define QUIC_CONNID_INITIAL_SEQUENCE 0
+
+/**
+ * @brief Sequence number for preferred_address CID.
+ *
+ * If preferred_address transport parameter is sent, its CID has sequence 1.
+ */
+#define QUIC_CONNID_PREFERRED_ADDRESS_SEQUENCE 1
+
+/**
+ * @brief Default active_connection_id_limit.
+ *
+ * Minimum value that endpoints must support (RFC 9000 Section 18.2).
+ */
+#define QUIC_CONNID_DEFAULT_LIMIT 2
+
+/* ============================================================================
+ * Data Structures
+ * ============================================================================
+ */
+
+/**
+ * @brief QUIC Connection ID structure.
+ *
+ * Represents a single Connection ID with its associated metadata.
+ * Connection IDs are used in packet headers to route packets.
+ */
+typedef struct SocketQUICConnectionID
+{
+  uint8_t data[QUIC_CONNID_MAX_LEN]; /**< Raw Connection ID bytes */
+  uint8_t len;                       /**< Length of Connection ID (0-20) */
+
+  uint64_t sequence; /**< Sequence number assigned to this CID */
+
+  uint8_t stateless_reset_token[QUIC_STATELESS_RESET_TOKEN_LEN];
+  /**< 16-byte stateless reset token */
+
+  int has_reset_token; /**< Non-zero if reset token is valid */
+
+} SocketQUICConnectionID_T;
+
+/**
+ * @brief Result codes for Connection ID operations.
+ */
+typedef enum
+{
+  QUIC_CONNID_OK = 0,            /**< Operation succeeded */
+  QUIC_CONNID_ERROR_NULL,        /**< NULL pointer argument */
+  QUIC_CONNID_ERROR_LENGTH,      /**< Invalid CID length */
+  QUIC_CONNID_ERROR_BUFFER,      /**< Output buffer too small */
+  QUIC_CONNID_ERROR_INCOMPLETE,  /**< Need more input data */
+  QUIC_CONNID_ERROR_RANDOM       /**< Random generation failed */
+} SocketQUICConnectionID_Result;
+
+/* ============================================================================
+ * Initialization Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Initialize a Connection ID structure.
+ *
+ * Zeros all fields. Call this before using a CID structure.
+ *
+ * @param cid Connection ID structure to initialize.
+ */
+extern void SocketQUICConnectionID_init (SocketQUICConnectionID_T *cid);
+
+/**
+ * @brief Initialize a Connection ID with specific data.
+ *
+ * Copies the provided bytes into the CID structure.
+ *
+ * @param cid   Connection ID structure to initialize.
+ * @param data  Raw Connection ID bytes.
+ * @param len   Length of data (0-20).
+ *
+ * @return QUIC_CONNID_OK on success, error code otherwise.
+ */
+extern SocketQUICConnectionID_Result
+SocketQUICConnectionID_set (SocketQUICConnectionID_T *cid, const uint8_t *data,
+                            size_t len);
+
+/* ============================================================================
+ * Generation Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Generate a random Connection ID.
+ *
+ * Creates a cryptographically random CID of the specified length.
+ * Uses the system's secure random number generator.
+ *
+ * @param cid Connection ID structure to populate.
+ * @param len Desired length (1-20). Use 0 for zero-length CID.
+ *
+ * @return QUIC_CONNID_OK on success, error code otherwise.
+ *
+ * @note The sequence number is NOT set by this function.
+ *       Set it separately after calling this.
+ */
+extern SocketQUICConnectionID_Result
+SocketQUICConnectionID_generate (SocketQUICConnectionID_T *cid, size_t len);
+
+/**
+ * @brief Generate a random Stateless Reset Token.
+ *
+ * Creates a cryptographically random 16-byte token.
+ *
+ * @param cid Connection ID structure to populate token in.
+ *
+ * @return QUIC_CONNID_OK on success, error code otherwise.
+ */
+extern SocketQUICConnectionID_Result
+SocketQUICConnectionID_generate_reset_token (SocketQUICConnectionID_T *cid);
+
+/* ============================================================================
+ * Comparison Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Compare two Connection IDs for equality.
+ *
+ * Compares only the CID data and length, not sequence or reset token.
+ *
+ * @param a First Connection ID.
+ * @param b Second Connection ID.
+ *
+ * @return 1 if equal, 0 if not equal or either is NULL.
+ */
+extern int SocketQUICConnectionID_equal (const SocketQUICConnectionID_T *a,
+                                         const SocketQUICConnectionID_T *b);
+
+/**
+ * @brief Compare a Connection ID with raw bytes.
+ *
+ * @param cid  Connection ID structure.
+ * @param data Raw bytes to compare.
+ * @param len  Length of data.
+ *
+ * @return 1 if equal, 0 otherwise.
+ */
+extern int SocketQUICConnectionID_equal_raw (const SocketQUICConnectionID_T *cid,
+                                             const uint8_t *data, size_t len);
+
+/**
+ * @brief Copy a Connection ID.
+ *
+ * Copies all fields from src to dst.
+ *
+ * @param dst Destination Connection ID.
+ * @param src Source Connection ID.
+ *
+ * @return QUIC_CONNID_OK on success, error code otherwise.
+ */
+extern SocketQUICConnectionID_Result
+SocketQUICConnectionID_copy (SocketQUICConnectionID_T *dst,
+                             const SocketQUICConnectionID_T *src);
+
+/* ============================================================================
+ * Wire Format Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode Connection ID length for long header packets.
+ *
+ * In long header packets, the CID length is encoded as a single byte.
+ *
+ * @param cid         Connection ID to encode length for.
+ * @param output      Output buffer.
+ * @param output_size Size of output buffer.
+ *
+ * @return Number of bytes written (1), or 0 on error.
+ */
+extern size_t
+SocketQUICConnectionID_encode_length (const SocketQUICConnectionID_T *cid,
+                                      uint8_t *output, size_t output_size);
+
+/**
+ * @brief Encode Connection ID for packet header.
+ *
+ * Writes the raw CID bytes without length prefix.
+ *
+ * @param cid         Connection ID to encode.
+ * @param output      Output buffer.
+ * @param output_size Size of output buffer.
+ *
+ * @return Number of bytes written, or 0 on error.
+ */
+extern size_t SocketQUICConnectionID_encode (const SocketQUICConnectionID_T *cid,
+                                             uint8_t *output, size_t output_size);
+
+/**
+ * @brief Encode Connection ID with length prefix.
+ *
+ * Writes length byte followed by CID bytes. Used in long header packets.
+ *
+ * @param cid         Connection ID to encode.
+ * @param output      Output buffer.
+ * @param output_size Size of output buffer.
+ *
+ * @return Number of bytes written (1 + len), or 0 on error.
+ */
+extern size_t
+SocketQUICConnectionID_encode_with_length (const SocketQUICConnectionID_T *cid,
+                                           uint8_t *output, size_t output_size);
+
+/**
+ * @brief Decode Connection ID from packet with length prefix.
+ *
+ * Reads a length byte followed by CID bytes.
+ *
+ * @param data     Input buffer.
+ * @param len      Size of input buffer.
+ * @param cid      Output Connection ID structure.
+ * @param consumed Output: number of bytes consumed.
+ *
+ * @return QUIC_CONNID_OK on success, error code otherwise.
+ */
+extern SocketQUICConnectionID_Result
+SocketQUICConnectionID_decode (const uint8_t *data, size_t len,
+                               SocketQUICConnectionID_T *cid, size_t *consumed);
+
+/**
+ * @brief Decode Connection ID with known length.
+ *
+ * Reads exactly cid_len bytes as the CID (no length prefix).
+ *
+ * @param data    Input buffer.
+ * @param len     Size of input buffer.
+ * @param cid     Output Connection ID structure.
+ * @param cid_len Expected CID length.
+ *
+ * @return QUIC_CONNID_OK on success, error code otherwise.
+ */
+extern SocketQUICConnectionID_Result
+SocketQUICConnectionID_decode_fixed (const uint8_t *data, size_t len,
+                                     SocketQUICConnectionID_T *cid,
+                                     size_t cid_len);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Compute hash of Connection ID for hash tables.
+ *
+ * Returns a hash suitable for use in hash table lookups.
+ *
+ * @param cid Connection ID to hash.
+ *
+ * @return Hash value.
+ */
+extern uint32_t SocketQUICConnectionID_hash (const SocketQUICConnectionID_T *cid);
+
+/**
+ * @brief Check if Connection ID is zero-length.
+ *
+ * @param cid Connection ID to check.
+ *
+ * @return 1 if zero-length, 0 otherwise.
+ */
+static inline int
+SocketQUICConnectionID_is_empty (const SocketQUICConnectionID_T *cid)
+{
+  return (cid == NULL || cid->len == 0);
+}
+
+/**
+ * @brief Check if Connection ID length is valid.
+ *
+ * @param len Length to check.
+ *
+ * @return 1 if valid (0-20), 0 otherwise.
+ */
+static inline int
+SocketQUICConnectionID_is_valid_length (size_t len)
+{
+  return (len <= QUIC_CONNID_MAX_LEN);
+}
+
+/**
+ * @brief Get string representation of result code.
+ *
+ * @param result Result code to convert.
+ *
+ * @return Human-readable string describing the result.
+ */
+extern const char *
+SocketQUICConnectionID_result_string (SocketQUICConnectionID_Result result);
+
+/**
+ * @brief Format Connection ID as hex string.
+ *
+ * Writes the CID as a hex string to the provided buffer.
+ * Format: "XX:XX:XX:..." for non-empty CIDs, "empty" for zero-length.
+ *
+ * @param cid  Connection ID to format.
+ * @param buf  Output buffer for string.
+ * @param size Size of output buffer.
+ *
+ * @return Number of characters written (excluding null), or -1 on error.
+ */
+extern int SocketQUICConnectionID_to_hex (const SocketQUICConnectionID_T *cid,
+                                          char *buf, size_t size);
+
+/** @} */
+
+#endif /* SOCKETQUICCONNECTIONID_INCLUDED */

--- a/src/fuzz/fuzz_quic_connid.c
+++ b/src/fuzz/fuzz_quic_connid.c
@@ -1,0 +1,271 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_connid.c - libFuzzer harness for QUIC Connection IDs
+ *
+ * Part of the Socket Library Fuzzing Suite
+ *
+ * Targets:
+ * - Connection ID initialization and setting
+ * - Wire format decoding with arbitrary input
+ * - Encoding/decoding round-trips
+ * - Hash function with various inputs
+ * - Comparison functions
+ *
+ * Build: CC=clang cmake .. -DENABLE_FUZZING=ON && make fuzz_quic_connid
+ * Run:   ./fuzz_quic_connid -fork=16 -max_len=64
+ */
+
+#include <assert.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "quic/SocketQUICConnectionID.h"
+
+/**
+ * LLVMFuzzerTestOneInput - libFuzzer entry point
+ */
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 1)
+    return 0;
+
+  /* Extract operation from first byte */
+  uint8_t op = data[0] % 8;
+
+  switch (op)
+    {
+    case 0:
+      {
+        /* Test Connection ID set with arbitrary data */
+        SocketQUICConnectionID_T cid;
+        size_t len = (size > 1) ? data[1] % 25 : 0; /* Include invalid lengths */
+
+        SocketQUICConnectionID_Result res
+            = SocketQUICConnectionID_set (&cid, data + 2, len);
+
+        if (len <= QUIC_CONNID_MAX_LEN && size >= 2 + len)
+          {
+            assert (res == QUIC_CONNID_OK);
+            assert (cid.len == len);
+          }
+        else if (len > QUIC_CONNID_MAX_LEN)
+          {
+            assert (res == QUIC_CONNID_ERROR_LENGTH);
+          }
+      }
+      break;
+
+    case 1:
+      {
+        /* Test Connection ID decode with length prefix */
+        if (size < 2)
+          return 0;
+
+        SocketQUICConnectionID_T cid;
+        size_t consumed = 0;
+
+        SocketQUICConnectionID_Result res
+            = SocketQUICConnectionID_decode (data + 1, size - 1, &cid,
+                                             &consumed);
+
+        if (res == QUIC_CONNID_OK)
+          {
+            assert (consumed >= 1);
+            assert (consumed <= size - 1);
+            assert (cid.len <= QUIC_CONNID_MAX_LEN);
+
+            /* Verify round-trip */
+            uint8_t buf[25];
+            size_t encoded
+                = SocketQUICConnectionID_encode_with_length (&cid, buf,
+                                                             sizeof (buf));
+            assert (encoded == consumed);
+            assert (memcmp (buf, data + 1, consumed) == 0);
+          }
+      }
+      break;
+
+    case 2:
+      {
+        /* Test Connection ID decode with fixed length */
+        if (size < 2)
+          return 0;
+
+        SocketQUICConnectionID_T cid;
+        size_t cid_len = data[1] % 25;
+
+        SocketQUICConnectionID_Result res
+            = SocketQUICConnectionID_decode_fixed (data + 2, size - 2, &cid,
+                                                   cid_len);
+
+        if (res == QUIC_CONNID_OK)
+          {
+            assert (cid.len == cid_len);
+            assert (cid.len <= QUIC_CONNID_MAX_LEN);
+          }
+      }
+      break;
+
+    case 3:
+      {
+        /* Test Connection ID comparison */
+        SocketQUICConnectionID_T cid1, cid2;
+
+        if (size < 4)
+          return 0;
+
+        size_t len1 = data[1] % (QUIC_CONNID_MAX_LEN + 1);
+        size_t len2 = data[2] % (QUIC_CONNID_MAX_LEN + 1);
+
+        if (size >= 3 + len1)
+          SocketQUICConnectionID_set (&cid1, data + 3, len1);
+        else
+          SocketQUICConnectionID_init (&cid1);
+
+        if (size >= 3 + len1 + len2)
+          SocketQUICConnectionID_set (&cid2, data + 3 + len1, len2);
+        else
+          SocketQUICConnectionID_init (&cid2);
+
+        int eq = SocketQUICConnectionID_equal (&cid1, &cid2);
+
+        /* Verify equality is reflexive */
+        assert (SocketQUICConnectionID_equal (&cid1, &cid1));
+        assert (SocketQUICConnectionID_equal (&cid2, &cid2));
+
+        /* Verify equality is symmetric */
+        assert (eq == SocketQUICConnectionID_equal (&cid2, &cid1));
+      }
+      break;
+
+    case 4:
+      {
+        /* Test hash function */
+        SocketQUICConnectionID_T cid;
+
+        if (size < 2)
+          return 0;
+
+        size_t len = data[1] % (QUIC_CONNID_MAX_LEN + 1);
+
+        if (size >= 2 + len)
+          SocketQUICConnectionID_set (&cid, data + 2, len);
+        else
+          SocketQUICConnectionID_init (&cid);
+
+        uint32_t hash1 = SocketQUICConnectionID_hash (&cid);
+        uint32_t hash2 = SocketQUICConnectionID_hash (&cid);
+
+        /* Hash should be deterministic */
+        assert (hash1 == hash2);
+      }
+      break;
+
+    case 5:
+      {
+        /* Test encoding functions */
+        SocketQUICConnectionID_T cid;
+        uint8_t buf[25];
+
+        if (size < 2)
+          return 0;
+
+        size_t len = data[1] % (QUIC_CONNID_MAX_LEN + 1);
+
+        if (size >= 2 + len)
+          SocketQUICConnectionID_set (&cid, data + 2, len);
+        else
+          SocketQUICConnectionID_init (&cid);
+
+        /* Test all encoding functions */
+        size_t n1 = SocketQUICConnectionID_encode_length (&cid, buf,
+                                                          sizeof (buf));
+        assert (n1 == 1);
+        assert (buf[0] == cid.len);
+
+        if (cid.len > 0)
+          {
+            size_t n2 = SocketQUICConnectionID_encode (&cid, buf, sizeof (buf));
+            assert (n2 == cid.len);
+          }
+
+        size_t n3 = SocketQUICConnectionID_encode_with_length (&cid, buf,
+                                                               sizeof (buf));
+        assert (n3 == 1 + cid.len);
+      }
+      break;
+
+    case 6:
+      {
+        /* Test copy function */
+        SocketQUICConnectionID_T src, dst;
+
+        if (size < 2)
+          return 0;
+
+        size_t len = data[1] % (QUIC_CONNID_MAX_LEN + 1);
+
+        if (size >= 2 + len)
+          SocketQUICConnectionID_set (&src, data + 2, len);
+        else
+          SocketQUICConnectionID_init (&src);
+
+        src.sequence = 42;
+
+        SocketQUICConnectionID_Result res
+            = SocketQUICConnectionID_copy (&dst, &src);
+
+        assert (res == QUIC_CONNID_OK);
+        assert (SocketQUICConnectionID_equal (&dst, &src));
+        assert (dst.sequence == 42);
+      }
+      break;
+
+    case 7:
+      {
+        /* Test hex formatting */
+        SocketQUICConnectionID_T cid;
+        char buf[100];
+
+        if (size < 2)
+          return 0;
+
+        size_t len = data[1] % (QUIC_CONNID_MAX_LEN + 1);
+
+        if (size >= 2 + len)
+          SocketQUICConnectionID_set (&cid, data + 2, len);
+        else
+          SocketQUICConnectionID_init (&cid);
+
+        int n = SocketQUICConnectionID_to_hex (&cid, buf, sizeof (buf));
+
+        if (cid.len == 0)
+          {
+            assert (n == 5); /* "empty" */
+            assert (strcmp (buf, "empty") == 0);
+          }
+        else
+          {
+            assert (n > 0);
+            assert ((size_t)n == cid.len * 3 - 1); /* "XX:XX:..." */
+          }
+      }
+      break;
+    }
+
+  /* Exercise is_empty and is_valid_length with all input bytes */
+  for (size_t i = 0; i < size && i < 30; i++)
+    {
+      int valid = SocketQUICConnectionID_is_valid_length (data[i]);
+      assert (valid == (data[i] <= QUIC_CONNID_MAX_LEN));
+    }
+
+  return 0;
+}

--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -1,0 +1,368 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQUICConnectionID.c - QUIC Connection ID Management (RFC 9000 §5.1)
+ *
+ * Implements Connection ID generation, comparison, encoding/decoding,
+ * and utility functions.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "quic/SocketQUICConnectionID.h"
+
+/* Use getrandom() on Linux, arc4random_buf() on BSD/macOS */
+#ifdef __linux__
+#include <sys/random.h>
+#define SECURE_RANDOM(buf, len) (getrandom ((buf), (len), 0) == (ssize_t)(len))
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <stdlib.h>
+#define SECURE_RANDOM(buf, len)                                               \
+  (arc4random_buf ((buf), (len)), 1) /* Always succeeds */
+#else
+/* Fallback to /dev/urandom */
+#include <fcntl.h>
+#include <unistd.h>
+static int
+secure_random_fallback (void *buf, size_t len)
+{
+  int fd = open ("/dev/urandom", O_RDONLY);
+  if (fd < 0)
+    return 0;
+  ssize_t n = read (fd, buf, len);
+  close (fd);
+  return (n == (ssize_t)len);
+}
+#define SECURE_RANDOM(buf, len) secure_random_fallback ((buf), (len))
+#endif
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QUIC_CONNID_OK] = "OK",
+  [QUIC_CONNID_ERROR_NULL] = "NULL pointer argument",
+  [QUIC_CONNID_ERROR_LENGTH] = "Invalid Connection ID length",
+  [QUIC_CONNID_ERROR_BUFFER] = "Output buffer too small",
+  [QUIC_CONNID_ERROR_INCOMPLETE] = "Need more input data",
+  [QUIC_CONNID_ERROR_RANDOM] = "Random generation failed",
+};
+
+const char *
+SocketQUICConnectionID_result_string (SocketQUICConnectionID_Result result)
+{
+  if (result < 0 || result > QUIC_CONNID_ERROR_RANDOM)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Initialization Functions
+ * ============================================================================
+ */
+
+void
+SocketQUICConnectionID_init (SocketQUICConnectionID_T *cid)
+{
+  if (cid == NULL)
+    return;
+
+  memset (cid, 0, sizeof (*cid));
+}
+
+SocketQUICConnectionID_Result
+SocketQUICConnectionID_set (SocketQUICConnectionID_T *cid, const uint8_t *data,
+                            size_t len)
+{
+  if (cid == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
+  if (len > QUIC_CONNID_MAX_LEN)
+    return QUIC_CONNID_ERROR_LENGTH;
+
+  SocketQUICConnectionID_init (cid);
+
+  if (len > 0 && data != NULL)
+    memcpy (cid->data, data, len);
+
+  cid->len = (uint8_t)len;
+  return QUIC_CONNID_OK;
+}
+
+/* ============================================================================
+ * Generation Functions
+ * ============================================================================
+ */
+
+SocketQUICConnectionID_Result
+SocketQUICConnectionID_generate (SocketQUICConnectionID_T *cid, size_t len)
+{
+  if (cid == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
+  if (len > QUIC_CONNID_MAX_LEN)
+    return QUIC_CONNID_ERROR_LENGTH;
+
+  SocketQUICConnectionID_init (cid);
+  cid->len = (uint8_t)len;
+
+  if (len > 0)
+    {
+      if (!SECURE_RANDOM (cid->data, len))
+        return QUIC_CONNID_ERROR_RANDOM;
+    }
+
+  return QUIC_CONNID_OK;
+}
+
+SocketQUICConnectionID_Result
+SocketQUICConnectionID_generate_reset_token (SocketQUICConnectionID_T *cid)
+{
+  if (cid == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
+  if (!SECURE_RANDOM (cid->stateless_reset_token, QUIC_STATELESS_RESET_TOKEN_LEN))
+    return QUIC_CONNID_ERROR_RANDOM;
+
+  cid->has_reset_token = 1;
+  return QUIC_CONNID_OK;
+}
+
+/* ============================================================================
+ * Comparison Functions
+ * ============================================================================
+ */
+
+int
+SocketQUICConnectionID_equal (const SocketQUICConnectionID_T *a,
+                              const SocketQUICConnectionID_T *b)
+{
+  if (a == NULL || b == NULL)
+    return 0;
+
+  if (a->len != b->len)
+    return 0;
+
+  if (a->len == 0)
+    return 1; /* Both zero-length CIDs are equal */
+
+  return (memcmp (a->data, b->data, a->len) == 0);
+}
+
+int
+SocketQUICConnectionID_equal_raw (const SocketQUICConnectionID_T *cid,
+                                  const uint8_t *data, size_t len)
+{
+  if (cid == NULL)
+    return 0;
+
+  if (cid->len != len)
+    return 0;
+
+  if (len == 0)
+    return 1;
+
+  if (data == NULL)
+    return 0;
+
+  return (memcmp (cid->data, data, len) == 0);
+}
+
+SocketQUICConnectionID_Result
+SocketQUICConnectionID_copy (SocketQUICConnectionID_T *dst,
+                             const SocketQUICConnectionID_T *src)
+{
+  if (dst == NULL || src == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
+  memcpy (dst, src, sizeof (*dst));
+  return QUIC_CONNID_OK;
+}
+
+/* ============================================================================
+ * Wire Format Functions
+ * ============================================================================
+ */
+
+size_t
+SocketQUICConnectionID_encode_length (const SocketQUICConnectionID_T *cid,
+                                      uint8_t *output, size_t output_size)
+{
+  if (cid == NULL || output == NULL)
+    return 0;
+
+  if (output_size < 1)
+    return 0;
+
+  output[0] = cid->len;
+  return 1;
+}
+
+size_t
+SocketQUICConnectionID_encode (const SocketQUICConnectionID_T *cid,
+                               uint8_t *output, size_t output_size)
+{
+  if (cid == NULL)
+    return 0;
+
+  if (cid->len == 0)
+    return 0; /* Nothing to write */
+
+  if (output == NULL || output_size < cid->len)
+    return 0;
+
+  memcpy (output, cid->data, cid->len);
+  return cid->len;
+}
+
+size_t
+SocketQUICConnectionID_encode_with_length (const SocketQUICConnectionID_T *cid,
+                                           uint8_t *output, size_t output_size)
+{
+  size_t total;
+
+  if (cid == NULL || output == NULL)
+    return 0;
+
+  total = 1 + cid->len;
+
+  if (output_size < total)
+    return 0;
+
+  output[0] = cid->len;
+
+  if (cid->len > 0)
+    memcpy (output + 1, cid->data, cid->len);
+
+  return total;
+}
+
+SocketQUICConnectionID_Result
+SocketQUICConnectionID_decode (const uint8_t *data, size_t len,
+                               SocketQUICConnectionID_T *cid, size_t *consumed)
+{
+  uint8_t cid_len;
+
+  if (data == NULL || cid == NULL || consumed == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
+  if (len < 1)
+    return QUIC_CONNID_ERROR_INCOMPLETE;
+
+  cid_len = data[0];
+
+  if (cid_len > QUIC_CONNID_MAX_LEN)
+    return QUIC_CONNID_ERROR_LENGTH;
+
+  if (len < 1 + (size_t)cid_len)
+    return QUIC_CONNID_ERROR_INCOMPLETE;
+
+  SocketQUICConnectionID_init (cid);
+  cid->len = cid_len;
+
+  if (cid_len > 0)
+    memcpy (cid->data, data + 1, cid_len);
+
+  *consumed = 1 + cid_len;
+  return QUIC_CONNID_OK;
+}
+
+SocketQUICConnectionID_Result
+SocketQUICConnectionID_decode_fixed (const uint8_t *data, size_t len,
+                                     SocketQUICConnectionID_T *cid,
+                                     size_t cid_len)
+{
+  if (data == NULL || cid == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
+  if (cid_len > QUIC_CONNID_MAX_LEN)
+    return QUIC_CONNID_ERROR_LENGTH;
+
+  if (len < cid_len)
+    return QUIC_CONNID_ERROR_INCOMPLETE;
+
+  SocketQUICConnectionID_init (cid);
+  cid->len = (uint8_t)cid_len;
+
+  if (cid_len > 0)
+    memcpy (cid->data, data, cid_len);
+
+  return QUIC_CONNID_OK;
+}
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+uint32_t
+SocketQUICConnectionID_hash (const SocketQUICConnectionID_T *cid)
+{
+  uint32_t hash;
+  size_t i;
+
+  if (cid == NULL || cid->len == 0)
+    return 0;
+
+  /* FNV-1a hash */
+  hash = 2166136261u;
+
+  for (i = 0; i < cid->len; i++)
+    {
+      hash ^= cid->data[i];
+      hash *= 16777619u;
+    }
+
+  return hash;
+}
+
+int
+SocketQUICConnectionID_to_hex (const SocketQUICConnectionID_T *cid, char *buf,
+                               size_t size)
+{
+  static const char hex[] = "0123456789abcdef";
+  size_t pos;
+  size_t i;
+
+  if (buf == NULL || size == 0)
+    return -1;
+
+  if (cid == NULL || cid->len == 0)
+    {
+      if (size < 6)
+        {
+          buf[0] = '\0';
+          return -1;
+        }
+      memcpy (buf, "empty", 6);
+      return 5;
+    }
+
+  /* Format: "XX:XX:XX..." requires 3*len-1 chars + null */
+  if (size < (size_t)(cid->len * 3))
+    {
+      buf[0] = '\0';
+      return -1;
+    }
+
+  pos = 0;
+
+  for (i = 0; i < cid->len; i++)
+    {
+      if (i > 0)
+        buf[pos++] = ':';
+
+      buf[pos++] = hex[(cid->data[i] >> 4) & 0x0f];
+      buf[pos++] = hex[cid->data[i] & 0x0f];
+    }
+
+  buf[pos] = '\0';
+  return (int)pos;
+}

--- a/src/test/test_quic_connid.c
+++ b/src/test/test_quic_connid.c
@@ -1,0 +1,679 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_quic_connid.c - QUIC Connection ID unit tests (RFC 9000 §5.1)
+ *
+ * Tests Connection ID structure, generation, comparison, encoding/decoding,
+ * and utility functions.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "quic/SocketQUICConnectionID.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Constant Value Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_max_len)
+{
+  ASSERT_EQ (QUIC_CONNID_MAX_LEN, 20);
+}
+
+TEST (quic_connid_min_len)
+{
+  ASSERT_EQ (QUIC_CONNID_MIN_LEN, 1);
+}
+
+TEST (quic_connid_reset_token_len)
+{
+  ASSERT_EQ (QUIC_STATELESS_RESET_TOKEN_LEN, 16);
+}
+
+TEST (quic_connid_initial_sequence)
+{
+  ASSERT_EQ (QUIC_CONNID_INITIAL_SEQUENCE, 0);
+}
+
+TEST (quic_connid_preferred_address_sequence)
+{
+  ASSERT_EQ (QUIC_CONNID_PREFERRED_ADDRESS_SEQUENCE, 1);
+}
+
+TEST (quic_connid_default_limit)
+{
+  ASSERT_EQ (QUIC_CONNID_DEFAULT_LIMIT, 2);
+}
+
+/* ============================================================================
+ * Initialization Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_init)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_init (&cid);
+
+  ASSERT_EQ (cid.len, 0);
+  ASSERT_EQ (cid.sequence, 0);
+  ASSERT_EQ (cid.has_reset_token, 0);
+}
+
+TEST (quic_connid_init_null)
+{
+  /* Should not crash */
+  SocketQUICConnectionID_init (NULL);
+}
+
+TEST (quic_connid_set_basic)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t data[] = { 0x01, 0x02, 0x03, 0x04, 0x05 };
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_set (&cid, data, sizeof (data));
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 5);
+  ASSERT (memcmp (cid.data, data, 5) == 0);
+}
+
+TEST (quic_connid_set_max_len)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t data[20];
+
+  memset (data, 0xAB, sizeof (data));
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_set (&cid, data, 20);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 20);
+}
+
+TEST (quic_connid_set_zero_len)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_set (&cid, NULL, 0);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 0);
+}
+
+TEST (quic_connid_set_too_long)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t data[25] = { 0 };
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_set (&cid, data, 21);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_LENGTH);
+}
+
+TEST (quic_connid_set_null)
+{
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_set (NULL, NULL, 0);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_NULL);
+}
+
+/* ============================================================================
+ * Generation Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_generate_basic)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_generate (&cid, 8);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 8);
+}
+
+TEST (quic_connid_generate_max_len)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_generate (&cid, 20);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 20);
+}
+
+TEST (quic_connid_generate_zero_len)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_generate (&cid, 0);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 0);
+}
+
+TEST (quic_connid_generate_too_long)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_generate (&cid, 21);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_LENGTH);
+}
+
+TEST (quic_connid_generate_null)
+{
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_generate (NULL, 8);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_NULL);
+}
+
+TEST (quic_connid_generate_unique)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+
+  SocketQUICConnectionID_generate (&cid1, 8);
+  SocketQUICConnectionID_generate (&cid2, 8);
+
+  /* Two random CIDs should be different (with overwhelming probability) */
+  ASSERT (!SocketQUICConnectionID_equal (&cid1, &cid2));
+}
+
+TEST (quic_connid_generate_reset_token)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_init (&cid);
+  ASSERT_EQ (cid.has_reset_token, 0);
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_generate_reset_token (&cid);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.has_reset_token, 1);
+}
+
+TEST (quic_connid_generate_reset_token_null)
+{
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_generate_reset_token (NULL);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_NULL);
+}
+
+/* ============================================================================
+ * Comparison Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_equal_same)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+  const uint8_t data[] = { 0x01, 0x02, 0x03, 0x04 };
+
+  SocketQUICConnectionID_set (&cid1, data, 4);
+  SocketQUICConnectionID_set (&cid2, data, 4);
+
+  ASSERT (SocketQUICConnectionID_equal (&cid1, &cid2));
+}
+
+TEST (quic_connid_equal_different_data)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+  const uint8_t data1[] = { 0x01, 0x02, 0x03, 0x04 };
+  const uint8_t data2[] = { 0x01, 0x02, 0x03, 0x05 };
+
+  SocketQUICConnectionID_set (&cid1, data1, 4);
+  SocketQUICConnectionID_set (&cid2, data2, 4);
+
+  ASSERT (!SocketQUICConnectionID_equal (&cid1, &cid2));
+}
+
+TEST (quic_connid_equal_different_len)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+  const uint8_t data[] = { 0x01, 0x02, 0x03, 0x04 };
+
+  SocketQUICConnectionID_set (&cid1, data, 4);
+  SocketQUICConnectionID_set (&cid2, data, 3);
+
+  ASSERT (!SocketQUICConnectionID_equal (&cid1, &cid2));
+}
+
+TEST (quic_connid_equal_zero_len)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+
+  SocketQUICConnectionID_set (&cid1, NULL, 0);
+  SocketQUICConnectionID_set (&cid2, NULL, 0);
+
+  ASSERT (SocketQUICConnectionID_equal (&cid1, &cid2));
+}
+
+TEST (quic_connid_equal_null)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_init (&cid);
+
+  ASSERT (!SocketQUICConnectionID_equal (NULL, &cid));
+  ASSERT (!SocketQUICConnectionID_equal (&cid, NULL));
+  ASSERT (!SocketQUICConnectionID_equal (NULL, NULL));
+}
+
+TEST (quic_connid_equal_raw)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t data[] = { 0xAA, 0xBB, 0xCC };
+
+  SocketQUICConnectionID_set (&cid, data, 3);
+
+  ASSERT (SocketQUICConnectionID_equal_raw (&cid, data, 3));
+  ASSERT (!SocketQUICConnectionID_equal_raw (&cid, data, 2));
+}
+
+TEST (quic_connid_equal_raw_null)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_init (&cid);
+
+  ASSERT (!SocketQUICConnectionID_equal_raw (NULL, NULL, 0));
+}
+
+TEST (quic_connid_copy)
+{
+  SocketQUICConnectionID_T src, dst;
+  const uint8_t data[] = { 0x11, 0x22, 0x33, 0x44, 0x55 };
+
+  SocketQUICConnectionID_set (&src, data, 5);
+  src.sequence = 42;
+  src.has_reset_token = 1;
+  memset (src.stateless_reset_token, 0xAB, 16);
+
+  SocketQUICConnectionID_Result res = SocketQUICConnectionID_copy (&dst, &src);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT (SocketQUICConnectionID_equal (&dst, &src));
+  ASSERT_EQ (dst.sequence, 42);
+  ASSERT_EQ (dst.has_reset_token, 1);
+}
+
+TEST (quic_connid_copy_null)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_init (&cid);
+
+  ASSERT_EQ (SocketQUICConnectionID_copy (NULL, &cid), QUIC_CONNID_ERROR_NULL);
+  ASSERT_EQ (SocketQUICConnectionID_copy (&cid, NULL), QUIC_CONNID_ERROR_NULL);
+}
+
+/* ============================================================================
+ * Wire Format Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_encode_length)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t buf[1];
+
+  SocketQUICConnectionID_generate (&cid, 8);
+
+  size_t n = SocketQUICConnectionID_encode_length (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, 1);
+  ASSERT_EQ (buf[0], 8);
+}
+
+TEST (quic_connid_encode)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t data[] = { 0xDE, 0xAD, 0xBE, 0xEF };
+  uint8_t buf[20];
+
+  SocketQUICConnectionID_set (&cid, data, 4);
+
+  size_t n = SocketQUICConnectionID_encode (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, 4);
+  ASSERT (memcmp (buf, data, 4) == 0);
+}
+
+TEST (quic_connid_encode_zero_len)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t buf[1];
+
+  SocketQUICConnectionID_set (&cid, NULL, 0);
+
+  size_t n = SocketQUICConnectionID_encode (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, 0); /* Nothing to write for zero-length CID */
+}
+
+TEST (quic_connid_encode_buffer_too_small)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t buf[2];
+
+  SocketQUICConnectionID_generate (&cid, 8);
+
+  size_t n = SocketQUICConnectionID_encode (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, 0);
+}
+
+TEST (quic_connid_encode_with_length)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t data[] = { 0x11, 0x22, 0x33 };
+  uint8_t buf[10];
+
+  SocketQUICConnectionID_set (&cid, data, 3);
+
+  size_t n = SocketQUICConnectionID_encode_with_length (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, 4);
+  ASSERT_EQ (buf[0], 3);
+  ASSERT (memcmp (buf + 1, data, 3) == 0);
+}
+
+TEST (quic_connid_encode_with_length_zero)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t buf[10];
+
+  SocketQUICConnectionID_set (&cid, NULL, 0);
+
+  size_t n = SocketQUICConnectionID_encode_with_length (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, 1);
+  ASSERT_EQ (buf[0], 0);
+}
+
+TEST (quic_connid_decode)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t wire[] = { 0x04, 0xAA, 0xBB, 0xCC, 0xDD };
+  size_t consumed = 0;
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode (wire, sizeof (wire), &cid, &consumed);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (consumed, 5);
+  ASSERT_EQ (cid.len, 4);
+  ASSERT (memcmp (cid.data, wire + 1, 4) == 0);
+}
+
+TEST (quic_connid_decode_zero_len)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t wire[] = { 0x00 };
+  size_t consumed = 0;
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode (wire, sizeof (wire), &cid, &consumed);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (consumed, 1);
+  ASSERT_EQ (cid.len, 0);
+}
+
+TEST (quic_connid_decode_max_len)
+{
+  SocketQUICConnectionID_T cid;
+  uint8_t wire[21];
+  size_t consumed = 0;
+
+  wire[0] = 20;
+  memset (wire + 1, 0xFF, 20);
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode (wire, sizeof (wire), &cid, &consumed);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (consumed, 21);
+  ASSERT_EQ (cid.len, 20);
+}
+
+TEST (quic_connid_decode_incomplete)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t wire[] = { 0x04, 0xAA, 0xBB };
+  size_t consumed = 0;
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode (wire, sizeof (wire), &cid, &consumed);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_INCOMPLETE);
+}
+
+TEST (quic_connid_decode_too_long)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t wire[] = { 21, 0x00 }; /* Length 21 > max 20 */
+  size_t consumed = 0;
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode (wire, sizeof (wire), &cid, &consumed);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_LENGTH);
+}
+
+TEST (quic_connid_decode_fixed)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t wire[] = { 0x11, 0x22, 0x33, 0x44 };
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode_fixed (wire, sizeof (wire), &cid, 4);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (cid.len, 4);
+  ASSERT (memcmp (cid.data, wire, 4) == 0);
+}
+
+TEST (quic_connid_decode_fixed_incomplete)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t wire[] = { 0x11, 0x22 };
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode_fixed (wire, sizeof (wire), &cid, 4);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_INCOMPLETE);
+}
+
+/* ============================================================================
+ * Utility Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_hash)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+  const uint8_t data[] = { 0x01, 0x02, 0x03, 0x04 };
+
+  SocketQUICConnectionID_set (&cid1, data, 4);
+  SocketQUICConnectionID_set (&cid2, data, 4);
+
+  ASSERT_EQ (SocketQUICConnectionID_hash (&cid1),
+             SocketQUICConnectionID_hash (&cid2));
+}
+
+TEST (quic_connid_hash_different)
+{
+  SocketQUICConnectionID_T cid1, cid2;
+
+  SocketQUICConnectionID_generate (&cid1, 8);
+  SocketQUICConnectionID_generate (&cid2, 8);
+
+  /* Different CIDs should have different hashes (with high probability) */
+  ASSERT (SocketQUICConnectionID_hash (&cid1)
+          != SocketQUICConnectionID_hash (&cid2));
+}
+
+TEST (quic_connid_hash_empty)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_set (&cid, NULL, 0);
+
+  ASSERT_EQ (SocketQUICConnectionID_hash (&cid), 0);
+}
+
+TEST (quic_connid_hash_null)
+{
+  ASSERT_EQ (SocketQUICConnectionID_hash (NULL), 0);
+}
+
+TEST (quic_connid_is_empty)
+{
+  SocketQUICConnectionID_T cid;
+
+  SocketQUICConnectionID_set (&cid, NULL, 0);
+  ASSERT (SocketQUICConnectionID_is_empty (&cid));
+
+  SocketQUICConnectionID_generate (&cid, 4);
+  ASSERT (!SocketQUICConnectionID_is_empty (&cid));
+}
+
+TEST (quic_connid_is_empty_null)
+{
+  ASSERT (SocketQUICConnectionID_is_empty (NULL));
+}
+
+TEST (quic_connid_is_valid_length)
+{
+  ASSERT (SocketQUICConnectionID_is_valid_length (0));
+  ASSERT (SocketQUICConnectionID_is_valid_length (1));
+  ASSERT (SocketQUICConnectionID_is_valid_length (20));
+  ASSERT (!SocketQUICConnectionID_is_valid_length (21));
+  ASSERT (!SocketQUICConnectionID_is_valid_length (100));
+}
+
+TEST (quic_connid_to_hex)
+{
+  SocketQUICConnectionID_T cid;
+  const uint8_t data[] = { 0xAB, 0xCD, 0xEF };
+  char buf[20];
+
+  SocketQUICConnectionID_set (&cid, data, 3);
+
+  int n = SocketQUICConnectionID_to_hex (&cid, buf, sizeof (buf));
+
+  ASSERT (n > 0);
+  ASSERT (strcmp (buf, "ab:cd:ef") == 0);
+}
+
+TEST (quic_connid_to_hex_empty)
+{
+  SocketQUICConnectionID_T cid;
+  char buf[20];
+
+  SocketQUICConnectionID_set (&cid, NULL, 0);
+
+  int n = SocketQUICConnectionID_to_hex (&cid, buf, sizeof (buf));
+
+  ASSERT (n > 0);
+  ASSERT (strcmp (buf, "empty") == 0);
+}
+
+TEST (quic_connid_to_hex_buffer_small)
+{
+  SocketQUICConnectionID_T cid;
+  char buf[3];
+
+  SocketQUICConnectionID_generate (&cid, 8);
+
+  int n = SocketQUICConnectionID_to_hex (&cid, buf, sizeof (buf));
+
+  ASSERT_EQ (n, -1);
+}
+
+TEST (quic_connid_result_string)
+{
+  ASSERT (strcmp (SocketQUICConnectionID_result_string (QUIC_CONNID_OK), "OK")
+          == 0);
+  ASSERT (strstr (SocketQUICConnectionID_result_string (QUIC_CONNID_ERROR_NULL),
+                  "NULL")
+          != NULL);
+  ASSERT (
+      strstr (SocketQUICConnectionID_result_string (QUIC_CONNID_ERROR_LENGTH),
+              "length")
+      != NULL);
+}
+
+/* ============================================================================
+ * Round-Trip Tests
+ * ============================================================================
+ */
+
+TEST (quic_connid_encode_decode_roundtrip)
+{
+  SocketQUICConnectionID_T original, decoded;
+  uint8_t buf[25];
+  size_t consumed;
+
+  SocketQUICConnectionID_generate (&original, 12);
+
+  size_t encoded = SocketQUICConnectionID_encode_with_length (&original, buf,
+                                                              sizeof (buf));
+  ASSERT (encoded > 0);
+
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_decode (buf, encoded, &decoded, &consumed);
+
+  ASSERT_EQ (res, QUIC_CONNID_OK);
+  ASSERT_EQ (consumed, encoded);
+  ASSERT (SocketQUICConnectionID_equal (&original, &decoded));
+}
+
+TEST (quic_connid_roundtrip_all_lengths)
+{
+  for (size_t len = 0; len <= 20; len++)
+    {
+      SocketQUICConnectionID_T original, decoded;
+      uint8_t buf[25];
+      size_t consumed;
+
+      SocketQUICConnectionID_generate (&original, len);
+
+      size_t encoded = SocketQUICConnectionID_encode_with_length (&original, buf,
+                                                                  sizeof (buf));
+
+      SocketQUICConnectionID_Result res
+          = SocketQUICConnectionID_decode (buf, encoded, &decoded, &consumed);
+
+      ASSERT_EQ (res, QUIC_CONNID_OK);
+      ASSERT (SocketQUICConnectionID_equal (&original, &decoded));
+    }
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Implements QUIC Connection ID management per RFC 9000 Section 5.1
- Adds `SocketQUICConnectionID_T` structure with data, length, sequence, and stateless reset token
- Provides initialization, generation, comparison, encoding/decoding, and utility functions
- Uses secure random generation (getrandom/arc4random/urandom fallback)
- Implements FNV-1a hash for hash table lookups

Fixes #380

## Test plan
- [x] 56 new unit tests for Connection ID functionality
- [x] 8 fuzz test operations covering all code paths
- [x] All 91 tests pass with AddressSanitizer and UndefinedBehaviorSanitizer
- [x] Encoding/decoding round-trip verification
- [x] Edge cases: zero-length CIDs, max-length CIDs, NULL handling

## Files changed
- `include/quic/SocketQUICConnectionID.h` - Header with structures and declarations
- `src/quic/SocketQUICConnectionID.c` - Implementation
- `src/test/test_quic_connid.c` - Unit tests (56 tests)
- `src/fuzz/fuzz_quic_connid.c` - Fuzz harness (8 operations)
- `CMakeLists.txt` - Build integration