### PR TITLE
refactor(core): replace magic number 16 with SOCKET_IPV6_ADDR_BYTES constant

### DIFF
--- a/src/core/SocketSYNProtect-ip.c
+++ b/src/core/SocketSYNProtect-ip.c
@@ -136,7 +136,7 @@ ip_matches_cidr_bytes (int family, const uint8_t *ip_bytes,
 int
 ip_matches_cidr (const char *ip, const SocketSYN_WhitelistEntry *entry)
 {
-  uint8_t ip_bytes[16];
+  uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES];
   int family;
 
   if (!ip)
@@ -184,7 +184,7 @@ whitelist_check_bucket_bytes (const SocketSYN_WhitelistEntry *entry,
 int
 whitelist_check_bucket (const SocketSYN_WhitelistEntry *entry, const char *ip)
 {
-  uint8_t ip_bytes[16];
+  uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES];
   int family;
 
   if (!ip)
@@ -219,7 +219,7 @@ int
 whitelist_check_all_cidrs (SocketSYNProtect_T protect, const char *ip,
                            unsigned skip_bucket)
 {
-  uint8_t ip_bytes[16];
+  uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES];
   int family;
 
   if (!ip)
@@ -236,7 +236,7 @@ int
 whitelist_check (SocketSYNProtect_T protect, const char *ip)
 {
   unsigned bucket;
-  uint8_t ip_bytes[16];
+  uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES];
   int family;
 
   if (!ip || protect->whitelist_count == 0)


### PR DESCRIPTION
## Summary

Implements #593

Replace hardcoded magic number `16` with the defined constant `SOCKET_IPV6_ADDR_BYTES` in four IPv6 address buffer declarations in `src/core/SocketSYNProtect-ip.c`.

## Changes

- `ip_matches_cidr()`: line 127 - Changed `uint8_t ip_bytes[16]` to `uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES]`
- `whitelist_check_bucket()`: line 170 - Changed `uint8_t ip_bytes[16]` to `uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES]`
- `whitelist_check_all_cidrs()`: line 200 - Changed `uint8_t ip_bytes[16]` to `uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES]`
- `whitelist_check()`: line 212 - Changed `uint8_t ip_bytes[16]` to `uint8_t ip_bytes[SOCKET_IPV6_ADDR_BYTES]`

## Benefits

- **Maintainability**: Centralized constant definition in `include/core/SocketConfig.h`
- **Consistency**: Same constant already used elsewhere in the file (lines 23, 24, 37, 47, 63, 64, 81, 143)
- **Code clarity**: Named constant is more self-documenting than magic number

## Test Plan

- [x] Build succeeds with changes
- [x] All SYN protection tests pass: 36/36 tests passed
- [x] Tests pass with sanitizers enabled (ASAN_OPTIONS=detect_leaks=1:abort_on_error=1)
- [x] No functional changes - pure refactoring

Closes #593