### PR TITLE
fix(quic): repair corrupted MAX frames implementation

### DIFF
--- a/src/quic/SocketQUICFrame-flow.c
+++ b/src/quic/SocketQUICFrame-flow.c
@@ -6,13 +6,12 @@
 
 /**
  * @file SocketQUICFrame-flow.c
- * @brief QUIC Flow Control Frame Encoding (RFC 9000 Sections 19.9-19.11).
- *
- * Implements encoding for MAX_DATA, MAX_STREAM_DATA, and MAX_STREAMS frames
- * which advertise flow control credit to peers.
- * @brief QUIC Flow Control Frame Encoding (RFC 9000 Sections 19.12-19.14).
+ * @brief QUIC Flow Control Frame Encoding (RFC 9000 Sections 19.9-19.14).
  *
  * Implements encoding for:
+ * - MAX_DATA (0x10) - Connection-level flow control limit
+ * - MAX_STREAM_DATA (0x11) - Stream-level flow control limit
+ * - MAX_STREAMS (0x12-0x13) - Stream limit
  * - DATA_BLOCKED (0x14) - Connection-level flow control blocking
  * - STREAM_DATA_BLOCKED (0x15) - Stream-level flow control blocking
  * - STREAMS_BLOCKED (0x16-0x17) - Stream limit blocking
@@ -59,7 +58,94 @@ SocketQUICFrame_encode_max_data (uint64_t max_data, uint8_t *out,
     return 0;
 
   pos += encoded;
-#include <string.h>
+
+  return pos;
+}
+
+/* ============================================================================
+ * MAX_STREAM_DATA Frame Encoding (RFC 9000 Section 19.10)
+ * ============================================================================
+ *
+ * Format:
+ *   Type (0x11)
+ *   Stream ID (varint)
+ *   Maximum Stream Data (varint)
+ */
+
+size_t
+SocketQUICFrame_encode_max_stream_data (uint64_t stream_id, uint64_t max_data,
+                                         uint8_t *out, size_t out_size)
+{
+  size_t pos;
+  size_t encoded;
+
+  if (!out)
+    return 0;
+
+  /* Need at least 1 byte for type + 2 bytes for minimum varints */
+  if (out_size < 3)
+    return 0;
+
+  pos = 0;
+
+  /* Type: 0x11 */
+  out[pos++] = QUIC_FRAME_MAX_STREAM_DATA;
+
+  /* Stream ID */
+  encoded = SocketQUICVarInt_encode (stream_id, out + pos, out_size - pos);
+  if (encoded == 0)
+    return 0;
+
+  pos += encoded;
+
+  /* Maximum Stream Data */
+  encoded = SocketQUICVarInt_encode (max_data, out + pos, out_size - pos);
+  if (encoded == 0)
+    return 0;
+
+  pos += encoded;
+
+  return pos;
+}
+
+/* ============================================================================
+ * MAX_STREAMS Frame Encoding (RFC 9000 Section 19.11)
+ * ============================================================================
+ *
+ * Format:
+ *   Type (0x12 for bidirectional, 0x13 for unidirectional)
+ *   Maximum Streams (varint)
+ */
+
+size_t
+SocketQUICFrame_encode_max_streams (int bidirectional, uint64_t max_streams,
+                                     uint8_t *out, size_t out_size)
+{
+  size_t pos;
+  size_t encoded;
+
+  if (!out)
+    return 0;
+
+  /* Need at least 1 byte for type + 1 byte for minimum varint */
+  if (out_size < 2)
+    return 0;
+
+  pos = 0;
+
+  /* Type: 0x12 (bidi) or 0x13 (uni) */
+  out[pos++] = bidirectional ? QUIC_FRAME_MAX_STREAMS_BIDI
+                              : QUIC_FRAME_MAX_STREAMS_UNI;
+
+  /* Maximum Streams */
+  encoded = SocketQUICVarInt_encode (max_streams, out + pos, out_size - pos);
+  if (encoded == 0)
+    return 0;
+
+  pos += encoded;
+
+  return pos;
+}
 
 /* ============================================================================
  * DATA_BLOCKED Frame Encoding (RFC 9000 Section 19.12)
@@ -116,47 +202,6 @@ SocketQUICFrame_encode_data_blocked (uint64_t max_data, uint8_t *out,
 }
 
 /* ============================================================================
- * MAX_STREAM_DATA Frame Encoding (RFC 9000 Section 19.10)
- * ============================================================================
- *
- * Format:
- *   Type (0x11)
- *   Stream ID (varint)
- *   Maximum Stream Data (varint)
- */
-
-size_t
-SocketQUICFrame_encode_max_stream_data (uint64_t stream_id, uint64_t max_data,
-                                         uint8_t *out, size_t out_size)
-{
-  size_t pos;
-  size_t encoded;
-
-  if (!out)
-    return 0;
-
-  /* Need at least 1 byte for type + 2 bytes for minimum varints */
-  if (out_size < 3)
-    return 0;
-
-  pos = 0;
-
-  /* Type: 0x11 */
-  out[pos++] = QUIC_FRAME_MAX_STREAM_DATA;
-
-  /* Stream ID */
-  encoded = SocketQUICVarInt_encode (stream_id, out + pos, out_size - pos);
-  if (encoded == 0)
-    return 0;
-
-  pos += encoded;
-
-  /* Maximum Stream Data */
-  encoded = SocketQUICVarInt_encode (max_data, out + pos, out_size - pos);
-  if (encoded == 0)
-    return 0;
-
-  pos += encoded;
  * STREAM_DATA_BLOCKED Frame Encoding (RFC 9000 Section 19.13)
  * ============================================================================
  */
@@ -222,40 +267,6 @@ SocketQUICFrame_encode_stream_data_blocked (uint64_t stream_id,
 }
 
 /* ============================================================================
- * MAX_STREAMS Frame Encoding (RFC 9000 Section 19.11)
- * ============================================================================
- *
- * Format:
- *   Type (0x12 for bidirectional, 0x13 for unidirectional)
- *   Maximum Streams (varint)
- */
-
-size_t
-SocketQUICFrame_encode_max_streams (int bidirectional, uint64_t max_streams,
-                                     uint8_t *out, size_t out_size)
-{
-  size_t pos;
-  size_t encoded;
-
-  if (!out)
-    return 0;
-
-  /* Need at least 1 byte for type + 1 byte for minimum varint */
-  if (out_size < 2)
-    return 0;
-
-  pos = 0;
-
-  /* Type: 0x12 (bidi) or 0x13 (uni) */
-  out[pos++] = bidirectional ? QUIC_FRAME_MAX_STREAMS_BIDI
-                              : QUIC_FRAME_MAX_STREAMS_UNI;
-
-  /* Maximum Streams */
-  encoded = SocketQUICVarInt_encode (max_streams, out + pos, out_size - pos);
-  if (encoded == 0)
-    return 0;
-
-  pos += encoded;
  * STREAMS_BLOCKED Frame Encoding (RFC 9000 Section 19.14)
  * ============================================================================
  */


### PR DESCRIPTION
## Summary
- Fix malformed source files where new MAX_DATA, MAX_STREAM_DATA, and MAX_STREAMS encoding functions were incorrectly merged with existing code
- SocketQUICFrame-flow.c: Add missing return statements, remove duplicate includes and garbage code inserted mid-function
- test_quic_frame.c: Fix duplicate variable declarations and restore proper test function structure

## Details

PR #436 was merged with corrupted code - the new MAX frames code was inserted mid-function without proper structure:

1. **Missing return statements**: All three new encode functions (`encode_max_data`, `encode_max_stream_data`, `encode_max_streams`) ended without a `return pos;` statement
2. **Duplicate includes**: `#include <string.h>` appeared in the middle of function bodies
3. **Interleaved code**: Test functions had duplicate variable declarations and mixed-up code blocks

The encoding functions now properly implement RFC 9000 §19.9-19.11 for MAX_DATA (0x10), MAX_STREAM_DATA (0x11), and MAX_STREAMS (0x12-0x13) frames.

## Test plan
- [x] Build with sanitizers passes
- [x] All test_quic_frame tests pass
- [x] No memory leaks detected