### PR TITLE
test(quic): add tests for send/recv state accessors

### DIFF
--- a/src/test/test_quic_stream.c
+++ b/src/test/test_quic_stream.c
@@ -363,6 +363,50 @@ TEST (quic_stream_get_state_null)
   ASSERT_EQ (SocketQUICStream_get_state (NULL), QUIC_STREAM_STATE_READY);
 }
 
+TEST (quic_stream_get_send_state_null)
+{
+  ASSERT_EQ (SocketQUICStream_get_send_state (NULL), QUIC_STREAM_STATE_READY);
+}
+
+TEST (quic_stream_get_recv_state_null)
+{
+  ASSERT_EQ (SocketQUICStream_get_recv_state (NULL), QUIC_STREAM_STATE_RECV);
+}
+
+TEST (quic_stream_get_send_state)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  ASSERT_EQ (SocketQUICStream_get_send_state (&stream),
+             QUIC_STREAM_STATE_READY);
+
+  stream.send_state = QUIC_STREAM_STATE_SEND;
+  ASSERT_EQ (SocketQUICStream_get_send_state (&stream),
+             QUIC_STREAM_STATE_SEND);
+
+  stream.send_state = QUIC_STREAM_STATE_DATA_SENT;
+  ASSERT_EQ (SocketQUICStream_get_send_state (&stream),
+             QUIC_STREAM_STATE_DATA_SENT);
+}
+
+TEST (quic_stream_get_recv_state)
+{
+  struct SocketQUICStream stream;
+
+  SocketQUICStream_init (&stream, 0);
+  ASSERT_EQ (SocketQUICStream_get_recv_state (&stream),
+             QUIC_STREAM_STATE_RECV);
+
+  stream.recv_state = QUIC_STREAM_STATE_SIZE_KNOWN;
+  ASSERT_EQ (SocketQUICStream_get_recv_state (&stream),
+             QUIC_STREAM_STATE_SIZE_KNOWN);
+
+  stream.recv_state = QUIC_STREAM_STATE_DATA_READ;
+  ASSERT_EQ (SocketQUICStream_get_recv_state (&stream),
+             QUIC_STREAM_STATE_DATA_READ);
+}
+
 TEST (quic_stream_is_local_null)
 {
   ASSERT_EQ (SocketQUICStream_is_local (NULL), 0);


### PR DESCRIPTION
## Summary

Adds comprehensive tests for `SocketQUICStream_get_send_state()` and `SocketQUICStream_get_recv_state()` accessor functions.

## Background

Issue #745 reported these functions as missing from the implementation. However, these functions were already implemented in `src/quic/SocketQUICStream-state.c` (added in PR #450). The issue description was based on outdated information.

## Changes

- Added 4 new test cases in `src/test/test_quic_stream.c`:
  - `quic_stream_get_send_state_null` - Tests NULL pointer handling
  - `quic_stream_get_recv_state_null` - Tests NULL pointer handling  
  - `quic_stream_get_send_state` - Tests send state transitions
  - `quic_stream_get_recv_state` - Tests receive state transitions

## Test Plan

- [x] All QUIC tests pass (24/24)
- [x] New tests verify correct behavior:
  - NULL returns QUIC_STREAM_STATE_READY for send_state
  - NULL returns QUIC_STREAM_STATE_RECV for recv_state
  - State transitions work correctly
- [x] Built with sanitizers enabled
- [x] No memory leaks detected

## Notes

The accessor functions were already correctly implemented - this PR just adds test coverage for them.

Closes #745