### PR TITLE
docs(dns): add RFC 1035 §2.3.4 reference for DNS_NEGCACHE_MAX_NAME constants

### DIFF
--- a/include/dns/SocketDNSNegCache.h
+++ b/include/dns/SocketDNSNegCache.h
@@ -63,13 +63,13 @@
  * @{
  */
 
-/** Maximum hostname length in cache key. */
+/** Maximum hostname length in cache key (RFC 1035 §2.3.4). */
 #define DNS_NEGCACHE_MAX_NAME 255
 
 /** Maximum SOA RDATA length (typical SOA is ~100 bytes). */
 #define DNS_NEGCACHE_MAX_SOA_RDATA 512
 
-/** Maximum SOA owner name length. */
+/** Maximum SOA owner name length (RFC 1035 §2.3.4). */
 #define DNS_NEGCACHE_MAX_SOA_NAME 255
 
 /** Default maximum cache entries. */


### PR DESCRIPTION
## Summary

Implements #707

Added RFC 1035 §2.3.4 references to the documentation for `DNS_NEGCACHE_MAX_NAME` and `DNS_NEGCACHE_MAX_SOA_NAME` constants to clarify that the 255-byte limit comes from the DNS protocol specification for maximum domain name length.

## Changes

- Updated `include/dns/SocketDNSNegCache.h`:
  - Added RFC 1035 §2.3.4 reference to `DNS_NEGCACHE_MAX_NAME` comment (line 66)
  - Added RFC 1035 §2.3.4 reference to `DNS_NEGCACHE_MAX_SOA_NAME` comment (line 72)

## Test Plan

- [x] All DNS negcache tests pass (26/26)
- [x] Build succeeds with sanitizers enabled
- [x] No code logic changes - documentation only
- [x] Individual test runs confirm all tests pass (parallel test flakiness is pre-existing)

Closes #707