### PR TITLE
refactor(core): extract millisecond-to-timespec conversion helper

### DIFF
--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -804,6 +804,30 @@ SocketTimeout_elapsed_ms (int64_t start_ms)
   return SocketTimeout_now_ms () - start_ms;
 }
 
+/**
+ * @brief Convert milliseconds to timespec structure.
+ * @ingroup foundation
+ * @param ms Milliseconds to convert.
+ * @param ts Output timespec structure.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts a millisecond value to a timespec structure for use with
+ * functions like nanosleep(), pthread_cond_timedwait(), etc.
+ *
+ * This helper eliminates duplicate conversion code across modules.
+ *
+ * Usage:
+ *   struct timespec req;
+ *   socket_util_ms_to_timespec(100, &req);  // 100ms
+ *   nanosleep(&req, NULL);
+ */
+static inline void
+socket_util_ms_to_timespec (int ms, struct timespec *ts)
+{
+  ts->tv_sec = ms / 1000;
+  ts->tv_nsec = (ms % 1000) * 1000000L;
+}
+
 /* ============================================================================
  * MUTEX + ARENA MANAGER PATTERN
  * ============================================================================

--- a/src/core/SocketRetry.c
+++ b/src/core/SocketRetry.c
@@ -253,8 +253,7 @@ retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / MILLISECONDS_PER_SECOND;
-  req.tv_nsec = (ms % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
+  socket_util_ms_to_timespec (ms, &req);
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -499,10 +499,11 @@ SocketDNS_request_settimeout (struct SocketDNS_T *dns,
 static void
 compute_deadline (int timeout_ms, struct timespec *deadline)
 {
+  struct timespec timeout;
   clock_gettime (CLOCK_MONOTONIC, deadline);
-  deadline->tv_sec += timeout_ms / SOCKET_MS_PER_SECOND;
-  deadline->tv_nsec += (timeout_ms % SOCKET_MS_PER_SECOND)
-                       * (SOCKET_NS_PER_SECOND / SOCKET_MS_PER_SECOND);
+  socket_util_ms_to_timespec (timeout_ms, &timeout);
+  deadline->tv_sec += timeout.tv_sec;
+  deadline->tv_nsec += timeout.tv_nsec;
 
   if (deadline->tv_nsec >= SOCKET_NS_PER_SECOND)
     {

--- a/src/http/SocketHTTPClient-retry.c
+++ b/src/http/SocketHTTPClient-retry.c
@@ -11,10 +11,8 @@
 #include <time.h>
 
 #include "core/SocketRetry.h"
+#include "core/SocketUtil.h"
 #include "http/SocketHTTPClient-private.h"
-
-#define MILLISECONDS_PER_SECOND 1000
-#define NANOSECONDS_PER_MILLISECOND 1000000L
 
 #define CLEAR_RESPONSE(r)                                                     \
   do                                                                          \
@@ -62,8 +60,7 @@ httpclient_retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / MILLISECONDS_PER_SECOND;
-  req.tv_nsec = (ms % MILLISECONDS_PER_SECOND) * NANOSECONDS_PER_MILLISECOND;
+  socket_util_ms_to_timespec (ms, &req);
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/poll/SocketPoll_uring.c
+++ b/src/poll/SocketPoll_uring.c
@@ -366,8 +366,7 @@ backend_wait (PollBackend_T backend, int timeout_ms)
       /* Convert timeout to kernel timespec */
       if (remaining_ms >= 0)
         {
-          ts.tv_sec = remaining_ms / SOCKET_MS_PER_SECOND;
-          ts.tv_nsec = (remaining_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
+          socket_util_ms_to_timespec (remaining_ms, &ts);
           ts_ptr = &ts;
         }
       else

--- a/src/pool/SocketPool-drain.c
+++ b/src/pool/SocketPool-drain.c
@@ -614,8 +614,7 @@ SocketPool_drain_wait (T pool, int timeout_ms)
   while ((result = SocketPool_drain_poll (pool)) > 0)
     {
       /* Sleep with exponential backoff */
-      ts.tv_sec = backoff_ms / 1000;
-      ts.tv_nsec = (backoff_ms % 1000) * NSEC_PER_MSEC;
+      socket_util_ms_to_timespec (backoff_ms, &ts);
       nanosleep (&ts, NULL);
 
       /* Increase backoff up to max */

--- a/src/pool/SocketPool-health.c
+++ b/src/pool/SocketPool-health.c
@@ -341,10 +341,12 @@ health_worker_thread (void *arg)
       pthread_mutex_lock (&health->worker_mutex);
       if (!atomic_load (&health->shutdown))
         {
+          struct timespec interval;
           interval_ms = health->config.probe_interval_ms;
           clock_gettime (CLOCK_REALTIME, &ts);
-          ts.tv_sec += interval_ms / 1000;
-          ts.tv_nsec += (interval_ms % 1000) * 1000000;
+          socket_util_ms_to_timespec (interval_ms, &interval);
+          ts.tv_sec += interval.tv_sec;
+          ts.tv_nsec += interval.tv_nsec;
           if (ts.tv_nsec >= 1000000000)
             {
               ts.tv_sec++;

--- a/src/socket/SocketAsync.c
+++ b/src/socket/SocketAsync.c
@@ -581,8 +581,7 @@ process_kqueue_completions (T async, int timeout_ms, int max_completions)
   if (max_completions > SOCKET_MAX_EVENT_BATCH)
     max_completions = SOCKET_MAX_EVENT_BATCH;
 
-  timeout.tv_sec = timeout_ms / SOCKET_MS_PER_SECOND;
-  timeout.tv_nsec = (timeout_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
+  socket_util_ms_to_timespec (timeout_ms, &timeout);
 
   n = kevent (async->kqueue_fd, NULL, 0, events, max_completions, &timeout);
   if (n < 0)

--- a/src/test/test_pool_health.c
+++ b/src/test/test_pool_health.c
@@ -19,6 +19,7 @@
 
 #include "core/Arena.h"
 #include "core/Except.h"
+#include "core/SocketUtil.h"
 #include "pool/SocketPool.h"
 #include "pool/SocketPoolHealth.h"
 #include "socket/Socket.h"
@@ -47,8 +48,7 @@ static void
 sleep_ms(int ms)
 {
     struct timespec ts;
-    ts.tv_sec = ms / 1000;
-    ts.tv_nsec = (ms % 1000) * 1000000;
+    socket_util_ms_to_timespec(ms, &ts);
     nanosleep(&ts, NULL);
 }
 


### PR DESCRIPTION
## Summary

Implements #619 by consolidating duplicated millisecond-to-timespec conversion code across 8+ source files into a single static inline helper function.

## Changes

- Add `socket_util_ms_to_timespec()` to `SocketUtil.h` as a static inline function
- Replace duplicated conversion patterns in:
  - `src/core/SocketRetry.c`
  - `src/http/SocketHTTPClient-retry.c`
  - `src/pool/SocketPool-health.c`
  - `src/pool/SocketPool-drain.c`
  - `src/dns/SocketDNS.c`
  - `src/socket/SocketAsync.c`
  - `src/poll/SocketPoll_uring.c`
  - `src/test/test_pool_health.c`

## Benefits

- Eliminates code duplication across multiple modules
- Centralizes time conversion logic in one place
- Improves code maintainability and readability
- Reduces potential for copy-paste errors
- Provides single point for optimization if needed

## Test Plan

- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] All 111 tests pass
- [x] No new warnings or errors
- [x] Verified consistent behavior across all affected modules

Closes #619