### PR TITLE
fix(skills): repair issue-processor pipeline and add missing scripts

### DIFF
--- a/.claude/skills/issue-processor/scripts/RESULT_FORMAT.md
+++ b/.claude/skills/issue-processor/scripts/RESULT_FORMAT.md
@@ -1,0 +1,106 @@
+# Result File Format
+
+This document describes the JSON format for issue implementation results.
+
+## Location
+
+Results are written to: `{state_dir}/results/{issue_number}.json`
+
+## Success Format
+
+```json
+{
+    "issue": 391,
+    "status": "success",
+    "pr_url": "https://github.com/owner/repo/pull/123",
+    "pr_number": 123,
+    "branch": "issue-391-feature-name",
+    "commits": 3,
+    "files_changed": 5,
+    "completed_at": "2025-01-15T10:30:00Z"
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue` | int | The GitHub issue number |
+| `status` | string | Must be `"success"` |
+| `pr_url` | string | Full URL to the created pull request |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `pr_number` | int | PR number (extracted from URL if not provided) |
+| `branch` | string | Branch name used for the implementation |
+| `commits` | int | Number of commits in the PR |
+| `files_changed` | int | Number of files modified |
+| `completed_at` | string | ISO 8601 timestamp |
+
+## Failure Format
+
+```json
+{
+    "issue": 392,
+    "status": "failed",
+    "error": "Build failed: undefined reference to SocketPool_drain",
+    "stage": "build",
+    "branch": "issue-392-fix-pool",
+    "failed_at": "2025-01-15T10:35:00Z"
+}
+```
+
+### Required Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `issue` | int | The GitHub issue number |
+| `status` | string | Must be `"failed"` |
+| `error` | string | Human-readable error description (max 100 chars recommended) |
+
+### Optional Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `stage` | string | Where failure occurred: `checkout`, `implement`, `build`, `test`, `commit`, `push`, `pr` |
+| `branch` | string | Branch name (for cleanup) |
+| `failed_at` | string | ISO 8601 timestamp |
+
+## Writing Results
+
+The issue-implementer agent should write results atomically:
+
+```python
+import json
+from pathlib import Path
+
+def write_result(state_dir: Path, issue_num: int, result: dict):
+    result_file = state_dir / "results" / f"{issue_num}.json"
+    tmp_file = result_file.with_suffix('.tmp')
+
+    with open(tmp_file, 'w') as f:
+        json.dump(result, f, indent=2)
+    tmp_file.rename(result_file)
+```
+
+## Example: Minimal Success
+
+```json
+{
+    "issue": 400,
+    "status": "success",
+    "pr_url": "https://github.com/7etsuo/tetsuo-socket/pull/450"
+}
+```
+
+## Example: Minimal Failure
+
+```json
+{
+    "issue": 401,
+    "status": "failed",
+    "error": "Tests timeout after 5 minutes"
+}
+```

--- a/.claude/skills/issue-processor/scripts/check_status.py
+++ b/.claude/skills/issue-processor/scripts/check_status.py
@@ -7,11 +7,13 @@ Usage:
     python check_status.py --state-dir DIR
 
 Output (one of):
