### PR TITLE
refactor(core): rename private helpers to follow module prefix convention

### DIFF
--- a/src/core/SocketMetrics.c
+++ b/src/core/SocketMetrics.c
@@ -256,7 +256,7 @@ histogram_is_valid (SocketHistogramMetric metric)
 }
 
 static int
-compare_double (const void *a, const void *b)
+metrics_compare_double (const void *a, const void *b)
 {
   const double da = *(const double *)a;
   const double db = *(const double *)b;
@@ -378,7 +378,7 @@ histogram_get_sorted_copy (Histogram *h, size_t *out_count)
     }
 
   n = histogram_copy_values (h, sorted, count);
-  qsort (sorted, n, sizeof (double), compare_double);
+  qsort (sorted, n, sizeof (double), metrics_compare_double);
 
   *out_count = n;
   return sorted;

--- a/src/core/SocketRetry.c
+++ b/src/core/SocketRetry.c
@@ -128,7 +128,7 @@ validate_policy (const SocketRetry_Policy *policy)
 
 /* Compute base^exp iteratively to avoid pow() overhead */
 static double
-power_double (double base, int exp)
+retry_power_double (double base, int exp)
 {
   double result = 1.0;
 
@@ -169,7 +169,7 @@ exponential_backoff (const SocketRetry_Policy *policy, int attempt)
   if (attempt < 1)
     return 0.0;
 
-  multiplier_pow = power_double (policy->multiplier, attempt - 1);
+  multiplier_pow = retry_power_double (policy->multiplier, attempt - 1);
   base_delay = (double)policy->initial_delay_ms * multiplier_pow;
 
   if (isinf (base_delay) || isnan (base_delay))


### PR DESCRIPTION
## Summary

Implements #499

Renamed static helper functions to align with project naming patterns:
- `SocketMetrics.c`: `compare_double` -> `metrics_compare_double`
- `SocketRetry.c`: `power_double` -> `retry_power_double`

## Changes

- Renamed `compare_double` to `metrics_compare_double` in `src/core/SocketMetrics.c`
- Updated qsort call site to use new name
- Renamed `power_double` to `retry_power_double` in `src/core/SocketRetry.c`
- Updated function call site in exponential backoff calculation

## Test Plan

- [x] All tests pass with sanitizers enabled (111/111 passed)
- [x] Build succeeds with ASan/UBSan
- [x] No functional changes - pure refactoring

Closes #499