### PR TITLE
refactor(proxy): simplify colon search with memchr

### DIFF
--- a/src/socket/SocketProxy.c
+++ b/src/socket/SocketProxy.c
@@ -209,34 +209,7 @@ socketproxy_parse_userinfo (const char *start, SocketProxy_Config *config,
       return -1;
     }
 
-  colon = strchr (start, ':');
-  if (colon != NULL && colon > at_sign)
-    {
-      colon = NULL;
-      for (const char *p = start; p < at_sign; p++)
-        {
-          if (*p == ':')
-            {
-              colon = p;
-              break;
-            }
-        }
-    }
-  else if (colon != NULL && colon < at_sign)
-    {
-    }
-  else
-    {
-      colon = NULL;
-      for (const char *p = start; p < at_sign; p++)
-        {
-          if (*p == ':')
-            {
-              colon = p;
-              break;
-            }
-        }
-    }
+  colon = memchr (start, ':', (size_t)(at_sign - start));
 
   if (colon != NULL && colon < at_sign)
     {


### PR DESCRIPTION
## Summary

Implements #482

## Changes

- Replaced 28 lines of duplicate loop logic with single `memchr` call in SocketProxy.c
- Removed dead `else-if` branch
- Simplified colon search in URL parsing userinfo section

## Test Plan

- [x] Tests pass with sanitizers (all 111 tests passed)
- [x] Build successful with ASAN/UBSAN enabled
- [x] No functional changes, pure refactoring

Closes #482