### PR TITLE
refactor(http): remove unused includes from SocketHTTPServer.c

### DIFF
--- a/src/http/SocketHTTPServer.c
+++ b/src/http/SocketHTTPServer.c
@@ -10,10 +10,8 @@
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
-#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
-#include <strings.h>
 #include <sys/socket.h>
 
 #include "core/Arena.h"


### PR DESCRIPTION
## Summary

- Remove unused `<stdatomic.h>` and `<strings.h>` includes from SocketHTTPServer.c

Identified by /pipeline analysis. These headers were included but not used by any code in the file.

Fixes #473

## Test plan

- [x] Build succeeds
- [x] All HTTP tests pass with sanitizers enabled