### PR TITLE
refactor(http2): Define named constant for stream hash chain limit

### DIFF
--- a/include/http/SocketHTTP2-private.h
+++ b/include/http/SocketHTTP2-private.h
@@ -49,6 +49,9 @@ static const unsigned char HTTP2_CLIENT_PREFACE[HTTP2_PREFACE_SIZE]
 #define HTTP2_GOAWAY_HEADER_SIZE 8
 #define HTTP2_WINDOW_UPDATE_SIZE 4
 #define HTTP2_RST_STREAM_PAYLOAD_SIZE 4
+
+/* SECURITY: Limit to prevent DoS via hash collision attacks */
+#define HTTP2_STREAM_MAX_HASH_CHAIN_LEN 32
 typedef enum
 {
   HTTP2_CONN_STATE_INIT = 0,

--- a/src/http/SocketHTTP2-stream.c
+++ b/src/http/SocketHTTP2-stream.c
@@ -78,7 +78,7 @@ http2_stream_lookup (const SocketHTTP2_Conn_T conn, uint32_t stream_id)
   while (stream)
     {
       chain_len++;
-      if (chain_len > 32)
+      if (chain_len > HTTP2_STREAM_MAX_HASH_CHAIN_LEN)
         { /* Prevent DoS from hash collision chains */
           SOCKET_LOG_WARN_MSG (
               "Long hash chain in stream lookup: %d (potential DoS)",


### PR DESCRIPTION
## Summary

Implements #510

Replaces magic number 32 with a named constant `HTTP2_STREAM_MAX_HASH_CHAIN_LEN` for the stream hash chain length limit in HTTP/2 stream lookup.

## Changes

- Added `HTTP2_STREAM_MAX_HASH_CHAIN_LEN` constant to `include/http/SocketHTTP2-private.h`
- Updated `http2_stream_lookup()` in `src/http/SocketHTTP2-stream.c` to use the new constant
- Added security comment following the pattern used in other HTTP modules (SocketHTTP-headers.c, SocketHTTPClient-pool.c)

## Rationale

This change improves code maintainability and consistency:
- Eliminates magic number, making the code more self-documenting
- Follows the existing pattern used in other HTTP modules for similar security limits
- Makes the limit easier to find and modify if needed in the future
- Places constant definition in the appropriate private header near other HTTP/2 size constants

## Test Plan

- [x] All existing tests pass with sanitizers enabled (111/111 passed)
- [x] Build completes without warnings
- [x] No functional changes - purely a refactoring to improve code clarity

Closes #510