### PR TITLE
refactor(core): remove duplicate SOCKETBUF_ALLOC_OVERHEAD definition

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -408,14 +408,6 @@ extern const char *Socket_safe_strerror (int errnum);
 #endif
 
 /**
- * @brief Allocation overhead for arena bookkeeping during buffer resize.
- *
- */
-#ifndef SOCKETBUF_ALLOC_OVERHEAD
-#define SOCKETBUF_ALLOC_OVERHEAD 64
-#endif
-
-/**
  * @brief SOCKETBUF_MAX_CAPACITY - Maximum buffer capacity (SIZE_MAX/2)
  *
  * Conservative limit providing guaranteed safety:


### PR DESCRIPTION
## Summary

Implements #613

Removes redundant duplicate definition of `SOCKETBUF_ALLOC_OVERHEAD` constant that was causing code duplication and potential maintenance confusion.

## Changes

- Removed duplicate definition at lines 422-424 in `include/core/SocketConfig.h`
- Kept the first definition at lines 218-220 in the "Size Limits and Capacity Configuration" section
- Both definitions had identical value (64)

## Details

The file contained two separate definitions of `SOCKETBUF_ALLOC_OVERHEAD`:

**First definition (lines 218-220)** - **KEPT**:
```c
#ifndef SOCKETBUF_ALLOC_OVERHEAD
#define SOCKETBUF_ALLOC_OVERHEAD 64
#endif
```

**Second definition (lines 422-424)** - **REMOVED**:
```c
#ifndef SOCKETBUF_ALLOC_OVERHEAD
#define SOCKETBUF_ALLOC_OVERHEAD 64
#endif
```

Due to the `#ifndef` guard, only the first definition was active. The second was dead code.

## Benefits

1. Eliminates maintenance confusion where developers might change second definition expecting it to work
2. Follows DRY (Don't Repeat Yourself) principle
3. Reduces code duplication between configuration sections
4. No functional changes - both had same value

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All previously passing tests still pass
- [x] No new compilation errors or warnings
- [x] Verified constant is defined exactly once

## Related Issues

- Related to #596 (similar duplicate for `SOCKETBUF_INITIAL_CAPACITY`)
- Part of general configuration file cleanup effort

Closes #613