### PR TITLE
docs(quic): clarify magic number 3 in hex formatting calculation

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -319,7 +319,9 @@ SocketQUICConnectionID_to_hex (const SocketQUICConnectionID_T *cid, char *buf,
       return 5;
     }
 
-  /* Format: "XX:XX:XX..." requires 3*len-1 chars + null */
+  /* Format: "XX:XX:XX..." requires 3*len-1 chars + null terminator.
+   * Each byte: 2 hex chars + 1 colon separator = 3 chars per byte.
+   * Last byte has no trailing colon: (3*len - 1) + 1 null = 3*len total. */
   if (size < (size_t)(cid->len * 3))
     {
       buf[0] = '\0';


### PR DESCRIPTION
## Summary

Implements #742 by adding clear documentation for the magic number `3` in the buffer size calculation within `SocketQUICConnectionID_to_hex()`.

## Changes

- Enhanced comment in `src/quic/SocketQUICConnectionID.c` at line 322-324
- Explains the hex formatting formula: `(cid->len * 3)`
- Clarifies why we use `3*len` instead of `3*len-1` (accounts for null terminator)

## Details

The buffer size calculation uses `(cid->len * 3)` because:
- Each byte requires 2 hex chars + 1 colon separator = 3 chars per byte
- Last byte has no trailing colon: `(3*len - 1)` actual characters
- Plus 1 for null terminator: `(3*len - 1) + 1 = 3*len` total buffer needed

This resolves the ambiguity between the original comment stating "3*len-1 chars" and the code using "3*len".

## Test Plan

- [x] All 112 tests pass with sanitizers enabled
- [x] QUIC Connection ID tests (56 tests) all pass
- [x] Code builds cleanly with no warnings
- [x] Documentation-only change, no functional impact

Closes #742