### PR TITLE
refactor(quic): replace magic number with QUIC_ACK_DELAY_EXPONENT_DEFAULT

### DIFF
--- a/include/quic/SocketQUICAck.h
+++ b/include/quic/SocketQUICAck.h
@@ -69,6 +69,18 @@
  */
 #define QUIC_ACK_INITIAL_RANGE_CAPACITY 16
 
+/**
+ * @brief Default ACK delay exponent per RFC 9000 Section 18.2.
+ *
+ * The ack_delay field in ACK frames uses units of 2^ack_delay_exponent
+ * microseconds. Default value is 3, meaning units of 8 microseconds (2^3).
+ * This value can be negotiated via the ack_delay_exponent transport parameter.
+ *
+ * @see RFC 9000 Section 13.2.5 (ACK Delay)
+ * @see RFC 9000 Section 18.2 (Transport Parameters)
+ */
+#define QUIC_ACK_DELAY_EXPONENT_DEFAULT 3
+
 /* ============================================================================
  * Data Structures
  * ============================================================================

--- a/src/quic/SocketQUICAck.c
+++ b/src/quic/SocketQUICAck.c
@@ -350,7 +350,7 @@ static uint64_t
 calculate_ack_delay (uint64_t current_time, uint64_t recv_time)
 {
   if (current_time > recv_time)
-    return (current_time - recv_time) >> 3;
+    return (current_time - recv_time) >> QUIC_ACK_DELAY_EXPONENT_DEFAULT;
   return 0;
 }
 


### PR DESCRIPTION
## Summary

Implements #730 by replacing the hardcoded bit shift value of 3 in ACK delay calculation with a named constant `QUIC_ACK_DELAY_EXPONENT_DEFAULT`.

## Changes

- Added `QUIC_ACK_DELAY_EXPONENT_DEFAULT` constant to `SocketQUICAck.h` with full documentation
- Updated `SocketQUICAck_encode()` to use the constant instead of magic number `3`
- Added RFC 9000 Section 13.2.5 and 18.2 references in documentation

## Benefits

- **Maintainability**: Named constant makes the code intent clearer
- **RFC Compliance**: Explicitly documents this is a protocol-defined value  
- **Future-proofing**: Easier to support negotiated `ack_delay_exponent` values via transport parameters

## Test Plan

- [x] All 24 QUIC tests pass with sanitizers enabled
- [x] test_quic_ack passes all 30 test cases
- [x] Build succeeds with sanitizers (ASan + UBSan)
- [x] No behavioral changes - purely refactoring

Closes #730