### PR TITLE
refactor(websocket): define constant for handshake timeout

### DIFF
--- a/include/socket/SocketWS-private.h
+++ b/include/socket/SocketWS-private.h
@@ -281,6 +281,9 @@
 /** Default ping timeout */
 #define SOCKETWS_DEFAULT_PING_TIMEOUT_MS 30000
 
+/** Handshake timeout in milliseconds */
+#define SOCKETWS_HANDSHAKE_TIMEOUT_MS 5000
+
 /** Default deflate window bits */
 #define SOCKETWS_DEFAULT_DEFLATE_WINDOW_BITS 15
 

--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -1512,7 +1512,7 @@ SocketWS_connect (const char *url, const char *protocols)
     while ((result = SocketWS_handshake (ws)) > 0)
       {
         struct pollfd pfd = { .fd = Socket_fd (sock), .events = POLLIN | POLLOUT };
-        poll (&pfd, 1, 5000);
+        poll (&pfd, 1, SOCKETWS_HANDSHAKE_TIMEOUT_MS);
         SocketWS_process (ws, ws_translate_poll_revents (pfd.revents));
       }
 


### PR DESCRIPTION
## Summary

Implements #561

## Changes

- Added `SOCKETWS_HANDSHAKE_TIMEOUT_MS` constant (5000ms) in `SocketWS-private.h`
- Replaced hardcoded timeout value in `SocketWS.c` poll() call for handshake completion
- Improves code maintainability and makes timeout configuration explicit

## Test Plan

- [x] Tests pass with sanitizers (excluding pre-existing failures in test_tls_phase4 and test_http_integration)
- [x] WebSocket test suite passes (24/24 tests)
- [x] No functional changes - timeout value remains 5000ms

Closes #561