### PR TITLE
refactor(socket): extract predicates and split long functions

### DIFF
--- a/src/socket/Socket-convenience.c
+++ b/src/socket/Socket-convenience.c
@@ -30,6 +30,13 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketConvenience);
 
 #define RAISE_MODULE_ERROR(e) SOCKET_RAISE_MODULE_ERROR (SocketConvenience, e)
 
+static inline int
+is_connect_in_progress_error (int err)
+{
+  return err == EINPROGRESS || err == EINTR || err == EAGAIN
+         || err == EWOULDBLOCK;
+}
+
 static int
 get_socket_flags (int fd, int *flags_out)
 {
@@ -368,7 +375,7 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
                 return;
         }
 
-        if (errno != EINPROGRESS && errno != EINTR && errno != EAGAIN && errno != EWOULDBLOCK) {
+        if (!is_connect_in_progress_error (errno)) {
                 with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
                 SOCKET_ERROR_FMT ("Unix connect to %.*s failed",
                                   SOCKET_ERROR_MAX_HOSTNAME, path);


### PR DESCRIPTION
## Summary

Implements the refactoring improvements identified by the code analysis pipeline on `src/socket/`.

### Changes

**Socket.c** - Extract path traversal predicate:
- New `contains_parent_dir_traversal()` function replaces inline conditional
- Makes security check self-documenting with comments for each case

**Socket-convenience.c** - Extract connect error predicate:
- New `is_connect_in_progress_error()` function clarifies async connect handling
- Replaces complex `errno != EINPROGRESS && errno != EINTR && ...` conditional

**SocketAsync.c** - Split long backend detection function:
- Original: 114-line `detect_async_backend_with_config()` with nested conditionals
- Now: ~15-line dispatcher with 5 focused helper functions:
  - `io_uring_register_and_activate()` - Common eventfd setup
  - `try_io_uring_sqpoll()` - SQPOLL mode initialization
  - `try_io_uring_default()` - Default mode initialization  
  - `detect_io_uring_backend()` - Main io_uring detection
  - `detect_kqueue_backend()` - kqueue backend detection

### Analysis Notes

Several flagged items were found to be false positives or already addressed:
- `Socket_accept` was already refactored into 7 helper functions
- `Socket_get_tcp_info` is field mapping (splitting adds no value)
- SWAP_BYTES macro doesn't exist
- Volatile loop counter issue was actually correct exception safety

Fixes #464

## Test plan
- [x] Build succeeds with sanitizers enabled
- [x] All 111 tests pass with ASan/UBSan