### PR TITLE
refactor(dns): replace magic number 1024 with DNS_CONFIG_MAX_LINE_LEN constant

### DIFF
--- a/include/dns/SocketDNSConfig.h
+++ b/include/dns/SocketDNSConfig.h
@@ -80,6 +80,9 @@
 /** Maximum ndots value (resolv.conf cap). */
 #define DNS_CONFIG_MAX_NDOTS 15
 
+/** Maximum line length in resolv.conf (typical limit is 256-1024 bytes). */
+#define DNS_CONFIG_MAX_LINE_LEN 1024
+
 /** Default resolv.conf path. */
 #define DNS_CONFIG_DEFAULT_PATH "/etc/resolv.conf"
 

--- a/src/dns/SocketDNSConfig.c
+++ b/src/dns/SocketDNSConfig.c
@@ -239,7 +239,7 @@ int
 SocketDNSConfig_load_file (SocketDNSConfig_T *config, const char *path)
 {
   FILE *fp;
-  char line[1024];
+  char line[DNS_CONFIG_MAX_LINE_LEN];
 
   assert (config != NULL);
   assert (path != NULL);


### PR DESCRIPTION
## Summary

Implements #739 - Replaces hardcoded magic number 1024 with a named constant for the line buffer size in `SocketDNSConfig_load_file()`.

## Changes

- Added `DNS_CONFIG_MAX_LINE_LEN` constant to `include/dns/SocketDNSConfig.h`
- Replaced magic number `1024` with `DNS_CONFIG_MAX_LINE_LEN` in `src/dns/SocketDNSConfig.c`
- Follows existing naming conventions (`DNS_CONFIG_MAX_*`)
- Properly documented with a descriptive comment

## Test Plan

- [x] All tests pass with sanitizers (`ctest -j8` passes 112/112 tests)
- [x] DNS config tests specifically pass (29/29 tests)
- [x] No functional changes - purely refactoring for maintainability

Closes #739