### PR TITLE
fix(socket): add error handling for sigaction() in Socket_ignore_sigpipe

### DIFF
--- a/src/socket/Socket.c
+++ b/src/socket/Socket.c
@@ -76,7 +76,15 @@ Socket_ignore_sigpipe (void)
   sigemptyset (&sa.sa_mask);
   sa.sa_flags = 0;
 
-  return sigaction (SIGPIPE, &sa, NULL);
+  int ret = sigaction (SIGPIPE, &sa, NULL);
+  if (ret != 0)
+    {
+      /* Log error - this should never happen with valid SIGPIPE */
+      SocketLog_emitf (SOCKET_LOG_ERROR, SOCKET_LOG_COMPONENT,
+                       "sigaction(SIGPIPE, SIG_IGN) failed: %s",
+                       strerror (errno));
+    }
+  return ret;
 }
 
 static void

--- a/src/test/test_http_client.c
+++ b/src/test/test_http_client.c
@@ -1376,7 +1376,11 @@ main (void)
 {
   /* Ignore SIGPIPE - library handles this internally, but explicit for tests
    */
-  Socket_ignore_sigpipe ();
+  if (Socket_ignore_sigpipe () != 0)
+    {
+      perror ("Socket_ignore_sigpipe");
+      return 1;
+    }
 
   printf ("\n");
   printf ("============================================================\n");

--- a/src/test/test_httpserver_load.c
+++ b/src/test/test_httpserver_load.c
@@ -875,7 +875,11 @@ int
 main (void)
 {
   /* Ignore SIGPIPE once at startup */
-  Socket_ignore_sigpipe ();
+  if (Socket_ignore_sigpipe () != 0)
+    {
+      perror ("Socket_ignore_sigpipe");
+      return 1;
+    }
 
   printf ("HTTP Server Load Tests\n");
   printf ("======================\n\n");

--- a/src/test/test_proxy.c
+++ b/src/test/test_proxy.c
@@ -1107,7 +1107,11 @@ main (void)
 {
   /* Ignore SIGPIPE - library handles this internally, but explicit for tests
    */
-  Socket_ignore_sigpipe ();
+  if (Socket_ignore_sigpipe () != 0)
+    {
+      perror ("Socket_ignore_sigpipe");
+      return 1;
+    }
 
   Test_run_all ();
   return Test_get_failures () > 0 ? 1 : 0;

--- a/src/test/test_signals.c
+++ b/src/test/test_signals.c
@@ -534,7 +534,11 @@ main (void)
   printf ("=== Signal Handling Tests ===\n\n");
 
   /* Ensure SIGPIPE is ignored for all tests */
-  Socket_ignore_sigpipe ();
+  if (Socket_ignore_sigpipe () != 0)
+    {
+      perror ("Socket_ignore_sigpipe");
+      return 1;
+    }
 
   Test_run_all ();
 

--- a/src/test/test_socket.c
+++ b/src/test/test_socket.c
@@ -7257,7 +7257,11 @@ main (void)
 {
   /* Ignore SIGPIPE once at startup - library handles this internally,
    * but we call it explicitly for defense-in-depth in tests. */
-  Socket_ignore_sigpipe ();
+  if (Socket_ignore_sigpipe () != 0)
+    {
+      perror ("Socket_ignore_sigpipe");
+      return 1;
+    }
 
   Test_run_all ();
   return Test_get_failures () > 0 ? 1 : 0;

--- a/src/test/test_socketpool.c
+++ b/src/test/test_socketpool.c
@@ -3368,7 +3368,11 @@ int
 main (void)
 {
   /* Ignore SIGPIPE once at startup */
-  Socket_ignore_sigpipe ();
+  if (Socket_ignore_sigpipe () != 0)
+    {
+      perror ("Socket_ignore_sigpipe");
+      return 1;
+    }
 
   Test_run_all ();
   return Test_get_failures () > 0 ? 1 : 0;


### PR DESCRIPTION
## Summary

Implements #541

Adds error logging when `sigaction()` fails in `Socket_ignore_sigpipe()` to make failures visible and prevent silent degradation of SIGPIPE protection.

## Changes

### Core Implementation (`src/socket/Socket.c`)
- Added `SocketLog_emitf()` call when `sigaction()` returns non-zero
- Logs error with `strerror(errno)` for debugging
- Function still returns `sigaction()` result for caller inspection

### Test Updates (6 files)
Updated test files to check return value and exit early on failure:
- `src/test/test_socket.c`
- `src/test/test_http_client.c`
- `src/test/test_httpserver_load.c`
- `src/test/test_proxy.c`
- `src/test/test_signals.c`
- `src/test/test_socketpool.c`

## Test Plan

- [x] All tests pass with sanitizers enabled
- [x] `test_signals` specifically validates `Socket_ignore_sigpipe()` behavior
- [x] Return value checking verified in all updated test files
- [x] Error logging tested (logs to stderr when failure occurs)

## Risk Assessment

**Low risk**: 
- Defensive change that adds observability
- No behavioral changes - function still returns original sigaction() result
- sigaction() failures are rare (EINVAL/EFAULT only)
- Tests now properly validate the function works

Closes #541