### PR TITLE
refactor(socket): extract wait_for_socket to SocketCommon for reuse

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -592,42 +592,6 @@ get_remaining_timeout_ms (int64_t deadline_ms)
   return deadline_ms - Socket_get_monotonic_ms ();
 }
 
-/**
- * wait_for_socket - Wait for socket to be ready with timeout
- * @fd: File descriptor
- * @events: POLLIN or POLLOUT
- * @timeout_ms: Timeout in ms (0 = no wait, -1 = block)
- *
- * Returns: 1 if ready, 0 if timeout, -1 on error
- */
-static int
-wait_for_socket (int fd, short events, int timeout_ms)
-{
-  struct pollfd pfd;
-  int ret;
-
-  if (timeout_ms == 0)
-    return 1; /* No timeout, proceed immediately */
-
-  pfd.fd = fd;
-  pfd.events = events;
-  pfd.revents = 0;
-
-  do
-    {
-      ret = poll (&pfd, 1, timeout_ms);
-    }
-  while (ret < 0 && errno == EINTR);
-
-  if (ret < 0)
-    return -1;
-  if (ret == 0)
-    return 0; /* Timeout */
-  if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))
-    return -1;
-
-  return 1;
-}
 
 /**
  * Socket_sendall_timeout - Send all data with timeout
@@ -670,13 +634,13 @@ Socket_sendall_timeout (T socket, const void *buf, size_t len, int timeout_ms)
             if (remaining_ms <= 0)
               break; /* Timeout */
 
-            if (wait_for_socket (fd, POLLOUT, (int)remaining_ms) <= 0)
+            if (SocketCommon_wait_for_fd (fd, POLLOUT, (int)remaining_ms) <= 0)
               break; /* Timeout or error */
           }
         else if (timeout_ms == -1)
           {
             /* Block indefinitely */
-            if (wait_for_socket (fd, POLLOUT, -1) < 0)
+            if (SocketCommon_wait_for_fd (fd, POLLOUT, -1) < 0)
               {
                 SOCKET_ERROR_FMT ("poll() failed during send");
                 RAISE_MODULE_ERROR (Socket_Failed);
@@ -740,13 +704,13 @@ Socket_recvall_timeout (T socket, void *buf, size_t len, int timeout_ms)
             if (remaining_ms <= 0)
               break; /* Timeout */
 
-            if (wait_for_socket (fd, POLLIN, (int)remaining_ms) <= 0)
+            if (SocketCommon_wait_for_fd (fd, POLLIN, (int)remaining_ms) <= 0)
               break; /* Timeout or error */
           }
         else if (timeout_ms == -1)
           {
             /* Block indefinitely */
-            if (wait_for_socket (fd, POLLIN, -1) < 0)
+            if (SocketCommon_wait_for_fd (fd, POLLIN, -1) < 0)
               {
                 SOCKET_ERROR_FMT ("poll() failed during recv");
                 RAISE_MODULE_ERROR (Socket_Failed);
@@ -796,7 +760,7 @@ Socket_sendv_timeout (T socket, const struct iovec *iov, int iovcnt,
   /* Wait for socket to be writable */
   if (timeout_ms != 0)
     {
-      int ready = wait_for_socket (fd, POLLOUT, timeout_ms);
+      int ready = SocketCommon_wait_for_fd (fd, POLLOUT, timeout_ms);
       if (ready == 0)
         return 0; /* Timeout */
       if (ready < 0)
@@ -834,7 +798,7 @@ Socket_recvv_timeout (T socket, struct iovec *iov, int iovcnt, int timeout_ms)
   /* Wait for socket to be readable */
   if (timeout_ms != 0)
     {
-      int ready = wait_for_socket (fd, POLLIN, timeout_ms);
+      int ready = SocketCommon_wait_for_fd (fd, POLLIN, timeout_ms);
       if (ready == 0)
         return 0; /* Timeout */
       if (ready < 0)


### PR DESCRIPTION
## Summary

Implements #564

Extracted the static `wait_for_socket()` function from `Socket-iov.c` to `SocketCommon` as `SocketCommon_wait_for_fd()` to enable reuse across socket modules.

## Changes

- Added `SocketCommon_wait_for_fd()` declaration to `SocketCommon.h` with full documentation
- Implemented `SocketCommon_wait_for_fd()` in `SocketCommon.c`
- Updated all 4 call sites in `Socket-iov.c` to use the new function
- Removed the static `wait_for_socket()` function

## Test Plan

- [x] All 297 socket tests pass with sanitizers (test_socket: 297/297 PASS)
- [x] Build completes successfully with ASAN/UBSAN enabled
- [x] Function behavior identical to original implementation
- [x] All timeout-based I/O operations tested

Note: test_tls_phase4 has a pre-existing memory leak unrelated to this change (confirmed to fail on main branch as well).

Closes #564