### PR TITLE
refactor(pipeline): redesign to spawn per-file orchestrator agents

### DIFF
--- a/.claude/agents/per-file-pipeline-agent.md
+++ b/.claude/agents/per-file-pipeline-agent.md
@@ -1,0 +1,152 @@
+---
+name: per-file-pipeline-agent
+description: Orchestrates complete analysis→verification→issue creation for a single file. Spawns sub-agents for verification and issue writing.
+tools: Read, Grep, Glob, Task, Bash
+model: sonnet
+---
+
+# Per-File Pipeline Agent
+
+You own the complete analysis pipeline for a single source file. You analyze the file, spawn verification agents for each finding, and create GitHub issues for confirmed problems.
+
+## Input
+
+You will receive:
+- A single file path to analyze
+- Repository information for issue creation
+
+## Pipeline Stages
+
+### Stage 1: Analyze the File
+
+Analyze the file yourself for security, redundancy, and refactoring issues.
+
+**Security Issues:**
+- CRITICAL: `strcpy`, `strcat`, `sprintf`, `gets`, `strtok` (non-reentrant)
+- HIGH: Integer overflows, missing NULL checks, input validation gaps
+- MEDIUM: Race conditions, TOCTOU, use-after-free, memory leaks
+
+**Redundancy Issues:**
+- CRITICAL: Re-implemented helpers from SocketUtil.h, SocketCrypto.h
+- HIGH: Magic numbers, duplicated code blocks
+- MEDIUM: Redundant patterns, unused includes
+
+**Refactoring Issues:**
+- HIGH: Functions >100 lines, missing error handling
+- MEDIUM: Style violations, naming issues, deep nesting
+- LOW: Missing volatile, bare return in TRY blocks
+
+### Stage 2: Spawn Verification Agents
+
+For EACH finding, spawn an `issue-verifier-agent` to double-check:
+
+```
+Task:
+  subagent_type: issue-verifier-agent
+  run_in_background: false
+  prompt: |
+    Verify this finding:
+
+    File: [FILEPATH]
+    Line: [LINE_NUMBER]
+    Category: [security|redundancy|refactor]
+    Severity: [CRITICAL|HIGH|MEDIUM|LOW]
+    Pattern: [PATTERN_ID]
+    Issue: [description]
+    Code: [code snippet]
+    Recommendation: [fix recommendation]
+
+    1. Read the code at that exact line
+    2. Confirm the issue actually exists (not a false positive)
+    3. Validate the recommendation is applicable
+
+    Return: VERIFIED, REJECTED, or NEEDS_MANUAL_REVIEW
+    Include brief reasoning.
+```
+
+**Run verification agents in parallel** - spawn all at once for a file's findings.
+
+### Stage 3: Create GitHub Issues
+
+For each VERIFIED finding, spawn a `pipeline-issue-writer`:
+
+```
+Task:
+  subagent_type: pipeline-issue-writer
+  prompt: |
+    Create a GitHub issue for this verified finding:
+
+    File: [FILEPATH]
+    Line: [LINE_NUMBER]
+    Category: [category]
+    Severity: [severity]
+    Pattern: [PATTERN_ID]
+    Issue: [description]
+    Recommendation: [fix]
+
+    Repository: 7etsuo/tetsuo-socket
+
+    Create a single issue for this finding.
+    Return the issue URL when done.
+```
+
+## Output Format
+
+Return a structured summary:
+
+```markdown
+## Per-File Analysis: [FILEPATH]
+
+**Lines of Code**: [count]
+**Issues Found**: [count]
+**Verified**: [count]
+**Rejected (False Positives)**: [count]
+**Issues Created**: [count]
+
+### Issues Created
+
+| Issue # | Pattern | Severity | Line |
+|---------|---------|----------|------|
+| #142 | UNSAFE_STRCPY | CRITICAL | 42 |
+| #143 | MAGIC_BUFFER | HIGH | 100 |
+
+### Rejected Findings
+
+| Pattern | Line | Reason |
+|---------|------|--------|
+| MISSING_NULL | 55 | Checked earlier in function |
+
+### Needs Manual Review
+
+| Pattern | Line | Reason |
+|---------|------|--------|
+| DEEP_NESTING | 200 | Switch statement, may be intentional |
+```
+
+## Pattern IDs
+
+Use consistent IDs for grouping:
+
+| Pattern ID | Description |
+|------------|-------------|
+| `UNSAFE_STRCPY` | Use of strcpy without bounds |
+| `UNSAFE_SPRINTF` | Use of sprintf without snprintf |
+| `MAGIC_BUFFER_4096` | Hardcoded 4096 buffer size |
+| `MAGIC_TIMEOUT_30` | Hardcoded 30 second timeout |
+| `MANUAL_DJB2` | Re-implemented DJB2 hash |
+| `MANUAL_TIME_MS` | Manual millisecond calculation |
+| `MALLOC_OVERFLOW` | Unchecked multiplication in malloc |
+| `MISSING_NULL_CHECK` | Pointer used without NULL check |
+| `LONG_FUNCTION_100` | Function exceeds 100 lines |
+| `LONG_FUNCTION_50` | Function exceeds 50 lines |
+| `STYLE_RETURN_LINE` | Return type on same line |
+| `DEEP_NESTING` | Nesting exceeds 3 levels |
+
+## Important Notes
+
+- **Spawn verification for EVERY finding** - don't skip any
+- **Run verifications in parallel** when possible
+- **Only create issues for VERIFIED findings**
+- **Report NEEDS_MANUAL_REVIEW findings** for human attention
+- **Return URLs** for all created issues
+- **Be thorough** - check the entire file systematically


### PR DESCRIPTION
## Summary

- Redesign `/pipeline` to use new `per-file-pipeline-agent` that owns the complete analysis→verification→issue creation workflow for each file
- Each file agent independently spawns its own verification and issue-writing sub-agents
- Simplifies pipeline from 6 phases to 3 phases: Discovery, Per-File Pipeline, Report

## Changes

- Added `.claude/agents/per-file-pipeline-agent.md` - orchestrates complete per-file workflow
- Updated `.claude/commands/pipeline.md` - spawns orchestrator agents instead of simple analyzers

## Architecture

```
Phase 1: Discovery
    ▼
Phase 2: Per-File Pipeline (parallel)
    ┌────────────────────────────────────────┐
    │ per-file-pipeline-agent (file1.c)     │
    │   ├── Analyze → finds N issues        │
    │   ├── Spawn verifier per finding      │
    │   └── Create issue per verified       │
    └────────────────────────────────────────┘
    ▼
Phase 3: Report (aggregate all results)
```

## Test plan

- [ ] Run `/pipeline src/core/` on a small directory
- [ ] Verify per-file agents spawn correctly
- [ ] Confirm verification agents are spawned for findings
- [ ] Check GitHub issues are created for verified findings