### PR TITLE
refactor(quic): replace FNV-1a magic constants with named definitions

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -21,6 +21,10 @@
 /* Use SocketCrypto_random_bytes() for platform-independent secure random */
 #define SECURE_RANDOM(buf, len) (SocketCrypto_random_bytes ((buf), (len)) == 0)
 
+/* FNV-1a 32-bit hash constants */
+#define FNV1A_OFFSET_BASIS 2166136261u
+#define FNV1A_PRIME        16777619u
+
 /* ============================================================================
  * Result Strings
  * ============================================================================
@@ -286,12 +290,12 @@ SocketQUICConnectionID_hash (const SocketQUICConnectionID_T *cid)
     return 0;
 
   /* FNV-1a hash */
-  hash = 2166136261u;
+  hash = FNV1A_OFFSET_BASIS;
 
   for (i = 0; i < cid->len; i++)
     {
       hash ^= cid->data[i];
-      hash *= 16777619u;
+      hash *= FNV1A_PRIME;
     }
 
   return hash;


### PR DESCRIPTION
## Summary

Implements #735 - Replaces hardcoded FNV-1a hash algorithm magic constants with named definitions in `SocketQUICConnectionID_hash()`.

## Changes

- Added `FNV1A_OFFSET_BASIS` (2166136261u) constant definition
- Added `FNV1A_PRIME` (16777619u) constant definition  
- Replaced magic numbers on lines 289 and 294 with named constants

## Test Plan

- [x] All QUIC module tests pass with sanitizers (24/24)
- [x] Hash function behavior unchanged (functional equivalence verified)
- [x] Improved code clarity following pattern from issue #538

## Notes

This refactoring follows the same pattern as #538 which addressed DJB2 hash constants, improving code maintainability without changing functionality.

Closes #735