### PR TITLE
fix(core): check pthread_mutex_destroy return value in histogram_destroy

### DIFF
--- a/src/core/SocketMetrics.c
+++ b/src/core/SocketMetrics.c
@@ -309,7 +309,8 @@ histogram_destroy (Histogram *h)
 {
   if (h->initialized)
     {
-      pthread_mutex_destroy (&h->mutex);
+      int rc = pthread_mutex_destroy (&h->mutex);
+      assert (rc == 0 && "pthread_mutex_destroy failed - mutex may be locked");
       h->initialized = 0;
     }
 }


### PR DESCRIPTION
## Summary

Implements #591 - Add return value checking for `pthread_mutex_destroy()` in the `histogram_destroy` function.

## Changes

- Added return value check for `pthread_mutex_destroy()` 
- Used assertion to catch errors during development and testing
- Prevents masking of synchronization bugs that could lead to use-after-free or race conditions

## Implementation Details

The function `pthread_mutex_destroy()` returns `EBUSY` if the mutex is still locked or referenced by another thread. Ignoring this return value can mask critical synchronization bugs. The fix adds an assertion that will:

1. Fail fast in debug builds if the mutex is still in use
2. Help identify potential race conditions during testing
3. Prevent difficult-to-debug issues from propagating

## Test Plan

- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] All 111 tests pass in worktree
- [x] `test_metrics` specifically tests init/shutdown lifecycle which exercises `histogram_destroy`
- [x] No memory leaks detected
- [x] No undefined behavior detected

Closes #591