### PR TITLE
refactor(tls): add SOCKET_OPENSSL_VERSION_3_0 constant for version checks

### DIFF
--- a/include/tls/SocketSSL-internal.h
+++ b/include/tls/SocketSSL-internal.h
@@ -51,6 +51,24 @@
  */
 #define SOCKET_SSL_UNUSED(x) (void)(x)
 
+/**
+ * @brief OpenSSL 3.0.0 version number for conditional compilation.
+ * @ingroup security
+ *
+ * Used to check for OpenSSL 3.0+ features and deprecations at compile time.
+ * OpenSSL version format: MNNFFPPS (major/minor/fix/patch/status).
+ *
+ * Version breakdown for 0x30000000L:
+ * - Major: 0x30 = 3
+ * - Minor: 0x00 = 0
+ * - Fix:   0x00 = 0
+ * - Patch: 0x00 = 0
+ * - Status: 0x0 = release
+ *
+ * @see OPENSSL_VERSION_NUMBER for runtime OpenSSL version
+ */
+#define SOCKET_OPENSSL_VERSION_3_0 0x30000000L
+
 /* ============================================================================
  * Common File Path Validation
  * ============================================================================

--- a/src/tls/SocketDTLSContext.c
+++ b/src/tls/SocketDTLSContext.c
@@ -22,6 +22,7 @@
 #include "core/SocketCrypto.h"
 #include "core/SocketSecurity.h"
 #include "tls/SocketDTLS-private.h"
+#include "tls/SocketSSL-internal.h"
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -283,7 +284,7 @@ SocketDTLSContext_free (T *ctx_p)
   /* Free SSL_CTX */
   if (ctx->ssl_ctx)
     {
-#if OPENSSL_VERSION_NUMBER < 0x30000000L
+#if OPENSSL_VERSION_NUMBER < SOCKET_OPENSSL_VERSION_3_0
       /* Flush session cache to prevent memory leaks (OpenSSL < 3.0) */
       SSL_CTX_flush_sessions (ctx->ssl_ctx, 0);
 #endif

--- a/src/tls/SocketTLSContext-verify.c
+++ b/src/tls/SocketTLSContext-verify.c
@@ -21,6 +21,7 @@
 #include "core/SocketSecurity.h"
 #include "core/SocketUtil.h"
 #include "tls/SocketTLS-private.h"
+#include "tls/SocketSSL-internal.h"
 #include <assert.h>
 
 /* Thread-local exception for SocketTLSContext module */
@@ -1218,8 +1219,8 @@ SocketTLSContext_ocsp_stapling_enabled (T ctx)
 }
 
 /* X509_STORE_set_lookup_certs_cb is only available in OpenSSL 3.0.0+
- * Check for OPENSSL_VERSION_NUMBER >= 0x30000000L */
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+ * Check for OPENSSL_VERSION_NUMBER >= SOCKET_OPENSSL_VERSION_3_0 */
+#if OPENSSL_VERSION_NUMBER >= SOCKET_OPENSSL_VERSION_3_0
 
 /* Security: Dynamically allocated ex_data index to avoid conflicts with
  * other libraries using X509_STORE ex_data. Using hardcoded index 0


### PR DESCRIPTION
## Summary

Implements #521 by replacing the magic number `0x30000000L` with a named constant `SOCKET_OPENSSL_VERSION_3_0` for improved code clarity and maintainability.

## Changes

- Added `SOCKET_OPENSSL_VERSION_3_0` constant to `include/tls/SocketSSL-internal.h` with comprehensive documentation
- Updated `src/tls/SocketDTLSContext.c` to use the constant for OpenSSL 3.0 session cache flush check
- Updated `src/tls/SocketTLSContext-verify.c` to use the constant for API availability check
- Included detailed documentation explaining OpenSSL version format (MNNFFPPS)

## Test Plan

- [x] All tests pass with sanitizers (111/111 tests passed)
- [x] Build succeeds with ASan/UBSan enabled
- [x] No functional changes - purely refactoring magic numbers to named constants

Closes #521