### PR TITLE
fix(core): use calloc to prevent overflow in histogram_get_sorted_copy

### DIFF
--- a/src/core/SocketMetrics.c
+++ b/src/core/SocketMetrics.c
@@ -370,7 +370,7 @@ histogram_get_sorted_copy (Histogram *h, size_t *out_count)
       return NULL;
     }
 
-  sorted = malloc (SOCKET_METRICS_HISTOGRAM_BUCKETS * sizeof (double));
+  sorted = calloc (SOCKET_METRICS_HISTOGRAM_BUCKETS, sizeof (double));
   if (!sorted)
     {
       *out_count = 0;


### PR DESCRIPTION
## Summary

Fixes #588 by replacing `malloc` with `calloc` in `histogram_get_sorted_copy` function.

## Changes

- Replace `malloc(SOCKET_METRICS_HISTOGRAM_BUCKETS * sizeof(double))` with `calloc(SOCKET_METRICS_HISTOGRAM_BUCKETS, sizeof(double))` in `/home/tetsuo/git/tetsuo-socket/src/core/SocketMetrics.c`

## Benefits

- Built-in overflow protection: `calloc` checks for integer overflow when multiplying count and size
- Zero-initialization: Provides defensive programming benefit
- Follows CERT C secure coding guidelines
- Prevents potential security issues if `SOCKET_METRICS_HISTOGRAM_BUCKETS` constant is increased in the future

## Test Plan

- [x] All metrics tests pass (35/35)
- [x] Full test suite passes with sanitizers (109/109 when run sequentially)
- [x] No functional changes - `calloc` provides same allocation with added safety

Closes #588