### PR TITLE
refactor(dns): eliminate duplicate constant for UDP payload size

### DIFF
--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -782,8 +782,11 @@ extern int SocketDNS_rdata_parse_soa (const unsigned char *msg, size_t msglen,
 /** EDNS0 version number (RFC 6891 Section 6.1.3). */
 #define DNS_EDNS0_VERSION 0
 
+/** RFC 6891 Section 6.2.5 recommended UDP payload size. */
+#define DNS_UDP_PAYLOAD_OPTIMAL 4096
+
 /** Default UDP payload size for EDNS0 (RFC 6891 Section 6.2.5). */
-#define DNS_EDNS0_DEFAULT_UDPSIZE 4096
+#define DNS_EDNS0_DEFAULT_UDPSIZE DNS_UDP_PAYLOAD_OPTIMAL
 
 /** Minimum UDP payload size (values below treated as 512, RFC 6891 Section 6.2.3). */
 #define DNS_EDNS0_MIN_UDPSIZE 512
@@ -1356,7 +1359,7 @@ extern int SocketDNS_edns_options_encode (const SocketDNS_EDNSOption *options,
  */
 
 /** Initial/optimal UDP payload size (RFC 6891 Section 6.2.5). */
-#define DNS_PAYLOAD_INITIAL 4096
+#define DNS_PAYLOAD_INITIAL DNS_UDP_PAYLOAD_OPTIMAL
 
 /** First fallback size: safe for most paths (IPv6 min MTU area). */
 #define DNS_PAYLOAD_FALLBACK1 1400


### PR DESCRIPTION
## Summary

Implements #708

## Changes

- Introduced `DNS_UDP_PAYLOAD_OPTIMAL` as the single base constant for RFC 6891 Section 6.2.5 recommended UDP payload size (4096 bytes)
- Both `DNS_EDNS0_DEFAULT_UDPSIZE` and `DNS_PAYLOAD_INITIAL` now reference this base constant
- Eliminates redundancy while maintaining backward compatibility
- Prevents inconsistency if one value is changed without updating the other

## Test Plan

- [x] All DNS-related tests pass with sanitizers (`test_dns_wire`, `test_dns_transport`, `test_dns_config`, etc.)
- [x] Build succeeds with sanitizers enabled
- [x] No changes to existing API - both constants still available for backward compatibility
- [x] Verified usage in `src/dns/SocketDNSTransport.c` and `src/dns/SocketDNSWire.c` still works correctly

Closes #708