### PR TITLE
refactor(quic): replace magic number with QUIC_STATELESS_RESET_MIN_PACKET_LEN constant

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -24,6 +24,9 @@
 #define QUIC_CONNECTION_MAX_CIDS 8
 #define QUIC_CONNECTION_MIN_CID_LIMIT 2
 
+/* RFC 9000 Section 10.3.1: Minimum packet size to avoid false positives */
+#define QUIC_STATELESS_RESET_MIN_PACKET_LEN 38
+
 typedef struct SocketQUICConnection *SocketQUICConnection_T;
 typedef struct SocketQUICConnTable *SocketQUICConnTable_T;
 

--- a/src/quic/SocketQUICConnection-termination.c
+++ b/src/quic/SocketQUICConnection-termination.c
@@ -294,7 +294,7 @@ SocketQUICConnection_verify_stateless_reset(const uint8_t *packet,
     return 0;
 
   /* RFC 9000 Section 10.3.1: Minimum size to avoid collisions */
-  if (packet_len < 38)
+  if (packet_len < QUIC_STATELESS_RESET_MIN_PACKET_LEN)
     return 0;
 
   /* Compare final 16 bytes with expected token */


### PR DESCRIPTION
## Summary

Implements #765

Defines `QUIC_STATELESS_RESET_MIN_PACKET_LEN` constant to replace the hardcoded value `38` for the RFC 9000 Section 10.3.1 mandated minimum packet size for stateless reset verification.

## Changes

- Added `QUIC_STATELESS_RESET_MIN_PACKET_LEN` constant to `include/quic/SocketQUICConnection.h`
- Replaced magic number `38` with the constant in `src/quic/SocketQUICConnection-termination.c`

## Benefits

- Improves code self-documentation
- Makes RFC compliance verification easier
- Centralizes protocol constant definition

## Test Plan

- [x] Library builds successfully (socket_static target)
- [x] QUIC module compiles without errors
- [x] Constant is properly defined and used

## Notes

There is a pre-existing build issue in `test_dns_mutex_macros.c` (missing `SocketDNS_DetailedException` declaration) that is unrelated to this change. The core library builds successfully, and this QUIC change does not introduce any new compilation errors.

Closes #765