### PR TITLE
refactor(proxy): remove redundant buffer overflow check in SOCKS4a

### DIFF
--- a/src/socket/SocketProxy-socks4.c
+++ b/src/socket/SocketProxy-socks4.c
@@ -277,14 +277,6 @@ proxy_socks4a_send_connect (struct SocketProxy_Conn_T *conn)
   buf[len++] = 0x00;
   buf[len++] = SOCKS4A_MARKER_IP_BYTE;
 
-  /* Check total buffer capacity before writing variable-length fields */
-  if (len + SOCKET_PROXY_MAX_USERNAME_LEN + 1 + host_len + 1
-      > sizeof (conn->send_buf))
-    {
-      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL, "Request too large");
-      return -1;
-    }
-
   /* Write userid with null terminator */
   if (socks4_write_userid (buf + len, sizeof (conn->send_buf) - len,
                            conn->username, &userid_written)


### PR DESCRIPTION
## Summary

Implements #585 - removes dead code overflow check that can mathematically never fail.

## Changes

- Removed redundant buffer overflow check in `proxy_socks4a_send_connect()` (lines 281-286)
- The check was comparing a maximum of 520 bytes against a 65536-byte buffer

## Analysis

The removed check verified:
```c
if (len + SOCKET_PROXY_MAX_USERNAME_LEN + 1 + host_len + 1 > sizeof(conn->send_buf))
```

This can never be true because:
| Component | Maximum Size |
|-----------|-------------|
| `len` (header + marker IP) | 8 bytes |
| `SOCKET_PROXY_MAX_USERNAME_LEN` | 255 bytes |
| Null terminator | 1 byte |
| `host_len` (validated ≤ 255) | 255 bytes |
| Null terminator | 1 byte |
| **Maximum total** | **520 bytes** |
| `sizeof(conn->send_buf)` (`SOCKET_PROXY_BUFFER_SIZE`) | 65536 bytes |

Since 520 < 65536, the condition is always false.

## Test Plan

- [x] All proxy tests pass (84/84)
- [x] All proxy integration tests pass (5/5)
- [x] Full test suite passes with sanitizers (111/111)
- [x] No memory leaks detected by ASan
- [x] No undefined behavior detected by UBSan

Closes #585