### PR TITLE
refactor(core): Consolidate big-endian pack/unpack helpers into SocketUtil

### DIFF
--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -1136,6 +1136,115 @@ socket_util_ttl_remaining (int64_t insert_time_ms, uint32_t ttl_sec,
 }
 
 /* ============================================================================
+ * BIG-ENDIAN BYTE MANIPULATION UTILITIES
+ * ============================================================================
+ */
+
+/**
+ * @brief Unpack 16-bit big-endian value.
+ * @ingroup foundation
+ * @param p Pointer to 2-byte buffer.
+ * @return Decoded 16-bit value in host byte order.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 2 bytes from big-endian (network) byte order to host byte order.
+ * Used for parsing network protocols (DNS, HTTP/2, QUIC).
+ */
+static inline uint16_t
+socket_util_unpack_be16 (const unsigned char *p)
+{
+  return ((uint16_t)p[0] << 8) | (uint16_t)p[1];
+}
+
+/**
+ * @brief Pack 16-bit value to big-endian.
+ * @ingroup foundation
+ * @param p Pointer to 2-byte buffer.
+ * @param v 16-bit value in host byte order.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 16-bit value from host byte order to big-endian (network) byte order.
+ * Used for serializing network protocols (DNS, HTTP/2, QUIC).
+ */
+static inline void
+socket_util_pack_be16 (unsigned char *p, uint16_t v)
+{
+  p[0] = (unsigned char)((v >> 8) & 0xFF);
+  p[1] = (unsigned char)(v & 0xFF);
+}
+
+/**
+ * @brief Unpack 24-bit big-endian value.
+ * @ingroup foundation
+ * @param p Pointer to 3-byte buffer.
+ * @return Decoded 24-bit value in host byte order (stored in uint32_t).
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 3 bytes from big-endian byte order to host byte order.
+ * Used for HTTP/2 frame length fields (24-bit).
+ */
+static inline uint32_t
+socket_util_unpack_be24 (const unsigned char *p)
+{
+  return ((uint32_t)p[0] << 16) | ((uint32_t)p[1] << 8) | (uint32_t)p[2];
+}
+
+/**
+ * @brief Pack 24-bit value to big-endian.
+ * @ingroup foundation
+ * @param p Pointer to 3-byte buffer.
+ * @param v 24-bit value in host byte order (lower 24 bits used).
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 24-bit value from host byte order to big-endian byte order.
+ * Used for HTTP/2 frame length fields (24-bit).
+ * Only the lower 24 bits of v are encoded.
+ */
+static inline void
+socket_util_pack_be24 (unsigned char *p, uint32_t v)
+{
+  p[0] = (unsigned char)((v >> 16) & 0xFF);
+  p[1] = (unsigned char)((v >> 8) & 0xFF);
+  p[2] = (unsigned char)(v & 0xFF);
+}
+
+/**
+ * @brief Unpack 32-bit big-endian value.
+ * @ingroup foundation
+ * @param p Pointer to 4-byte buffer.
+ * @return Decoded 32-bit value in host byte order.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 4 bytes from big-endian (network) byte order to host byte order.
+ * Used for parsing network protocols (DNS, HTTP/2, QUIC).
+ */
+static inline uint32_t
+socket_util_unpack_be32 (const unsigned char *p)
+{
+  return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
+         | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
+}
+
+/**
+ * @brief Pack 32-bit value to big-endian.
+ * @ingroup foundation
+ * @param p Pointer to 4-byte buffer.
+ * @param v 32-bit value in host byte order.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 32-bit value from host byte order to big-endian (network) byte order.
+ * Used for serializing network protocols (DNS, HTTP/2, QUIC).
+ */
+static inline void
+socket_util_pack_be32 (unsigned char *p, uint32_t v)
+{
+  p[0] = (unsigned char)((v >> 24) & 0xFF);
+  p[1] = (unsigned char)((v >> 16) & 0xFF);
+  p[2] = (unsigned char)((v >> 8) & 0xFF);
+  p[3] = (unsigned char)(v & 0xFF);
+}
+
+/* ============================================================================
  * IP ADDRESS UTILITY FUNCTIONS
  * ============================================================================
  */

