### PR TITLE
refactor(dns): define DOT_DEFAULT_QUERY_TIMEOUT_MS constant

### DIFF
--- a/include/dns/SocketDNSoverTLS.h
+++ b/include/dns/SocketDNSoverTLS.h
@@ -93,6 +93,9 @@
 /** TLS handshake timeout in milliseconds. */
 #define DOT_HANDSHAKE_TIMEOUT_MS 5000
 
+/** Default query timeout in milliseconds. */
+#define DOT_DEFAULT_QUERY_TIMEOUT_MS 5000
+
 /** Connection idle timeout before closing (per RFC 7858 Section 3.4). */
 #define DOT_IDLE_TIMEOUT_MS 120000
 

--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -771,7 +771,7 @@ SocketDNSoverTLS_new (Arena_T arena)
 
   transport->arena = arena;
   transport->handshake_timeout_ms = DOT_HANDSHAKE_TIMEOUT_MS;
-  transport->query_timeout_ms = 5000;
+  transport->query_timeout_ms = DOT_DEFAULT_QUERY_TIMEOUT_MS;
   transport->idle_timeout_ms = DOT_IDLE_TIMEOUT_MS;
 
   init_connection (&transport->conn);


### PR DESCRIPTION
## Summary

Implements #732

## Changes

- Add `DOT_DEFAULT_QUERY_TIMEOUT_MS` constant (5000ms) to `include/dns/SocketDNSoverTLS.h`
- Use constant in `SocketDNSoverTLS_new()` initialization instead of magic number

## Rationale

Brings consistency with existing timeout constants:
- `DOT_HANDSHAKE_TIMEOUT_MS` (line 94)
- `DOT_IDLE_TIMEOUT_MS` (line 97)

Makes the default query timeout value:
- Documented in the public header
- Configurable in one place
- Referenceable by library users

## Test Plan

- [x] All DNS-over-TLS tests pass (15/15)
- [x] Full test suite passes with sanitizers (107/107 excluding known flaky tests)
- [x] Build succeeds with no warnings

Closes #732