### PR TITLE
refactor(dns): remove redundant SIZE_MAX overflow check in SocketDNSConfig_parse

### DIFF
--- a/src/dns/SocketDNSConfig.c
+++ b/src/dns/SocketDNSConfig.c
@@ -25,10 +25,9 @@
 #include <sys/socket.h>
 
 /**
- * @brief Maximum size for config content to prevent integer overflow.
+ * @brief Maximum size for config content.
  *
  * 1MB is a reasonable upper bound for resolv.conf content.
- * This prevents integer overflow in malloc(len + 1).
  */
 #define MAX_CONFIG_SIZE (1024 * 1024)
 
@@ -283,8 +282,8 @@ SocketDNSConfig_parse (SocketDNSConfig_T *config, const char *content)
 
   len = strlen (content);
 
-  /* Check for integer overflow in malloc(len + 1) and reasonable size limit */
-  if (len > SIZE_MAX - 1 || len > MAX_CONFIG_SIZE)
+  /* Check for reasonable size limit */
+  if (len > MAX_CONFIG_SIZE)
     return -1;
 
   copy = malloc (len + 1);


### PR DESCRIPTION
## Summary

Implements #705 - Removes redundant overflow check in `SocketDNSConfig_parse()`.

## Changes

- Removed impossible-to-trigger condition `len > SIZE_MAX - 1`
- Updated comment to reflect practical size validation (not overflow prevention)
- Simplified the overflow check to only verify against MAX_CONFIG_SIZE (1MB)

## Rationale

The `len > SIZE_MAX - 1` check was redundant because:
1. `strlen()` returns length excluding null terminator
2. For a string to exist in memory, `len` can never be `SIZE_MAX` (the null terminator must also fit)
3. The `MAX_CONFIG_SIZE` check provides sufficient practical bounds validation

## Test Plan

- [x] All DNS tests pass with sanitizers (`ctest -R dns`)
- [x] Build succeeds with sanitizers enabled
- [x] Code review confirms logic correctness

**Note**: Some unrelated flaky tests (`test_http_integration`, `test_tls_phase4`, `test_multi_protocol_integration`) may fail intermittently due to port binding issues in parallel test execution. These failures also occur on main branch and are not related to this DNS configuration change.

Closes #705