### PR TITLE
refactor(websocket): define constant for URL path buffer size

### DIFF
--- a/include/socket/SocketWS-private.h
+++ b/include/socket/SocketWS-private.h
@@ -122,6 +122,9 @@
 /** No port specified (for Host header logic) */
 #define SOCKETWS_NO_PORT 0
 
+/** Maximum size for URL path buffer in SocketWS_connect() */
+#define SOCKETWS_MAX_PATH_SIZE 1024
+
 /**
  * @section masking_constants XOR Masking Constants
  * @internal

--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -1387,7 +1387,7 @@ SocketWS_connect (const char *url, const char *protocols)
   Socket_T sock = NULL;
   SocketWS_Config config;
   char host[NI_MAXHOST] = { 0 };
-  char path[1024] = { 0 };
+  char path[SOCKETWS_MAX_PATH_SIZE] = { 0 };
   volatile int port = 80;
   volatile int use_tls = 0;
 


### PR DESCRIPTION
## Summary

Implements #556

Replace hardcoded 1024-byte buffer with named constant `SOCKETWS_MAX_PATH_SIZE` in `SocketWS_connect()` function.

## Changes

- Add `SOCKETWS_MAX_PATH_SIZE` constant to `include/socket/SocketWS-private.h`
- Replace `char path[1024]` with `char path[SOCKETWS_MAX_PATH_SIZE]` in `src/socket/SocketWS.c`

## Test Plan

- [x] Tests pass with sanitizers (110/110 excluding flaky test)
- [x] WebSocket tests pass (24/24)
- [x] Build succeeds with no warnings

Closes #556