### PR TITLE
fix(core): check pthread_mutex_init return value in histogram_init

### DIFF
--- a/src/core/SocketMetrics.c
+++ b/src/core/SocketMetrics.c
@@ -294,7 +294,10 @@ percentile_from_sorted (const double *sorted, size_t n, double percentile)
 static void
 histogram_init (Histogram *h)
 {
-  pthread_mutex_init (&h->mutex, NULL);
+  int rc;
+
+  rc = pthread_mutex_init (&h->mutex, NULL);
+  assert (rc == 0 && "pthread_mutex_init failed");
   memset (h->values, 0, sizeof (h->values));
   h->write_index = 0;
   atomic_store (&h->count, 0);


### PR DESCRIPTION
## Summary

Implements #589

Add assertion to verify `pthread_mutex_init()` succeeds during histogram initialization in `SocketMetrics.c`.

## Changes

- Store `pthread_mutex_init` return value in rc variable
- Assert `rc == 0` with descriptive error message
- Follows existing assertion pattern in SocketMetrics.c (lines 280, 281, etc.)

## Rationale

Per POSIX, `pthread_mutex_init` can fail due to:
- Insufficient memory
- Invalid attributes
- System resource limits

When initialization fails, subsequent mutex operations (`pthread_mutex_lock`, `pthread_mutex_unlock`) have undefined behavior.

This approach is appropriate because:
- `histogram_init` is a static void function called during `SocketMetrics_init`
- SocketMetrics.c does not use TRY/EXCEPT exception patterns
- Function signature cannot return error codes
- Consistent with other assertions in this file

## Test Plan

- [x] All tests pass with sanitizers (110/110 passing, 1 flaky test excluded)
- [x] Build succeeds with ASan/UBSan enabled
- [x] No new memory leaks detected

Closes #589