### PR TITLE
fix(socket): add overflow checks for size_t to uInt casts in WebSocket deflate

### DIFF
--- a/src/socket/SocketWS-deflate.c
+++ b/src/socket/SocketWS-deflate.c
@@ -496,6 +496,21 @@ ws_compress_message (SocketWS_T ws, const unsigned char *input,
     }
 
   /* Set up zlib stream */
+  /* Check for overflow before casting size_t to uInt (zlib limitation) */
+  if (input_len > UINT_MAX)
+    {
+      ws_set_error (ws, WS_ERROR_COMPRESSION,
+                    "Input size %zu exceeds zlib limit %u", input_len,
+                    UINT_MAX);
+      return -1;
+    }
+  if (buf_size > UINT_MAX)
+    {
+      ws_set_error (ws, WS_ERROR_COMPRESSION,
+                    "Buffer size %zu exceeds zlib limit %u", buf_size,
+                    UINT_MAX);
+      return -1;
+    }
   strm->next_in = (Bytef *)input;
   strm->avail_in = (uInt)input_len;
   strm->next_out = buf;
@@ -578,6 +593,21 @@ ws_decompress_message (SocketWS_T ws, const unsigned char *input,
     }
 
   /* Set up zlib stream */
+  /* Check for overflow before casting size_t to uInt (zlib limitation) */
+  if (input_with_trailer_len > UINT_MAX)
+    {
+      ws_set_error (ws, WS_ERROR_COMPRESSION,
+                    "Input size %zu exceeds zlib limit %u",
+                    input_with_trailer_len, UINT_MAX);
+      return -1;
+    }
+  if (buf_size > UINT_MAX)
+    {
+      ws_set_error (ws, WS_ERROR_COMPRESSION,
+                    "Buffer size %zu exceeds zlib limit %u", buf_size,
+                    UINT_MAX);
+      return -1;
+    }
   strm->next_in = input_with_trailer;
   strm->avail_in = (uInt)input_with_trailer_len;
   strm->next_out = buf;


### PR DESCRIPTION
## Summary

Implements #570 - Adds UINT_MAX overflow validation before casting size_t to uInt in WebSocket compression/decompression functions.

## Security Impact

**Severity**: MEDIUM  
**Type**: Integer overflow / buffer overrun

On 64-bit systems, size_t is 64-bit while zlib's uInt is 32-bit (max ~4GB). Unchecked casts can silently truncate large message sizes, leading to:
- Incomplete compression/decompression (only first 4GB processed)
- Buffer overruns (output buffer appears smaller to zlib)
- Data corruption from partial processing
- Potential bypass of message size limits

## Changes

### ws_compress_message()
- Added overflow check for `input_len` before cast at line 500
- Added overflow check for `buf_size` before cast at line 502

### ws_decompress_message()
- Added overflow check for `input_with_trailer_len` before cast at line 582
- Added overflow check for `buf_size` before cast at line 584

All checks return WS_ERROR_COMPRESSION with descriptive error messages.

## Test Plan

- [x] All WebSocket tests pass (24/24 tests including compression roundtrip)
- [x] Full test suite passes with ASan/UBSan (110/111 tests, 1 flaky unrelated test)
- [x] Build succeeds with all sanitizers enabled
- [x] No new compiler warnings

## Verification

```bash
cd build
./test_websocket  # All compression tests pass
ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest -E "test_multi_protocol_integration" -j1
# 110/110 tests pass
```

Closes #570