### PR TITLE
refactor(quic): replace incorrect error code in unreachable default case

### DIFF
--- a/src/quic/SocketQUICVarInt.c
+++ b/src/quic/SocketQUICVarInt.c
@@ -103,8 +103,9 @@ SocketQUICVarInt_decode (const uint8_t *data, size_t len, uint64_t *value,
       required_len = 8;
       break;
     default:
-      /* Should not reach here - prefix is masked to 2 bits */
-      return QUIC_VARINT_ERROR_NULL;
+      /* Unreachable - prefix is masked to 2 bits (only 4 possible values) */
+      assert (0 && "Unreachable: prefix masked to 2 bits");
+      return QUIC_VARINT_INCOMPLETE;
     }
 
   if (len < required_len)


### PR DESCRIPTION
## Summary

Implements #750

## Changes

- Replaced semantically incorrect `QUIC_VARINT_ERROR_NULL` with `QUIC_VARINT_INCOMPLETE` in unreachable default case
- Added `assert()` to catch potential bugs in debug builds
- Updated comment to clarify that the default case is truly unreachable

## Details

The default case in `SocketQUICVarInt_decode`'s switch statement (line 107) was returning `QUIC_VARINT_ERROR_NULL`, which is semantically incorrect. This error code is specifically for NULL pointer arguments, not unreachable code paths.

Since the `prefix` variable is masked to 2 bits (`data[0] & VARINT_PREFIX_MASK` where mask is `0xC0`), only 4 possible values exist (0x00, 0x40, 0x80, 0xC0), all of which are explicitly handled. The default case is mathematically unreachable.

## Test Plan

- [x] All QUIC tests pass with sanitizers (24/24 tests)
- [x] Varint-specific tests pass (39/39 tests)
- [x] No functional changes - pure refactoring
- [x] Assert will catch any future bugs in debug builds

Closes #750