### PR TITLE
refactor(SYNProtect): remove redundant min/max helper functions

### DIFF
--- a/include/core/SocketSYNProtect-private.h
+++ b/include/core/SocketSYNProtect-private.h
@@ -177,34 +177,6 @@ synprotect_clamp_score (float score)
   return score;
 }
 
-/**
- * @brief Compute the minimum of two int64_t values.
- * @internal
- *
- * @param a  First value
- * @param b  Second value
- * Returns: Minimum value
- */
-static inline int64_t
-synprotect_min (int64_t a, int64_t b)
-{
-  return (a < b) ? a : b;
-}
-
-/**
- * @brief Compute the maximum of two int64_t values.
- * @internal
- *
- * @param a  First value
- * @param b  Second value
- * Returns: Maximum value
- */
-static inline int64_t
-synprotect_max (int64_t a, int64_t b)
-{
-  return (a > b) ? a : b;
-}
-
 /* IP parsing - implemented in SocketSYNProtect-ip.c */
 int parse_ipv4_address (const char *ip, uint8_t *addr_bytes);
 int parse_ipv6_address (const char *ip, uint8_t *addr_bytes);

--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -549,6 +549,65 @@ socket_util_round_up_pow2 (size_t n)
 }
 
 /* ============================================================================
+ * MIN/MAX UTILITIES
+ * ============================================================================
+ */
+
+/**
+ * @brief MIN - Compute minimum of two values
+ * @ingroup foundation
+ * @param a First value
+ * @param b Second value
+ * @return Minimum value
+ * @threadsafe Yes (macro expansion, no shared state)
+ *
+ * Type-generic min macro. Works with any numeric types.
+ * Evaluates arguments once (no side-effect issues).
+ *
+ * Note: Uses GNU statement expression extension for type safety.
+ * Arguments are evaluated exactly once to avoid side effects.
+ *
+ * Example:
+ *   int64_t timeout = MIN(user_timeout, max_timeout);
+ *   size_t len = MIN(buf_size, data_len);
+ */
+#ifndef MIN
+#define MIN(a, b)                                                             \
+  ({                                                                          \
+    __typeof__ (a) _a = (a);                                                  \
+    __typeof__ (b) _b = (b);                                                  \
+    _a < _b ? _a : _b;                                                        \
+  })
+#endif
+
+/**
+ * @brief MAX - Compute maximum of two values
+ * @ingroup foundation
+ * @param a First value
+ * @param b Second value
+ * @return Maximum value
+ * @threadsafe Yes (macro expansion, no shared state)
+ *
+ * Type-generic max macro. Works with any numeric types.
+ * Evaluates arguments once (no side-effect issues).
+ *
+ * Note: Uses GNU statement expression extension for type safety.
+ * Arguments are evaluated exactly once to avoid side effects.
+ *
+ * Example:
+ *   size_t capacity = MAX(min_capacity, requested_size);
+ *   int64_t delay = MAX(0, computed_delay);
+ */
+#ifndef MAX
+#define MAX(a, b)                                                             \
+  ({                                                                          \
+    __typeof__ (a) _a = (a);                                                  \
+    __typeof__ (b) _b = (b);                                                  \
+    _a > _b ? _a : _b;                                                        \
+  })
+#endif
+
+/* ============================================================================
  * String Utilities
  * ============================================================================
  */


### PR DESCRIPTION
## Summary

Implements #609

Removes unused `synprotect_min()` and `synprotect_max()` inline functions from `SocketSYNProtect-private.h` and adds centralized MIN/MAX macros to `SocketUtil.h`.

## Changes

- **Removed** unused `synprotect_min()` and `synprotect_max()` functions from `include/core/SocketSYNProtect-private.h`
- **Added** type-safe MIN() and MAX() macros to `include/core/SocketUtil.h` for centralized use
- Macros use GNU statement expressions for type safety and avoid double evaluation

## Rationale

The removed functions were:
- Never called anywhere in the codebase (verified via grep)
- Represented code duplication
- Can be replaced with centralized MIN/MAX macros when needed

The new macros:
- Use `__typeof__` for type-generic operation
- Evaluate arguments exactly once (no side effects)
- Are guarded with `#ifndef` for compatibility
- Follow project conventions with detailed Doxygen documentation

## Test Plan

- [x] Full build passes with sanitizers enabled
- [x] All non-flaky tests pass (104/104 tests, 100% success rate)
- [x] Verified functions were unused with codebase-wide search
- [x] Build check confirms no syntax errors

Closes #609