### PR TITLE
fix(security): add bounds validation for memcpy in dgram_try_addresses

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -621,11 +621,13 @@ dgram_try_addresses (T socket, struct addrinfo *res, int socket_family,
           /* Cache address in appropriate field based on operation type */
           if (op == DGRAM_OP_CONNECT)
             {
+              assert (rp->ai_addrlen <= sizeof (struct sockaddr_storage));
               memcpy (&socket->base->remote_addr, rp->ai_addr, rp->ai_addrlen);
               socket->base->remote_addrlen = rp->ai_addrlen;
             }
           else
             {
+              assert (rp->ai_addrlen <= sizeof (struct sockaddr_storage));
               memcpy (&socket->base->local_addr, rp->ai_addr, rp->ai_addrlen);
               socket->base->local_addrlen = rp->ai_addrlen;
             }


### PR DESCRIPTION
## Summary

Implements #580 - Adds bounds validation before `memcpy()` operations in `dgram_try_addresses()` to prevent potential buffer overflow.

## Changes

- Added `assert()` checks to validate `ai_addrlen <= sizeof(struct sockaddr_storage)` before both CONNECT and BIND operations
- Lines 624 and 630 in `src/socket/SocketDgram.c`

## Security Impact

Prevents potential buffer overflow if malicious DNS responses or corrupted `getaddrinfo()` results provide oversized address lengths. 

Addresses:
- CWE-120: Buffer Copy without Checking Size of Input
- CWE-805: Buffer Access with Incorrect Length Value

## Test Plan

- [x] All datagram socket tests pass (67/67 tests passed)
- [x] Tests run with AddressSanitizer and UndefinedBehaviorSanitizer enabled
- [x] No new sanitizer warnings introduced
- [x] Existing functionality preserved

## Testing Output

```
Running 67 tests...
...
Results: 67 passed, 0 failed, 67 total
```

Closes #580