### PR TITLE
refactor(SocketWSH2): replace magic buffer size 16384 with named constant

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -436,6 +436,21 @@ extern const char *Socket_safe_strerror (int errnum);
 #define SOCKETBUF_MAX_CAPACITY (SIZE_MAX / 2)
 #endif
 
+/**
+ * @brief Standard 16KB buffer size for WebSocket and HTTP/2 streams.
+ *
+ * Optimized for HTTP/2 multiplexing scenarios where many concurrent streams
+ * may exist on a single connection. Smaller than standard WebSocket buffers
+ * (64KB) to reduce memory footprint while maintaining good performance.
+ *
+ * Used by:
+ * - WebSocket-over-HTTP/2 (RFC 8441)
+ * - HTTP/2 stream buffers
+ */
+#ifndef SOCKET_BUFFER_SIZE_16KB
+#define SOCKET_BUFFER_SIZE_16KB (16 * 1024)
+#endif
+
 /* ============================================================================
  * DNS Configuration
  * ============================================================================

--- a/src/socket/SocketWSH2.c
+++ b/src/socket/SocketWSH2.c
@@ -34,9 +34,22 @@
 
 #include "core/SocketUtil.h"
 
-/** Buffer sizes for WebSocket-over-HTTP/2 */
-#define WSH2_RECV_BUFFER_SIZE 16384
-#define WSH2_SEND_BUFFER_SIZE 16384
+/**
+ * Buffer sizes for WebSocket-over-HTTP/2
+ *
+ * Uses smaller buffers (16KB) compared to standard WebSocket (64KB) to optimize
+ * memory usage in HTTP/2 multiplexing scenarios where many concurrent WebSocket
+ * streams may exist on a single connection.
+ *
+ * References SOCKET_BUFFER_SIZE_16KB from SocketConfig.h for consistency.
+ */
+#ifndef SOCKETWSH2_RECV_BUFFER_SIZE
+#define SOCKETWSH2_RECV_BUFFER_SIZE SOCKET_BUFFER_SIZE_16KB
+#endif
+
+#ifndef SOCKETWSH2_SEND_BUFFER_SIZE
+#define SOCKETWSH2_SEND_BUFFER_SIZE SOCKET_BUFFER_SIZE_16KB
+#endif
 
 static SocketWS_T
 wsh2_create_ws_context (Arena_T arena, SocketHTTP2_Stream_T stream,
@@ -71,14 +84,14 @@ wsh2_create_ws_context (Arena_T arena, SocketHTTP2_Stream_T stream,
   ws->role = role;
 
   /* Create I/O buffers */
-  ws->recv_buf = SocketBuf_new (arena, WSH2_RECV_BUFFER_SIZE);
+  ws->recv_buf = SocketBuf_new (arena, SOCKETWSH2_RECV_BUFFER_SIZE);
   if (!ws->recv_buf)
     {
       SOCKET_LOG_ERROR_MSG ("Failed to create recv buffer");
       return NULL;
     }
 
-  ws->send_buf = SocketBuf_new (arena, WSH2_SEND_BUFFER_SIZE);
+  ws->send_buf = SocketBuf_new (arena, SOCKETWSH2_SEND_BUFFER_SIZE);
   if (!ws->send_buf)
     {
       SocketBuf_release (&ws->recv_buf);


### PR DESCRIPTION
## Summary

Implements #549

Replaces hardcoded 16384 buffer sizes in SocketWSH2.c with named constant SOCKET_BUFFER_SIZE_16KB for improved maintainability and consistency across the codebase.

## Changes

- **SocketConfig.h**: Added `SOCKET_BUFFER_SIZE_16KB` constant (16 * 1024) with documentation
- **SocketWSH2.c**: 
  - Replaced magic number `16384` with `SOCKET_BUFFER_SIZE_16KB`
  - Renamed `WSH2_*_BUFFER_SIZE` to `SOCKETWSH2_*_BUFFER_SIZE` for naming consistency
  - Added `#ifndef` guards to allow compile-time override
  - Enhanced documentation explaining buffer size rationale

## Rationale

The 16KB buffer size is specifically optimized for HTTP/2 multiplexing scenarios where many concurrent WebSocket streams may exist on a single connection. This is smaller than standard WebSocket buffers (64KB) to reduce memory footprint while maintaining good performance.

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] `test_websocket_h2` passes all 11 tests with ASan/UBSan
- [x] No functional changes - pure refactoring
- [x] Buffer size calculation remains identical (16 * 1024 = 16384)

## Notes

Test results show 4 pre-existing test failures unrelated to this change:
- test_threadsafety (pre-existing memory leak)
- test_happy_eyeballs (pre-existing issue)  
- test_multi_protocol_integration (pre-existing issue)
- test_tls_phase4 (pre-existing Arena leak)

The specific test for our changes (`test_websocket_h2`) passes cleanly with all sanitizers enabled.

Closes #549