### PR TITLE
fix(socket): add debug log for Arena_alloc failure in SocketBuf compact

### DIFF
--- a/src/socket/SocketBuf.c
+++ b/src/socket/SocketBuf.c
@@ -602,6 +602,10 @@ SocketBuf_compact (T buf)
             }
           else
             {
+              SOCKET_LOG_DEBUG_MSG (
+                  "Arena_alloc failed in compact, using in-place rotation "
+                  "(size=%zu)",
+                  buf->size);
               compact_rotate_in_place (buf->data, buf->capacity, buf->head,
                                        buf->size);
             }


### PR DESCRIPTION
## Summary

Implements #483 - Adds debug logging when Arena_alloc fails during buffer compaction.

## Changes

- Added `SOCKET_LOG_DEBUG_MSG` in `SocketBuf_compact()` to log when Arena_alloc fails and the code falls back to in-place rotation
- Log message includes buffer size to help diagnose memory pressure situations

## Test Plan

- [x] Tests pass with sanitizers (`ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest -j$(nproc) --output-on-failure`)
- [x] All 111 tests passed
- [x] No memory leaks or undefined behavior detected
- [x] Code compiles without warnings

## Location

`src/socket/SocketBuf.c`, lines 605-608

Closes #483