### PR TITLE
refactor(Socket-iov): mark variables as volatile for exception safety

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -514,8 +514,8 @@ Socket_sendvall (T socket, const struct iovec *iov, int iovcnt)
 {
   struct iovec *iov_copy = NULL;
   volatile size_t total_sent = 0;
-  size_t total_len;
-  ssize_t sent;
+  volatile size_t total_len;
+  volatile ssize_t sent;
 
   assert (socket);
   assert (iov);
@@ -528,7 +528,7 @@ Socket_sendvall (T socket, const struct iovec *iov, int iovcnt)
   TRY
   {
     while (total_sent < total_len
-           && sendvall_iteration (socket, iov_copy, iovcnt, &sent))
+           && sendvall_iteration (socket, iov_copy, iovcnt, (ssize_t *)&sent))
       total_sent += (size_t)sent;
   }
   EXCEPT (Socket_Closed)
@@ -546,8 +546,8 @@ Socket_recvvall (T socket, struct iovec *iov, int iovcnt)
 {
   struct iovec *iov_copy = NULL;
   volatile size_t total_received = 0;
-  size_t total_len;
-  ssize_t received;
+  volatile size_t total_len;
+  volatile ssize_t received;
 
   assert (socket);
   assert (iov);
@@ -560,7 +560,7 @@ Socket_recvvall (T socket, struct iovec *iov, int iovcnt)
   TRY
   {
     while (total_received < total_len
-           && recvvall_iteration (socket, iov_copy, iovcnt, &received))
+           && recvvall_iteration (socket, iov_copy, iovcnt, (ssize_t *)&received))
       total_received += (size_t)received;
   }
   EXCEPT (Socket_Closed)


### PR DESCRIPTION
## Summary

Implements #706

Marks `total_len`, `sent`, and `received` variables as `volatile` in `Socket_sendvall()` and `Socket_recvvall()` functions to ensure proper exception safety according to CLAUDE.md guidelines.

## Changes

- **Socket_sendvall()**: Marked `total_len` and `sent` as volatile, added explicit cast when passing to iteration function
- **Socket_recvvall()**: Marked `total_len` and `received` as volatile, added explicit cast when passing to iteration function

## Rationale

According to CLAUDE.md exception safety rules:
> Variables modified in TRY blocks must be `volatile`

These variables are:
1. Used within TRY blocks (as loop conditions or modified by iteration functions)
2. Read after potential exception handling
3. Need to have their values preserved across exception boundaries to prevent compiler optimization from causing undefined behavior

## Test Plan

- [x] All socket I/O tests pass (test_socket: 298/298)
- [x] All socketio tests pass (test_socketio: 21/21)
- [x] Build succeeds with sanitizers enabled
- [x] Tests pass with ASan/UBSan (111/112 - one pre-existing flaky TLS test)

Closes #706