### PR TITLE
refactor(dns): replace magic number with SOCKET_MS_PER_SECOND constant

### DIFF
--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -618,7 +618,7 @@ cache_entry_expired (const struct SocketDNS_T *dns,
   now_ms = Socket_get_monotonic_ms ();
   age_ms = now_ms - entry->insert_time_ms;
 
-  return age_ms >= (int64_t)dns->cache_ttl_seconds * 1000;
+  return age_ms >= (int64_t)dns->cache_ttl_seconds * SOCKET_MS_PER_SECOND;
 }
 
 static void


### PR DESCRIPTION
## Summary
- Replace hardcoded `1000` with `SOCKET_MS_PER_SECOND` in cache TTL calculation for consistency

Fixes #503

## Test plan
- [x] All 111 tests pass with sanitizers enabled
- [x] Build completes successfully