### PR TITLE
refactor(dns): use socket_util_safe_strncpy in SocketDNSoverTLS_configure

### DIFF
--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -36,6 +36,7 @@
 #include <unistd.h>
 
 #include "core/Arena.h"
+#include "core/SocketUtil.h"
 #include "dns/SocketDNSWire.h"
 #include "socket/Socket.h"
 #include "tls/SocketTLS.h"
@@ -818,37 +819,32 @@ SocketDNSoverTLS_configure (T transport, const SocketDNSoverTLS_Config *config)
   server = &transport->servers[transport->server_count];
   memset (server, 0, sizeof (*server));
 
-  strncpy (server->address, config->server_address, sizeof (server->address) - 1);
-  server->address[sizeof (server->address) - 1] = '\0'; /* Ensure null termination (CWE-170) */
+  socket_util_safe_strncpy (server->address, config->server_address, sizeof (server->address));
   server->port = (config->port > 0) ? config->port : DOT_PORT;
   server->family = family;
   server->mode = config->mode;
 
   if (config->server_name)
     {
-      strncpy (server->server_name, config->server_name,
-               sizeof (server->server_name) - 1);
-      server->server_name[sizeof (server->server_name) - 1] = '\0';
+      socket_util_safe_strncpy (server->server_name, config->server_name,
+                                sizeof (server->server_name));
     }
   else
     {
       /* Use address as SNI if no server name provided */
-      strncpy (server->server_name, config->server_address,
-               sizeof (server->server_name) - 1);
-      server->server_name[sizeof (server->server_name) - 1] = '\0';
+      socket_util_safe_strncpy (server->server_name, config->server_address,
+                                sizeof (server->server_name));
     }
 
   if (config->spki_pin)
     {
-      strncpy (server->spki_pin, config->spki_pin, sizeof (server->spki_pin) - 1);
-      server->spki_pin[sizeof (server->spki_pin) - 1] = '\0';
+      socket_util_safe_strncpy (server->spki_pin, config->spki_pin, sizeof (server->spki_pin));
     }
 
   if (config->spki_pin_backup)
     {
-      strncpy (server->spki_pin_backup, config->spki_pin_backup,
-               sizeof (server->spki_pin_backup) - 1);
-      server->spki_pin_backup[sizeof (server->spki_pin_backup) - 1] = '\0';
+      socket_util_safe_strncpy (server->spki_pin_backup, config->spki_pin_backup,
+                                sizeof (server->spki_pin_backup));
     }
 
   transport->server_count++;


### PR DESCRIPTION
## Summary

Implements #747 by refactoring SocketDNSoverTLS_configure to use the existing socket_util_safe_strncpy helper function instead of the repetitive manual strncpy + null-termination pattern.

## Changes

- Added `SocketUtil.h` include to access `socket_util_safe_strncpy`
- Replaced 5 instances of manual string copy pattern:
  - `server->address` (line 822)
  - `server->server_name` (lines 829-830, 835-836)
  - `server->spki_pin` (line 841)
  - `server->spki_pin_backup` (lines 846-847)

## Before/After

**Before:**
```c
strncpy(server->address, config->server_address, sizeof(server->address) - 1);
server->address[sizeof(server->address) - 1] = '\0';
```

**After:**
```c
socket_util_safe_strncpy(server->address, config->server_address, sizeof(server->address));
```

## Test Plan

- [x] All DNS tests pass (14/14) with sanitizers enabled
- [x] DNS-over-TLS specific tests pass (15/15)
- [x] Build succeeds with -DENABLE_SANITIZERS=ON
- [x] No functional changes - maintains same behavior

## Benefits

- Reduces code duplication (eliminates 8 lines of boilerplate)
- Makes safe string copy pattern easier to apply consistently
- Improves code readability by reducing visual noise
- Uses existing utility function already in codebase

Closes #747