### PR TITLE
refactor(proxy): document magic number +2 in SOCKET_PROXY_CREDENTIALS_BUFSIZE

### DIFF
--- a/src/socket/SocketProxy-http.c
+++ b/src/socket/SocketProxy-http.c
@@ -45,9 +45,19 @@
  * ============================================================================
  */
 
+/** Length of ':' separator in "username:password" format */
+#define SOCKET_PROXY_CREDS_SEPARATOR_LEN 1
+
+/** Length of null terminator for credential string */
+#define SOCKET_PROXY_CREDS_NULL_TERM 1
+
+/** Overhead for credential formatting (separator + null terminator) */
+#define SOCKET_PROXY_CREDS_OVERHEAD \
+  (SOCKET_PROXY_CREDS_SEPARATOR_LEN + SOCKET_PROXY_CREDS_NULL_TERM)
+
 /** Buffer size for Basic auth credentials (username:password) */
 #define SOCKET_PROXY_CREDENTIALS_BUFSIZE                                      \
-  (SOCKET_PROXY_MAX_USERNAME_LEN + SOCKET_PROXY_MAX_PASSWORD_LEN + 2)
+  (SOCKET_PROXY_MAX_USERNAME_LEN + SOCKET_PROXY_MAX_PASSWORD_LEN + SOCKET_PROXY_CREDS_OVERHEAD)
 
 /** Length of "Basic " prefix for Proxy-Authorization header */
 #define SOCKET_PROXY_BASIC_AUTH_PREFIX_LEN (sizeof ("Basic ") - 1)


### PR DESCRIPTION
## Summary

Implements #572

## Changes

- Replaced magic number `+2` in `SOCKET_PROXY_CREDENTIALS_BUFSIZE` with named constants
- Added `SOCKET_PROXY_CREDS_SEPARATOR_LEN` (1) for the ':' separator 
- Added `SOCKET_PROXY_CREDS_NULL_TERM` (1) for the null terminator
- Added `SOCKET_PROXY_CREDS_OVERHEAD` to combine both overhead components
- Updated `SOCKET_PROXY_CREDENTIALS_BUFSIZE` to use the new named constant

## Test Plan

- [x] All proxy tests pass (test_proxy: 84/84, test_proxy_integration: pass)
- [x] Core tests pass (arena, except, socketbuf, http_core)
- [x] No functional changes - pure refactoring of macro definitions
- [x] Buffer size calculation remains mathematically identical

## Impact

This is a documentation/clarity improvement with zero functional impact. The buffer size calculation is unchanged, only made more explicit and self-documenting.

Closes #572