### PR TITLE
refactor(core): use socket_util_ms_to_timespec helper for consistency

### DIFF
--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -499,10 +499,11 @@ SocketDNS_request_settimeout (struct SocketDNS_T *dns,
 static void
 compute_deadline (int timeout_ms, struct timespec *deadline)
 {
+  struct timespec timeout;
   clock_gettime (CLOCK_MONOTONIC, deadline);
-  deadline->tv_sec += timeout_ms / SOCKET_MS_PER_SECOND;
-  deadline->tv_nsec += (timeout_ms % SOCKET_MS_PER_SECOND)
-                       * (SOCKET_NS_PER_SECOND / SOCKET_MS_PER_SECOND);
+  timeout = socket_util_ms_to_timespec ((unsigned long)timeout_ms);
+  deadline->tv_sec += timeout.tv_sec;
+  deadline->tv_nsec += timeout.tv_nsec;
 
   if (deadline->tv_nsec >= SOCKET_NS_PER_SECOND)
     {

--- a/src/http/SocketHTTPClient-retry.c
+++ b/src/http/SocketHTTPClient-retry.c
@@ -11,6 +11,7 @@
 #include <time.h>
 
 #include "core/SocketRetry.h"
+#include "core/SocketUtil.h"
 #include "http/SocketHTTPClient-private.h"
 
 #define CLEAR_RESPONSE(r)                                                     \
@@ -59,8 +60,7 @@ httpclient_retry_sleep_ms (int ms)
   if (ms <= 0)
     return;
 
-  req.tv_sec = ms / SOCKET_MS_PER_SECOND;
-  req.tv_nsec = (ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
+  req = socket_util_ms_to_timespec ((unsigned long)ms);
 
   while (nanosleep (&req, &rem) == -1)
     {

--- a/src/poll/SocketPoll_uring.c
+++ b/src/poll/SocketPoll_uring.c
@@ -366,8 +366,7 @@ backend_wait (PollBackend_T backend, int timeout_ms)
       /* Convert timeout to kernel timespec */
       if (remaining_ms >= 0)
         {
-          ts.tv_sec = remaining_ms / SOCKET_MS_PER_SECOND;
-          ts.tv_nsec = (remaining_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
+          ts = socket_util_ms_to_timespec ((unsigned long)remaining_ms);
           ts_ptr = &ts;
         }
       else

--- a/src/pool/SocketPool-drain.c
+++ b/src/pool/SocketPool-drain.c
@@ -611,8 +611,7 @@ SocketPool_drain_wait (T pool, int timeout_ms)
   while ((result = SocketPool_drain_poll (pool)) > 0)
     {
       /* Sleep with exponential backoff */
-      ts.tv_sec = backoff_ms / SOCKET_MS_PER_SECOND;
-      ts.tv_nsec = (backoff_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
+      ts = socket_util_ms_to_timespec (backoff_ms);
       nanosleep (&ts, NULL);
 
       /* Increase backoff up to max */

--- a/src/pool/SocketPool-health.c
+++ b/src/pool/SocketPool-health.c
@@ -340,10 +340,12 @@ health_worker_thread (void *arg)
       pthread_mutex_lock (&health->worker_mutex);
       if (!atomic_load (&health->shutdown))
         {
+          struct timespec interval;
           interval_ms = health->config.probe_interval_ms;
           clock_gettime (CLOCK_REALTIME, &ts);
-          ts.tv_sec += interval_ms / 1000;
-          ts.tv_nsec += (interval_ms % 1000) * 1000000;
+          interval = socket_util_ms_to_timespec ((unsigned long)interval_ms);
+          ts.tv_sec += interval.tv_sec;
+          ts.tv_nsec += interval.tv_nsec;
           if (ts.tv_nsec >= 1000000000)
             {
               ts.tv_sec++;

--- a/src/socket/SocketAsync.c
+++ b/src/socket/SocketAsync.c
@@ -581,8 +581,7 @@ process_kqueue_completions (T async, int timeout_ms, int max_completions)
   if (max_completions > SOCKET_MAX_EVENT_BATCH)
     max_completions = SOCKET_MAX_EVENT_BATCH;
 
-  timeout.tv_sec = timeout_ms / SOCKET_MS_PER_SECOND;
-  timeout.tv_nsec = (timeout_ms % SOCKET_MS_PER_SECOND) * SOCKET_NS_PER_MS;
+  timeout = socket_util_ms_to_timespec ((unsigned long)timeout_ms);
 
   n = kevent (async->kqueue_fd, NULL, 0, events, max_completions, &timeout);
   if (n < 0)

--- a/src/test/test_pool_health.c
+++ b/src/test/test_pool_health.c
@@ -19,6 +19,7 @@
 
 #include "core/Arena.h"
 #include "core/Except.h"
+#include "core/SocketUtil.h"
 #include "pool/SocketPool.h"
 #include "pool/SocketPoolHealth.h"
 #include "socket/Socket.h"
@@ -47,8 +48,7 @@ static void
 sleep_ms(int ms)
 {
     struct timespec ts;
-    ts.tv_sec = ms / 1000;
-    ts.tv_nsec = (ms % 1000) * 1000000;
+    ts = socket_util_ms_to_timespec((unsigned long)ms);
     nanosleep(&ts, NULL);
 }
 


### PR DESCRIPTION
## Summary
- Replace inline millisecond-to-timespec conversion with the centralized helper function from SocketUtil.h
- Improves code consistency and maintainability
- Follow-up to PR #683 which added the helper function

## Files Updated
- src/dns/SocketDNS.c
- src/http/SocketHTTPClient-retry.c
- src/poll/SocketPoll_uring.c
- src/pool/SocketPool-drain.c
- src/pool/SocketPool-health.c
- src/socket/SocketAsync.c
- src/test/test_pool_health.c

## Test plan
- [x] Builds successfully with sanitizers
- [x] All existing tests pass