### PR TITLE
refactor: replace magic host buffer size with NI_MAXHOST

### DIFF
--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -24,6 +24,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <netdb.h>
 #include <poll.h>
 #include <stdarg.h>
 #include <stdlib.h>
@@ -1385,7 +1386,7 @@ SocketWS_connect (const char *url, const char *protocols)
   SocketWS_T ws = NULL;
   Socket_T sock = NULL;
   SocketWS_Config config;
-  char host[256] = { 0 };
+  char host[NI_MAXHOST] = { 0 };
   char path[1024] = { 0 };
   volatile int port = 80;
   volatile int use_tls = 0;


### PR DESCRIPTION
## Summary

Implements #554 - Replaces hardcoded 256-byte buffer for hostname parsing with standard POSIX constant `NI_MAXHOST`.

## Changes

- Added `#include <netdb.h>` to `src/socket/SocketWS.c`
- Replaced `char host[256]` with `char host[NI_MAXHOST]` in `SocketWS_connect()`

## Benefits

- Uses proper POSIX constant (typically 1025 bytes vs arbitrary 256)
- Matches pattern used in `SocketCommon.c` (`SOCKET_NI_MAXHOST`)
- Complies with RFC 1035 DNS name limits (253 characters)
- More maintainable and portable

## Test Plan

- [x] All tests pass with sanitizers enabled (111/111 tests)
- [x] Build succeeds with no warnings
- [x] Existing buffer overflow checks remain in place (lines 1420, 1440)

Closes #554