### PR TITLE
refactor(dns): replace magic number 5381 with SOCKET_UTIL_DJB2_SEED constant

### DIFF
--- a/src/dns/SocketDNSNegCache.c
+++ b/src/dns/SocketDNSNegCache.c
@@ -103,7 +103,7 @@ normalize_name (char *dest, const char *src, size_t max_len)
 static unsigned
 compute_hash_with_seed (const char *name, uint16_t qtype, uint16_t qclass, uint32_t seed)
 {
-  unsigned hash = 5381; /* djb2 initial value */
+  unsigned hash = SOCKET_UTIL_DJB2_SEED;
 
   /* Mix in random seed for DoS protection */
   hash = ((hash << 5) + hash) ^ seed;

--- a/src/dns/SocketDNSServfailCache.c
+++ b/src/dns/SocketDNSServfailCache.c
@@ -91,7 +91,7 @@ static unsigned
 compute_hash_with_seed (const char *name, uint16_t qtype, uint16_t qclass,
                         const char *nameserver, uint32_t seed)
 {
-  unsigned hash = 5381; /* djb2 initial value */
+  unsigned hash = SOCKET_UTIL_DJB2_SEED;
 
   /* Mix in random seed for DoS protection */
   hash = ((hash << 5) + hash) ^ seed;


### PR DESCRIPTION
## Summary

Implements #538

Replace hardcoded DJB2 hash seed value `5381` with the existing named constant `SOCKET_UTIL_DJB2_SEED` defined in `include/core/SocketUtil.h`.

## Changes

- **src/dns/SocketDNSNegCache.c**: Replace `5381` with `SOCKET_UTIL_DJB2_SEED` in `compute_hash_with_seed()`
- **src/dns/SocketDNSServfailCache.c**: Replace `5381` with `SOCKET_UTIL_DJB2_SEED` in `compute_hash_with_seed()`

Both files already include `core/SocketUtil.h`, so no additional includes were needed.

## Benefits

- **Consistency**: Uses the centrally-defined constant instead of duplicating the magic number
- **Readability**: Makes the purpose of the value clearer
- **Maintainability**: Any future changes to the seed value only need to be made in one place
- **Type safety**: The constant definition (`5381u`) ensures unsigned type matching

## Test Plan

- [x] All 111 tests pass with sanitizers enabled (ASan + UBSan)
- [x] DNS cache tests verify hash values remain consistent
- [x] No behavioral changes - the numeric value is identical

```bash
cmake -B build -DENABLE_SANITIZERS=ON
cmake --build build -j$(nproc)
cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest --output-on-failure
```

Result: 100% tests passed, 0 tests failed out of 111

Closes #538