### PR TITLE
docs(dns): explain DNS_NEGCACHE_MAX_SOA_RDATA buffer size rationale

### DIFF
--- a/include/dns/SocketDNSNegCache.h
+++ b/include/dns/SocketDNSNegCache.h
@@ -66,7 +66,15 @@
 /** Maximum hostname length in cache key. */
 #define DNS_NEGCACHE_MAX_NAME 255
 
-/** Maximum SOA RDATA length (typical SOA is ~100 bytes). */
+/**
+ * Maximum SOA RDATA length (typical SOA is ~100 bytes).
+ *
+ * While worst-case SOA (2x255 byte names + 20 byte fields) = 530 bytes,
+ * practical SOA records are much smaller. 512 bytes chosen to match
+ * standard DNS UDP message size (RFC 1035) and accommodate typical use.
+ *
+ * If larger SOA needed, increase this constant.
+ */
 #define DNS_NEGCACHE_MAX_SOA_RDATA 512
 
 /** Maximum SOA owner name length. */


### PR DESCRIPTION
## Summary

Implements #713 by improving documentation for the `DNS_NEGCACHE_MAX_SOA_RDATA` constant.

## Changes

- Enhanced the comment for `DNS_NEGCACHE_MAX_SOA_RDATA` in `include/dns/SocketDNSNegCache.h` to explain:
  - Worst-case SOA RDATA size calculation (530 bytes)
  - Rationale for 512-byte buffer size (matches RFC 1035 DNS UDP message size)
  - Typical SOA record sizes (~100 bytes in practice)
  - Guidance for maintainers if larger buffers are needed

## Test Plan

- [x] All DNS-related tests pass with sanitizers
- [x] Documentation-only change, no code modifications
- [x] Verified in `include/dns/SocketDNSNegCache.h` at line 69-78

Closes #713