### PR TITLE
docs(quic): correct thread-safety documentation in SocketQUICError.h

### DIFF
--- a/include/quic/SocketQUICError.h
+++ b/include/quic/SocketQUICError.h
@@ -301,8 +301,11 @@ SocketQUIC_is_transport_error (uint64_t code)
  * @param code Error code to convert.
  * @return Static string describing the error. Never returns NULL.
  *
- * @note For crypto errors, a static buffer is used. Not thread-safe
- *       for crypto errors if called concurrently with different codes.
+ * @note Thread-safe: Uses thread-local storage for crypto error formatting.
+ *       Each thread maintains its own buffer, so concurrent calls from
+ *       different threads are safe. However, the returned pointer is only
+ *       valid until the next call to this function in the same thread.
+ *       Copy the result if you need to preserve it across multiple calls.
  */
 extern const char *SocketQUIC_error_string (uint64_t code);
 


### PR DESCRIPTION
## Summary

Implements #751 - Corrects incorrect thread-safety documentation for `SocketQUIC_error_string()` function.

## Changes

- Updated documentation in `include/quic/SocketQUICError.h` to accurately reflect thread-safety
- Clarified that the function uses `__thread` storage (thread-local), making it thread-safe for concurrent calls from different threads
- Documented that each thread maintains its own buffer
- Noted that the returned pointer is valid until the next call in the same thread
- Follows the common pattern used by similar error string functions (like `strerror()`)

## Test Plan

- [x] Documentation builds successfully with `make doc`
- [x] No code changes required (implementation is already correct)
- [x] Header file compiles without warnings

## Notes

This is a documentation-only change. The implementation in `src/quic/SocketQUICError.c` already correctly uses thread-local storage (`static __thread char crypto_buf[32]`), making the function thread-safe. The documentation previously incorrectly stated it was not thread-safe for crypto errors.

Closes #751