### PR TITLE
refactor(Arena): eliminate redundant multiplication in Arena_calloc

### DIFF
--- a/src/core/Arena.c
+++ b/src/core/Arena.c
@@ -524,8 +524,8 @@ Arena_calloc (T arena, size_t count, size_t nbytes, const char *file, int line)
                       total, SocketSecurity_get_max_allocation (),
                       "Arena_calloc");
 
-  void *ptr = Arena_alloc (arena, count * nbytes, file, line);
-  memset (ptr, 0, count * nbytes);
+  void *ptr = Arena_alloc (arena, total, file, line);
+  memset (ptr, 0, total);
 
   return ptr;
 }


### PR DESCRIPTION
## Summary

Implements #587

This refactoring eliminates redundant multiplications in the `Arena_calloc` function by reusing the `total` variable that is already computed during overflow checking.

## Changes

- Modified `/home/tetsuo/git/tetsuo-socket-issue-587/src/core/Arena.c`:
  - Changed `Arena_alloc(arena, count * nbytes, file, line)` to use `total` instead
  - Changed `memset(ptr, 0, count * nbytes)` to use `total` instead
  - Eliminates 2 redundant multiplications per calloc call

## Benefits

- **Performance**: Eliminates two unnecessary multiplication operations
- **Correctness**: Guaranteed consistency with the overflow-checked value
- **Clarity**: Makes it clear that we're using the validated size
- **Maintainability**: Single source of truth for the allocation size

## Test Plan

- [x] All 110 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Specifically verified `test_arena` passes
- [x] No performance regression
- [x] Full test suite completed in 24.93 seconds

Closes #587