### PR TITLE
security(SYNProtect): add NULL pointer validation in synprotect_hash_ip()

### DIFF
--- a/include/core/SocketSYNProtect-private.h
+++ b/include/core/SocketSYNProtect-private.h
@@ -150,11 +150,13 @@ struct SocketSYNProtect_T
  * @brief Compute hash index for an IP address using instance-specific seed.
  * @internal
  *
- * @param protect  The SYN protection instance
- * @param ip       IP address string
+ * @param protect  The SYN protection instance (must not be NULL)
+ * @param ip       IP address string (must not be NULL)
  * @param table_size  Number of buckets in hash table
  * Returns: Hash index in range [0, table_size)
  *
+ * @pre ip != NULL
+ * @pre protect != NULL
  * @threadsafe Yes
  */
 unsigned synprotect_hash_ip (SocketSYNProtect_T protect, const char *ip,

--- a/src/core/SocketSYNProtect.c
+++ b/src/core/SocketSYNProtect.c
@@ -182,6 +182,9 @@ calculate_window_progress (int64_t elapsed, int window_ms)
 unsigned
 synprotect_hash_ip (T protect, const char *ip, unsigned table_size)
 {
+  assert (ip != NULL);
+  assert (protect != NULL);
+
   unsigned h = socket_util_hash_djb2 (ip, table_size);
   h ^= protect->hash_seed;
   h = socket_util_hash_uint (h, table_size);


### PR DESCRIPTION
## Summary

Implements #621

Adds NULL pointer validation to the internal `synprotect_hash_ip()` function to prevent potential segmentation faults.

## Changes

- Added `assert(ip != NULL)` to validate IP address string parameter
- Added `assert(protect != NULL)` to validate SYNProtect instance parameter
- Updated function documentation with `@pre` conditions
- Clarified parameter requirements in header comments

## Rationale

The function previously dereferenced the `ip` pointer immediately via `socket_util_hash_djb2()` without validation. While public API functions use `SOCKET_VALID_IP_STRING()` checks to prevent NULL from reaching this internal function, adding assertions provides:

1. **Early error detection** during development and testing
2. **Clear contract documentation** via `@pre` conditions
3. **Defensive programming** for internal callers
4. **Consistent with project patterns** of using assertions for internal functions

## Test Plan

- [x] All existing tests pass with sanitizers enabled
- [x] test_synprotect: 36/36 tests passed
- [x] Full test suite: 111/111 tests passed
- [x] No memory leaks detected by ASan
- [x] No undefined behavior detected by UBSan

Closes #621