### PR TITLE
fix(HashTable): prevent integer overflow in bucket_count cast

### DIFF
--- a/src/core/HashTable.c
+++ b/src/core/HashTable.c
@@ -7,6 +7,7 @@
 /* Generic intrusive hash table with chained collision handling */
 
 #include <assert.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -91,6 +92,11 @@ HashTable_new (Arena_T arena, const HashTable_Config *config)
   T table;
 
   validate_config (config);
+
+  /* Prevent integer overflow in compute_bucket() cast */
+  if (config->bucket_count > UINT_MAX)
+    SOCKET_RAISE_MSG (HashTable, HashTable_Failed,
+                      "bucket_count exceeds maximum of %u", UINT_MAX);
 
   if (arena != NULL)
     table = Arena_alloc (arena, sizeof (*table), __FILE__, __LINE__);

--- a/src/test/test_hashtable.c
+++ b/src/test/test_hashtable.c
@@ -11,6 +11,7 @@
  */
 
 #include <assert.h>
+#include <limits.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -453,6 +454,25 @@ TEST (hashtable_null_hash_raises)
   volatile int raised = 0;
   HashTable_Config config = make_config (16);
   config.hash = NULL;
+
+  TRY
+  {
+    HashTable_new (NULL, &config);
+  }
+  EXCEPT (HashTable_Failed)
+  {
+    raised = 1;
+  }
+  END_TRY;
+  ASSERT_EQ (raised, 1);
+}
+
+TEST (hashtable_bucket_count_overflow_raises)
+{
+  volatile int raised = 0;
+  HashTable_Config config = make_config (16);
+  /* Set bucket_count to exceed UINT_MAX (4,294,967,295) */
+  config.bucket_count = (size_t)UINT_MAX + 1;
 
   TRY
   {


### PR DESCRIPTION
## Summary

Implements #710

Adds validation to prevent integer overflow when casting `size_t bucket_count` to `unsigned` in the `compute_bucket()` function.

## Changes

- Added `#include <limits.h>` to `src/core/HashTable.c`
- Added validation in `HashTable_new()` to reject `bucket_count > UINT_MAX`
- Raises `HashTable_Failed` exception with descriptive error message
- Added test case `hashtable_bucket_count_overflow_raises` to verify the validation

## Issue Description

On 64-bit systems, the `bucket_count` field (declared as `size_t`) could exceed `UINT_MAX` (4,294,967,295). The cast at line 71 would silently truncate the value, causing:
- Incorrect hash calculations
- Increased hash collisions  
- Potential memory corruption if hash functions use size for bounds checking

## Fix Approach

Option 1 (implemented): Add validation to prevent `bucket_count > UINT_MAX`
- Quick, safe fix that prevents the issue
- No API changes required
- Maintains backward compatibility with existing hash function implementations

Option 2 (future enhancement): Change hash function typedef to accept `size_t`
- Would require updating all hash function implementations
- Breaking API change

## Test Plan

- [x] New test `hashtable_bucket_count_overflow_raises` passes
- [x] All existing HashTable tests pass (16/16)
- [x] Core tests pass with sanitizers enabled
- [x] Memory leak free (verified with ASan)

## Security Impact

This fix prevents a potential integer overflow vulnerability (CWE-197, CWE-681) that could lead to memory corruption in edge cases on 64-bit systems with very large hash tables.

Closes #710