### PR TITLE
refactor(dns): use Request_T typedef consistently in SocketDNS_geterror

### DIFF
--- a/include/dns/SocketDNS.h
+++ b/include/dns/SocketDNS.h
@@ -353,7 +353,7 @@ extern struct addrinfo *SocketDNS_getresult (T dns, Request_T req);
  * @see SocketDNS_getresult() for retrieving successful results.
  * @see SocketDNS_resolve() for creating requests.
  */
-extern int SocketDNS_geterror (T dns, const struct SocketDNS_Request_T *req);
+extern int SocketDNS_geterror (T dns, Request_T req);
 
 /**
  * @brief Override timeout for specific request.

--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -441,7 +441,7 @@ SocketDNS_getresult (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
 
 int
 SocketDNS_geterror (struct SocketDNS_T *dns,
-                    const struct SocketDNS_Request_T *req)
+                    struct SocketDNS_Request_T *req)
 {
   int error = 0;
 


### PR DESCRIPTION
## Summary

Implements #719

- Changed `SocketDNS_geterror()` declaration to use `Request_T` typedef instead of `const struct SocketDNS_Request_T *`
- Updated implementation to match new signature
- Ensures consistency with all other SocketDNS API functions (`SocketDNS_resolve`, `SocketDNS_cancel`, `SocketDNS_getresult`)

## Changes

- `include/dns/SocketDNS.h`: Updated function declaration at line 356
- `src/dns/SocketDNS.c`: Updated function implementation at line 443

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All DNS tests pass
- [x] No compilation warnings or errors
- [x] Type consistency verified across SocketDNS API

Closes #719