### PR TITLE
refactor(socket): make dgram_validate_iov static inline to reduce call overhead

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -691,7 +691,7 @@ SocketDgram_connect (T socket, const char *host, int port)
   dgram_perform_address_operation (socket, host, port, DGRAM_OP_CONNECT);
 }
 
-static void
+static inline void
 dgram_validate_iov (const struct iovec *iov, int iovcnt)
 {
   (void)iov;    /* Used only in assertions */


### PR DESCRIPTION
## Summary

Implements #581 - Convert `dgram_validate_iov()` to `static inline` to eliminate function call overhead.

## Changes

- Modified `src/socket/SocketDgram.c` line 694: changed `static void` to `static inline void`
- The function only contains void casts and assertions (no runtime code in release builds)
- Compiler can now optimize away the call entirely in both debug and release builds

## Performance Impact

- **Debug builds**: Eliminates function call overhead while maintaining assertion checks
- **Release builds**: Compiler can inline the empty function body (assertions compile to nothing)

## Test Plan

- [x] All 67 SocketDgram tests pass with sanitizers
- [x] Full test suite: 107/107 tests passed (excluding known flaky network tests)
- [x] Built successfully with ASan + UBSan

## Verification

```bash
# All datagram-related tests passed
cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ./test_socketdgram
# Results: 67 passed, 0 failed, 67 total
```

Closes #581