### PR TITLE
fix(Socket-iov): improve pipe() error diagnostics for splice operation

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -910,7 +910,15 @@ Socket_splice (T socket_in, T socket_out, size_t len)
   /* Create pipe for intermediate buffer */
   if (pipe (pipe_fds) < 0)
     {
-      SOCKET_ERROR_FMT ("pipe() failed for splice");
+      int saved_errno = errno;
+      if (saved_errno == EMFILE || saved_errno == ENFILE)
+        SOCKET_ERROR_FMT ("pipe() failed: too many open file descriptors "
+                          "(consider increasing ulimit)");
+      else if (saved_errno == ENOMEM)
+        SOCKET_ERROR_FMT ("pipe() failed: insufficient kernel memory");
+      else
+        SOCKET_ERROR_FMT ("pipe() failed for splice");
+      errno = saved_errno;
       RAISE_MODULE_ERROR (Socket_Failed);
     }
 


### PR DESCRIPTION
## Summary

Implements #711

Enhanced error messages for pipe() failures in Socket_splice() to help users diagnose resource exhaustion issues.

## Changes

- Added errno-specific error messages for pipe() failures in Socket_splice()
- EMFILE/ENFILE: Indicates too many open file descriptors with suggestion to increase ulimit
- ENOMEM: Indicates insufficient kernel memory
- Other errors: Generic pipe() failure message
- Properly saves and restores errno to preserve error information

## Test Plan

- [x] Tests pass with sanitizers (108/108 non-flaky tests pass)
- [x] Build succeeds with ASAN/UBSAN enabled
- [x] Error handling follows project conventions (similar to socket_get_connect_error_msg pattern)
- [x] Errno is properly preserved across error handling

Closes #711