### PR TITLE
refactor(dns): replace magic buffer size with DNS_CONFIG_MAX_LINE_LEN constant

### DIFF
--- a/include/dns/SocketDNSConfig.h
+++ b/include/dns/SocketDNSConfig.h
@@ -62,6 +62,9 @@
 /** Maximum total search list length (glibc <= 2.25 limit). */
 #define DNS_CONFIG_MAX_SEARCH_LEN 256
 
+/** Maximum line length when reading resolv.conf. */
+#define DNS_CONFIG_MAX_LINE_LEN 1024
+
 /** Default query timeout in seconds (RES_TIMEOUT). */
 #define DNS_CONFIG_DEFAULT_TIMEOUT 5
 

--- a/src/dns/SocketDNSConfig.c
+++ b/src/dns/SocketDNSConfig.c
@@ -239,7 +239,7 @@ int
 SocketDNSConfig_load_file (SocketDNSConfig_T *config, const char *path)
 {
   FILE *fp;
-  char line[1024];
+  char line[DNS_CONFIG_MAX_LINE_LEN];
 
   assert (config != NULL);
   assert (path != NULL);


### PR DESCRIPTION
## Summary

Implements #703

## Changes

- Added `DNS_CONFIG_MAX_LINE_LEN` constant (1024) to `include/dns/SocketDNSConfig.h`
- Replaced hardcoded buffer size `1024` with `DNS_CONFIG_MAX_LINE_LEN` in `src/dns/SocketDNSConfig.c:242`

## Test Plan

- [x] All DNS config tests pass (29/29)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - purely a refactoring

Closes #703