--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -26,6 +26,7 @@
  */
 
 #include "core/Except.h"
+#include "core/SocketUtil.h"
 #include <netinet/in.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/src/dns/SocketDNSWire.c
+++ b/src/dns/SocketDNSWire.c
@@ -16,46 +16,13 @@ const Except_T SocketDNS_WireError
     = { &SocketDNS_WireError, "DNS wire format error" };
 
 /*
- * Big-endian pack/unpack helpers.
- * Following the pattern from SocketHTTP2-frame.c for explicit byte
- * manipulation rather than relying on htons/ntohs macros.
+ * Big-endian pack/unpack helpers - now using shared utilities from SocketUtil.h
  */
 
-static inline uint16_t
-dns_unpack_be16 (const unsigned char *p)
-{
-  return ((uint16_t)p[0] << 8) | (uint16_t)p[1];
-}
-
-static inline void
-dns_pack_be16 (unsigned char *p, uint16_t v)
-{
-  p[0] = (unsigned char)((v >> 8) & 0xFF);
-  p[1] = (unsigned char)(v & 0xFF);
-}
-
-static inline uint32_t
-dns_unpack_be32 (const unsigned char *p)
-{
-  return ((uint32_t)p[0] << 24) | ((uint32_t)p[1] << 16)
-         | ((uint32_t)p[2] << 8) | (uint32_t)p[3];
-}
-
-static inline void
-dns_pack_be32 (unsigned char *p, uint32_t v)
-{
-  p[0] = (unsigned char)((v >> 24) & 0xFF);
-  p[1] = (unsigned char)((v >> 16) & 0xFF);
-  p[2] = (unsigned char)((v >> 8) & 0xFF);
-  p[3] = (unsigned char)(v & 0xFF);
-}
-
-/* Silence compiler warning for unused static inline */
-static inline void
-dns_pack_be32_unused_check (void)
-{
-  (void)dns_pack_be32;
-}
+#define dns_unpack_be16(p) socket_util_unpack_be16(p)
+#define dns_pack_be16(p, v) socket_util_pack_be16(p, v)
+#define dns_unpack_be32(p) socket_util_unpack_be32(p)
+#define dns_pack_be32(p, v) socket_util_pack_be32(p, v)
 
 /*
  * Flags word layout (16 bits):

--- a/src/http/SocketHTTP2-frame.c
+++ b/src/http/SocketHTTP2-frame.c
@@ -136,21 +136,12 @@ static const char *stream_state_names[]
 #define STREAM_STATE_COUNT                                                    \
   (sizeof (stream_state_names) / sizeof (stream_state_names[0]))
 
-static inline uint32_t
-http2_unpack_be24 (const unsigned char *data)
-{
-  return ((uint32_t)data[0] << 16) | ((uint32_t)data[1] << 8)
-         | (uint32_t)data[2];
-}
+/* Big-endian pack/unpack helpers - using shared utilities from SocketUtil.h */
+#define http2_unpack_be24(data) socket_util_unpack_be24(data)
+#define http2_pack_be24(data, value) socket_util_pack_be24(data, value)
+#define http2_pack_uint32_be(data, value) socket_util_pack_be32(data, value)
 
-static inline void
-http2_pack_be24 (unsigned char *data, uint32_t value)
-{
-  data[0] = (unsigned char)((value >> 16) & 0xFF);
-  data[1] = (unsigned char)((value >> 8) & 0xFF);
-  data[2] = (unsigned char)(value & 0xFF);
-}
-
+/* Stream ID helpers with reserved bit masking (bit 31) - HTTP/2 specific */
 static inline uint32_t
 http2_unpack_stream_id (const unsigned char *data)
 {
@@ -165,15 +156,6 @@ http2_pack_stream_id (unsigned char *data, uint32_t stream_id)
   data[1] = (unsigned char)((stream_id >> 16) & 0xFF);
   data[2] = (unsigned char)((stream_id >> 8) & 0xFF);
   data[3] = (unsigned char)(stream_id & 0xFF);
-}
-
-static inline void
-http2_pack_uint32_be (unsigned char *data, uint32_t value)
-{
-  data[0] = (unsigned char)((value >> 24) & 0xFF);
-  data[1] = (unsigned char)((value >> 16) & 0xFF);
-  data[2] = (unsigned char)((value >> 8) & 0xFF);
-  data[3] = (unsigned char)(value & 0xFF);
 }
 
 int

