### PR TITLE
fix(websocket): validate strtol endptr in ws_parse_window_bits

### DIFF
--- a/src/socket/SocketWS-handshake.c
+++ b/src/socket/SocketWS-handshake.c
@@ -467,6 +467,9 @@ ws_parse_window_bits (const char *extensions, const char *param_name)
   {
     char *endptr;
     long v = strtol (eq + 1, &endptr, 10);
+    /* Validate endptr: must have consumed digits and hit separator or end */
+    if (endptr == eq + 1 || (*endptr != '\0' && *endptr != ';' && *endptr != ',' && *endptr != ' '))
+      return SOCKETWS_DEFAULT_DEFLATE_WINDOW_BITS;
     value
         = (v >= 8 && v <= 15) ? (int)v : SOCKETWS_DEFAULT_DEFLATE_WINDOW_BITS;
   }


### PR DESCRIPTION
## Summary

Fixes #484 - Adds proper validation of strtol endptr in `ws_parse_window_bits()` function.

## Changes

- Added validation to ensure strtol successfully consumed digits from the input
- Checks that endptr points to a valid separator (`\0`, `;`, `,`, or space) after parsing
- Prevents malformed values like `"server_max_window_bits=9garbage"` from being accepted as valid window bits value of 9

## Test Plan

- [x] All tests pass with sanitizers enabled
- [x] Build completes without warnings
- [x] No memory leaks detected by ASan

Closes #484