### PR TITLE
refactor(quic): use encode_varint_field helper in CONNECTION_CLOSE frames

### DIFF
--- a/src/quic/SocketQUICFrame-close.c
+++ b/src/quic/SocketQUICFrame-close.c
@@ -65,38 +65,23 @@ SocketQUICFrame_encode_connection_close_transport (uint64_t error_code,
     return 0;
 
   size_t pos = 0;
-  uint8_t temp[SOCKETQUICVARINT_MAX_SIZE];
-  size_t len;
 
   /* Frame type (0x1c) */
-  len = SocketQUICVarInt_encode (QUIC_FRAME_CONNECTION_CLOSE, temp,
-                                 sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (QUIC_FRAME_CONNECTION_CLOSE, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Error Code */
-  len = SocketQUICVarInt_encode (error_code, temp, sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (error_code, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Frame Type */
-  len = SocketQUICVarInt_encode (frame_type, temp, sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (frame_type, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Reason Phrase Length */
   size_t reason_len = reason ? strlen (reason) : 0;
-  len = SocketQUICVarInt_encode (reason_len, temp, sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (reason_len, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Reason Phrase */
   if (reason_len > 0)
@@ -152,31 +137,19 @@ SocketQUICFrame_encode_connection_close_app (uint64_t error_code,
     return 0;
 
   size_t pos = 0;
-  uint8_t temp[SOCKETQUICVARINT_MAX_SIZE];
-  size_t len;
 
   /* Frame type (0x1d) */
-  len = SocketQUICVarInt_encode (QUIC_FRAME_CONNECTION_CLOSE_APP, temp,
-                                 sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (QUIC_FRAME_CONNECTION_CLOSE_APP, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Error Code */
-  len = SocketQUICVarInt_encode (error_code, temp, sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (error_code, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Reason Phrase Length */
   size_t reason_len = reason ? strlen (reason) : 0;
-  len = SocketQUICVarInt_encode (reason_len, temp, sizeof (temp));
-  if (len == 0 || pos + len > out_len)
+  if (!encode_varint_field (reason_len, out, &pos, out_len))
     return 0;
-  memcpy (out + pos, temp, len);
-  pos += len;
 
   /* Reason Phrase */
   if (reason_len > 0)


### PR DESCRIPTION
## Summary

Implements #743

Refactors `SocketQUICFrame-close.c` to use the `encode_varint_field()` helper function instead of manual varint encoding in both CONNECTION_CLOSE frame encoding functions.

## Changes

- **Modified**: `src/quic/SocketQUICFrame-close.c`
  - Replaced manual varint encoding pattern in `SocketQUICFrame_encode_connection_close_transport()`
  - Replaced manual varint encoding pattern in `SocketQUICFrame_encode_connection_close_app()`
  - Eliminated ~40 lines of redundant code

## Benefits

1. **Consistency**: Aligns with pattern used in all other QUIC frame encoding modules
2. **Maintainability**: Reduces code duplication
3. **Clarity**: Makes encoding logic more explicit and easier to understand
4. **No behavior change**: Maintains identical functionality and error handling

## Pattern Before

```c
uint8_t temp[SOCKETQUICVARINT_MAX_SIZE];
size_t len;

len = SocketQUICVarInt_encode(value, temp, sizeof(temp));
if (len == 0 || pos + len > out_len)
    return 0;
memcpy(out + pos, temp, len);
pos += len;
```

## Pattern After

```c
if (!encode_varint_field(value, out, &pos, out_len))
    return 0;
```

## Test Plan

- [x] All QUIC tests pass with sanitizers (24/24)
- [x] Full test suite passes (103/103 excluding flaky tests)
- [x] No functional changes - identical encoding behavior
- [x] Verified consistency with other frame encoders

Closes #743