### PR TITLE
fix(proxy): add defensive buffer check for SOCKS4a hostname

### DIFF
--- a/src/socket/SocketProxy-socks4.c
+++ b/src/socket/SocketProxy-socks4.c
@@ -305,6 +305,13 @@ proxy_socks4a_send_connect (struct SocketProxy_Conn_T *conn)
     }
   len += userid_written;
 
+  /* Validate buffer space for hostname + null terminator */
+  if (len + host_len + 1 > sizeof (conn->send_buf))
+    {
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL, "Request too large");
+      return -1;
+    }
+
   /* Write hostname with null terminator */
   memcpy (buf + len, conn->target_host, host_len);
   len += host_len;


### PR DESCRIPTION
## Summary

Implements #700 by adding defensive buffer validation for SOCKS4a hostname writes.

## Changes

- Added explicit buffer space check before writing hostname in `proxy_socks4a_send_connect()`
- Matches the defensive pattern used for userid validation (lines 299-305)
- Returns error if buffer space is insufficient (mathematically impossible with current constants, but provides defense-in-depth)

## Code Location

File: `src/socket/SocketProxy-socks4.c`
Lines: 308-313 (new validation block)

## Rationale

While buffer overflow is mathematically impossible due to:
- Buffer size: `SOCKET_PROXY_BUFFER_SIZE` (65536 bytes)  
- Max hostname: `SOCKET_PROXY_MAX_HOSTNAME_LEN` (255 bytes)
- Max userid: `SOCKET_PROXY_MAX_USERNAME_LEN` (255 bytes)
- Max total request: ~520 bytes

This explicit check provides:
1. **Defense in depth**: Protects against future changes to buffer size constants
2. **Code consistency**: Matches the pattern used for userid validation  
3. **Clarity**: Makes buffer safety explicit to code reviewers
4. **Maintainability**: Self-documenting bounds checking

## Test Plan

- [x] All tests pass with sanitizers enabled (112/112)
- [x] Build succeeds with `-Wall -Wextra -Werror`
- [x] No functional changes to SOCKS4a protocol implementation

Closes #700