### PR TITLE
refactor(core): consolidate redundant time conversion constants

### DIFF
--- a/src/core/SocketRetry.c
+++ b/src/core/SocketRetry.c
@@ -25,8 +25,6 @@
 #define SOCKET_RETRY_MAX_MULTIPLIER 16.0
 #define SOCKET_RETRY_MAX_DELAY_VALUE_MS 3600000
 #define RETRY_MAX_EXPONENT 1000 /* Prevent CPU DoS from excessive loops */
-#define MILLISECONDS_PER_SECOND 1000
-#define NANOSECONDS_PER_MILLISECOND 1000000L
 #define UINT32_MAX_DOUBLE ((double)0xFFFFFFFFU)
 
 #define T SocketRetry_T
@@ -253,8 +251,8 @@ retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / MILLISECONDS_PER_SECOND;
-  req.tv_nsec = (ms % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
+  req.tv_sec = ms / SOCKET_MS_PER_SECOND;
+  req.tv_nsec = (ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/http/SocketHTTPClient-pool.c
+++ b/src/http/SocketHTTPClient-pool.c
@@ -47,10 +47,6 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPClient);
 #define POOL_MAX_HASH_CHAIN_LEN 1024
 #endif
 
-#ifndef POOL_MS_PER_SECOND
-#define POOL_MS_PER_SECOND 1000
-#endif
-
 /* Forward declarations */
 static void pool_entry_remove_and_recycle (HTTPPool *pool, HTTPPoolEntry *entry);
 
@@ -537,7 +533,7 @@ httpclient_pool_cleanup_idle (HTTPPool *pool)
   pthread_mutex_lock (&pool->mutex);
 
   now = pool_time ();
-  idle_threshold = pool->idle_timeout_ms / POOL_MS_PER_SECOND;
+  idle_threshold = pool->idle_timeout_ms / SOCKET_MS_PER_SECOND;
 
   HTTPPoolEntry *entry = pool->all_conns;
   while (entry != NULL)

--- a/src/http/SocketHTTPClient-retry.c
+++ b/src/http/SocketHTTPClient-retry.c
@@ -13,9 +13,6 @@
 #include "core/SocketRetry.h"
 #include "http/SocketHTTPClient-private.h"
 
-#define MILLISECONDS_PER_SECOND 1000
-#define NANOSECONDS_PER_MILLISECOND 1000000L
-
 #define CLEAR_RESPONSE(r)                                                     \
   do                                                                          \
     {                                                                         \
@@ -62,8 +59,8 @@ httpclient_retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / MILLISECONDS_PER_SECOND;
-  req.tv_nsec = (ms % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
+  req.tv_sec = ms / SOCKET_MS_PER_SECOND;
+  req.tv_nsec = (ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/pool/SocketPool-drain.c
+++ b/src/pool/SocketPool-drain.c
@@ -53,9 +53,6 @@
 /** Infinite timeout sentinel */
 #define SOCKET_POOL_DRAIN_TIMEOUT_INFINITE (-1)
 
-/** Nanoseconds per millisecond (for nanosleep conversion) */
-#define NSEC_PER_MSEC 1000000L
-
 /* ============================================================================
  * Internal Helpers
  * ============================================================================
@@ -614,8 +611,8 @@ SocketPool_drain_wait (T pool, int timeout_ms)
   while ((result = SocketPool_drain_poll (pool)) > 0)
     {
       /* Sleep with exponential backoff */
-      ts.tv_sec = backoff_ms / 1000;
-      ts.tv_nsec = (backoff_ms % 1000) * NSEC_PER_MSEC;
+      ts.tv_sec = backoff_ms / SOCKET_MS_PER_SECOND;
+      ts.tv_nsec = (backoff_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
       nanosleep (&ts, NULL);
 
       /* Increase backoff up to max */


### PR DESCRIPTION
## Summary

Consolidates redundant time conversion constants across multiple modules by replacing them with standardized definitions from `SocketConfig.h`.

## Changes

This PR eliminates duplicate time conversion constant definitions in:

- **src/core/SocketRetry.c**
  - Removed: `MILLISECONDS_PER_SECOND`, `NANOSECONDS_PER_MILLISECOND`
  - Now uses: `SOCKET_MS_PER_SECOND`, `SOCKET_NS_PER_MS`

- **src/http/SocketHTTPClient-retry.c**
  - Removed: `MILLISECONDS_PER_SECOND`, `NANOSECONDS_PER_MILLISECOND`
  - Now uses: `SOCKET_MS_PER_SECOND`, `SOCKET_NS_PER_MS`

- **src/http/SocketHTTPClient-pool.c**
  - Removed: `POOL_MS_PER_SECOND`
  - Now uses: `SOCKET_MS_PER_SECOND`

- **src/pool/SocketPool-drain.c**
  - Removed: `NSEC_PER_MSEC`
  - Now uses: `SOCKET_NS_PER_MS`

## Benefits

- Reduces code duplication (12 lines removed)
- Centralizes time constant definitions in `SocketConfig.h`
- Ensures consistency across all modules
- Improves long-term maintainability

## Test Plan

- [x] All relevant tests pass with sanitizers enabled
  - `test_socketretry`: PASSED
  - `test_http_client`: PASSED
  - `test_socketpool`: PASSED
  - `test_socketpool_tls`: PASSED
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] No functional changes, purely refactoring

Closes #617