--- a/src/quic/SocketQUICPacket.c
+++ b/src/quic/SocketQUICPacket.c
@@ -16,6 +16,7 @@
 #include "quic/SocketQUICPacket.h"
 #include "quic/SocketQUICVarInt.h"
 #include "quic/SocketQUICConstants.h"
+#include "core/SocketUtil.h"
 
 /* ============================================================================
  * Result String Table
@@ -72,22 +73,11 @@ SocketQUICPacketHeader_init (SocketQUICPacketHeader_T *header)
  * ============================================================================
  */
 
-static inline uint32_t
-unpack_be32 (const uint8_t *data)
-{
-  return ((uint32_t)data[0] << 24) | ((uint32_t)data[1] << 16)
-         | ((uint32_t)data[2] << 8) | (uint32_t)data[3];
-}
+/* Big-endian pack/unpack helpers - using shared utilities from SocketUtil.h */
+#define unpack_be32(data) socket_util_unpack_be32(data)
+#define pack_be32(data, value) socket_util_pack_be32(data, value)
 
-static inline void
-pack_be32 (uint8_t *data, uint32_t value)
-{
-  data[0] = (uint8_t)((value >> 24) & 0xFF);
-  data[1] = (uint8_t)((value >> 16) & 0xFF);
-  data[2] = (uint8_t)((value >> 8) & 0xFF);
-  data[3] = (uint8_t)(value & 0xFF);
-}
-
+/* Variable-length packet number encoding - QUIC specific */
 static inline uint32_t
 unpack_pn (const uint8_t *data, uint8_t pn_length)
 {


### PR DESCRIPTION
## Summary

Implements #514 by consolidating duplicate big-endian byte pack/unpack functions from three modules into shared utilities in `SocketUtil.h`.

## Changes

### New Utilities in SocketUtil.h
- `socket_util_unpack_be16()` / `socket_util_pack_be16()` - 16-bit big-endian
- `socket_util_unpack_be24()` / `socket_util_pack_be24()` - 24-bit big-endian (HTTP/2 frame lengths)
- `socket_util_unpack_be32()` / `socket_util_pack_be32()` - 32-bit big-endian

### Modules Updated
1. **DNS (SocketDNSWire.c)**: Replaced local `dns_unpack_be16/32` and `dns_pack_be16/32` with macros to shared utilities
2. **HTTP/2 (SocketHTTP2-frame.c)**: Replaced `http2_unpack_be24`, `http2_pack_be24`, `http2_pack_uint32_be` with shared utilities
3. **QUIC (SocketQUICPacket.c)**: Replaced `unpack_be32`, `pack_be32` with shared utilities

### Module-Specific Functions Retained
- **HTTP/2**: `http2_unpack_stream_id()` / `http2_pack_stream_id()` - Stream IDs have bit 31 reserved (0x7F masking)
- **QUIC**: `unpack_pn()` / `pack_pn()` - Variable-length packet number encoding (QUIC-specific)

## Test Plan

- [x] All DNS wire format tests pass (172 tests)
- [x] All HTTP/2 tests pass (27 tests)
- [x] All QUIC packet tests pass (35 tests)
- [x] Full test suite passes with sanitizers (109/111 - 2 pre-existing failures unrelated to changes)

## Benefits

- Eliminates ~60 lines of duplicate code
- Single maintenance point for byte-order operations
- Consistent naming convention across modules (`socket_util_*` prefix)
- Inline functions for zero performance overhead

Closes #514