### PR TITLE
fix(security): add errno checking for strtol overflow in SocketDgram.c

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -237,9 +237,11 @@ extract_sender_info (const struct sockaddr_storage *addr, socklen_t addrlen,
   if (result == 0)
     {
       char *endptr;
+      errno = 0;
       long port_long = strtol (serv, &endptr, 10);
       *port
-          = (*endptr == '\0' && port_long > 0 && port_long <= SOCKET_MAX_PORT)
+          = (*endptr == '\0' && errno != ERANGE && port_long > 0
+             && port_long <= SOCKET_MAX_PORT)
                 ? (int)port_long
                 : 0;
     }


### PR DESCRIPTION
## Summary

Implements #579 - adds proper errno checking for strtol overflow in extract_sender_info()

## Changes

- Added `errno = 0` before strtol() call to clear errno state
- Added `errno != ERANGE` check to validate no overflow occurred
- Formatted the conditional check across multiple lines for readability

## Security Impact

This fix addresses CWE-190 (Integer Overflow or Wraparound) by properly detecting when strtol() encounters overflow and sets errno to ERANGE. While the existing range check (port_long > 0 && port_long <= SOCKET_MAX_PORT) provides protection, the ERANGE check ensures compliance with POSIX strtol() specification and prevents unexpected behavior from malformed input.

## Test Plan

- [x] All tests pass with sanitizers (ASAN + UBSAN)
- [x] test_socketdgram specifically verified
- [x] 111/111 tests passing

Closes #579