### PR TITLE
fix(core): standardize mutex initialization error handling in SocketSYNProtect

### DIFF
--- a/src/core/SocketSYNProtect.c
+++ b/src/core/SocketSYNProtect.c
@@ -821,10 +821,16 @@ synprotect_init_base (T protect, Arena_T arena,
 }
 
 static int
-synprotect_init_mutex (T protect)
+synprotect_init_mutex (T protect, int *error_code)
 {
-  if (pthread_mutex_init (&protect->mutex, NULL) != 0)
-    return 0;
+  int rc;
+
+  rc = pthread_mutex_init (&protect->mutex, NULL);
+  if (rc != 0)
+    {
+      *error_code = rc;
+      return 0;
+    }
 
   protect->initialized = SOCKET_MUTEX_INITIALIZED;
   return 1;
@@ -874,12 +880,16 @@ SocketSYNProtect_new (Arena_T arena, const SocketSYNProtect_Config *config)
 
   synprotect_init_base (protect, arena, cfg);
 
-  if (!synprotect_init_mutex (protect))
-    {
-      cleanup_synprotect_init (protect, SYN_CLEANUP_NONE);
-      SOCKET_RAISE_FMT (SocketSYNProtect, SocketSYNProtect_Failed,
-                        "Failed to initialize mutex");
-    }
+  {
+    int mutex_error = 0;
+    if (!synprotect_init_mutex (protect, &mutex_error))
+      {
+        cleanup_synprotect_init (protect, SYN_CLEANUP_NONE);
+        SOCKET_RAISE_MSG (SocketSYNProtect, SocketSYNProtect_Failed,
+                          "Failed to initialize mutex: %s",
+                          strerror (mutex_error));
+      }
+  }
 
   init_result = synprotect_init_tables (protect, cfg);
   if (init_result >= 0)


### PR DESCRIPTION
## Summary

Implements #604

Improves error diagnostics for pthread_mutex_init failures by capturing and reporting the specific error code via strerror(). Previously, the function returned a simple boolean without providing error context.

## Changes

- Modified `synprotect_init_mutex()` to accept `error_code` output parameter
- Capture `pthread_mutex_init()` return code for diagnostic purposes  
- Updated caller to include `strerror(error_code)` in error message
- Changed from `SOCKET_RAISE_FMT` to `SOCKET_RAISE_MSG` (no errno needed, pthread functions return error codes directly)

## Rationale

Pthread functions (unlike most POSIX functions) return error codes directly rather than setting errno. The previous implementation discarded this error code, making debugging mutex initialization failures difficult. This change follows the pattern of capturing and reporting system call error details used elsewhere in the codebase.

## Test Plan

- [x] Tests pass with sanitizers (`test_synprotect` - 36/36 passed)
- [x] No changes to test files needed - existing tests validate behavior
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`

Closes #604