### PR TITLE
refactor(socket): replace bare return with RETURN macro in exception handler

### DIFF
--- a/src/socket/Socket-connect.c
+++ b/src/socket/Socket-connect.c
@@ -401,7 +401,7 @@ Socket_connect (T socket, const char *host, int port)
     if (SocketError_is_retryable_errno(saved_errno))
       {
         errno = saved_errno;
-        return;
+        RETURN;
       }
     errno = saved_errno;
     RERAISE;


### PR DESCRIPTION
## Summary

Implements #563 - Replaces bare `return;` with `RETURN;` macro in Socket_connect exception handler at line 404.

## Changes

- Modified `src/socket/Socket-connect.c` line 404
- Changed bare `return;` to `RETURN;` in EXCEPT block
- Ensures proper exception stack unwinding when returning early from TRY/EXCEPT blocks

## Rationale

The `RETURN` macro is required when returning from within TRY/EXCEPT/FINALLY blocks to properly unwind the thread-local exception stack. Using bare `return` can leave the exception state in an inconsistent state.

## Test Plan

- [x] Tests pass with sanitizers (ASAN/UBSAN)
- [x] All 111 tests passed in worktree build
- [x] Build completes without warnings
- [x] Exception safety verified

Closes #563