-    READY:5/20           - Setup complete, ready to start
-    RUNNING:5/20         - Processing in progress
-    CHECKPOINT:batch_3   - Coordinator needs respawn
-    COMPLETED:20/20:18_success:2_failed
-    ERROR:message
+    READY:5/20                        - Setup complete, ready to start
+    RUNNING:5/20                      - Processing in progress
+    COMPLETED:20/20:18_success:2_fail - All issues processed
+    ERROR:message                     - Error occurred
+
+Note: CHECKPOINT status was removed as coordinator respawn is handled
+via manifest.json state rather than status.txt signaling.
 """
 
 import argparse

--- a/.claude/skills/issue-processor/scripts/next_batch.py
+++ b/.claude/skills/issue-processor/scripts/next_batch.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""
+Get the next batch of issues to process with their worktree paths.
+
+Reads manifest.json to find ready issues that haven't been completed,
+failed, or are in progress. Creates git worktrees for parallel development.
+
+Usage:
+    python next_batch.py --state-dir DIR --batch-size N [--create-worktrees]
+
+Output (JSON):
+    {
+        "batch": [
+            {"issue": 391, "worktree": "/path/to/repo-issue-391"},
+            {"issue": 392, "worktree": "/path/to/repo-issue-392"}
+        ],
+        "remaining": 5
+    }
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_git(args: list[str], cwd: str | None = None) -> tuple[bool, str]:
+    """Run git command and return (success, output)."""
+    result = subprocess.run(
+        ["git"] + args,
+        capture_output=True,
+        text=True,
+        cwd=cwd
+    )
+    return result.returncode == 0, result.stdout.strip() or result.stderr.strip()
+
+
+def get_repo_root() -> Path:
+    """Get the git repository root directory."""
+    success, output = run_git(["rev-parse", "--show-toplevel"])
+    if not success:
+        print("ERROR: Not in a git repository", file=sys.stderr)
+        sys.exit(1)
+    return Path(output)
+
+
+def create_worktree(repo_root: Path, issue_num: int, branch_name: str) -> Path | None:
+    """Create a git worktree for an issue, return worktree path or None on failure."""
+    worktree_dir = repo_root.parent / f"{repo_root.name}-issue-{issue_num}"
+
+    # Check if worktree already exists
+    if worktree_dir.exists():
+        # Verify it's a valid worktree
+        success, _ = run_git(["worktree", "list", "--porcelain"], cwd=str(repo_root))
+        if str(worktree_dir) in _:
+            return worktree_dir
+        # Directory exists but not a worktree - remove it
+        import shutil
+        shutil.rmtree(worktree_dir, ignore_errors=True)
+
+    # Fetch latest from origin
+    run_git(["fetch", "origin"], cwd=str(repo_root))
+
+    # Create worktree with new branch from origin/main
+    success, output = run_git(
+        ["worktree", "add", str(worktree_dir), "-b", branch_name, "origin/main"],
+        cwd=str(repo_root)
+    )
+
+    if not success:
+        # Branch might already exist, try without -b
+        success, output = run_git(
+            ["worktree", "add", str(worktree_dir), branch_name],
+            cwd=str(repo_root)
+        )
+
+    if success:
+        return worktree_dir
+
+    print(f"Warning: Failed to create worktree for #{issue_num}: {output}", file=sys.stderr)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Get next batch of issues with worktree paths")
+    parser.add_argument("--state-dir", required=True, help="State directory path")
+    parser.add_argument("--batch-size", type=int, default=5, help="Maximum issues in batch")
+    parser.add_argument("--create-worktrees", action="store_true",
+                        help="Create git worktrees for each issue")
+    args = parser.parse_args()
+
+    state_dir = Path(args.state_dir)
+
+    # Load manifest
+    manifest_path = state_dir / "manifest.json"
+    if not manifest_path.exists():
+        print(json.dumps({"error": "manifest_not_found", "batch": [], "remaining": 0}))
+        sys.exit(1)
+
+    with open(manifest_path) as f:
+        manifest = json.load(f)
+
+    # Get sets of processed issues
+    completed = set(manifest.get("completed", []))
+    failed = set(manifest.get("failed", []))
+    in_progress = set(manifest.get("in_progress", []))
+    processed = completed | failed | in_progress
+
+    # Get ready issues that haven't been processed
+    ready = [i for i in manifest.get("ready", []) if i not in processed]
+
+    # Take batch
+    batch_issues = ready[:args.batch_size]
+    remaining = len(ready) - len(batch_issues)
+
+    # Get repo root for worktree creation
+    repo_root = get_repo_root()
+    repo_name = manifest.get("repository", "unknown/repo").split("/")[-1]
+
+    # Build batch with worktree paths
+    batch = []
+    for issue_num in batch_issues:
+        branch_name = f"issue-{issue_num}"
+
+        if args.create_worktrees:
+            worktree_path = create_worktree(repo_root, issue_num, branch_name)
+            if worktree_path:
+                batch.append({
+                    "issue": issue_num,
+                    "worktree": str(worktree_path),
+                    "branch": branch_name
+                })
+            else:
+                # Fallback to main repo if worktree creation fails
+                batch.append({
+                    "issue": issue_num,
+                    "worktree": str(repo_root),
+                    "branch": branch_name,
+                    "worktree_failed": True
+                })
+        else:
+            # Just return issue info without creating worktrees
+            worktree_path = repo_root.parent / f"{repo_root.name}-issue-{issue_num}"
+            batch.append({
+                "issue": issue_num,
+                "worktree": str(worktree_path),
+                "branch": branch_name
+            })
+
+    # Update manifest with in_progress
+    manifest["in_progress"] = list(in_progress | set(batch_issues))
+    with open(manifest_path, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    # Output result
+    result = {
+        "batch": batch,
+        "remaining": remaining,
+        "total_ready": len(manifest.get("ready", [])),
+        "completed": len(completed),
+        "failed": len(failed)
+    }
+
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-processor/scripts/summarize.py
+++ b/.claude/skills/issue-processor/scripts/summarize.py
@@ -12,6 +12,7 @@ Output:
 
 import argparse
 import json
+import re
 import sys
 from pathlib import Path
 
@@ -69,8 +70,18 @@ def main():
         print("|-------|-------|-----|")
         for s in successes:
             issue_num = s.get("issue", "?")
-            pr_num = s.get("pr_number", "?")
             pr_url = s.get("pr_url", "")
+
+            # Extract PR number from URL if not provided directly
+            pr_num = s.get("pr_number")
+            if not pr_num and pr_url:
+                # URL format: https://github.com/owner/repo/pull/123
+                match = re.search(r'/pull/(\d+)', pr_url)
+                if match:
+                    pr_num = match.group(1)
+            if not pr_num:
+                pr_num = "?"
+
             # Try to get title from issue file
             issue_file = state_dir / "issues" / f"{issue_num}.json"
             title = "—"
@@ -81,7 +92,11 @@ def main():
                     # Truncate long titles
                     if len(title) > 50:
                         title = title[:47] + "..."
-            print(f"| #{issue_num} | {title} | [#{pr_num}]({pr_url}) |")
+
+            if pr_url:
+                print(f"| #{issue_num} | {title} | [#{pr_num}]({pr_url}) |")
+            else:
+                print(f"| #{issue_num} | {title} | #{pr_num} |")
         print()
 
     if failures:


### PR DESCRIPTION
## Summary

- Add `next_batch.py` script for getting batches with worktree paths
- Add `create_worktrees()` function to `setup.py` for parallel development
- Clean up confusing dependency checking logic (removed redundant code with "Wait, this is wrong" comment)
- Add `RESULT_FORMAT.md` documenting expected result JSON structure for implementer agents
- Fix `summarize.py` to extract PR number from URL when not provided directly
- Update `check_status.py` docstring (removed unused CHECKPOINT status reference)
- Update `SKILL.md` with new scripts and state file documentation

Fixes #442

## Test plan

- [x] All scripts pass `--help`
- [x] `setup.py` properly filters dependencies and creates worktrees when requested
- [x] `next_batch.py` returns correct batch JSON with worktree paths
- [x] `check_status.py` reports accurate status from status.txt/manifest.json
- [x] `summarize.py` extracts PR number from URL if not provided