### PR TITLE
fix(quic): add bounds check for negative event values in SocketQUICStream_event_string

### DIFF
--- a/src/quic/SocketQUICStream-state.c
+++ b/src/quic/SocketQUICStream-state.c
@@ -49,7 +49,7 @@ static const char *event_strings[] = {
 const char *
 SocketQUICStream_event_string (SocketQUICStreamEvent event)
 {
-  if (event > QUIC_STREAM_EVENT_RECV_STOP_SENDING)
+  if (event < 0 || event > QUIC_STREAM_EVENT_RECV_STOP_SENDING)
     return "Unknown";
   return event_strings[event];
 }

--- a/src/test/test_quic_stream.c
+++ b/src/test/test_quic_stream.c
@@ -474,6 +474,56 @@ TEST (quic_stream_result_string)
           == 0);
 }
 
+TEST (quic_stream_event_string)
+{
+  /* Send-side events */
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_SEND_DATA),
+                  "SendData")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_SEND_FIN),
+                  "SendFin")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_ALL_DATA_ACKED),
+                  "AllDataAcked")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_SEND_RESET),
+                  "SendReset")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RESET_ACKED),
+                  "ResetAcked")
+          == 0);
+
+  /* Receive-side events */
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RECV_DATA),
+                  "RecvData")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RECV_FIN),
+                  "RecvFin")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_ALL_DATA_RECVD),
+                  "AllDataRecvd")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_APP_READ_DATA),
+                  "AppReadData")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RECV_RESET),
+                  "RecvReset")
+          == 0);
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_APP_READ_RESET),
+                  "AppReadReset")
+          == 0);
+
+  /* Bidirectional events */
+  ASSERT (strcmp (SocketQUICStream_event_string (QUIC_STREAM_EVENT_RECV_STOP_SENDING),
+                  "RecvStopSending")
+          == 0);
+
+  /* Invalid event */
+  ASSERT (strcmp (SocketQUICStream_event_string ((SocketQUICStreamEvent)99),
+                  "Unknown")
+          == 0);
+}
+
 /* ============================================================================
  * Combined Type and Sequence Tests
  * ============================================================================


### PR DESCRIPTION
## Summary

Fixes #772

The `SocketQUICStream_event_string()` utility function was already implemented but had incomplete bounds checking. This PR adds a check for negative event values to prevent potential out-of-bounds array access.

## Changes

- **SocketQUICStream-state.c**: Added `event < 0` check in `SocketQUICStream_event_string()`
- **test_quic_stream.c**: Added comprehensive test coverage for all 12 stream event types and invalid event handling

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] All 12 QUIC stream events return correct strings
- [x] Invalid events return "Unknown"
- [x] test_quic_stream: 38/38 tests pass
- [x] test_quic_stream_state: 39/39 tests pass

## Notes

The function was already correctly implemented in `SocketQUICStream-state.c` with the event string table and all event mappings. The only missing piece was the lower bound check for negative values, which could potentially cause array underflow if an invalid negative event value was passed.