### PR TITLE
refactor(dns): replace magic number 64 with DNS_ADDR_STR_MAX constant

### DIFF
--- a/include/dns/SocketDNSConfig.h
+++ b/include/dns/SocketDNSConfig.h
@@ -41,6 +41,7 @@
  */
 
 #include "core/Arena.h"
+#include "dns/SocketDNSDeadServer.h"
 #include <stddef.h>
 
 /**
@@ -109,8 +110,8 @@ typedef enum
  */
 typedef struct
 {
-  char address[64]; /**< IPv4 or IPv6 address string */
-  int family;       /**< AF_INET or AF_INET6 (0 if not detected) */
+  char address[DNS_ADDR_STR_MAX]; /**< IPv4 or IPv6 address string */
+  int family;                     /**< AF_INET or AF_INET6 (0 if not detected) */
 } SocketDNSConfig_Nameserver;
 
 /**

--- a/include/dns/SocketDNSDeadServer.h
+++ b/include/dns/SocketDNSDeadServer.h
@@ -61,8 +61,14 @@
  * @{
  */
 
+/**
+ * Maximum length for IPv4/IPv6 address string.
+ * INET6_ADDRSTRLEN is 46 bytes, padded to 64 for null termination and extensibility.
+ */
+#define DNS_ADDR_STR_MAX 64
+
 /** Maximum nameserver address length (IPv6 + scope). */
-#define DNS_DEAD_SERVER_MAX_ADDR 64
+#define DNS_DEAD_SERVER_MAX_ADDR DNS_ADDR_STR_MAX
 
 /** Maximum tracked dead servers. */
 #define DNS_DEAD_SERVER_MAX_TRACKED 32

--- a/include/dns/SocketDNSTransport.h
+++ b/include/dns/SocketDNSTransport.h
@@ -141,9 +141,9 @@ typedef void (*SocketDNSTransport_Callback) (SocketDNSQuery_T query,
  */
 typedef struct
 {
-  char address[64]; /**< IPv4 or IPv6 address string */
-  int port;         /**< Port number (default: 53) */
-  int family;       /**< AF_INET or AF_INET6 (0 for auto-detect) */
+  char address[DNS_ADDR_STR_MAX]; /**< IPv4 or IPv6 address string */
+  int port;                       /**< Port number (default: 53) */
+  int family;                     /**< AF_INET or AF_INET6 (0 for auto-detect) */
 } SocketDNS_Nameserver;
 
 /**


### PR DESCRIPTION
## Summary

Implements #720

Replace hardcoded buffer size of 64 with a named constant `DNS_ADDR_STR_MAX` for IP address string buffers in DNS modules, improving consistency and maintainability.

## Changes

- Define `DNS_ADDR_STR_MAX` constant in `SocketDNSDeadServer.h`
- Update `DNS_DEAD_SERVER_MAX_ADDR` to use the new constant
- Replace `char address[64]` with `char address[DNS_ADDR_STR_MAX]` in:
  - `SocketDNSTransport.h` (`SocketDNS_Nameserver` struct)
  - `SocketDNSConfig.h` (`SocketDNSConfig_Nameserver` struct)
- Add include for `SocketDNSDeadServer.h` in `SocketDNSConfig.h`

## Rationale

The value of 64 bytes provides padding beyond `INET6_ADDRSTRLEN` (46 bytes) for null termination and extensibility. Using a named constant instead of magic numbers improves code maintainability and makes the intent clearer.

## Test Plan

- [x] All DNS tests pass with sanitizers
- [x] No functional changes - purely cosmetic refactoring
- [x] Build succeeds with sanitizers enabled

Closes #720