### PR TITLE
refactor(quic): replace magic number with QUIC_STATELESS_RESET_TOKEN_LEN constant

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -23,6 +23,7 @@
 #define QUIC_CONNTABLE_MAX_CHAIN_LEN 32
 #define QUIC_CONNECTION_MAX_CIDS 8
 #define QUIC_CONNECTION_MIN_CID_LIMIT 2
+#define QUIC_STATELESS_RESET_TOKEN_LEN 16
 
 typedef struct SocketQUICConnection *SocketQUICConnection_T;
 typedef struct SocketQUICConnTable *SocketQUICConnTable_T;
@@ -78,7 +79,7 @@ struct SocketQUICConnection {
   uint64_t last_packet_received_ms;
   uint64_t closing_deadline_ms;
   uint64_t draining_deadline_ms;
-  uint8_t stateless_reset_token[16];
+  uint8_t stateless_reset_token[QUIC_STATELESS_RESET_TOKEN_LEN];
   int has_stateless_reset_token;
 };
 

--- a/src/quic/SocketQUICConnection-termination.c
+++ b/src/quic/SocketQUICConnection-termination.c
@@ -270,7 +270,7 @@ SocketQUICConnection_set_stateless_reset_token(SocketQUICConnection_T conn,
   if (!conn || !token)
     return;
 
-  memcpy(conn->stateless_reset_token, token, 16);
+  memcpy(conn->stateless_reset_token, token, QUIC_STATELESS_RESET_TOKEN_LEN);
   conn->has_stateless_reset_token = 1;
 }
 
@@ -298,6 +298,6 @@ SocketQUICConnection_verify_stateless_reset(const uint8_t *packet,
     return 0;
 
   /* Compare final 16 bytes with expected token */
-  const uint8_t *actual_token = packet + packet_len - 16;
-  return memcmp(actual_token, expected_token, 16) == 0;
+  const uint8_t *actual_token = packet + packet_len - QUIC_STATELESS_RESET_TOKEN_LEN;
+  return memcmp(actual_token, expected_token, QUIC_STATELESS_RESET_TOKEN_LEN) == 0;
 }


### PR DESCRIPTION
## Summary

Implements #755 - Define constant for stateless reset token size (16 bytes)

## Changes

- Add `QUIC_STATELESS_RESET_TOKEN_LEN` (16) constant to `include/quic/SocketQUICConnection.h`
- Replace 3 occurrences of magic number `16` in `src/quic/SocketQUICConnection-termination.c`:
  - Line 273: `memcpy()` call in `SocketQUICConnection_set_stateless_reset_token()`
  - Line 301: Pointer arithmetic in `SocketQUICConnection_verify_stateless_reset()`
  - Line 302: `memcmp()` call in `SocketQUICConnection_verify_stateless_reset()`
- Update struct field `stateless_reset_token` array declaration to use the constant

## Benefits

- Improves code maintainability by centralizing the token size definition
- Makes semantic meaning clear (per RFC 9000 Section 10.3)
- Ensures consistency across all uses of the stateless reset token size
- Facilitates future changes if needed

## Test Plan

- [x] Code compiles cleanly with `-Wall -Wextra`
- [x] QUIC files build successfully
- [x] Changes verified with syntax checking

Note: Pre-existing test failure in `test_dns_mutex_macros.c` (unrelated to this change) prevents full test suite run. This issue only modifies QUIC constants and has no impact on DNS modules.

Closes #755