### PR TITLE
refactor(proxy): extract validation logic from proxy_socks5_send_auth

### DIFF
--- a/src/socket/SocketProxy-socks5.c
+++ b/src/socket/SocketProxy-socks5.c
@@ -228,20 +228,24 @@ proxy_socks5_recv_method (struct SocketProxy_Conn_T *conn)
  * PASSWD: Password
  */
 
-int
-proxy_socks5_send_auth (struct SocketProxy_Conn_T *conn)
+/**
+ * validate_socks5_auth_credentials - Validate username/password credentials
+ * @conn: Proxy connection context for error reporting
+ * @ulen: Username length in bytes
+ * @plen: Password length in bytes
+ *
+ * Validates that:
+ * - Username length does not exceed SOCKET_PROXY_MAX_USERNAME_LEN
+ * - Password length does not exceed SOCKET_PROXY_MAX_PASSWORD_LEN
+ * - Username contains valid UTF-8
+ * - Password contains valid UTF-8
+ *
+ * Returns: 0 on success, -1 on validation failure (with error set in conn)
+ */
+static int
+validate_socks5_auth_credentials (struct SocketProxy_Conn_T *conn,
+                                   size_t ulen, size_t plen)
 {
-  unsigned char *buf = conn->send_buf;
-  size_t len = 0;
-  size_t ulen;
-  size_t plen;
-
-  assert (conn->username != NULL);
-  assert (conn->password != NULL);
-
-  ulen = strlen (conn->username);
-  plen = strlen (conn->password);
-
   /* Validate lengths */
   if (ulen > SOCKET_PROXY_MAX_USERNAME_LEN)
     {
@@ -256,7 +260,7 @@ proxy_socks5_send_auth (struct SocketProxy_Conn_T *conn)
       return -1;
     }
 
-  /* Additional validation: UTF-8 check for username and password */
+  /* Validate UTF-8 encoding */
   if (SocketUTF8_validate_str (conn->username) != UTF8_VALID)
     {
       socketproxy_set_error (conn, PROXY_ERROR, "Invalid UTF-8 in username");
@@ -267,6 +271,27 @@ proxy_socks5_send_auth (struct SocketProxy_Conn_T *conn)
       socketproxy_set_error (conn, PROXY_ERROR, "Invalid UTF-8 in password");
       return -1;
     }
+
+  return 0;
+}
+
+int
+proxy_socks5_send_auth (struct SocketProxy_Conn_T *conn)
+{
+  unsigned char *buf = conn->send_buf;
+  size_t len = 0;
+  size_t ulen;
+  size_t plen;
+
+  assert (conn->username != NULL);
+  assert (conn->password != NULL);
+
+  ulen = strlen (conn->username);
+  plen = strlen (conn->password);
+
+  /* Validate credentials */
+  if (validate_socks5_auth_credentials (conn, ulen, plen) != 0)
+    return -1;
 
   /* Build auth request */
   buf[len++] = SOCKS5_AUTH_VERSION; /* VER = 0x01 */


### PR DESCRIPTION
## Summary

Implements #565 by extracting credential validation logic from `proxy_socks5_send_auth()` into a dedicated helper function.

## Changes

- **Extract validation helper**: Created `validate_socks5_auth_credentials()` (31 lines) to handle:
  - Username/password length validation
  - UTF-8 encoding validation
- **Reduce main function**: Simplified `proxy_socks5_send_auth()` from 55 lines to 32 lines
- **Improve separation of concerns**: Validation logic isolated from protocol encoding
- **Enhance testability**: Validation logic can now be unit tested independently

## Implementation Details

### Before (55 lines)
```c
int
proxy_socks5_send_auth (struct SocketProxy_Conn_T *conn)
{
  // ... assertions and setup ...
  
  // Length validation (12 lines)
  if (ulen > SOCKET_PROXY_MAX_USERNAME_LEN) { ... }
  if (plen > SOCKET_PROXY_MAX_PASSWORD_LEN) { ... }
  
  // UTF-8 validation (10 lines)
  if (SocketUTF8_validate_str(conn->username) != UTF8_VALID) { ... }
  if (SocketUTF8_validate_str(conn->password) != UTF8_VALID) { ... }
  
  // Buffer building (12 lines)
  buf[len++] = SOCKS5_AUTH_VERSION;
  ...
}
```

### After (32 lines + 31-line helper)
```c
static int
validate_socks5_auth_credentials (struct SocketProxy_Conn_T *conn,
                                   size_t ulen, size_t plen)
{
  /* All validation logic here */
  return 0;  // success or -1 on failure
}

int
proxy_socks5_send_auth (struct SocketProxy_Conn_T *conn)
{
  // ... setup ...
  if (validate_socks5_auth_credentials(conn, ulen, plen) != 0)
    return -1;
  // Buffer building only
}
```

## Test Results

All proxy-related tests pass with sanitizers enabled:

```bash
$ ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ./test_proxy
Results: 84 passed, 0 failed, 84 total

$ ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ./test_proxy_integration  
Results: 5 passed, 0 failed, 5 total
```

## Benefits

1. **Readability**: Main function now clearly shows two phases: validate, then encode
2. **Maintainability**: Validation logic centralized in single location
3. **Testability**: Helper can be unit tested in isolation
4. **Compliance**: Brings function under 50-line guideline (now 32 lines)

## Verification

- File: `/home/tetsuo/git/tetsuo-socket/src/socket/SocketProxy-socks5.c`
- Function: `proxy_socks5_send_auth()` (lines 278-310, was 231-285)
- Helper: `validate_socks5_auth_credentials()` (lines 245-276)
- Tests: All proxy tests pass (89 total)
- No functional changes: Identical behavior and error messages

Closes #565