### PR TITLE
perf(dns): avoid redundant strlen call in is_valid_domain_name

### DIFF
--- a/src/dns/SocketDNSConfig.c
+++ b/src/dns/SocketDNSConfig.c
@@ -379,8 +379,8 @@ is_valid_domain_name (const char *domain)
   if (domain[0] == '.' || domain[0] == '-')
     return 0;
 
-  p = domain + strlen (domain) - 1;
-  if (*p == '.' || *p == '-')
+  /* p now points to '\0', so p-1 is the last character */
+  if (p > domain && (*(p - 1) == '.' || *(p - 1) == '-'))
     return 0;
 
   return 1;


### PR DESCRIPTION
## Summary

Implements #709 - Eliminates redundant `strlen()` call in `is_valid_domain_name()` function.

## Changes

- Modified `src/dns/SocketDNSConfig.c` to use pointer arithmetic instead of `strlen()`
- After the validation loop, pointer `p` already points to the null terminator
- Changed to use `p-1` to check the last character, avoiding a redundant O(n) string traversal

## Test Plan

- [x] All DNS config tests pass (29/29)
- [x] Built with sanitizers enabled
- [x] No functional changes, purely a performance optimization

## Performance Impact

Eliminates one full string traversal (O(n)) when validating domain names, improving efficiency for DNS configuration parsing.

Closes #709