### PR TITLE
feat(quic): implement stream state machines (RFC 9000 Section 3)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -383,6 +383,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICError-handling.c
     src/quic/SocketQUICConnectionID.c
     src/quic/SocketQUICStream.c
+    src/quic/SocketQUICStream-state.c
     src/quic/SocketQUICPacket.c
     src/quic/SocketQUICPacket-initial.c
     src/quic/SocketQUICWire.c
@@ -785,6 +786,7 @@ set(TEST_SOURCES
     test_quic_version
     test_quic_connid
     test_quic_stream
+    test_quic_stream_state
     test_quic_packet
     test_quic_wire
     test_quic_frame

--- a/src/quic/SocketQUICStream-state.c
+++ b/src/quic/SocketQUICStream-state.c
@@ -1,0 +1,286 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICStream-state.c
+ * @brief QUIC Stream State Machines (RFC 9000 Section 3).
+ *
+ * Implements dual state machines for sending and receiving parts of streams.
+ * Each stream has independent send and receive state machines that track
+ * the lifecycle of data flow in each direction.
+ *
+ * Send States (RFC 9000 Section 3.1):
+ *   Ready -> Send -> DataSent -> DataRecvd (normal flow)
+ *   Ready/Send/DataSent -> ResetSent -> ResetRecvd (reset flow)
+ *
+ * Receive States (RFC 9000 Section 3.2):
+ *   Recv -> SizeKnown -> DataRecvd -> DataRead (normal flow)
+ *   Recv/SizeKnown -> ResetRecvd -> ResetRead (reset flow)
+ */
+
+#include "quic/SocketQUICStream.h"
+
+#include <assert.h>
+#include <stddef.h>
+
+/* ============================================================================
+ * Event String Table
+ * ============================================================================
+ */
+
+static const char *event_strings[] = {
+  [QUIC_STREAM_EVENT_SEND_DATA] = "SendData",
+  [QUIC_STREAM_EVENT_SEND_FIN] = "SendFin",
+  [QUIC_STREAM_EVENT_ALL_DATA_ACKED] = "AllDataAcked",
+  [QUIC_STREAM_EVENT_SEND_RESET] = "SendReset",
+  [QUIC_STREAM_EVENT_RESET_ACKED] = "ResetAcked",
+  [QUIC_STREAM_EVENT_RECV_DATA] = "RecvData",
+  [QUIC_STREAM_EVENT_RECV_FIN] = "RecvFin",
+  [QUIC_STREAM_EVENT_ALL_DATA_RECVD] = "AllDataRecvd",
+  [QUIC_STREAM_EVENT_APP_READ_DATA] = "AppReadData",
+  [QUIC_STREAM_EVENT_RECV_RESET] = "RecvReset",
+  [QUIC_STREAM_EVENT_APP_READ_RESET] = "AppReadReset",
+  [QUIC_STREAM_EVENT_RECV_STOP_SENDING] = "RecvStopSending"
+};
+
+const char *
+SocketQUICStream_event_string (SocketQUICStreamEvent event)
+{
+  if (event > QUIC_STREAM_EVENT_RECV_STOP_SENDING)
+    return "Unknown";
+  return event_strings[event];
+}
+
+/* ============================================================================
+ * State Accessor Functions
+ * ============================================================================
+ */
+
+SocketQUICStreamState
+SocketQUICStream_get_send_state (const SocketQUICStream_T stream)
+{
+  if (stream == NULL)
+    return QUIC_STREAM_STATE_READY;
+  return stream->send_state;
+}
+
+SocketQUICStreamState
+SocketQUICStream_get_recv_state (const SocketQUICStream_T stream)
+{
+  if (stream == NULL)
+    return QUIC_STREAM_STATE_RECV;
+  return stream->recv_state;
+}
+
+/* ============================================================================
+ * Send-Side State Machine (RFC 9000 Section 3.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Validate and execute send-side state transition.
+ *
+ * State transition table:
+ *
+ *   Ready:
+ *     - SEND_DATA -> Send
+ *     - SEND_RESET -> ResetSent
+ *     - RECV_STOP_SENDING -> ResetSent
+ *
+ *   Send:
+ *     - SEND_DATA -> Send (stay in state)
+ *     - SEND_FIN -> DataSent
+ *     - SEND_RESET -> ResetSent
+ *     - RECV_STOP_SENDING -> ResetSent
+ *
+ *   DataSent:
+ *     - ALL_DATA_ACKED -> DataRecvd (terminal)
+ *     - SEND_RESET -> ResetSent
+ *     - RECV_STOP_SENDING -> ResetSent
+ *
+ *   ResetSent:
+ *     - RESET_ACKED -> ResetRecvd (terminal)
+ *
+ *   DataRecvd: Terminal state (no transitions)
+ *   ResetRecvd: Terminal state (no transitions)
+ */
+SocketQUICStream_Result
+SocketQUICStream_transition_send (SocketQUICStream_T stream,
+                                  SocketQUICStreamEvent event)
+{
+  SocketQUICStreamState current;
+  SocketQUICStreamState next;
+
+  if (stream == NULL)
+    return QUIC_STREAM_ERROR_NULL;
+
+  current = stream->send_state;
+
+  /* Terminal states */
+  if (current == QUIC_STREAM_STATE_DATA_RECVD
+      || current == QUIC_STREAM_STATE_RESET_RECVD)
+    {
+      return QUIC_STREAM_ERROR_STATE; /* No transitions from terminal states */
+    }
+
+  /* State transition logic */
+  switch (current)
+    {
+    case QUIC_STREAM_STATE_READY:
+      if (event == QUIC_STREAM_EVENT_SEND_DATA)
+        next = QUIC_STREAM_STATE_SEND;
+      else if (event == QUIC_STREAM_EVENT_SEND_RESET
+               || event == QUIC_STREAM_EVENT_RECV_STOP_SENDING)
+        next = QUIC_STREAM_STATE_RESET_SENT;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    case QUIC_STREAM_STATE_SEND:
+      if (event == QUIC_STREAM_EVENT_SEND_DATA)
+        next = QUIC_STREAM_STATE_SEND; /* Stay in Send */
+      else if (event == QUIC_STREAM_EVENT_SEND_FIN)
+        next = QUIC_STREAM_STATE_DATA_SENT;
+      else if (event == QUIC_STREAM_EVENT_SEND_RESET
+               || event == QUIC_STREAM_EVENT_RECV_STOP_SENDING)
+        next = QUIC_STREAM_STATE_RESET_SENT;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    case QUIC_STREAM_STATE_DATA_SENT:
+      if (event == QUIC_STREAM_EVENT_ALL_DATA_ACKED)
+        next = QUIC_STREAM_STATE_DATA_RECVD;
+      else if (event == QUIC_STREAM_EVENT_SEND_RESET
+               || event == QUIC_STREAM_EVENT_RECV_STOP_SENDING)
+        next = QUIC_STREAM_STATE_RESET_SENT;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    case QUIC_STREAM_STATE_RESET_SENT:
+      if (event == QUIC_STREAM_EVENT_RESET_ACKED)
+        next = QUIC_STREAM_STATE_RESET_RECVD;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    default:
+      return QUIC_STREAM_ERROR_STATE; /* Invalid state */
+    }
+
+  /* Execute transition */
+  stream->send_state = next;
+
+  /* Update legacy combined state for backwards compatibility */
+  if (stream->send_state == QUIC_STREAM_STATE_SEND
+      || stream->send_state == QUIC_STREAM_STATE_DATA_SENT)
+    stream->state = stream->send_state;
+
+  return QUIC_STREAM_OK;
+}
+
+/* ============================================================================
+ * Receive-Side State Machine (RFC 9000 Section 3.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Validate and execute receive-side state transition.
+ *
+ * State transition table:
+ *
+ *   Recv:
+ *     - RECV_DATA -> Recv (stay in state)
+ *     - RECV_FIN -> SizeKnown
+ *     - RECV_RESET -> ResetRecvd
+ *
+ *   SizeKnown:
+ *     - RECV_DATA -> SizeKnown (stay in state)
+ *     - ALL_DATA_RECVD -> DataRecvd
+ *     - RECV_RESET -> ResetRecvd
+ *
+ *   DataRecvd:
+ *     - APP_READ_DATA -> DataRead (terminal)
+ *
+ *   ResetRecvd:
+ *     - APP_READ_RESET -> ResetRead (terminal)
+ *
+ *   DataRead: Terminal state (no transitions)
+ *   ResetRead: Terminal state (no transitions)
+ */
+SocketQUICStream_Result
+SocketQUICStream_transition_recv (SocketQUICStream_T stream,
+                                  SocketQUICStreamEvent event)
+{
+  SocketQUICStreamState current;
+  SocketQUICStreamState next;
+
+  if (stream == NULL)
+    return QUIC_STREAM_ERROR_NULL;
+
+  current = stream->recv_state;
+
+  /* Terminal states */
+  if (current == QUIC_STREAM_STATE_DATA_READ
+      || current == QUIC_STREAM_STATE_RESET_READ)
+    {
+      return QUIC_STREAM_ERROR_STATE; /* No transitions from terminal states */
+    }
+
+  /* State transition logic */
+  switch (current)
+    {
+    case QUIC_STREAM_STATE_RECV:
+      if (event == QUIC_STREAM_EVENT_RECV_DATA)
+        next = QUIC_STREAM_STATE_RECV; /* Stay in Recv */
+      else if (event == QUIC_STREAM_EVENT_RECV_FIN)
+        next = QUIC_STREAM_STATE_SIZE_KNOWN;
+      else if (event == QUIC_STREAM_EVENT_RECV_RESET)
+        next = QUIC_STREAM_STATE_RESET_RECVD;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    case QUIC_STREAM_STATE_SIZE_KNOWN:
+      if (event == QUIC_STREAM_EVENT_RECV_DATA)
+        next = QUIC_STREAM_STATE_SIZE_KNOWN; /* Stay in SizeKnown */
+      else if (event == QUIC_STREAM_EVENT_ALL_DATA_RECVD)
+        next = QUIC_STREAM_STATE_DATA_RECVD;
+      else if (event == QUIC_STREAM_EVENT_RECV_RESET)
+        next = QUIC_STREAM_STATE_RESET_RECVD;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    case QUIC_STREAM_STATE_DATA_RECVD:
+      if (event == QUIC_STREAM_EVENT_APP_READ_DATA)
+        next = QUIC_STREAM_STATE_DATA_READ;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    case QUIC_STREAM_STATE_RESET_RECVD:
+      if (event == QUIC_STREAM_EVENT_APP_READ_RESET)
+        next = QUIC_STREAM_STATE_RESET_READ;
+      else
+        return QUIC_STREAM_ERROR_STATE;
+      break;
+
+    default:
+      return QUIC_STREAM_ERROR_STATE; /* Invalid state */
+    }
+
+  /* Execute transition */
+  stream->recv_state = next;
+
+  /* Update legacy combined state for backwards compatibility */
+  if (stream->recv_state == QUIC_STREAM_STATE_RECV
+      || stream->recv_state == QUIC_STREAM_STATE_SIZE_KNOWN)
+    stream->state = stream->recv_state;
+
+  return QUIC_STREAM_OK;
+}

--- a/src/quic/SocketQUICStream.c
+++ b/src/quic/SocketQUICStream.c
@@ -155,7 +155,9 @@ SocketQUICStream_init (SocketQUICStream_T stream, uint64_t stream_id)
 
   stream->id = stream_id;
   stream->type = SocketQUICStream_type (stream_id);
-  stream->state = QUIC_STREAM_STATE_READY;
+  stream->state = QUIC_STREAM_STATE_READY; /* Legacy */
+  stream->send_state = QUIC_STREAM_STATE_READY;
+  stream->recv_state = QUIC_STREAM_STATE_RECV;
 
   return QUIC_STREAM_OK;
 }
