### PR TITLE
refactor(SocketUtil): remove duplicate arena_strndup implementation

### DIFF
--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -647,7 +647,7 @@ socket_util_arena_strdup_len (Arena_T arena, const char *str, size_t len)
 }
 
 /**
- * @brief Duplicate string with length into arena (simplified alias).
+ * @brief Duplicate string with length into arena (convenience alias).
  * @ingroup foundation
  * @param arena Arena for allocation.
  * @param src String to duplicate (may not be null-terminated).
@@ -655,26 +655,13 @@ socket_util_arena_strdup_len (Arena_T arena, const char *str, size_t len)
  * @return Null-terminated copy in arena, or NULL if src is NULL or alloc fails.
  * @threadsafe Yes (if arena is thread-safe)
  *
- * Simplified wrapper consolidating duplicate string duplication logic.
- * Handles null source gracefully and always null-terminates result.
+ * Convenience wrapper for socket_util_arena_strdup_len with a shorter name.
+ * Eliminates code duplication by delegating to the canonical implementation.
  */
 static inline char *
 arena_strndup (Arena_T arena, const char *src, size_t len)
 {
-  char *copy;
-
-  if (src == NULL)
-    return NULL;
-
-  copy = Arena_alloc (arena, len + 1, __FILE__, __LINE__);
-  if (copy != NULL)
-    {
-      if (len > 0)
-        memcpy (copy, src, len);
-      copy[len] = '\0';
-    }
-
-  return copy;
+  return socket_util_arena_strdup_len (arena, src, len);
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #600

Removes duplicate implementation of `arena_strndup()` by converting it into a thin wrapper that delegates to `socket_util_arena_strdup_len()`.

## Changes

- **File**: `include/core/SocketUtil.h`
- Replaced duplicate implementation (lines 662-678) with single-line delegation to `socket_util_arena_strdup_len()`
- Updated function documentation to clarify it's a convenience alias
- Maintains backward compatibility - both function names still work

## Benefits

- Eliminates 17 lines of duplicated code
- Single source of truth for string duplication logic
- Reduces maintenance burden (bugs only need fixing once)
- No breaking changes - existing callers continue to work

## Test Plan

- [x] All 111 tests pass with AddressSanitizer and UBSanitizer
- [x] Build completes without warnings
- [x] No functional changes - pure refactoring

Closes #600