### PR TITLE
docs(dns): replace magic number with DNS_QUESTION_FIXED_SIZE constant

### DIFF
--- a/include/dns/SocketDNSWire.h
+++ b/include/dns/SocketDNSWire.h
@@ -340,6 +340,9 @@ extern size_t SocketDNS_name_wire_length (const char *name);
  * @{
  */
 
+/** Fixed fields size in question section: QTYPE(2) + QCLASS(2) bytes (RFC 1035 Section 4.1.2). */
+#define DNS_QUESTION_FIXED_SIZE 4
+
 /**
  * @brief DNS record types (RFC 1035 Section 3.2.2, RFC 3596).
  *

--- a/src/dns/SocketDNSNegCache.c
+++ b/src/dns/SocketDNSNegCache.c
@@ -875,7 +875,7 @@ SocketDNSNegCache_build_response (const SocketDNS_NegCacheEntry *entry,
     return -1;
 
   /* Need at least header + question + SOA RR space */
-  if (buflen < DNS_HEADER_SIZE + 4 + DNS_MAX_NAME_LEN)
+  if (buflen < DNS_HEADER_SIZE + DNS_QUESTION_FIXED_SIZE + DNS_MAX_NAME_LEN)
     return -1;
 
   size_t offset = 0;


### PR DESCRIPTION
## Summary

Implements #724

## Changes

- Added `DNS_QUESTION_FIXED_SIZE` constant (value: 4) to `include/dns/SocketDNSWire.h`
- Replaced magic number `+ 4` with `DNS_QUESTION_FIXED_SIZE` in `src/dns/SocketDNSNegCache.c` buffer size validation
- Improved code clarity by documenting that the 4 bytes represent QTYPE (2 bytes) + QCLASS (2 bytes) fields

## Test Plan

- [x] Tests pass with sanitizers (test_dns_negcache: 26/26 passed)
- [x] Build succeeds with no new warnings
- [x] Constant follows existing naming pattern (DNS_SOA_FIXED_SIZE, DNS_OPT_FIXED_SIZE, etc.)

Closes #724