### PR TITLE
refactor(Except): simplify nested conditionals in except_emit_location

### DIFF
--- a/src/core/Except.c
+++ b/src/core/Except.c
@@ -111,13 +111,24 @@ except_emit_location (const char *file, int line)
 #endif
 
   if (display_file != NULL && line > 0)
-    fprintf (stderr, " raised at %s:%d\n", display_file, line);
-  else if (display_file != NULL)
-    fprintf (stderr, " raised at %s\n", display_file);
-  else if (line > 0)
-    fprintf (stderr, " raised at line %d\n", line);
-  else
-    fprintf (stderr, " (location unknown)\n");
+    {
+      fprintf (stderr, " raised at %s:%d\n", display_file, line);
+      return;
+    }
+
+  if (display_file != NULL)
+    {
+      fprintf (stderr, " raised at %s\n", display_file);
+      return;
+    }
+
+  if (line > 0)
+    {
+      fprintf (stderr, " raised at line %d\n", line);
+      return;
+    }
+
+  fprintf (stderr, " (location unknown)\n");
 }
 
 EXCEPT_COLD EXCEPT_NORETURN static void


### PR DESCRIPTION
## Summary

Implements #586

## Changes

- Refactored `except_emit_location()` in `src/core/Except.c` to use early returns instead of nested if-else conditionals
- Improved readability by flattening control flow
- Added braces around single-statement blocks for consistency with project style
- No functional changes - logic remains identical

## Test Plan

- [x] All tests pass (111/111)
- [x] Build succeeds with sanitizers enabled
- [x] Exception handling behavior unchanged
- [x] Code compiles without warnings

The refactoring reduces cognitive complexity while maintaining the exact same functionality - the function still handles all four cases (file+line, file only, line only, unknown) with the same priority order.

Closes #586