### PR TITLE
refactor(quic): replace placeholder timestamp with Socket_get_monotonic_ms()

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -11,6 +11,7 @@
 
 #include "quic/SocketQUICMigration.h"
 #include "quic/SocketQUICConstants.h"
+#include "core/SocketUtil.h"
 #include <string.h>
 #include <stdio.h>
 #include <arpa/inet.h>
@@ -217,8 +218,8 @@ SocketQUICMigration_probe_path (SocketQUICMigration_T *migration,
   path->state = QUIC_PATH_VALIDATING;
   path->challenge_count = 1;
 
-  /* Record timestamp (placeholder - would use actual timer in real impl) */
-  current_time_ms = 0; /* TODO: get actual timestamp */
+  /* Record timestamp using monotonic clock */
+  current_time_ms = Socket_get_monotonic_ms ();
   path->challenge_sent_time = current_time_ms;
 
   /* Initialize congestion control for this path */


### PR DESCRIPTION
## Summary

Fixes #795 by replacing the hardcoded `current_time_ms = 0` placeholder with proper monotonic timestamp using `Socket_get_monotonic_ms()`.

## Changes

- Add include for `core/SocketUtil.h` to access `Socket_get_monotonic_ms()`
- Replace `current_time_ms = 0` with call to `Socket_get_monotonic_ms()` in `SocketQUICMigration_probe_path()`
- Remove TODO comment about incomplete timestamp implementation

## Impact

Fixes broken path validation timeout logic in QUIC connection migration:
- PATH_CHALLENGE retransmission now properly times out after 3 seconds (per RFC 9000)
- NAT rebinding detection timing now functions correctly
- Path validation timeout detection works as specified

## Test Plan

- [x] test_quic_migration passes all 19 tests with sanitizers enabled
- [x] Existing test_path_validation_timeout verifies timeout behavior
- [x] No memory leaks detected by AddressSanitizer
- [x] No undefined behavior detected by UBSan

Closes #795