### PR TITLE
refactor(http): Consolidate token character validation

### DIFF
--- a/include/http/SocketHTTP-private.h
+++ b/include/http/SocketHTTP-private.h
@@ -103,6 +103,26 @@ sockethttp_is_token_boundary (char c)
   return c == '\0' || c == ',' || c == ' ' || c == '\t';
 }
 
+/**
+ * @brief Validate that a string contains only valid HTTP token characters.
+ * @param s String to validate.
+ * @param len Length of the string.
+ * @return 1 if all characters are valid token characters, 0 otherwise.
+ *
+ * Used for validating HTTP methods, header names, media types, and other
+ * token-based fields as defined by RFC 7230.
+ */
+static inline int
+sockethttp_is_token_valid (const char *s, size_t len)
+{
+  for (size_t i = 0; i < len; i++)
+    {
+      if (!SOCKETHTTP_IS_TCHAR (s[i]))
+        return 0;
+    }
+  return 1;
+}
+
 /* ============================================================================
  * HTTP PORT UTILITIES
  * ============================================================================

--- a/src/http/SocketHTTP-core.c
+++ b/src/http/SocketHTTP-core.c
@@ -141,17 +141,6 @@ sockethttp_parse_enum(const char *str, size_t len, const struct ParseEntry *tabl
   return default_val;
 }
 
-static int
-sockethttp_is_token (const char *s, size_t len)
-{
-  for (size_t i = 0; i < len; i++)
-    {
-      if (!SOCKETHTTP_IS_TCHAR (s[i]))
-        return 0;
-    }
-  return 1;
-}
-
 /* SECURITY: Check for NUL/CR/LF to prevent header injection (CWE-113) */
 static int
 sockethttp_header_value_is_safe (const char *s, size_t len)
@@ -293,7 +282,7 @@ SocketHTTP_method_valid (const char *str, size_t len)
   len = sockethttp_effective_length (str, len);
   if (len == 0)
     return 0;
-  return sockethttp_is_token (str, len);
+  return sockethttp_is_token_valid (str, len);
 }
 
 /* ============================================================================
@@ -436,7 +425,7 @@ SocketHTTP_header_name_valid (const char *name, size_t len)
   len = sockethttp_effective_length (name, len);
   if (len == 0 || len > SOCKETHTTP_MAX_HEADER_NAME)
     return 0;
-  return sockethttp_is_token (name, len);
+  return sockethttp_is_token_valid (name, len);
 }
 
 int

--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -928,17 +928,6 @@ SocketHTTP_URI_build (const SocketHTTP_URI *uri, char *output, size_t output_siz
  */
 
 static inline int
-validate_token_span (const char *start, size_t len)
-{
-  for (size_t i = 0; i < len; i++)
-    {
-      if (!SOCKETHTTP_IS_TCHAR (start[i]))
-        return 0;
-    }
-  return 1;
-}
-
-static inline int
 is_unreserved (unsigned char c)
 {
   return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z')
@@ -1207,7 +1196,7 @@ mediatype_parse_type_subtype (const char *p, const char *end,
     return NULL;
 
   size_t type_len = (size_t)(p - type_start);
-  if (!validate_token_span (type_start, type_len))
+  if (!sockethttp_is_token_valid (type_start, type_len))
     return NULL;
 
   char *type = arena_strndup (arena, type_start, type_len);
@@ -1225,7 +1214,7 @@ mediatype_parse_type_subtype (const char *p, const char *end,
     return NULL;
 
   size_t subtype_len = (size_t)(p - subtype_start);
-  if (!validate_token_span (subtype_start, subtype_len))
+  if (!sockethttp_is_token_valid (subtype_start, subtype_len))
     return NULL;
 
   char *subtype = arena_strndup (arena, subtype_start, subtype_len);
@@ -1256,7 +1245,7 @@ mediatype_parse_parameter (const char *p, const char *end,
   size_t param_len = (size_t)(p - param_start);
   if (param_len == 0)
     return NULL;
-  if (!validate_token_span (param_start, param_len))
+  if (!sockethttp_is_token_valid (param_start, param_len))
     return NULL;
 
   p++;
@@ -1279,7 +1268,7 @@ mediatype_parse_parameter (const char *p, const char *end,
 
       if (value_len == 0)
         return NULL;
-      if (!validate_token_span (value_start, value_len))
+      if (!sockethttp_is_token_valid (value_start, value_len))
         return NULL;
     }
 


### PR DESCRIPTION
## Summary

Implements #515

Consolidates two nearly identical token validation functions into a single shared implementation.

## Changes

- Added `sockethttp_is_token_valid()` to `SocketHTTP-private.h` as static inline function
- Removed `sockethttp_is_token()` from `SocketHTTP-core.c`  
- Removed `validate_token_span()` from `SocketHTTP-uri.c`
- Updated all 6 call sites (2 in core, 4 in uri) to use the shared function

## Impact

- Eliminates 8 lines of duplicate code
- Single point of maintenance for token validation logic
- No functional changes - both functions performed identical validation using `SOCKETHTTP_IS_TCHAR` macro

## Test Plan

- [x] All 111 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Build completes without warnings
- [x] Token validation behavior unchanged (HTTP methods, header names, media types)

Closes #515