### PR TITLE
refactor(core): remove redundant safe_copy_ip wrapper

### DIFF
--- a/include/core/SocketSYNProtect-private.h
+++ b/include/core/SocketSYNProtect-private.h
@@ -234,7 +234,6 @@ void free_memory (T protect, void *ptr);
 void remove_ip_entry_from_hash (T protect, SocketSYN_IPEntry *entry);
 
 /* Local to main file */
-static void safe_copy_ip (char *dest, const char *src);
 static SocketSYN_WhitelistEntry * find_whitelist_entry_exact (SocketSYN_WhitelistEntry *bucket_head, const char *ip);
 static SocketSYN_BlacklistEntry * find_blacklist_entry (SocketSYN_BlacklistEntry *bucket_head, const char *ip);
 static void insert_whitelist_entry (T protect, SocketSYN_WhitelistEntry *entry, unsigned bucket);

--- a/src/core/SocketSYNProtect.c
+++ b/src/core/SocketSYNProtect.c
@@ -69,12 +69,6 @@ synprotect_get_fallback_seed (void)
   return seed;
 }
 
-static void
-safe_copy_ip (char *dest, const char *src)
-{
-  socket_util_safe_copy_ip (dest, src, SOCKET_IP_MAX_LEN);
-}
-
 static void *
 alloc_zeroed (T protect, size_t count, size_t size)
 {
@@ -103,7 +97,7 @@ static void
 init_ip_state (SocketSYN_IPState *state, const char *ip, int64_t now_ms)
 {
   memset (state, 0, sizeof (*state));
-  safe_copy_ip (state->ip, ip);
+  socket_util_safe_copy_ip (state->ip, ip, SOCKET_IP_MAX_LEN);
   state->window_start_ms = now_ms;
   state->last_attempt_ms = now_ms;
   state->rep = SYN_REP_NEUTRAL;
@@ -300,7 +294,7 @@ fill_ip_state_out (SocketSYN_IPState *state_out, const char *ip,
     return;
 
   memset (state_out, 0, sizeof (*state_out));
-  safe_copy_ip (state_out->ip, ip);
+  socket_util_safe_copy_ip (state_out->ip, ip, SOCKET_IP_MAX_LEN);
   state_out->rep = rep;
   state_out->score = score;
 }
@@ -625,7 +619,7 @@ create_whitelist_entry (T protect, const char *ip, int is_cidr)
   if (entry == NULL)
     return NULL;
 
-  safe_copy_ip (entry->ip, ip);
+  socket_util_safe_copy_ip (entry->ip, ip, SOCKET_IP_MAX_LEN);
   entry->is_cidr = is_cidr;
   return entry;
 }
@@ -639,7 +633,7 @@ create_blacklist_entry (T protect, const char *ip, int64_t expires_ms)
   if (entry == NULL)
     return NULL;
 
-  safe_copy_ip (entry->ip, ip);
+  socket_util_safe_copy_ip (entry->ip, ip, SOCKET_IP_MAX_LEN);
   entry->expires_ms = expires_ms;
   return entry;
 }


### PR DESCRIPTION
## Summary

Implements #590

## Changes

- Removed redundant `safe_copy_ip()` wrapper function (5 lines)
- Removed forward declaration from `SocketSYNProtect-private.h`
- Updated 4 call sites to use `socket_util_safe_copy_ip()` directly with explicit `SOCKET_IP_MAX_LEN`:
  - `init_ip_state()`
  - `fill_ip_state_out()`
  - `create_whitelist_entry()`
  - `create_blacklist_entry()`

## Benefits

- Eliminates unnecessary function call overhead
- Reduces code size
- Makes the buffer size limit explicit at call sites
- Improves code clarity by removing indirection

## Test Plan

- [x] Tests pass with sanitizers (test_synprotect, test_security)
- [x] No functional changes - pure refactoring
- [x] Build succeeds with sanitizers enabled

Closes #590