### PR TITLE
refactor(core): remove unused constant SOCKET_RATELIMIT_MIN_WAIT_MS

### DIFF
--- a/include/core/SocketRateLimit-private.h
+++ b/include/core/SocketRateLimit-private.h
@@ -22,10 +22,6 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#ifndef SOCKET_RATELIMIT_MIN_WAIT_MS
-#define SOCKET_RATELIMIT_MIN_WAIT_MS 1
-#endif
-
 #ifndef SOCKET_RATELIMIT_IMPOSSIBLE_WAIT
 #define SOCKET_RATELIMIT_IMPOSSIBLE_WAIT (-1)
 #endif


### PR DESCRIPTION
## Summary

Implements #610

## Changes

- Removed unused `SOCKET_RATELIMIT_MIN_WAIT_MS` constant from `include/core/SocketRateLimit-private.h`
- The constant was defined but never used anywhere in the codebase

## Test Plan

- [x] Builds successfully with sanitizers enabled
- [x] All 28 rate limiter tests pass (test_ratelimit: 28/28)
- [x] Overall test suite: 99% pass rate (108-109/111 tests)
- [x] Verified constant is not used anywhere via grep search

The 1-2 intermittently failing tests (test_tls_phase4, test_threadsafety) are pre-existing flaky tests unrelated to this change - they involve TLS handshake timeouts and DNS memory leaks.

Closes #610