### PR TITLE
security(SocketCrypto): replace raw pthread_mutex_lock calls with SOCKET_MUTEX_LOCK_OR_RAISE

### DIFF
--- a/src/core/SocketCrypto.c
+++ b/src/core/SocketCrypto.c
@@ -625,11 +625,11 @@ SocketCrypto_random_bytes (void *output, size_t len)
 #else
   int result = -1;
 
-  pthread_mutex_lock (&urand_mutex);
+  SOCKET_MUTEX_LOCK_OR_RAISE (&urand_mutex, SocketCrypto, SocketCrypto_Failed);
   int fd = urandom_ensure_open ();
   if (fd >= 0)
     result = urandom_read_all (fd, (unsigned char *)output, len);
-  pthread_mutex_unlock (&urand_mutex);
+  SOCKET_MUTEX_UNLOCK (&urand_mutex);
 
   return result;
 #endif
@@ -651,13 +651,13 @@ void
 SocketCrypto_cleanup (void)
 {
 #if !SOCKET_HAS_TLS
-  pthread_mutex_lock (&urand_mutex);
+  SOCKET_MUTEX_LOCK_OR_RAISE (&urand_mutex, SocketCrypto, SocketCrypto_Failed);
   if (urand_fd >= 0)
     {
       close (urand_fd);
       urand_fd = -1;
     }
-  pthread_mutex_unlock (&urand_mutex);
+  SOCKET_MUTEX_UNLOCK (&urand_mutex);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Implements #599: Migrates SocketCrypto.c to use standardized mutex error handling macros.

## Changes

- Replaced raw `pthread_mutex_lock()` calls with `SOCKET_MUTEX_LOCK_OR_RAISE` macro in two locations:
  - `SocketCrypto_random_bytes()` (line 628)
  - `SocketCrypto_cleanup()` (line 654)
- Replaced raw `pthread_mutex_unlock()` calls with `SOCKET_MUTEX_UNLOCK` macro
- Both changes apply to non-TLS build paths (when `SOCKET_HAS_TLS` is false)

## Security Impact

**Severity**: MEDIUM

Raw `pthread_mutex_lock` does not check return values, which can lead to:
- Race conditions if lock acquisition fails silently
- Undefined behavior if mutex is in error state
- Inconsistent error handling across the codebase

The standardized macros now raise `SocketCrypto_Failed` exception on mutex lock errors, ensuring proper error propagation.

## Test Plan

- [x] All crypto tests pass with ASan/UBSan
- [x] Build succeeds with sanitizers enabled
- [x] No new memory leaks or undefined behavior detected

## Related

- PR #536: Initial mutex macro standardization
- PR #545: Arena.c migration to standardized macros
- Issue #540: Arena mutex error handling

Closes #599
