### PR TITLE
refactor(core): remove duplicate SOCKETBUF_INITIAL_CAPACITY definition

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -408,14 +408,6 @@ extern const char *Socket_safe_strerror (int errnum);
 #endif
 
 /**
- * @brief Initial capacity when buffer reserve grows from zero.
- *
- */
-#ifndef SOCKETBUF_INITIAL_CAPACITY
-#define SOCKETBUF_INITIAL_CAPACITY 1024
-#endif
-
-/**
  * @brief Allocation overhead for arena bookkeeping during buffer resize.
  *
  */


### PR DESCRIPTION
## Summary

Implements #596

## Changes

- Removed duplicate `SOCKETBUF_INITIAL_CAPACITY` definition from "Buffer Configuration" section (lines 414-416, value 1024)
- Kept original definition in "Size Limits and Capacity Configuration" section (lines 208-210, value 4096)
- Removed associated comment block for the duplicate definition

## Problem

The constant was defined twice in the same file with conflicting values (4096 and 1024). Due to the `#ifndef` guard, only the first definition took effect, making the second one dead code that could cause:
- Maintenance confusion
- Inconsistent documentation
- Potential bugs if sections were reordered

## Test Plan

- [x] All tests pass with sanitizers enabled (110/110 tests excluding known flaky `test_http_integration`)
- [x] Build succeeds with no warnings
- [x] No code references the removed duplicate

Closes #596