### PR TITLE
feat(quic): implement Error Handling (RFC 9000 Section 11)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -379,6 +379,7 @@ set(LIB_SOURCES
     # QUIC foundational module (RFC 9000)
     src/quic/SocketQUICVarInt.c
     src/quic/SocketQUICError.c
+    src/quic/SocketQUICError-handling.c
     src/quic/SocketQUICConnectionID.c
     src/quic/SocketQUICStream.c
     src/quic/SocketQUICPacket.c


### PR DESCRIPTION
## Summary

Implements connection-level and stream-level error handling with appropriate termination as specified in RFC 9000 Section 11.

## Changes

- **Error Classification**: Added `SocketQUIC_error_is_connection_fatal()` to determine if an error requires connection termination or can be handled at the stream level
- **CONNECTION_CLOSE**: Implemented `SocketQUIC_send_connection_close()` to properly encode and send CONNECTION_CLOSE frames (0x1c for transport errors, 0x1d for application errors)
- **RESET_STREAM**: Implemented `SocketQUIC_send_stream_reset()` to terminate individual streams without closing the connection
- **STOP_SENDING**: Implemented `SocketQUIC_send_stop_sending()` to request peer stop sending on a stream
- **Test Coverage**: Added 7 comprehensive tests covering all new functions and edge cases

## Key Requirements Met

- Connection errors trigger CONNECTION_CLOSE and close all streams
- Stream errors use RESET_STREAM or STOP_SENDING, connection continues
- Application can escalate stream error to connection error  
- Error code propagation to peer via proper frame encoding

## Test Plan

- [x] All QUIC tests pass (11/11)
- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] Error classification tests
- [x] CONNECTION_CLOSE frame encoding tests (transport and application)
- [x] RESET_STREAM frame encoding tests
- [x] STOP_SENDING frame encoding tests
- [x] NULL pointer handling tests

## Files Modified

- `include/quic/SocketQUICError.h`: Added error handling API
- `src/quic/SocketQUICError-handling.c`: Implementation (~250 lines)
- `src/test/test_quic_error.c`: Added error handling tests
- `CMakeLists.txt`: Added new source file to build

Closes #403