### PR TITLE
refactor(quic): replace magic number 16 with QUIC_ACK_INITIAL_RANGE_CAPACITY

### DIFF
--- a/include/quic/SocketQUICAck.h
+++ b/include/quic/SocketQUICAck.h
@@ -61,6 +61,14 @@
  */
 #define QUIC_ACK_PACKET_THRESHOLD 2
 
+/**
+ * @brief Initial capacity for ACK range storage.
+ *
+ * Pre-allocated range capacity to avoid frequent reallocations.
+ * The capacity will grow dynamically if more ranges are needed.
+ */
+#define QUIC_ACK_INITIAL_RANGE_CAPACITY 16
+
 /* ============================================================================
  * Data Structures
  * ============================================================================

--- a/src/quic/SocketQUICAck.c
+++ b/src/quic/SocketQUICAck.c
@@ -60,7 +60,7 @@ SocketQUICAck_new (Arena_T arena, int is_handshake, uint64_t max_ack_delay_us)
       = (max_ack_delay_us > 0) ? max_ack_delay_us : QUIC_ACK_DEFAULT_MAX_DELAY_US;
 
   /* Pre-allocate some range capacity */
-  state->range_capacity = 16;
+  state->range_capacity = QUIC_ACK_INITIAL_RANGE_CAPACITY;
   state->ranges = CALLOC (arena, state->range_capacity, sizeof (*state->ranges));
   if (state->ranges == NULL)
     return NULL;


### PR DESCRIPTION
## Summary

Implements #721

## Changes

- Added `QUIC_ACK_INITIAL_RANGE_CAPACITY` constant to `include/quic/SocketQUICAck.h`
- Replaced magic number `16` with the named constant in `src/quic/SocketQUICAck.c`
- Improved code documentation explaining the purpose of the initial capacity

## Test Plan

- [x] All QUIC tests pass (24/24 tests passing)
- [x] Specifically verified test_quic_ack passes with 30/30 tests
- [x] Tested with sanitizers enabled (ASAN + UBSan)
- [x] No memory leaks or undefined behavior detected
- [x] Build completes successfully

## Rationale

The magic number `16` for initial ACK range capacity lacked context. Using a named constant makes the code more maintainable and documents why this specific value was chosen for pre-allocation.

Closes #721