### PR TITLE
refactor(core): replace magic numbers with named constants

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -945,6 +945,17 @@ extern const char *Socket_safe_strerror (int errnum);
 #endif
 
 /**
+ * @brief Minimum duration for TimeWindow to prevent division by zero.
+ *
+ * Enforces a minimum window duration of 1ms in TimeWindow_init.
+ * This prevents division by zero in rate calculations.
+ *
+ */
+#ifndef TIMEWINDOW_MIN_DURATION_MS
+#define TIMEWINDOW_MIN_DURATION_MS 1
+#endif
+
+/**
  * @brief Maximum allowed window duration for SYN protection.
  *
  * Caps config.window_duration_ms to prevent excessive memory usage.

--- a/include/core/SocketSYNProtect-private.h
+++ b/include/core/SocketSYNProtect-private.h
@@ -18,6 +18,7 @@
  */
 
 #include "core/Arena.h"
+#include "core/SocketConfig.h"
 #include "core/SocketRateLimit.h"
 #include "core/SocketSYNProtect.h"
 #include "core/SocketUtil.h"

--- a/src/core/SocketSYNProtect-ip.c
+++ b/src/core/SocketSYNProtect-ip.c
@@ -93,7 +93,7 @@ int
 cidr_partial_byte_match (const uint8_t *ip_bytes, const uint8_t *entry_bytes,
                          int byte_index, int remaining_bits)
 {
-  uint8_t mask = (uint8_t)(0xFF << (8 - remaining_bits));
+  uint8_t mask = (uint8_t)(0xFF << (SOCKET_BITS_PER_BYTE - remaining_bits));
   return ((ip_bytes[byte_index] & mask) == (entry_bytes[byte_index] & mask));
 }
 
@@ -107,8 +107,8 @@ ip_matches_cidr_bytes (int family, const uint8_t *ip_bytes,
     return 0;
 
   bits = entry->prefix_len;
-  bytes_to_match = bits / 8;
-  remaining_bits = bits % 8;
+  bytes_to_match = bits / SOCKET_BITS_PER_BYTE;
+  remaining_bits = bits % SOCKET_BITS_PER_BYTE;
 
   if (!cidr_full_bytes_match (ip_bytes, entry->addr_bytes, bytes_to_match))
     return 0;

--- a/src/core/TimeWindow.c
+++ b/src/core/TimeWindow.c
@@ -9,6 +9,7 @@
 #include <assert.h>
 #include <stddef.h>
 
+#include "core/SocketConfig.h"
 #include "core/TimeWindow.h"
 
 #define T TimeWindow_T
@@ -32,7 +33,7 @@ TimeWindow_init (T *tw, int duration_ms, int64_t now_ms)
 {
   assert (tw != NULL);
 
-  tw->duration_ms = (duration_ms > 0) ? duration_ms : 1;
+  tw->duration_ms = (duration_ms > 0) ? duration_ms : TIMEWINDOW_MIN_DURATION_MS;
   tw->window_start_ms = now_ms;
   tw->current_count = 0;
   tw->previous_count = 0;


### PR DESCRIPTION
## Summary

Replaces magic numbers in `src/core/` files with descriptive named constants to improve code readability and maintainability.

## Changes

### 1. SocketSYNProtect-ip.c - Use SOCKET_BITS_PER_BYTE constant

**File:** `src/core/SocketSYNProtect-ip.c` (lines 110-111, 96)

**Before:**
```c
bytes_to_match = bits / 8;
remaining_bits = bits % 8;
uint8_t mask = (uint8_t)(0xFF << (8 - remaining_bits));
```

**After:**
```c
bytes_to_match = bits / SOCKET_BITS_PER_BYTE;
remaining_bits = bits % SOCKET_BITS_PER_BYTE;
uint8_t mask = (uint8_t)(0xFF << (SOCKET_BITS_PER_BYTE - remaining_bits));
```

The constant `SOCKET_BITS_PER_BYTE` was already defined in `include/core/SocketConfig.h` (line 944) but not being used. Added include to `SocketSYNProtect-private.h` to make the constant available.

### 2. TimeWindow.c - Add TIMEWINDOW_MIN_DURATION_MS constant

**File:** `src/core/TimeWindow.c` (line 35)

**Before:**
```c
tw->duration_ms = (duration_ms > 0) ? duration_ms : 1;
```

**After:**
```c
tw->duration_ms = (duration_ms > 0) ? duration_ms : TIMEWINDOW_MIN_DURATION_MS;
```

Added new constant `TIMEWINDOW_MIN_DURATION_MS` to `SocketConfig.h` (lines 947-956) to document this policy decision that prevents division by zero in later rate calculations.

## Test Plan

- [x] All 111 tests pass with sanitizers enabled
- [x] Build completes without warnings
- [x] No functional changes - pure refactoring

```bash
cmake -B build -DENABLE_SANITIZERS=ON
cmake --build build -j$(nproc)
cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest -j$(nproc)
```

Result: **100% tests passed, 0 tests failed out of 111**

Closes #497