### PR TITLE
refactor: replace redundant time conversion constants with SocketConfig.h definitions

### DIFF
--- a/src/core/SocketRetry.c
+++ b/src/core/SocketRetry.c
@@ -25,8 +25,6 @@
 #define SOCKET_RETRY_MAX_MULTIPLIER 16.0
 #define SOCKET_RETRY_MAX_DELAY_VALUE_MS 3600000
 #define RETRY_MAX_EXPONENT 1000 /* Prevent CPU DoS from excessive loops */
-#define MILLISECONDS_PER_SECOND 1000
-#define NANOSECONDS_PER_MILLISECOND 1000000L
 #define UINT32_MAX_DOUBLE ((double)0xFFFFFFFFU)
 
 #define T SocketRetry_T
@@ -253,8 +251,8 @@ retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / MILLISECONDS_PER_SECOND;
-  req.tv_nsec = (ms % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
+  req.tv_sec = ms / SOCKET_MS_PER_SECOND;
+  req.tv_nsec = (ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/http/SocketHTTPClient-retry.c
+++ b/src/http/SocketHTTPClient-retry.c
@@ -13,9 +13,6 @@
 #include "core/SocketRetry.h"
 #include "http/SocketHTTPClient-private.h"
 
-#define MILLISECONDS_PER_SECOND 1000
-#define NANOSECONDS_PER_MILLISECOND 1000000L
-
 #define CLEAR_RESPONSE(r)                                                     \
   do                                                                          \
     {                                                                         \
@@ -62,8 +59,8 @@ httpclient_retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / MILLISECONDS_PER_SECOND;
-  req.tv_nsec = (ms % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
+  req.tv_sec = ms / SOCKET_MS_PER_SECOND;
+  req.tv_nsec = (ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/pool/SocketPool-drain.c
+++ b/src/pool/SocketPool-drain.c
@@ -53,9 +53,6 @@
 /** Infinite timeout sentinel */
 #define SOCKET_POOL_DRAIN_TIMEOUT_INFINITE (-1)
 
-/** Nanoseconds per millisecond (for nanosleep conversion) */
-#define NSEC_PER_MSEC 1000000L
-
 /* ============================================================================
  * Internal Helpers
  * ============================================================================
@@ -614,8 +611,8 @@ SocketPool_drain_wait (T pool, int timeout_ms)
   while ((result = SocketPool_drain_poll (pool)) > 0)
     {
       /* Sleep with exponential backoff */
-      ts.tv_sec = backoff_ms / 1000;
-      ts.tv_nsec = (backoff_ms % 1000) * NSEC_PER_MSEC;
+      ts.tv_sec = backoff_ms / SOCKET_MS_PER_SECOND;
+      ts.tv_nsec = (backoff_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
       nanosleep (&ts, NULL);
 
       /* Increase backoff up to max */


### PR DESCRIPTION
## Summary

Removes redundant time conversion constant definitions across the codebase in favor of centralized constants defined in `SocketConfig.h`:
- `SOCKET_MS_PER_SECOND` (1000)
- `SOCKET_NS_PER_MS` (1000000LL)

## Changes

**Files Modified:**
- **src/core/SocketRetry.c**: Removed `MILLISECONDS_PER_SECOND` and `NANOSECONDS_PER_MILLISECOND`, replaced usages with `SOCKET_MS_PER_SECOND` and `SOCKET_NS_PER_MS`
- **src/http/SocketHTTPClient-retry.c**: Same changes as SocketRetry.c  
- **src/pool/SocketPool-drain.c**: Removed `NSEC_PER_MSEC` (equivalent to `NANOSECONDS_PER_MILLISECOND`), replaced usages with `SOCKET_NS_PER_MS` and `SOCKET_MS_PER_SECOND`

## Impact

- **Severity**: Low
- **Category**: Code maintainability improvement
- Reduces code duplication and improves consistency
- No functional changes - values are identical
- All affected files already include `SocketConfig.h` (directly via `SocketUtil.h` or indirectly via their private headers)

## Test Plan

- [x] All retry tests pass (`test_socketretry`: 26/26 passed)
- [x] All pool tests pass (`test_socketpool`: 97/97 passed)
- [x] Full test suite: 110/111 passed with sanitizers (1 pre-existing unrelated failure in `test_tls_phase4`)

Closes #608