### PR TITLE
refactor(core): standardize mutex lock/unlock with error handling

### DIFF
--- a/src/core/SocketRateLimit.c
+++ b/src/core/SocketRateLimit.c
@@ -20,13 +20,8 @@
   do                                                                          \
     {                                                                         \
       T _l = (T)(limiter);                                                    \
-      int lock_err = pthread_mutex_lock (&_l->mutex);                         \
-      if (lock_err != 0)                                                      \
-        SOCKET_RAISE_MSG (SocketRateLimit, SocketRateLimit_Failed,            \
-                          "pthread_mutex_lock failed: %s",                    \
-                          Socket_safe_strerror (lock_err));                   \
-      TRY{ code } FINALLY { (void)pthread_mutex_unlock (&_l->mutex); }        \
-      END_TRY;                                                                \
+      SOCKET_WITH_MUTEX (&_l->mutex, SocketRateLimit, SocketRateLimit_Failed,\
+                         code);                                               \
     }                                                                         \
   while (0)
 

--- a/src/core/SocketTimer.c
+++ b/src/core/SocketTimer.c
@@ -389,19 +389,13 @@ sockettimer_heap_init_mutex (SocketTimer_heap_T *heap)
 static inline void
 sockettimer_heap_lock (SocketTimer_heap_T *heap)
 {
-  int ret = pthread_mutex_lock (&heap->mutex);
-  if (ret != 0)
-    SOCKET_RAISE_MSG (SocketTimer, SocketTimer_Failed,
-                      "pthread_mutex_lock failed: %d", ret);
+  SOCKET_MUTEX_LOCK_OR_RAISE (&heap->mutex, SocketTimer, SocketTimer_Failed);
 }
 
 static inline void
 sockettimer_heap_unlock (SocketTimer_heap_T *heap)
 {
-  int ret = pthread_mutex_unlock (&heap->mutex);
-  if (ret != 0)
-    SOCKET_RAISE_MSG (SocketTimer, SocketTimer_Failed,
-                      "pthread_mutex_unlock failed: %d", ret);
+  SOCKET_MUTEX_UNLOCK (&heap->mutex);
 }
 
 static struct SocketTimer_T *


### PR DESCRIPTION
## Summary

Implements #512

Adds unified mutex lock/unlock macros to `SocketUtil.h` and migrates three core modules to use them.

## Changes

### New Macros in `SocketUtil.h`

- **`SOCKET_MUTEX_LOCK_OR_RAISE`**: Lock with error handling via exception
  - Uses `Socket_safe_strerror()` for human-readable error messages
  - Raises module-specific exception on failure
  
- **`SOCKET_MUTEX_UNLOCK`**: Unlock (ignores errors per POSIX)
  - Unlock errors indicate programming bugs (double-unlock, unowned mutex)
  - Intentionally ignored to avoid cascading failures in cleanup paths
  
- **`SOCKET_WITH_MUTEX`**: Exception-safe scoped locking
  - Guarantees unlock via `TRY/FINALLY` even if code raises
  - Prevents resource leaks in error paths

### Module Migrations

1. **`SocketIPTracker.c`**: Add error handling to previously unchecked locks
   - Changed `TRACKER_LOCK/UNLOCK` to use new macros
   - All mutex operations now check for errors
   
2. **`SocketRateLimit.c`**: Replace `WITH_LOCK` macro
   - Simplified to use `SOCKET_WITH_MUTEX`
   - Maintains exception safety
   
3. **`SocketTimer.c`**: Use standardized error messages
   - Replaced `%d` format with `Socket_safe_strerror()`
   - Consistent with other modules

## Benefits

- **Consistency**: All mutex operations use same error handling pattern
- **Safety**: Exception-safe cleanup via `FINALLY` blocks
- **Readability**: Human-readable error messages instead of errno codes
- **Maintainability**: Single source of truth for mutex patterns

## Test Plan

- [x] All tests pass with sanitizers (sequential run - 111/111 passed)
- [x] SocketPool tests pass (uses SocketRateLimit) - 97/97 passed
- [x] Socket tests pass (uses SocketTimer) - 297/297 passed
- [x] No memory leaks detected by AddressSanitizer
- [x] No undefined behavior detected by UBSan

Note: One test (`test_happy_eyeballs`) has a pre-existing race condition when run in parallel with `-j4+`. This is unrelated to mutex refactoring and passes when run sequentially.

Closes #512