### PR TITLE
refactor: extract compress_flush_phase helper from compress_loop

### DIFF
--- a/src/socket/SocketWS-deflate.c
+++ b/src/socket/SocketWS-deflate.c
@@ -246,36 +246,10 @@ try_grow_zlib_buffer (SocketWS_T ws, z_stream *strm, unsigned char **buf,
 
 
 static int
-compress_loop (SocketWS_T ws, z_stream *strm, unsigned char **buf,
-               size_t *buf_size, size_t *total_out)
+compress_flush_phase (SocketWS_T ws, z_stream *strm, unsigned char **buf,
+                      size_t *buf_size, size_t *total_out, int flush_type)
 {
   int ret;
-
-  /* Data compression phase with Z_NO_FLUSH */
-  do
-    {
-      ret = deflate (strm, Z_NO_FLUSH);
-      if (ret == Z_STREAM_ERROR)
-        {
-          ws_set_error (ws, WS_ERROR_COMPRESSION,
-                        "deflate data phase failed: %d", ret);
-          return -1;
-        }
-
-      *total_out = *buf_size - strm->avail_out;
-
-      /* Grow buffer if needed */
-      if (strm->avail_out == 0 && strm->avail_in > 0)
-        {
-          if (try_grow_zlib_buffer (ws, strm, buf, buf_size, *total_out, 0 /* compress */)
-              < 0)
-            return -1;
-        }
-    }
-  while (strm->avail_in > 0);
-
-  /* Flush phase to output remaining data and end block for BFINAL=1 */
-  int flush_type = should_reset_zlib_context (ws, 1 /* deflate */) ? Z_FINISH : Z_SYNC_FLUSH;
   int finished = 0;
 
   while (!finished)
@@ -315,6 +289,41 @@ compress_loop (SocketWS_T ws, z_stream *strm, unsigned char **buf,
 
   *total_out = *buf_size - strm->avail_out;
   return 0;
+}
+
+
+static int
+compress_loop (SocketWS_T ws, z_stream *strm, unsigned char **buf,
+               size_t *buf_size, size_t *total_out)
+{
+  int ret;
+
+  /* Data compression phase with Z_NO_FLUSH */
+  do
+    {
+      ret = deflate (strm, Z_NO_FLUSH);
+      if (ret == Z_STREAM_ERROR)
+        {
+          ws_set_error (ws, WS_ERROR_COMPRESSION,
+                        "deflate data phase failed: %d", ret);
+          return -1;
+        }
+
+      *total_out = *buf_size - strm->avail_out;
+
+      /* Grow buffer if needed */
+      if (strm->avail_out == 0 && strm->avail_in > 0)
+        {
+          if (try_grow_zlib_buffer (ws, strm, buf, buf_size, *total_out, 0 /* compress */)
+              < 0)
+            return -1;
+        }
+    }
+  while (strm->avail_in > 0);
+
+  /* Flush phase to output remaining data and end block for BFINAL=1 */
+  int flush_type = should_reset_zlib_context (ws, 1 /* deflate */) ? Z_FINISH : Z_SYNC_FLUSH;
+  return compress_flush_phase (ws, strm, buf, buf_size, total_out, flush_type);
 }
 
 


### PR DESCRIPTION
## Summary

Implements #577 by extracting the flush phase logic from `compress_loop()` into a separate helper function.

## Changes

- **Created `compress_flush_phase()` helper** (lines 248-292)
  - Handles the flush phase with `Z_FINISH` or `Z_SYNC_FLUSH`
  - Manages buffer growth during flush
  - Determines flush completion based on deflate return codes
  
- **Refactored `compress_loop()`** (lines 295-327)
  - Reduced from 70 to 28 lines (60% reduction)
  - Now focuses on data compression phase only
  - Calls `compress_flush_phase()` for final flush operation
  - Makes the two-phase compression process more explicit

## Impact

- Improves code readability by separating concerns
- Makes the data compression vs. flush phases clearer
- Easier to test and maintain each phase independently
- No functional changes - pure refactoring

## Test Plan

- [x] All WebSocket tests pass with sanitizers:
  - `test_websocket` (24/24 tests)
  - `test_ws_integration` (6/6 tests)  
  - `test_websocket_h2` (all tests)
- [x] All HTTP/2 and HPACK tests pass
- [x] Verified compression roundtrip functionality intact
- [x] No changes to public API or behavior

Closes #577