### PR TITLE
refactor(reconnect): replace magic numbers with named constants in policy validation

### DIFF
--- a/include/socket/SocketReconnect.h
+++ b/include/socket/SocketReconnect.h
@@ -128,6 +128,15 @@ typedef struct SocketReconnect_Policy
 #define SOCKET_RECONNECT_DEFAULT_HEALTH_TIMEOUT_MS 5000
 #endif
 
+/* Minimum validation thresholds */
+#ifndef SOCKET_RECONNECT_MIN_CIRCUIT_RESET_MS
+#define SOCKET_RECONNECT_MIN_CIRCUIT_RESET_MS 1000
+#endif
+
+#ifndef SOCKET_RECONNECT_MIN_HEALTH_TIMEOUT_MS
+#define SOCKET_RECONNECT_MIN_HEALTH_TIMEOUT_MS 100
+#endif
+
 /* ============================================================================
  * Event Callbacks
  * ============================================================================

--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -762,13 +762,13 @@ socketreconnect_validate_policy (SocketReconnect_Policy_T *policy)
   if (policy->circuit_failure_threshold < 1)
     policy->circuit_failure_threshold
         = SOCKET_RECONNECT_DEFAULT_CIRCUIT_THRESHOLD;
-  if (policy->circuit_reset_timeout_ms < 1000)
+  if (policy->circuit_reset_timeout_ms < SOCKET_RECONNECT_MIN_CIRCUIT_RESET_MS)
     policy->circuit_reset_timeout_ms
         = SOCKET_RECONNECT_DEFAULT_CIRCUIT_RESET_MS;
   if (policy->health_check_interval_ms < 0)
     policy->health_check_interval_ms
         = SOCKET_RECONNECT_DEFAULT_HEALTH_INTERVAL_MS;
-  if (policy->health_check_timeout_ms < 100)
+  if (policy->health_check_timeout_ms < SOCKET_RECONNECT_MIN_HEALTH_TIMEOUT_MS)
     policy->health_check_timeout_ms
         = SOCKET_RECONNECT_DEFAULT_HEALTH_TIMEOUT_MS;
 }


### PR DESCRIPTION
## Summary

Implements #557 by replacing magic numbers 1000 and 100 in SocketReconnect policy validation with named constants for better maintainability.

## Changes

- Added `SOCKET_RECONNECT_MIN_CIRCUIT_RESET_MS` (1000) constant to `include/socket/SocketReconnect.h`
- Added `SOCKET_RECONNECT_MIN_HEALTH_TIMEOUT_MS` (100) constant to `include/socket/SocketReconnect.h`
- Updated `socketreconnect_validate_policy()` in `src/socket/SocketReconnect.c` to use the new constants instead of magic numbers

## Test Plan

- [x] All 67 reconnect tests pass with sanitizers
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - purely refactoring for code clarity

Closes #557