### PR TITLE
docs(dns): Clarify DOT_MAX_MESSAGE_SIZE RFC reference

### DIFF
--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -44,7 +44,11 @@
 #undef T
 #define T SocketDNSoverTLS_T
 
-/** Maximum DNS message size (64KB minus length prefix). */
+/**
+ * Maximum DNS message size (65535 bytes).
+ * RFC 1035 §4.2.2: TCP messages have a 16-bit length field,
+ * limiting message size to 2^16 - 1 bytes (excluding the length prefix itself).
+ */
 #define DOT_MAX_MESSAGE_SIZE 65535
 
 /** Receive buffer size. */


### PR DESCRIPTION
## Summary

Implements #737

Updated the documentation for `DOT_MAX_MESSAGE_SIZE` in `src/dns/SocketDNSoverTLS.c` to accurately reflect the RFC 1035 §4.2.2 constraint.

## Changes

- Improved comment clarity for `DOT_MAX_MESSAGE_SIZE` constant
- Added explicit RFC 1035 §4.2.2 reference
- Explained that 65535 is the maximum 16-bit value, not "64KB minus length prefix"
- Clarified that the length prefix itself is excluded from the count

## Test Plan

- [x] Documentation-only change (no code modification)
- [x] Build completes successfully with sanitizers
- [x] No functional changes to test

Closes #737