### PR TITLE
docs(socket): clarify internal function locations

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -66,6 +66,12 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketIOV);
 
 /* ==================== Scatter/Gather I/O ==================== */
 
+/**
+ * Note: socket_sendv_internal() and socket_recvv_internal() are TLS-aware
+ * internal functions defined in SocketIO.c and declared in SocketIO.h.
+ * They handle routing I/O through TLS when enabled, or raw sockets otherwise.
+ */
+
 ssize_t
 Socket_sendv (T socket, const struct iovec *iov, int iovcnt)
 {


### PR DESCRIPTION
## Summary

Addresses #698 by adding clarifying documentation to Socket-iov.c.

## Analysis

Issue #698 reported that `socket_sendv_internal()` and `socket_recvv_internal()` were missing. However, this was a **false positive**:

- These functions ARE properly defined in `src/socket/SocketIO.c` (lines 212-250)
- They ARE properly declared in `include/socket/SocketIO.h` (lines 115, 140)
- Socket-iov.c correctly includes SocketIO.h
- All tests pass and the code compiles without errors

## Changes

- Added documentation comment in Socket-iov.c explaining where these internal functions are defined
- This prevents future confusion from static analysis tools

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All socket I/O tests pass (test_socket, test_socketio)
- [x] No functional changes - pure documentation update

Closes #698