@@ -172,7 +174,9 @@ SocketQUICStream_reset (SocketQUICStream_T stream)
   memset (stream, 0, sizeof (*stream));
   stream->id = id;
   stream->type = SocketQUICStream_type (id);
-  stream->state = QUIC_STREAM_STATE_READY;
+  stream->state = QUIC_STREAM_STATE_READY; /* Legacy */
+  stream->send_state = QUIC_STREAM_STATE_READY;
+  stream->recv_state = QUIC_STREAM_STATE_RECV;
 
   return QUIC_STREAM_OK;
 }

--- a/src/test/test_quic_stream_state.c
+++ b/src/test/test_quic_stream_state.c
@@ -1,0 +1,562 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_quic_stream_state.c - QUIC Stream State Machine tests (RFC 9000 Section 3)
+ *
+ * Tests the dual state machines for sending and receiving parts of streams.
+ * Each stream has independent send and receive state machines.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "quic/SocketQUICStream.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Send State Machine Tests (RFC 9000 Section 3.1)
+ * ============================================================================
+ */
+
+TEST (quic_stream_send_ready_to_send)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_READY);
+
+  /* Ready -> Send on SEND_DATA */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_SEND);
+}
+
+TEST (quic_stream_send_ready_to_reset)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Ready -> ResetSent on SEND_RESET */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_SEND_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_SENT);
+}
+
+TEST (quic_stream_send_ready_stop_sending)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Ready -> ResetSent on RECV_STOP_SENDING */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_RECV_STOP_SENDING);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_SENT);
+}
+
+TEST (quic_stream_send_stay_in_send)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_SEND;
+
+  /* Send -> Send on SEND_DATA (stay in state) */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_SEND);
+}
+
+TEST (quic_stream_send_to_data_sent)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_SEND;
+
+  /* Send -> DataSent on SEND_FIN */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_FIN);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_DATA_SENT);
+}
+
+TEST (quic_stream_send_to_reset_from_send)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_SEND;
+
+  /* Send -> ResetSent on SEND_RESET */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_SEND_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_SENT);
+}
+
+TEST (quic_stream_data_sent_to_data_recvd)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_DATA_SENT;
+
+  /* DataSent -> DataRecvd on ALL_DATA_ACKED */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_ALL_DATA_ACKED);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_DATA_RECVD);
+}
+
+TEST (quic_stream_data_sent_to_reset)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_DATA_SENT;
+
+  /* DataSent -> ResetSent on RECV_STOP_SENDING */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_RECV_STOP_SENDING);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_SENT);
+}
+
+TEST (quic_stream_reset_sent_to_reset_recvd)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_RESET_SENT;
+
+  /* ResetSent -> ResetRecvd on RESET_ACKED */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_RESET_ACKED);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_RECVD);
+}
+
+TEST (quic_stream_send_terminal_data_recvd)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_DATA_RECVD;
+
+  /* DataRecvd is terminal - no transitions allowed */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_STATE);
+}
+
+TEST (quic_stream_send_terminal_reset_recvd)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_RESET_RECVD;
+
+  /* ResetRecvd is terminal - no transitions allowed */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_RESET_ACKED);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_STATE);
+}
+
+TEST (quic_stream_send_invalid_transition)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Invalid transition: Ready -> DataSent (must go through Send first) */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_FIN);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_STATE);
+}
+
+TEST (quic_stream_send_null_stream)
+{
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_send (NULL, QUIC_STREAM_EVENT_SEND_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_NULL);
+}
+
+/* ============================================================================
+ * Receive State Machine Tests (RFC 9000 Section 3.2)
+ * ============================================================================
+ */
+
+TEST (quic_stream_recv_initial_state)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RECV);
+}
+
+TEST (quic_stream_recv_stay_in_recv)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Recv -> Recv on RECV_DATA (stay in state) */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RECV);
+}
+
+TEST (quic_stream_recv_to_size_known)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Recv -> SizeKnown on RECV_FIN */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_FIN);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_SIZE_KNOWN);
+}
+
+TEST (quic_stream_recv_to_reset_recvd)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Recv -> ResetRecvd on RECV_RESET */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_RECV_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RESET_RECVD);
+}
+
+TEST (quic_stream_size_known_stay)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_SIZE_KNOWN;
+
+  /* SizeKnown -> SizeKnown on RECV_DATA (stay in state) */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_SIZE_KNOWN);
+}
+
+TEST (quic_stream_size_known_to_data_recvd)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_SIZE_KNOWN;
+
+  /* SizeKnown -> DataRecvd on ALL_DATA_RECVD */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_ALL_DATA_RECVD);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_DATA_RECVD);
+}
+
+TEST (quic_stream_size_known_to_reset)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_SIZE_KNOWN;
+
+  /* SizeKnown -> ResetRecvd on RECV_RESET */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_RECV_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RESET_RECVD);
+}
+
+TEST (quic_stream_data_recvd_to_data_read)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_DATA_RECVD;
+
+  /* DataRecvd -> DataRead on APP_READ_DATA */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_APP_READ_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_DATA_READ);
+}
+
+TEST (quic_stream_reset_recvd_to_reset_read)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_RESET_RECVD;
+
+  /* ResetRecvd -> ResetRead on APP_READ_RESET */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_APP_READ_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RESET_READ);
+}
+
+TEST (quic_stream_recv_terminal_data_read)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_DATA_READ;
+
+  /* DataRead is terminal - no transitions allowed */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_STATE);
+}
+
+TEST (quic_stream_recv_terminal_reset_read)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_RESET_READ;
+
+  /* ResetRead is terminal - no transitions allowed */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_APP_READ_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_STATE);
+}
+
+TEST (quic_stream_recv_invalid_transition)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Invalid transition: Recv -> DataRecvd (must go through SizeKnown) */
+  SocketQUICStream_Result res = SocketQUICStream_transition_recv (
+      &stream, QUIC_STREAM_EVENT_ALL_DATA_RECVD);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_STATE);
+}
+
+TEST (quic_stream_recv_null_stream)
+{
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_recv (NULL, QUIC_STREAM_EVENT_RECV_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_ERROR_NULL);
+}
+
+/* ============================================================================
+ * Combined State Machine Tests
+ * ============================================================================
+ */
+
+TEST (quic_stream_independent_state_machines)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Advance send state */
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_SEND);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RECV); /* Unchanged */
+
+  /* Advance recv state */
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_FIN);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_SEND); /* Unchanged */
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_SIZE_KNOWN);
+}
+
+TEST (quic_stream_normal_completion_flow)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Send side: Ready -> Send -> DataSent -> DataRecvd */
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_FIN);
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_ALL_DATA_ACKED);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_DATA_RECVD);
+
+  /* Receive side: Recv -> SizeKnown -> DataRecvd -> DataRead */
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_FIN);
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_ALL_DATA_RECVD);
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_APP_READ_DATA);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_DATA_READ);
+}
+
+TEST (quic_stream_reset_flow)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Send side: Ready -> Send -> ResetSent -> ResetRecvd */
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_RESET);
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_RESET_ACKED);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_RECVD);
+
+  /* Receive side: Recv -> ResetRecvd -> ResetRead */
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_RESET);
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_APP_READ_RESET);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RESET_READ);
+}
+
+TEST (quic_stream_stop_sending_triggers_reset)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_SEND;
+
+  /* STOP_SENDING from peer should trigger reset */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_RECV_STOP_SENDING);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_SENT);
+}
+
+/* ============================================================================
+ * State Accessor Tests
+ * ============================================================================
+ */
+
+TEST (quic_stream_get_send_state)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.send_state = QUIC_STREAM_STATE_SEND;
+
+  ASSERT_EQ (SocketQUICStream_get_send_state (&stream),
+             QUIC_STREAM_STATE_SEND);
+}
+
+TEST (quic_stream_get_send_state_null)
+{
+  ASSERT_EQ (SocketQUICStream_get_send_state (NULL), QUIC_STREAM_STATE_READY);
+}
+
+TEST (quic_stream_get_recv_state)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  stream.recv_state = QUIC_STREAM_STATE_SIZE_KNOWN;
+
+  ASSERT_EQ (SocketQUICStream_get_recv_state (&stream),
+             QUIC_STREAM_STATE_SIZE_KNOWN);
+}
+
+TEST (quic_stream_get_recv_state_null)
+{
+  ASSERT_EQ (SocketQUICStream_get_recv_state (NULL), QUIC_STREAM_STATE_RECV);
+}
+
+/* ============================================================================
+ * Utility Function Tests
+ * ============================================================================
+ */
+
+TEST (quic_stream_event_string)
+{
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_SEND_DATA),
+                  "SendData")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RECV_FIN),
+                  "RecvFin")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RECV_RESET),
+                  "RecvReset")
+          == 0);
+  ASSERT (strcmp (
+              SocketQUICStream_event_string ((SocketQUICStreamEvent)999),
+              "Unknown")
+          == 0);
+}
+
+/* ============================================================================
+ * Edge Case Tests
+ * ============================================================================
+ */
+
+TEST (quic_stream_multiple_data_sends)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Multiple SEND_DATA events should keep stream in Send state */
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  SocketQUICStream_transition_send (&stream, QUIC_STREAM_EVENT_SEND_DATA);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_SEND);
+}
+
+TEST (quic_stream_multiple_data_receives)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Multiple RECV_DATA events should keep stream in Recv state */
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_RECV);
+}
+
+TEST (quic_stream_data_after_fin)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_FIN);
+
+  /* Can still receive data in SizeKnown (filling gaps) */
+  SocketQUICStream_Result res
+      = SocketQUICStream_transition_recv (&stream, QUIC_STREAM_EVENT_RECV_DATA);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.recv_state, QUIC_STREAM_STATE_SIZE_KNOWN);
+}
+
+TEST (quic_stream_early_reset_from_ready)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+
+  /* Can reset immediately from Ready without sending any data */
+  SocketQUICStream_Result res = SocketQUICStream_transition_send (
+      &stream, QUIC_STREAM_EVENT_SEND_RESET);
+  ASSERT_EQ (res, QUIC_STREAM_OK);
+  ASSERT_EQ (stream.send_state, QUIC_STREAM_STATE_RESET_SENT);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Implements dual state machines for send and receive halves of QUIC streams as specified in RFC 9000 Section 3.

