### PR TITLE
fix(core): remove unsigned < 0 check in SocketMetrics_snapshot_value

### DIFF
--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -307,7 +307,7 @@ SocketMetrics_snapshot_value (const SocketMetricsSnapshot *snapshot,
 {
   if (!snapshot)
     return 0ULL;
-  if (metric < 0 || metric >= SOCKET_METRIC_COUNT)
+  if (metric >= SOCKET_METRIC_COUNT)
     return 0ULL;
   return snapshot->values[metric];
 }


### PR DESCRIPTION
## Summary

Fixes #592

Removes redundant unsigned < 0 comparison in `SocketMetrics_snapshot_value()` function.

## Changes

- Remove `metric < 0` check in `SocketMetrics_snapshot_value()` (line 310 of `include/core/SocketUtil.h`)
- The check was always false since `SocketMetric` is an enum type (defaults to unsigned in C)
- Retain the `metric >= SOCKET_METRIC_COUNT` upper bound check which correctly validates the enum value

## Test Plan

- [x] All tests pass with sanitizers enabled (excluding pre-existing flaky integration tests)
- [x] Build succeeds with no warnings
- [x] Change is purely a code quality improvement - removes dead code that generates compiler warnings with `-Wtype-limits`
- [x] No behavioral changes (condition was always false)

Closes #592