### PR TITLE
refactor(core): change TimeWindow.duration_ms from int to int64_t for type consistency

### DIFF
--- a/include/core/TimeWindow.h
+++ b/include/core/TimeWindow.h
@@ -57,7 +57,7 @@ typedef struct TimeWindow_T
   int64_t window_start_ms;   /**< Start time of current window */
   uint32_t current_count;    /**< Events in current window */
   uint32_t previous_count;   /**< Events in previous window */
-  int duration_ms;           /**< Window duration in milliseconds */
+  int64_t duration_ms;       /**< Window duration in milliseconds */
 } TimeWindow_T;
 
 /**
@@ -66,7 +66,7 @@ typedef struct TimeWindow_T
  * Sets up the window with zero counts starting at the given time.
  * Duration is clamped to minimum of 1ms if invalid.
  */
-extern void TimeWindow_init (TimeWindow_T *tw, int duration_ms, int64_t now_ms);
+extern void TimeWindow_init (TimeWindow_T *tw, int64_t duration_ms, int64_t now_ms);
 
 /**
  * @brief Record an event in the time window

--- a/src/core/TimeWindow.c
+++ b/src/core/TimeWindow.c
@@ -16,20 +16,19 @@
 
 /* Clamp elapsed time to [0, duration] to handle clock skew */
 static inline int64_t
-timewindow_clamp_to_duration (int64_t elapsed, int duration)
+timewindow_clamp_to_duration (int64_t elapsed, int64_t duration)
 {
   if (duration <= 0)
     return 0;
   if (elapsed < 0)
     return 0;
-  int64_t d = duration;
-  if (elapsed > d)
-    return d;
+  if (elapsed > duration)
+    return duration;
   return elapsed;
 }
 
 void
-TimeWindow_init (T *tw, int duration_ms, int64_t now_ms)
+TimeWindow_init (T *tw, int64_t duration_ms, int64_t now_ms)
 {
   assert (tw != NULL);
 
@@ -73,7 +72,7 @@ TimeWindow_effective_count (const T *tw, int64_t now_ms)
 {
   assert (tw != NULL);
 
-  int duration_ms = tw->duration_ms;
+  int64_t duration_ms = tw->duration_ms;
   if (duration_ms <= 0)
     return tw->current_count;
 
@@ -81,7 +80,7 @@ TimeWindow_effective_count (const T *tw, int64_t now_ms)
   int64_t clamped_elapsed
       = timewindow_clamp_to_duration (elapsed, duration_ms);
 
-  int64_t remaining = (int64_t)duration_ms - clamped_elapsed;
+  int64_t remaining = duration_ms - clamped_elapsed;
   uint32_t weighted_previous = 0;
   if (remaining > 0)
     {
@@ -108,7 +107,7 @@ TimeWindow_progress (const T *tw, int64_t now_ms)
 {
   assert (tw != NULL);
 
-  int duration_ms = tw->duration_ms;
+  int64_t duration_ms = tw->duration_ms;
   if (duration_ms <= 0)
     return 1.0f;
 

--- a/src/http/SocketHTTP2-stream.c
+++ b/src/http/SocketHTTP2-stream.c
@@ -174,7 +174,7 @@ http2_stream_rate_check (SocketHTTP2_Conn_T conn)
   if (window_count >= conn->stream_max_per_window)
     {
       SOCKET_LOG_WARN_MSG ("SECURITY: HTTP/2 stream creation window limit exceeded: "
-                           "%" PRIu32 " >= %" PRIu32 " in %d ms - potential DoS attack",
+                           "%" PRIu32 " >= %" PRIu32 " in %" PRId64 " ms - potential DoS attack",
                            window_count, conn->stream_max_per_window,
                            conn->stream_create_window.duration_ms);
       return -1;
@@ -185,7 +185,7 @@ http2_stream_rate_check (SocketHTTP2_Conn_T conn)
   if (burst_count >= conn->stream_burst_threshold)
     {
       SOCKET_LOG_WARN_MSG ("SECURITY: HTTP/2 stream creation burst detected: "
-                           "%" PRIu32 " >= %" PRIu32 " in %d ms - potential DoS attack",
+                           "%" PRIu32 " >= %" PRIu32 " in %" PRId64 " ms - potential DoS attack",
                            burst_count, conn->stream_burst_threshold,
                            conn->stream_burst_window.duration_ms);
       return -1;
@@ -196,7 +196,7 @@ http2_stream_rate_check (SocketHTTP2_Conn_T conn)
   if (churn_count >= conn->stream_churn_threshold)
     {
       SOCKET_LOG_WARN_MSG ("SECURITY: HTTP/2 stream churn limit exceeded: "
-                           "%" PRIu32 " >= %" PRIu32 " in %d ms - "
+                           "%" PRIu32 " >= %" PRIu32 " in %" PRId64 " ms - "
                            "CVE-2023-44487 Rapid Reset Attack detected",
                            churn_count, conn->stream_churn_threshold,
                            conn->stream_churn_window.duration_ms);


### PR DESCRIPTION
## Summary

Implements #620

Changes `TimeWindow_T.duration_ms` from `int` (32-bit) to `int64_t` (64-bit) to maintain type consistency with other time-related fields in the structure.

## Changes

- Updated `TimeWindow_T.duration_ms` field from `int` to `int64_t`
- Updated `TimeWindow_init()` parameter type from `int` to `int64_t`
- Updated `timewindow_clamp_to_duration()` helper function to accept `int64_t`
- Updated local variables in implementation to use `int64_t`
- Fixed format strings in `SocketHTTP2-stream.c` to use `PRId64` for `int64_t` values

## Benefits

- **Type consistency**: All time-related fields now use `int64_t`
- **Eliminates casts**: No need for explicit type conversions in arithmetic
- **Extended range**: Supports window durations longer than ~24 days (previous INT_MAX limit)
- **Cleaner code**: Simplified arithmetic operations without type mismatches

## Test Plan

- [x] All tests pass with sanitizers enabled (111/111 tests passed)
- [x] Build succeeds with `-Werror` (all warnings treated as errors)
- [x] No memory leaks detected by AddressSanitizer
- [x] No undefined behavior detected by UBSan

Closes #620