This closes #399 by providing complete state machine implementations that track the lifecycle of data flow in each direction independently.

## Changes

### Send State Machine (RFC 9000 Section 3.1)
- **Ready** → Send (on SEND_DATA)
- **Send** → DataSent (on SEND_FIN)
- **Send** → ResetSent (on SEND_RESET or RECV_STOP_SENDING)
- **DataSent** → DataRecvd (on ALL_DATA_ACKED) - terminal
- **ResetSent** → ResetRecvd (on RESET_ACKED) - terminal

### Receive State Machine (RFC 9000 Section 3.2)
- **Recv** → SizeKnown (on RECV_FIN)
- **Recv** → ResetRecvd (on RECV_RESET)
- **SizeKnown** → DataRecvd (on ALL_DATA_RECVD)
- **DataRecvd** → DataRead (on APP_READ_DATA) - terminal
- **ResetRecvd** → ResetRead (on APP_READ_RESET) - terminal

### Implementation Details
- Dual independent state machines per stream
- Support for STOP_SENDING triggering send-side reset
- Complete state transition validation
- Event-driven state transitions
- Backward compatibility with existing code

### Files Modified/Added
- `include/quic/SocketQUICStream.h`: Added event enum, transition functions, and dual state fields
- `src/quic/SocketQUICStream.c`: Updated initialization to set both send/recv states
- `src/quic/SocketQUICStream-state.c`: New file with state machine logic (~280 lines)
- `src/test/test_quic_stream_state.c`: Comprehensive test suite (~600 lines, 39 tests)
- `CMakeLists.txt`: Added new source and test files

## Test Plan

- [x] All 39 new state transition tests pass
- [x] All existing 33 stream tests pass (backward compatibility)
- [x] Full test suite passes (104/104 tests)
- [x] Tests pass with ASan enabled
- [x] Tests pass with UBSan enabled
- [x] No memory leaks detected

### Coverage
- Ready → Send → DataSent → DataRecvd (normal flow)
- Ready → ResetSent → ResetRecvd (early reset)
- Send → ResetSent (reset during transmission)
- DataSent → ResetSent (reset after FIN)
- Recv → SizeKnown → DataRecvd → DataRead (normal flow)
- Recv → ResetRecvd → ResetRead (reset flow)
- STOP_SENDING triggering reset
- Terminal state enforcement
- Invalid transition rejection
- Multiple data sends/receives staying in state

Closes #399