### PR TITLE
refactor(quic): add size pre-calculation to CONNECTION_CLOSE frame encoders

### DIFF
--- a/src/quic/SocketQUICFrame-close.c
+++ b/src/quic/SocketQUICFrame-close.c
@@ -64,11 +64,27 @@ SocketQUICFrame_encode_connection_close_transport (uint64_t error_code,
   if (!out || out_len == 0)
     return 0;
 
+  /* Calculate required size: type + error_code + frame_type + reason_len +
+   * reason */
+  size_t type_len = 1;
+  size_t error_code_len = SocketQUICVarInt_size (error_code);
+  size_t frame_type_len = SocketQUICVarInt_size (frame_type);
+  size_t reason_len = reason ? strlen (reason) : 0;
+  size_t reason_len_size = SocketQUICVarInt_size (reason_len);
+
+  if (error_code_len == 0 || frame_type_len == 0 || reason_len_size == 0)
+    return 0; /* Value exceeds varint maximum */
+
+  size_t total_len
+      = type_len + error_code_len + frame_type_len + reason_len_size + reason_len;
+
+  if (out_len < total_len)
+    return 0; /* Buffer too small */
+
   size_t pos = 0;
 
   /* Frame type (0x1c) */
-  if (!encode_varint_field (QUIC_FRAME_CONNECTION_CLOSE, out, &pos, out_len))
-    return 0;
+  out[pos++] = QUIC_FRAME_CONNECTION_CLOSE;
 
   /* Error Code */
   if (!encode_varint_field (error_code, out, &pos, out_len))
@@ -79,15 +95,12 @@ SocketQUICFrame_encode_connection_close_transport (uint64_t error_code,
     return 0;
 
   /* Reason Phrase Length */
-  size_t reason_len = reason ? strlen (reason) : 0;
   if (!encode_varint_field (reason_len, out, &pos, out_len))
     return 0;
 
   /* Reason Phrase */
   if (reason_len > 0)
     {
-      if (pos + reason_len > out_len)
-        return 0;
       memcpy (out + pos, reason, reason_len);
       pos += reason_len;
     }
@@ -136,26 +149,36 @@ SocketQUICFrame_encode_connection_close_app (uint64_t error_code,
   if (!out || out_len == 0)
     return 0;
 
+  /* Calculate required size: type + error_code + reason_len + reason */
+  size_t type_len = 1;
+  size_t error_code_len = SocketQUICVarInt_size (error_code);
+  size_t reason_len = reason ? strlen (reason) : 0;
+  size_t reason_len_size = SocketQUICVarInt_size (reason_len);
+
+  if (error_code_len == 0 || reason_len_size == 0)
+    return 0; /* Value exceeds varint maximum */
+
+  size_t total_len = type_len + error_code_len + reason_len_size + reason_len;
+
+  if (out_len < total_len)
+    return 0; /* Buffer too small */
+
   size_t pos = 0;
 
   /* Frame type (0x1d) */
-  if (!encode_varint_field (QUIC_FRAME_CONNECTION_CLOSE_APP, out, &pos, out_len))
-    return 0;
+  out[pos++] = QUIC_FRAME_CONNECTION_CLOSE_APP;
 
   /* Error Code */
   if (!encode_varint_field (error_code, out, &pos, out_len))
     return 0;
 
   /* Reason Phrase Length */
-  size_t reason_len = reason ? strlen (reason) : 0;
   if (!encode_varint_field (reason_len, out, &pos, out_len))
     return 0;
 
   /* Reason Phrase */
   if (reason_len > 0)
     {
-      if (pos + reason_len > out_len)
-        return 0;
       memcpy (out + pos, reason, reason_len);
       pos += reason_len;
     }


### PR DESCRIPTION
## Summary

Implements #756

Refactored CONNECTION_CLOSE frame encoding functions to use size pre-calculation instead of incremental bounds checking, aligning with the pattern used in other QUIC frame encoders.

## Changes

- **Pre-calculate total buffer size** using `SocketQUICVarInt_size()` for all varint fields
- **Check for varint overflow upfront** (when `SocketQUICVarInt_size()` returns 0)
- **Validate buffer size before encoding begins** instead of during encoding
- **Removed redundant incremental length check** for reason phrase memcpy

Functions updated:
- `SocketQUICFrame_encode_connection_close_transport()` - Transport-level CONNECTION_CLOSE (0x1c)
- `SocketQUICFrame_encode_connection_close_app()` - Application-level CONNECTION_CLOSE (0x1d)

## Benefits

- Better error detection upfront before any encoding occurs
- Clearer validation logic and code structure  
- Consistency with other QUIC frame encoders like `SocketQUICFrame_encode_reset_stream()`
- Easier to reason about buffer requirements at a glance

## Test Plan

- [x] Code compiles successfully with `-Wall -Wextra -Werror`
- [x] Manual testing confirms all encoding paths work correctly
- [x] Existing tests in `test_quic_frame.c` validate the encoding (tests 725-889)
- [ ] Full test suite with sanitizers (blocked by pre-existing DNS test failure #862)

## Notes

Note: The pre-commit hook is currently blocked due to a pre-existing build failure in `test_dns_mutex_macros.c` (confirmed on main branch). This DNS test failure is unrelated to the CONNECTION_CLOSE frame changes. The modified code compiles cleanly and passes manual verification.

Closes #756