### PR TITLE
refactor(quic): replace magic number with QUIC_TERMINATION_PTO_MULTIPLIER constant

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -24,6 +24,9 @@
 #define QUIC_CONNECTION_MAX_CIDS 8
 #define QUIC_CONNECTION_MIN_CID_LIMIT 2
 
+/* RFC 9000 Section 10.2: Closing/draining timeout = 3 * PTO */
+#define QUIC_TERMINATION_PTO_MULTIPLIER 3
+
 typedef struct SocketQUICConnection *SocketQUICConnection_T;
 typedef struct SocketQUICConnTable *SocketQUICConnTable_T;
 

--- a/src/quic/SocketQUICConnection-termination.c
+++ b/src/quic/SocketQUICConnection-termination.c
@@ -157,7 +157,7 @@ SocketQUICConnection_initiate_close(SocketQUICConnection_T conn,
   conn->state = QUIC_CONN_STATE_CLOSING;
 
   /* Calculate closing deadline: 3 * PTO */
-  uint64_t timeout = pto_ms * 3;
+  uint64_t timeout = pto_ms * QUIC_TERMINATION_PTO_MULTIPLIER;
   if (now_ms > UINT64_MAX - timeout)
     conn->closing_deadline_ms = UINT64_MAX;
   else
@@ -194,7 +194,7 @@ SocketQUICConnection_enter_draining(SocketQUICConnection_T conn,
   conn->state = QUIC_CONN_STATE_DRAINING;
 
   /* Calculate draining deadline: 3 * PTO */
-  uint64_t timeout = pto_ms * 3;
+  uint64_t timeout = pto_ms * QUIC_TERMINATION_PTO_MULTIPLIER;
   if (now_ms > UINT64_MAX - timeout)
     conn->draining_deadline_ms = UINT64_MAX;
   else


### PR DESCRIPTION
## Summary

Implements #771

Replaces hardcoded value `3` with named constant `QUIC_TERMINATION_PTO_MULTIPLIER` in QUIC connection termination timeout calculations.

## Changes

- Added `QUIC_TERMINATION_PTO_MULTIPLIER` constant to `include/quic/SocketQUICConnection.h`
- Replaced magic number `3` in `SocketQUICConnection_initiate_close()` (line 160)
- Replaced magic number `3` in `SocketQUICConnection_enter_draining()` (line 197)

## Test Plan

- [x] QUIC termination test passes with sanitizers
- [x] Code compiles without errors
- [x] Constants properly defined in header

## RFC Compliance

Makes RFC 9000 Section 10.2 compliance explicit: "These states SHOULD persist for at least three times the current PTO interval."

Closes #771