### PR TITLE
feat(quic): implement Connection ID Pool (RFC 9000 §5.1.1-5.1.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -382,6 +382,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICVersion.c
     src/quic/SocketQUICError-handling.c
     src/quic/SocketQUICConnectionID.c
+    src/quic/SocketQUICConnectionID-pool.c
     src/quic/SocketQUICStream.c
     src/quic/SocketQUICStream-state.c
     src/quic/SocketQUICPacket.c
@@ -640,6 +641,7 @@ set(QUIC_HEADERS
     include/quic/SocketQUICError.h
     include/quic/SocketQUICVersion.h
     include/quic/SocketQUICConnectionID.h
+    include/quic/SocketQUICConnectionID-pool.h
     include/quic/SocketQUICStream.h
     include/quic/SocketQUICPacket.h
     include/quic/SocketQUICFrame.h
@@ -788,6 +790,7 @@ set(TEST_SOURCES
     test_quic_error
     test_quic_version
     test_quic_connid
+    test_quic_connid_pool
     test_quic_stream
     test_quic_stream_state
     test_quic_packet

--- a/include/quic/SocketQUICConnectionID-pool.h
+++ b/include/quic/SocketQUICConnectionID-pool.h
@@ -1,0 +1,389 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICConnectionID-pool.h
+ * @brief QUIC Connection ID Pool Management (RFC 9000 Section 5.1.1-5.1.2).
+ *
+ * Implements connection ID lifecycle operations including:
+ *   - Pool of active connection IDs with sequence number tracking
+ *   - Hash table lookup by connection ID bytes
+ *   - Retire Prior To bulk retirement (RFC 9000 §5.1.2)
+ *   - active_connection_id_limit enforcement
+ *
+ * RFC 9000 §5.1.1 - Connection ID Issuance:
+ *   - Initial CID has sequence 0
+ *   - preferred_address CID has sequence 1
+ *   - Endpoints must not exceed peer's active_connection_id_limit
+ *
+ * RFC 9000 §5.1.2 - Consuming and Retiring CIDs:
+ *   - Retire Prior To indicates all CIDs with lower sequence should be retired
+ *   - Endpoints should ensure sufficient CIDs for migration
+ *
+ * Thread Safety: Pool operations are NOT thread-safe. Use external
+ * synchronization when accessing from multiple threads.
+ *
+ * @defgroup quic_connid_pool QUIC Connection ID Pool
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9000#section-5.1
+ */
+
+#ifndef SOCKETQUICCONNECTIONID_POOL_INCLUDED
+#define SOCKETQUICCONNECTIONID_POOL_INCLUDED
+
+#include "core/Arena.h"
+#include "quic/SocketQUICConnectionID.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/**
+ * @brief Default hash table size for connection ID lookup.
+ *
+ * Should be a power of 2 for efficient modulo via bitmask.
+ */
+#define QUIC_CONNID_POOL_HASH_SIZE 32
+
+/**
+ * @brief Maximum hash chain length before considering it suspicious.
+ *
+ * Protects against hash collision DoS attacks.
+ */
+#define QUIC_CONNID_POOL_MAX_CHAIN_LEN 16
+
+/* ============================================================================
+ * Data Structures
+ * ============================================================================
+ */
+
+/**
+ * @brief Entry in the connection ID pool.
+ *
+ * Wraps a connection ID with pool management metadata.
+ */
+typedef struct SocketQUICConnectionIDEntry
+{
+  SocketQUICConnectionID_T cid; /**< The connection ID data */
+
+  int is_retired;   /**< Non-zero if retired but not yet removed */
+  int is_used;      /**< Non-zero if currently in use for a path */
+  uint64_t used_at; /**< Monotonic timestamp when last used (ms) */
+
+  struct SocketQUICConnectionIDEntry *hash_next; /**< Hash chain pointer */
+  struct SocketQUICConnectionIDEntry *list_next; /**< Sequence list pointer */
+  struct SocketQUICConnectionIDEntry *list_prev; /**< Sequence list pointer */
+
+} SocketQUICConnectionIDEntry_T;
+
+/**
+ * @brief Connection ID pool for managing active connection IDs.
+ *
+ * Maintains a hash table for O(1) lookup by CID bytes and a doubly-linked
+ * list for sequence-ordered operations like Retire Prior To.
+ */
+typedef struct SocketQUICConnectionIDPool
+{
+  Arena_T arena; /**< Memory arena for allocations */
+
+  SocketQUICConnectionIDEntry_T *hash_table[QUIC_CONNID_POOL_HASH_SIZE];
+  /**< Hash table for CID lookup */
+
+  SocketQUICConnectionIDEntry_T *list_head; /**< First entry by sequence */
+  SocketQUICConnectionIDEntry_T *list_tail; /**< Last entry by sequence */
+
+  uint64_t next_sequence;       /**< Next sequence number to assign */
+  uint64_t retire_prior_to;     /**< Current retire prior to value */
+  size_t active_count;          /**< Number of non-retired entries */
+  size_t total_count;           /**< Total entries including retired */
+  size_t peer_limit;            /**< Peer's active_connection_id_limit */
+  uint32_t hash_seed;           /**< Random seed for hash function */
+
+} *SocketQUICConnectionIDPool_T;
+
+/**
+ * @brief Result codes for pool operations.
+ */
+typedef enum
+{
+  QUIC_CONNID_POOL_OK = 0,       /**< Operation succeeded */
+  QUIC_CONNID_POOL_ERROR_NULL,   /**< NULL pointer argument */
+  QUIC_CONNID_POOL_ERROR_FULL,   /**< Pool at peer's limit */
+  QUIC_CONNID_POOL_ERROR_DUP,    /**< Duplicate connection ID */
+  QUIC_CONNID_POOL_ERROR_SEQ,    /**< Invalid sequence number */
+  QUIC_CONNID_POOL_ERROR_LIMIT,  /**< Limit exceeded */
+  QUIC_CONNID_POOL_ERROR_CHAIN,  /**< Hash chain too long (DoS) */
+  QUIC_CONNID_POOL_NOT_FOUND     /**< Connection ID not in pool */
+} SocketQUICConnectionIDPool_Result;
+
+/* ============================================================================
+ * Pool Lifecycle Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Create a new connection ID pool.
+ *
+ * @param arena      Memory arena for allocations.
+ * @param peer_limit Peer's active_connection_id_limit (minimum 2).
+ *
+ * @return New pool instance, or NULL on failure.
+ */
+extern SocketQUICConnectionIDPool_T
+SocketQUICConnectionIDPool_new (Arena_T arena, size_t peer_limit);
+
+/**
+ * @brief Get the number of active (non-retired) connection IDs.
+ *
+ * @param pool Pool to query.
+ *
+ * @return Number of active connection IDs.
+ */
+extern size_t
+SocketQUICConnectionIDPool_active_count (const SocketQUICConnectionIDPool_T pool);
+
+/**
+ * @brief Get the total number of connection IDs including retired.
+ *
+ * @param pool Pool to query.
+ *
+ * @return Total connection ID count.
+ */
+extern size_t
+SocketQUICConnectionIDPool_total_count (const SocketQUICConnectionIDPool_T pool);
+
+/**
+ * @brief Check if more connection IDs can be added.
+ *
+ * @param pool Pool to check.
+ *
+ * @return 1 if space available, 0 if at peer limit.
+ */
+extern int
+SocketQUICConnectionIDPool_can_add (const SocketQUICConnectionIDPool_T pool);
+
+/* ============================================================================
+ * Connection ID Management
+ * ============================================================================
+ */
+
+/**
+ * @brief Add a new connection ID to the pool.
+ *
+ * The connection ID is assigned the next sequence number automatically.
+ * The sequence number is stored in cid->sequence.
+ *
+ * @param pool Pool to add to.
+ * @param cid  Connection ID to add (sequence will be set).
+ *
+ * @return QUIC_CONNID_POOL_OK on success, error code otherwise.
+ *
+ * @note Caller should generate CID and reset token before calling.
+ * @note The CID is copied; caller retains ownership of input.
+ */
+extern SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_add (SocketQUICConnectionIDPool_T pool,
+                                 const SocketQUICConnectionID_T *cid);
+
+/**
+ * @brief Add a connection ID with explicit sequence number.
+ *
+ * Used for the initial connection ID (sequence 0) and preferred_address
+ * connection ID (sequence 1) which have predetermined sequence numbers.
+ *
+ * @param pool     Pool to add to.
+ * @param cid      Connection ID to add.
+ * @param sequence Explicit sequence number to assign.
+ *
+ * @return QUIC_CONNID_POOL_OK on success, error code otherwise.
+ */
+extern SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_add_with_sequence (SocketQUICConnectionIDPool_T pool,
+                                               const SocketQUICConnectionID_T *cid,
+                                               uint64_t sequence);
+
+/**
+ * @brief Look up a connection ID by its bytes.
+ *
+ * @param pool Pool to search.
+ * @param id   Raw connection ID bytes.
+ * @param len  Length of connection ID.
+ *
+ * @return Matching entry, or NULL if not found.
+ */
+extern SocketQUICConnectionIDEntry_T *
+SocketQUICConnectionIDPool_lookup (const SocketQUICConnectionIDPool_T pool,
+                                    const uint8_t *id, size_t len);
+
+/**
+ * @brief Look up a connection ID by sequence number.
+ *
+ * @param pool     Pool to search.
+ * @param sequence Sequence number to find.
+ *
+ * @return Matching entry, or NULL if not found.
+ */
+extern SocketQUICConnectionIDEntry_T *
+SocketQUICConnectionIDPool_lookup_sequence (const SocketQUICConnectionIDPool_T pool,
+                                             uint64_t sequence);
+
+/**
+ * @brief Remove a specific connection ID from the pool.
+ *
+ * @param pool Pool to remove from.
+ * @param id   Raw connection ID bytes.
+ * @param len  Length of connection ID.
+ *
+ * @return QUIC_CONNID_POOL_OK on success, QUIC_CONNID_POOL_NOT_FOUND if
+ *         the connection ID was not in the pool.
+ */
+extern SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_remove (SocketQUICConnectionIDPool_T pool,
+                                    const uint8_t *id, size_t len);
+
+/* ============================================================================
+ * Retirement Functions (RFC 9000 §5.1.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Process Retire Prior To value from NEW_CONNECTION_ID frame.
+ *
+ * Marks all connection IDs with sequence < retire_prior_to as retired.
+ * Does not remove them from the pool immediately to allow graceful
+ * transition.
+ *
+ * @param pool            Pool to update.
+ * @param retire_prior_to New retire prior to value.
+ * @param retired_count   Output: number of CIDs newly retired (optional).
+ *
+ * @return QUIC_CONNID_POOL_OK on success, error code otherwise.
+ *
+ * @note retire_prior_to must not decrease (RFC 9000 §5.1.2).
+ */
+extern SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_retire_prior_to (SocketQUICConnectionIDPool_T pool,
+                                             uint64_t retire_prior_to,
+                                             size_t *retired_count);
+
+/**
+ * @brief Retire a specific connection ID by sequence number.
+ *
+ * Called when sending RETIRE_CONNECTION_ID frame.
+ *
+ * @param pool     Pool to update.
+ * @param sequence Sequence number of CID to retire.
+ *
+ * @return QUIC_CONNID_POOL_OK on success, QUIC_CONNID_POOL_NOT_FOUND if
+ *         the sequence number was not in the pool.
+ */
+extern SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_retire_sequence (SocketQUICConnectionIDPool_T pool,
+                                             uint64_t sequence);
+
+/**
+ * @brief Remove all retired connection IDs from the pool.
+ *
+ * Should be called after confirming retirement with peer.
+ *
+ * @param pool          Pool to clean up.
+ * @param removed_count Output: number of CIDs removed (optional).
+ *
+ * @return QUIC_CONNID_POOL_OK on success.
+ */
+extern SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_purge_retired (SocketQUICConnectionIDPool_T pool,
+                                           size_t *removed_count);
+
+/**
+ * @brief Get the current Retire Prior To value.
+ *
+ * @param pool Pool to query.
+ *
+ * @return Current retire prior to value.
+ */
+extern uint64_t
+SocketQUICConnectionIDPool_get_retire_prior_to (const SocketQUICConnectionIDPool_T pool);
+
+/* ============================================================================
+ * Iteration Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Callback type for iterating over connection IDs.
+ *
+ * @param entry   Current entry.
+ * @param context User-provided context.
+ *
+ * @return 0 to continue iteration, non-zero to stop.
+ */
+typedef int (*SocketQUICConnectionIDPool_Iterator) (
+    SocketQUICConnectionIDEntry_T *entry, void *context);
+
+/**
+ * @brief Iterate over all non-retired connection IDs.
+ *
+ * @param pool     Pool to iterate.
+ * @param callback Function to call for each entry.
+ * @param context  User context passed to callback.
+ *
+ * @return Number of entries visited, or -1 on error.
+ */
+extern int SocketQUICConnectionIDPool_foreach (SocketQUICConnectionIDPool_T pool,
+                                                SocketQUICConnectionIDPool_Iterator callback,
+                                                void *context);
+
+/**
+ * @brief Get the next available connection ID for use.
+ *
+ * Returns a non-retired, currently unused connection ID.
+ * Marks it as in-use.
+ *
+ * @param pool Pool to search.
+ *
+ * @return Available entry, or NULL if none available.
+ */
+extern SocketQUICConnectionIDEntry_T *
+SocketQUICConnectionIDPool_get_available (SocketQUICConnectionIDPool_T pool);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Get string representation of pool result code.
+ *
+ * @param result Result code to convert.
+ *
+ * @return Human-readable string.
+ */
+extern const char *
+SocketQUICConnectionIDPool_result_string (SocketQUICConnectionIDPool_Result result);
+
+/**
+ * @brief Check if the pool needs more connection IDs.
+ *
+ * Returns true if active count is below a threshold that would
+ * impair migration capability.
+ *
+ * @param pool           Pool to check.
+ * @param min_for_migrate Minimum CIDs needed for migration (typically 2).
+ *
+ * @return 1 if more CIDs needed, 0 otherwise.
+ */
+extern int
+SocketQUICConnectionIDPool_needs_more (const SocketQUICConnectionIDPool_T pool,
+                                        size_t min_for_migrate);
+
+/** @} */
+
+#endif /* SOCKETQUICCONNECTIONID_POOL_INCLUDED */

--- a/src/quic/SocketQUICConnectionID-pool.c
+++ b/src/quic/SocketQUICConnectionID-pool.c
@@ -1,0 +1,592 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICConnectionID-pool.c
+ * @brief QUIC Connection ID Pool Management (RFC 9000 Section 5.1.1-5.1.2).
+ *
+ * Implements connection ID lifecycle operations including:
+ *   - Hash table for O(1) CID lookup
+ *   - Doubly-linked list for sequence-ordered iteration
+ *   - Retire Prior To bulk retirement
+ *   - active_connection_id_limit enforcement
+ */
+
+#include "quic/SocketQUICConnectionID-pool.h"
+#include "core/SocketUtil.h"
+
+#include <inttypes.h>
+#include <string.h>
+#include <time.h>
+
+/* Secure random for hash seed - copied from SocketQUICConnectionID.c */
+#ifdef __linux__
+#include <sys/random.h>
+#define SECURE_RANDOM(buf, len) (getrandom ((buf), (len), 0) == (ssize_t)(len))
+#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__)
+#include <stdlib.h>
+#define SECURE_RANDOM(buf, len)                                               \
+  (arc4random_buf ((buf), (len)), 1) /* Always succeeds */
+#else
+/* Fallback: just use time-based seed (not cryptographic, just for hash) */
+#define SECURE_RANDOM(buf, len) 0
+#endif
+
+#undef SOCKET_LOG_COMPONENT
+#define SOCKET_LOG_COMPONENT "QUIC-CID"
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+    [QUIC_CONNID_POOL_OK] = "OK",
+    [QUIC_CONNID_POOL_ERROR_NULL] = "NULL pointer argument",
+    [QUIC_CONNID_POOL_ERROR_FULL] = "Pool at peer's active_connection_id_limit",
+    [QUIC_CONNID_POOL_ERROR_DUP] = "Duplicate connection ID",
+    [QUIC_CONNID_POOL_ERROR_SEQ] = "Invalid sequence number",
+    [QUIC_CONNID_POOL_ERROR_LIMIT] = "Limit exceeded",
+    [QUIC_CONNID_POOL_ERROR_CHAIN] = "Hash chain too long (potential DoS)",
+    [QUIC_CONNID_POOL_NOT_FOUND] = "Connection ID not found",
+};
+
+const char *
+SocketQUICConnectionIDPool_result_string (SocketQUICConnectionIDPool_Result result)
+{
+  if (result < 0 || result > QUIC_CONNID_POOL_NOT_FOUND)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Internal Hash Functions
+ * ============================================================================
+ */
+
+static unsigned
+hash_cid_bytes (const uint8_t *id, size_t len, uint32_t seed)
+{
+  if (len == 0)
+    return 0;
+
+  /* FNV-1a hash with seed mixing */
+  uint32_t hash = 2166136261u ^ seed;
+
+  for (size_t i = 0; i < len; i++)
+    {
+      hash ^= id[i];
+      hash *= 16777619u;
+    }
+
+  return hash % QUIC_CONNID_POOL_HASH_SIZE;
+}
+
+/* ============================================================================
+ * Pool Lifecycle Functions
+ * ============================================================================
+ */
+
+SocketQUICConnectionIDPool_T
+SocketQUICConnectionIDPool_new (Arena_T arena, size_t peer_limit)
+{
+  SocketQUICConnectionIDPool_T pool;
+
+  if (arena == NULL)
+    return NULL;
+
+  /* Minimum peer limit per RFC 9000 Section 18.2 */
+  if (peer_limit < QUIC_CONNID_DEFAULT_LIMIT)
+    peer_limit = QUIC_CONNID_DEFAULT_LIMIT;
+
+  pool = CALLOC (arena, 1, sizeof (*pool));
+  if (pool == NULL)
+    return NULL;
+
+  pool->arena = arena;
+  pool->peer_limit = peer_limit;
+  pool->next_sequence = 0;
+  pool->retire_prior_to = 0;
+  pool->active_count = 0;
+  pool->total_count = 0;
+
+  /* Generate random hash seed for collision resistance */
+  if (!SECURE_RANDOM (&pool->hash_seed, sizeof (pool->hash_seed)))
+    {
+      /* Fallback seed if random fails - use time-based */
+      pool->hash_seed = (uint32_t)time (NULL) ^ (uint32_t)(uintptr_t)pool;
+    }
+
+  return pool;
+}
+
+size_t
+SocketQUICConnectionIDPool_active_count (const SocketQUICConnectionIDPool_T pool)
+{
+  if (pool == NULL)
+    return 0;
+  return pool->active_count;
+}
+
+size_t
+SocketQUICConnectionIDPool_total_count (const SocketQUICConnectionIDPool_T pool)
+{
+  if (pool == NULL)
+    return 0;
+  return pool->total_count;
+}
+
+int
+SocketQUICConnectionIDPool_can_add (const SocketQUICConnectionIDPool_T pool)
+{
+  if (pool == NULL)
+    return 0;
+  return pool->active_count < pool->peer_limit;
+}
+
+/* ============================================================================
+ * Internal List Operations
+ * ============================================================================
+ */
+
+static void
+list_append (SocketQUICConnectionIDPool_T pool,
+             SocketQUICConnectionIDEntry_T *entry)
+{
+  entry->list_prev = pool->list_tail;
+  entry->list_next = NULL;
+
+  if (pool->list_tail)
+    pool->list_tail->list_next = entry;
+  else
+    pool->list_head = entry;
+
+  pool->list_tail = entry;
+}
+
+static void
+list_remove (SocketQUICConnectionIDPool_T pool,
+             SocketQUICConnectionIDEntry_T *entry)
+{
+  if (entry->list_prev)
+    entry->list_prev->list_next = entry->list_next;
+  else
+    pool->list_head = entry->list_next;
+
+  if (entry->list_next)
+    entry->list_next->list_prev = entry->list_prev;
+  else
+    pool->list_tail = entry->list_prev;
+
+  entry->list_prev = NULL;
+  entry->list_next = NULL;
+}
+
+/* ============================================================================
+ * Internal Hash Table Operations
+ * ============================================================================
+ */
+
+static void
+hash_insert (SocketQUICConnectionIDPool_T pool,
+             SocketQUICConnectionIDEntry_T *entry)
+{
+  unsigned idx
+      = hash_cid_bytes (entry->cid.data, entry->cid.len, pool->hash_seed);
+
+  entry->hash_next = pool->hash_table[idx];
+  pool->hash_table[idx] = entry;
+}
+
+static void
+hash_remove (SocketQUICConnectionIDPool_T pool,
+             SocketQUICConnectionIDEntry_T *entry)
+{
+  unsigned idx
+      = hash_cid_bytes (entry->cid.data, entry->cid.len, pool->hash_seed);
+
+  SocketQUICConnectionIDEntry_T **prev = &pool->hash_table[idx];
+
+  while (*prev)
+    {
+      if (*prev == entry)
+        {
+          *prev = entry->hash_next;
+          entry->hash_next = NULL;
+          return;
+        }
+      prev = &(*prev)->hash_next;
+    }
+}
+
+/* ============================================================================
+ * Connection ID Management
+ * ============================================================================
+ */
+
+SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_add (SocketQUICConnectionIDPool_T pool,
+                                 const SocketQUICConnectionID_T *cid)
+{
+  if (pool == NULL || cid == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  return SocketQUICConnectionIDPool_add_with_sequence (pool, cid,
+                                                        pool->next_sequence);
+}
+
+SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_add_with_sequence (SocketQUICConnectionIDPool_T pool,
+                                               const SocketQUICConnectionID_T *cid,
+                                               uint64_t sequence)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+  unsigned idx;
+  int chain_len;
+
+  if (pool == NULL || cid == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  /* Check active_connection_id_limit */
+  if (pool->active_count >= pool->peer_limit)
+    {
+      SOCKET_LOG_WARN_MSG ("Cannot add CID: at peer limit (%zu)",
+                           pool->peer_limit);
+      return QUIC_CONNID_POOL_ERROR_FULL;
+    }
+
+  /* Check for duplicate by CID bytes */
+  idx = hash_cid_bytes (cid->data, cid->len, pool->hash_seed);
+  entry = pool->hash_table[idx];
+  chain_len = 0;
+
+  while (entry)
+    {
+      chain_len++;
+      if (chain_len > QUIC_CONNID_POOL_MAX_CHAIN_LEN)
+        {
+          SOCKET_LOG_WARN_MSG (
+              "SECURITY: Hash chain too long (%d) - potential DoS attack",
+              chain_len);
+          return QUIC_CONNID_POOL_ERROR_CHAIN;
+        }
+
+      if (SocketQUICConnectionID_equal (&entry->cid, cid))
+        {
+          SOCKET_LOG_DEBUG_MSG ("Duplicate CID detected at sequence %" PRIu64,
+                                entry->cid.sequence);
+          return QUIC_CONNID_POOL_ERROR_DUP;
+        }
+
+      entry = entry->hash_next;
+    }
+
+  /* Allocate new entry */
+  entry = CALLOC (pool->arena, 1, sizeof (*entry));
+  if (entry == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  /* Copy CID and set sequence */
+  SocketQUICConnectionID_copy (&entry->cid, cid);
+  entry->cid.sequence = sequence;
+  entry->is_retired = 0;
+  entry->is_used = 0;
+  entry->used_at = 0;
+
+  /* Insert into hash table and list */
+  hash_insert (pool, entry);
+  list_append (pool, entry);
+
+  pool->total_count++;
+  pool->active_count++;
+
+  /* Update next sequence if needed */
+  if (sequence >= pool->next_sequence)
+    pool->next_sequence = sequence + 1;
+
+  SOCKET_LOG_DEBUG_MSG ("Added CID with sequence %" PRIu64 " (active: %zu/%zu)",
+                        sequence, pool->active_count, pool->peer_limit);
+
+  return QUIC_CONNID_POOL_OK;
+}
+
+SocketQUICConnectionIDEntry_T *
+SocketQUICConnectionIDPool_lookup (const SocketQUICConnectionIDPool_T pool,
+                                    const uint8_t *id, size_t len)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+  unsigned idx;
+  int chain_len;
+
+  if (pool == NULL || id == NULL)
+    return NULL;
+
+  idx = hash_cid_bytes (id, len, pool->hash_seed);
+  entry = pool->hash_table[idx];
+  chain_len = 0;
+
+  while (entry)
+    {
+      chain_len++;
+      if (chain_len > QUIC_CONNID_POOL_MAX_CHAIN_LEN)
+        {
+          SOCKET_LOG_WARN_MSG (
+              "SECURITY: Hash chain too long in lookup (%d)", chain_len);
+          return NULL;
+        }
+
+      if (SocketQUICConnectionID_equal_raw (&entry->cid, id, len))
+        return entry;
+
+      entry = entry->hash_next;
+    }
+
+  return NULL;
+}
+
+SocketQUICConnectionIDEntry_T *
+SocketQUICConnectionIDPool_lookup_sequence (const SocketQUICConnectionIDPool_T pool,
+                                             uint64_t sequence)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+
+  if (pool == NULL)
+    return NULL;
+
+  /* Linear search through list - could be optimized with sequence index */
+  entry = pool->list_head;
+  while (entry)
+    {
+      if (entry->cid.sequence == sequence)
+        return entry;
+      entry = entry->list_next;
+    }
+
+  return NULL;
+}
+
+SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_remove (SocketQUICConnectionIDPool_T pool,
+                                    const uint8_t *id, size_t len)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+
+  if (pool == NULL || id == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  entry = SocketQUICConnectionIDPool_lookup (pool, id, len);
+  if (entry == NULL)
+    return QUIC_CONNID_POOL_NOT_FOUND;
+
+  /* Remove from data structures */
+  hash_remove (pool, entry);
+  list_remove (pool, entry);
+
+  pool->total_count--;
+  if (!entry->is_retired)
+    pool->active_count--;
+
+  SOCKET_LOG_DEBUG_MSG ("Removed CID with sequence %" PRIu64,
+                        entry->cid.sequence);
+
+  /* Entry memory will be freed when arena is disposed */
+  return QUIC_CONNID_POOL_OK;
+}
+
+/* ============================================================================
+ * Retirement Functions (RFC 9000 Section 5.1.2)
+ * ============================================================================
+ */
+
+SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_retire_prior_to (SocketQUICConnectionIDPool_T pool,
+                                             uint64_t retire_prior_to,
+                                             size_t *retired_count)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+  size_t count = 0;
+
+  if (pool == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  /* RFC 9000 §5.1.2: retire_prior_to must not decrease */
+  if (retire_prior_to < pool->retire_prior_to)
+    {
+      SOCKET_LOG_WARN_MSG ("Invalid retire_prior_to: %" PRIu64
+                           " < current %" PRIu64,
+                           retire_prior_to, pool->retire_prior_to);
+      return QUIC_CONNID_POOL_ERROR_SEQ;
+    }
+
+  if (retire_prior_to == pool->retire_prior_to)
+    {
+      if (retired_count)
+        *retired_count = 0;
+      return QUIC_CONNID_POOL_OK;
+    }
+
+  pool->retire_prior_to = retire_prior_to;
+
+  /* Mark all CIDs with sequence < retire_prior_to as retired */
+  entry = pool->list_head;
+  while (entry)
+    {
+      if (entry->cid.sequence < retire_prior_to && !entry->is_retired)
+        {
+          entry->is_retired = 1;
+          pool->active_count--;
+          count++;
+        }
+      entry = entry->list_next;
+    }
+
+  if (retired_count)
+    *retired_count = count;
+
+  SOCKET_LOG_DEBUG_MSG ("Retired %zu CIDs with sequence < %" PRIu64
+                        " (active: %zu)",
+                        count, retire_prior_to, pool->active_count);
+
+  return QUIC_CONNID_POOL_OK;
+}
+
+SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_retire_sequence (SocketQUICConnectionIDPool_T pool,
+                                             uint64_t sequence)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+
+  if (pool == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  entry = SocketQUICConnectionIDPool_lookup_sequence (pool, sequence);
+  if (entry == NULL)
+    return QUIC_CONNID_POOL_NOT_FOUND;
+
+  if (!entry->is_retired)
+    {
+      entry->is_retired = 1;
+      pool->active_count--;
+      SOCKET_LOG_DEBUG_MSG ("Retired CID with sequence %" PRIu64, sequence);
+    }
+
+  return QUIC_CONNID_POOL_OK;
+}
+
+SocketQUICConnectionIDPool_Result
+SocketQUICConnectionIDPool_purge_retired (SocketQUICConnectionIDPool_T pool,
+                                           size_t *removed_count)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+  SocketQUICConnectionIDEntry_T *next;
+  size_t count = 0;
+
+  if (pool == NULL)
+    return QUIC_CONNID_POOL_ERROR_NULL;
+
+  entry = pool->list_head;
+  while (entry)
+    {
+      next = entry->list_next;
+
+      if (entry->is_retired)
+        {
+          hash_remove (pool, entry);
+          list_remove (pool, entry);
+          pool->total_count--;
+          count++;
+          /* Memory freed when arena is disposed */
+        }
+
+      entry = next;
+    }
+
+  if (removed_count)
+    *removed_count = count;
+
+  SOCKET_LOG_DEBUG_MSG ("Purged %zu retired CIDs (total: %zu)", count,
+                        pool->total_count);
+
+  return QUIC_CONNID_POOL_OK;
+}
+
+uint64_t
+SocketQUICConnectionIDPool_get_retire_prior_to (const SocketQUICConnectionIDPool_T pool)
+{
+  if (pool == NULL)
+    return 0;
+  return pool->retire_prior_to;
+}
+
+/* ============================================================================
+ * Iteration Functions
+ * ============================================================================
+ */
+
+int
+SocketQUICConnectionIDPool_foreach (SocketQUICConnectionIDPool_T pool,
+                                     SocketQUICConnectionIDPool_Iterator callback,
+                                     void *context)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+  int count = 0;
+
+  if (pool == NULL || callback == NULL)
+    return -1;
+
+  entry = pool->list_head;
+  while (entry)
+    {
+      if (!entry->is_retired)
+        {
+          if (callback (entry, context) != 0)
+            break;
+          count++;
+        }
+      entry = entry->list_next;
+    }
+
+  return count;
+}
+
+SocketQUICConnectionIDEntry_T *
+SocketQUICConnectionIDPool_get_available (SocketQUICConnectionIDPool_T pool)
+{
+  SocketQUICConnectionIDEntry_T *entry;
+
+  if (pool == NULL)
+    return NULL;
+
+  entry = pool->list_head;
+  while (entry)
+    {
+      if (!entry->is_retired && !entry->is_used)
+        {
+          entry->is_used = 1;
+          entry->used_at = (uint64_t)Socket_get_monotonic_ms ();
+          return entry;
+        }
+      entry = entry->list_next;
+    }
+
+  return NULL;
+}
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+int
+SocketQUICConnectionIDPool_needs_more (const SocketQUICConnectionIDPool_T pool,
+                                        size_t min_for_migrate)
+{
+  if (pool == NULL)
+    return 0;
+
+  /* Need more if active count is below minimum for migration */
+  return pool->active_count < min_for_migrate;
+}

--- a/src/test/test_quic_connid_pool.c
+++ b/src/test/test_quic_connid_pool.c
@@ -1,0 +1,536 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_quic_connid_pool.c
+ * @brief Unit tests for QUIC Connection ID Pool (RFC 9000 §5.1.1-5.1.2).
+ */
+
+#include "core/Arena.h"
+#include "quic/SocketQUICConnectionID-pool.h"
+#include "quic/SocketQUICConnectionID.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * Pool Creation Tests
+ * ============================================================================
+ */
+
+TEST (connid_pool_new_creates_pool)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 0);
+  ASSERT_EQ (SocketQUICConnectionIDPool_total_count (pool), 0);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_new_null_arena_returns_null)
+{
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (NULL, 8);
+  ASSERT_NULL (pool);
+}
+
+TEST (connid_pool_new_enforces_minimum_peer_limit)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  /* Request limit of 1, should be upgraded to minimum (2) */
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 1);
+  ASSERT_NOT_NULL (pool);
+
+  /* Can add at least 2 CIDs */
+  ASSERT (SocketQUICConnectionIDPool_can_add (pool));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Add Connection ID Tests
+ * ============================================================================
+ */
+
+TEST (connid_pool_add_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  SocketQUICConnectionID_T cid;
+  ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+  ASSERT_EQ (SocketQUICConnectionID_generate_reset_token (&cid), QUIC_CONNID_OK);
+
+  SocketQUICConnectionIDPool_Result result
+      = SocketQUICConnectionIDPool_add (pool, &cid);
+  ASSERT_EQ (result, QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 1);
+  ASSERT_EQ (SocketQUICConnectionIDPool_total_count (pool), 1);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_add_with_sequence)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  SocketQUICConnectionID_T cid;
+  ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+
+  /* Add with sequence 0 (initial CID) */
+  SocketQUICConnectionIDPool_Result result
+      = SocketQUICConnectionIDPool_add_with_sequence (pool, &cid, 0);
+  ASSERT_EQ (result, QUIC_CONNID_POOL_OK);
+
+  /* Verify sequence was set */
+  SocketQUICConnectionIDEntry_T *entry
+      = SocketQUICConnectionIDPool_lookup_sequence (pool, 0);
+  ASSERT_NOT_NULL (entry);
+  ASSERT_EQ (entry->cid.sequence, 0);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_add_multiple)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  for (int i = 0; i < 5; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 5);
+  ASSERT_EQ (SocketQUICConnectionIDPool_total_count (pool), 5);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_add_respects_peer_limit)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 3);
+  ASSERT_NOT_NULL (pool);
+
+  /* Add up to limit */
+  for (int i = 0; i < 3; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  ASSERT (!SocketQUICConnectionIDPool_can_add (pool));
+
+  /* Adding another should fail */
+  SocketQUICConnectionID_T cid;
+  ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid),
+             QUIC_CONNID_POOL_ERROR_FULL);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_add_rejects_duplicate)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  SocketQUICConnectionID_T cid;
+  ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid),
+             QUIC_CONNID_POOL_ERROR_DUP);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Lookup Tests
+ * ============================================================================
+ */
+
+TEST (connid_pool_lookup_by_bytes)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  SocketQUICConnectionID_T cid;
+  uint8_t test_bytes[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  ASSERT_EQ (SocketQUICConnectionID_set (&cid, test_bytes, 8), QUIC_CONNID_OK);
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+
+  /* Lookup should find it */
+  SocketQUICConnectionIDEntry_T *entry
+      = SocketQUICConnectionIDPool_lookup (pool, test_bytes, 8);
+  ASSERT_NOT_NULL (entry);
+  ASSERT (SocketQUICConnectionID_equal_raw (&entry->cid, test_bytes, 8));
+
+  /* Lookup with different bytes should not find it */
+  uint8_t other_bytes[8] = { 0xFF, 0xFE, 0xFD, 0xFC, 0xFB, 0xFA, 0xF9, 0xF8 };
+  entry = SocketQUICConnectionIDPool_lookup (pool, other_bytes, 8);
+  ASSERT_NULL (entry);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_lookup_by_sequence)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  for (int i = 0; i < 5; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  /* Should find sequences 0-4 */
+  for (uint64_t i = 0; i < 5; i++)
+    {
+      SocketQUICConnectionIDEntry_T *entry
+          = SocketQUICConnectionIDPool_lookup_sequence (pool, i);
+      ASSERT_NOT_NULL (entry);
+      ASSERT_EQ (entry->cid.sequence, i);
+    }
+
+  /* Sequence 5 should not exist */
+  ASSERT_NULL (SocketQUICConnectionIDPool_lookup_sequence (pool, 5));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Remove Tests
+ * ============================================================================
+ */
+
+TEST (connid_pool_remove_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  uint8_t test_bytes[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  SocketQUICConnectionID_T cid;
+  ASSERT_EQ (SocketQUICConnectionID_set (&cid, test_bytes, 8), QUIC_CONNID_OK);
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 1);
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_remove (pool, test_bytes, 8),
+             QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 0);
+
+  /* Lookup should not find it anymore */
+  ASSERT_NULL (SocketQUICConnectionIDPool_lookup (pool, test_bytes, 8));
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_remove_not_found)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 8);
+  ASSERT_NOT_NULL (pool);
+
+  uint8_t test_bytes[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_remove (pool, test_bytes, 8),
+             QUIC_CONNID_POOL_NOT_FOUND);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Retire Prior To Tests (RFC 9000 §5.1.2)
+ * ============================================================================
+ */
+
+TEST (connid_pool_retire_prior_to_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Add 5 CIDs with sequences 0-4 */
+  for (int i = 0; i < 5; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 5);
+
+  /* Retire all with sequence < 3 */
+  size_t retired_count = 0;
+  ASSERT_EQ (
+      SocketQUICConnectionIDPool_retire_prior_to (pool, 3, &retired_count),
+      QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (retired_count, 3);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 2);
+  ASSERT_EQ (SocketQUICConnectionIDPool_total_count (pool), 5);
+
+  /* Entries 0, 1, 2 should be retired */
+  for (uint64_t i = 0; i < 3; i++)
+    {
+      SocketQUICConnectionIDEntry_T *entry
+          = SocketQUICConnectionIDPool_lookup_sequence (pool, i);
+      ASSERT_NOT_NULL (entry);
+      ASSERT (entry->is_retired);
+    }
+
+  /* Entries 3, 4 should still be active */
+  for (uint64_t i = 3; i < 5; i++)
+    {
+      SocketQUICConnectionIDEntry_T *entry
+          = SocketQUICConnectionIDPool_lookup_sequence (pool, i);
+      ASSERT_NOT_NULL (entry);
+      ASSERT (!entry->is_retired);
+    }
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_retire_prior_to_cannot_decrease)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Set retire_prior_to to 5 */
+  ASSERT_EQ (SocketQUICConnectionIDPool_retire_prior_to (pool, 5, NULL),
+             QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_get_retire_prior_to (pool), 5);
+
+  /* Trying to decrease should fail */
+  ASSERT_EQ (SocketQUICConnectionIDPool_retire_prior_to (pool, 3, NULL),
+             QUIC_CONNID_POOL_ERROR_SEQ);
+
+  /* Value should remain unchanged */
+  ASSERT_EQ (SocketQUICConnectionIDPool_get_retire_prior_to (pool), 5);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_retire_sequence)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Add 3 CIDs */
+  for (int i = 0; i < 3; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 3);
+
+  /* Retire sequence 1 */
+  ASSERT_EQ (SocketQUICConnectionIDPool_retire_sequence (pool, 1),
+             QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 2);
+
+  /* Verify it's retired */
+  SocketQUICConnectionIDEntry_T *entry
+      = SocketQUICConnectionIDPool_lookup_sequence (pool, 1);
+  ASSERT_NOT_NULL (entry);
+  ASSERT (entry->is_retired);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_purge_retired)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Add 5 CIDs */
+  for (int i = 0; i < 5; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  /* Retire first 3 */
+  ASSERT_EQ (SocketQUICConnectionIDPool_retire_prior_to (pool, 3, NULL),
+             QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_total_count (pool), 5);
+
+  /* Purge retired */
+  size_t removed_count = 0;
+  ASSERT_EQ (SocketQUICConnectionIDPool_purge_retired (pool, &removed_count),
+             QUIC_CONNID_POOL_OK);
+  ASSERT_EQ (removed_count, 3);
+  ASSERT_EQ (SocketQUICConnectionIDPool_total_count (pool), 2);
+  ASSERT_EQ (SocketQUICConnectionIDPool_active_count (pool), 2);
+
+  /* Purged entries should not be found */
+  for (uint64_t i = 0; i < 3; i++)
+    {
+      ASSERT_NULL (SocketQUICConnectionIDPool_lookup_sequence (pool, i));
+    }
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Iteration and Availability Tests
+ * ============================================================================
+ */
+
+static int
+count_iterator (SocketQUICConnectionIDEntry_T *entry, void *context)
+{
+  (void)entry;
+  int *count = (int *)context;
+  (*count)++;
+  return 0;
+}
+
+TEST (connid_pool_foreach_skips_retired)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Add 5 CIDs, retire 2 */
+  for (int i = 0; i < 5; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  ASSERT_EQ (SocketQUICConnectionIDPool_retire_prior_to (pool, 2, NULL),
+             QUIC_CONNID_POOL_OK);
+
+  /* Count via foreach - should only count non-retired */
+  int count = 0;
+  int visited = SocketQUICConnectionIDPool_foreach (pool, count_iterator, &count);
+  ASSERT_EQ (visited, 3);
+  ASSERT_EQ (count, 3);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_get_available)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Add 3 CIDs */
+  for (int i = 0; i < 3; i++)
+    {
+      SocketQUICConnectionID_T cid;
+      ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+      ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+    }
+
+  /* Get available - should return first one */
+  SocketQUICConnectionIDEntry_T *entry1
+      = SocketQUICConnectionIDPool_get_available (pool);
+  ASSERT_NOT_NULL (entry1);
+  ASSERT (entry1->is_used);
+
+  /* Get another - should return a different one */
+  SocketQUICConnectionIDEntry_T *entry2
+      = SocketQUICConnectionIDPool_get_available (pool);
+  ASSERT_NOT_NULL (entry2);
+  ASSERT (entry2->is_used);
+  ASSERT_NE (entry1, entry2);
+
+  /* Get third */
+  SocketQUICConnectionIDEntry_T *entry3
+      = SocketQUICConnectionIDPool_get_available (pool);
+  ASSERT_NOT_NULL (entry3);
+
+  /* No more available */
+  SocketQUICConnectionIDEntry_T *entry4
+      = SocketQUICConnectionIDPool_get_available (pool);
+  ASSERT_NULL (entry4);
+
+  Arena_dispose (&arena);
+}
+
+TEST (connid_pool_needs_more)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICConnectionIDPool_T pool = SocketQUICConnectionIDPool_new (arena, 10);
+  ASSERT_NOT_NULL (pool);
+
+  /* Empty pool needs more for migration (needs at least 2) */
+  ASSERT (SocketQUICConnectionIDPool_needs_more (pool, 2));
+
+  /* Add 1 CID - still needs more */
+  SocketQUICConnectionID_T cid;
+  ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+  ASSERT (SocketQUICConnectionIDPool_needs_more (pool, 2));
+
+  /* Add second - now has enough */
+  ASSERT_EQ (SocketQUICConnectionID_generate (&cid, 8), QUIC_CONNID_OK);
+  ASSERT_EQ (SocketQUICConnectionIDPool_add (pool, &cid), QUIC_CONNID_POOL_OK);
+  ASSERT (!SocketQUICConnectionIDPool_needs_more (pool, 2));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Result String Tests
+ * ============================================================================
+ */
+
+TEST (connid_pool_result_strings)
+{
+  ASSERT_NOT_NULL (
+      SocketQUICConnectionIDPool_result_string (QUIC_CONNID_POOL_OK));
+  ASSERT_NOT_NULL (
+      SocketQUICConnectionIDPool_result_string (QUIC_CONNID_POOL_ERROR_NULL));
+  ASSERT_NOT_NULL (
+      SocketQUICConnectionIDPool_result_string (QUIC_CONNID_POOL_ERROR_FULL));
+  ASSERT_NOT_NULL (
+      SocketQUICConnectionIDPool_result_string (QUIC_CONNID_POOL_ERROR_DUP));
+  ASSERT_NOT_NULL (
+      SocketQUICConnectionIDPool_result_string (QUIC_CONNID_POOL_NOT_FOUND));
+}
+
+/* ============================================================================
+ * Main Entry Point
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary
- Implement `SocketQUICConnectionIDPool_T` for managing connection ID lifecycle
- Hash table lookup by CID bytes with FNV-1a hash and random seed
- Retire Prior To bulk retirement support per RFC 9000 §5.1.2
- Enforce `active_connection_id_limit` from transport parameters

Fixes #401

## Test plan
- [x] 20 unit tests covering all pool operations
- [x] Tests pass with ASan + UBSan enabled
- [x] Duplicate detection works correctly
- [x] Retire Prior To correctly marks and purges CIDs