### PR TITLE
feat(quic): implement HANDSHAKE_DONE frame encoding (RFC 9000 §19.20)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,6 +392,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICFrame-connid.c
     src/quic/SocketQUICFrame-path.c
     src/quic/SocketQUICFrame-stream.c
+    src/quic/SocketQUICFrame-handshake.c
     src/quic/SocketQUICConnection-demux.c
     src/quic/SocketQUICConnection-termination.c
     src/quic/SocketQUICTransportParams.c

--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -215,4 +215,7 @@ extern int SocketQUICFrame_decode_stream(const uint8_t *data, size_t len,
 extern size_t SocketQUICFrame_encode_reset_stream(uint64_t stream_id, uint64_t error_code, uint64_t final_size, uint8_t *out, size_t out_size);
 extern size_t SocketQUICFrame_encode_stop_sending(uint64_t stream_id, uint64_t error_code, uint8_t *out, size_t out_size);
 
+/* HANDSHAKE_DONE frame encoding (RFC 9000 §19.20) */
+extern size_t SocketQUICFrame_encode_handshake_done(uint8_t *out);
+
 #endif /* SOCKETQUICFRAME_INCLUDED */

--- a/src/quic/SocketQUICFrame-handshake.c
+++ b/src/quic/SocketQUICFrame-handshake.c
@@ -1,0 +1,42 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICFrame-handshake.c
+ * @brief QUIC HANDSHAKE_DONE frame encoding (RFC 9000 §19.20).
+ */
+
+#include "quic/SocketQUICFrame.h"
+
+/* ============================================================================
+ * Encode HANDSHAKE_DONE frames (RFC 9000 §19.20)
+ * ============================================================================
+ *
+ * HANDSHAKE_DONE Frame {
+ *   Type (i) = 0x1e,
+ * }
+ *
+ * The HANDSHAKE_DONE frame is sent by the server to signal to the client
+ * that the handshake is confirmed. It has no fields beyond the type byte.
+ *
+ * Important constraints (RFC 9000 §19.20):
+ * - MUST NOT be sent by a client
+ * - MUST be sent only in 1-RTT packets
+ * - Signals that handshake keys can be discarded
+ * - Causes client to start sending 1-RTT packets with Handshake keys discarded
+ */
+
+size_t
+SocketQUICFrame_encode_handshake_done (uint8_t *out)
+{
+  if (!out)
+    return 0;
+
+  /* Frame type 0x1e */
+  out[0] = QUIC_FRAME_HANDSHAKE_DONE;
+
+  return 1; /* Just the type byte */
+}

--- a/src/test/test_quic_frame.c
+++ b/src/test/test_quic_frame.c
@@ -316,6 +316,22 @@ TEST (frame_handshake_done)
   ASSERT_EQ (1, consumed);
 }
 
+TEST (frame_handshake_done_encode)
+{
+  uint8_t encoded[1];
+
+  size_t len = SocketQUICFrame_encode_handshake_done (encoded);
+
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x1e, encoded[0]);
+}
+
+TEST (frame_handshake_done_encode_null_check)
+{
+  /* Null output pointer */
+  ASSERT_EQ (0, SocketQUICFrame_encode_handshake_done (NULL));
+}
+
 TEST (frame_validation_padding)
 {
   SocketQUICFrame_T frame = { .type = QUIC_FRAME_PADDING };


### PR DESCRIPTION
## Summary

Implements #398 - HANDSHAKE_DONE frame encoding for QUIC protocol.

## Changes

- **New file**: `src/quic/SocketQUICFrame-handshake.c`
  - Implements `SocketQUICFrame_encode_handshake_done()` 
  - Single-byte frame (type 0x1e)
  - Server-only signal for handshake completion
  
- **Header update**: `include/quic/SocketQUICFrame.h`
  - Add function declaration with RFC 9000 §19.20 documentation
  
- **Tests**: `src/test/test_quic_frame.c`
  - Basic encoding test
  - Null pointer validation test
  
- **Build**: `CMakeLists.txt`
  - Add new source file to build

## RFC 9000 §19.20 Compliance

The HANDSHAKE_DONE frame:
- Has type 0x1e
- Contains no fields (empty frame beyond type)
- MUST NOT be sent by clients (server-only)
- MUST be sent only in 1-RTT packets
- Signals that handshake keys can be discarded

## Test Plan

- [x] All QUIC tests pass with sanitizers enabled (16/16)
- [x] Frame encoding test verifies correct type byte (0x1e)
- [x] Null pointer validation test passes
- [x] Existing parsing support verified
- [x] Build succeeds with ASan/UBSan

## Dependencies

Depends on existing frame infrastructure from #384.

Closes #398