### PR TITLE
fix(quic): add bounds checking to HKDF label construction

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -251,8 +251,16 @@ hkdf_expand_label (const uint8_t *secret, size_t secret_len,
   /* Label length and "tls13 " prefix + actual label */
   size_t full_label_len = 6 + label_len;
   hkdf_label[hkdf_label_len++] = (uint8_t)full_label_len;
+
+  /* Check space for "tls13 " prefix */
+  if (hkdf_label_len + 6 > sizeof (hkdf_label))
+    goto cleanup;
   memcpy (hkdf_label + hkdf_label_len, "tls13 ", 6);
   hkdf_label_len += 6;
+
+  /* Check space for label */
+  if (hkdf_label_len + label_len > sizeof (hkdf_label))
+    goto cleanup;
   memcpy (hkdf_label + hkdf_label_len, label, label_len);
   hkdf_label_len += label_len;
 
@@ -260,6 +268,9 @@ hkdf_expand_label (const uint8_t *secret, size_t secret_len,
   hkdf_label[hkdf_label_len++] = (uint8_t)context_len;
   if (context_len > 0)
     {
+      /* Check space for context */
+      if (hkdf_label_len + context_len > sizeof (hkdf_label))
+        goto cleanup;
       memcpy (hkdf_label + hkdf_label_len, context, context_len);
       hkdf_label_len += context_len;
     }


### PR DESCRIPTION
## Summary

Implements #767 - Add defensive bounds checking to HKDF label construction in `hkdf_expand_label` function.

## Changes

- Added bounds validation before each `memcpy` operation in `hkdf_expand_label`
- Validates buffer space for "tls13 " prefix (6 bytes)
- Validates buffer space for label data
- Validates buffer space for context data
- Returns error via existing cleanup path if bounds check fails

## Security Impact

While current QUIC label usage ("client in", "server in", "quic key", "quic iv", "quic hp") keeps the 512-byte buffer safe, this defensive programming ensures safety if the function is reused with longer labels or context data in the future.

## Test Plan

- [x] Tests pass with sanitizers: `test_quic_initial` (all 19 tests passing)
- [x] RFC 9001 Appendix A test vectors still validate correctly
- [x] No regressions in key derivation
- [x] Bounds checking properly rejects oversized inputs via cleanup path

## RFC Reference

- RFC 8446 Section 7.1 (TLS 1.3 HKDF-Expand-Label)
- RFC 9001 Section 5.1 (QUIC-TLS Key Derivation)

Closes #767