### PR TITLE
refactor(dns): replace snprintf with socket_util_safe_strncpy in SocketDNSServfailCache

### DIFF
--- a/src/dns/SocketDNSServfailCache.c
+++ b/src/dns/SocketDNSServfailCache.c
@@ -426,8 +426,8 @@ SocketDNSServfailCache_insert (T cache, const char *qname, uint16_t qtype,
     }
 
   memset (entry, 0, sizeof (*entry));
-  snprintf (entry->name, sizeof (entry->name), "%s", normalized);
-  snprintf (entry->nameserver, sizeof (entry->nameserver), "%s", nameserver);
+  socket_util_safe_strncpy (entry->name, normalized, sizeof (entry->name));
+  socket_util_safe_strncpy (entry->nameserver, nameserver, sizeof (entry->nameserver));
   entry->qtype = qtype;
   entry->qclass = qclass;
   entry->ttl = ttl;


### PR DESCRIPTION
## Summary

Implements #726 by replacing inefficient `snprintf("%s", src)` pattern with `socket_util_safe_strncpy()` for simple string copying in the servfail cache.

## Changes

- Replaced `snprintf(entry->name, sizeof(entry->name), "%s", normalized)` with `socket_util_safe_strncpy(entry->name, normalized, sizeof(entry->name))`
- Replaced `snprintf(entry->nameserver, sizeof(entry->nameserver), "%s", nameserver)` with `socket_util_safe_strncpy(entry->nameserver, nameserver, sizeof(entry->nameserver))`

## Benefits

- **Performance**: Eliminates format string parsing overhead
- **Simplicity**: More direct code for string copying
- **Consistency**: Aligns with codebase patterns (SocketUtil.h line 1355)
- **Safety**: Maintains same guarantees (null-termination, bounds checking)

## Test Plan

- [x] All 18 servfailcache tests pass with sanitizers
- [x] Full test suite passes (110/110 tests excluding pre-existing failures)
- [x] No functional changes - purely refactoring

Closes #726