### PR TITLE
fix(proxy): add exception handling for Socket_setnonblocking call

### DIFF
--- a/src/socket/SocketProxy.c
+++ b/src/socket/SocketProxy.c
@@ -997,7 +997,17 @@ SocketProxy_Conn_new (const SocketProxy_Config *proxy, const char *target_host,
   if (proxy_connect_to_server_sync (conn) < 0)
     return conn;
 
-  Socket_setnonblocking (conn->socket);
+  TRY
+  {
+    Socket_setnonblocking (conn->socket);
+  }
+  EXCEPT (Socket_Failed)
+  {
+    socketproxy_set_error (conn, PROXY_ERROR_CONNECT,
+                           "Failed to set socket non-blocking");
+    return conn;
+  }
+  END_TRY;
 
   conn->state = PROXY_STATE_HANDSHAKE_SEND;
   conn->handshake_start_time_ms = socketproxy_get_time_ms ();


### PR DESCRIPTION
## Summary

Implements #485 by adding proper exception handling for the `Socket_setnonblocking()` call in `SocketProxy_Conn_new()`.

## Changes

- Wrapped `Socket_setnonblocking()` call in TRY/EXCEPT block
- Used `socketproxy_set_error()` to properly handle Socket_Failed exceptions
- Sets connection state to PROXY_STATE_FAILED with PROXY_ERROR_CONNECT result code on error

## Test Plan

- [x] Tests pass with sanitizers enabled (`ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest`)
- [x] All 111 tests pass including proxy-specific tests
- [x] No memory leaks detected
- [x] Follows existing error handling patterns in the module

Closes #485