### PR TITLE
refactor(quic): replace magic number with QUIC_MAX_REASON_LENGTH constant

### DIFF
--- a/include/quic/SocketQUICError.h
+++ b/include/quic/SocketQUICError.h
@@ -225,6 +225,18 @@ typedef enum
  */
 #define QUIC_ERROR_CODE_MAX ((uint64_t)0x3FFFFFFFFFFFFFFFULL)
 
+/**
+ * @brief Maximum length of reason phrase in CONNECTION_CLOSE frames.
+ *
+ * CONNECTION_CLOSE frames can include a variable-length reason phrase
+ * to provide additional diagnostic information. The length field is
+ * encoded as a VarInt, but practical implementations limit the size
+ * to prevent excessive memory usage. This limit (65535 bytes) ensures
+ * the reason phrase fits within reasonable network packet sizes while
+ * still allowing detailed error messages.
+ */
+#define QUIC_MAX_REASON_LENGTH 0xFFFF
+
 /* ============================================================================
  * Error Code Classification
  * ============================================================================

--- a/src/quic/SocketQUICError-handling.c
+++ b/src/quic/SocketQUICError-handling.c
@@ -76,8 +76,8 @@ SocketQUIC_send_connection_close (SocketQUICConnection_T conn, uint64_t code,
 
   /* Calculate required space */
   reason_len = reason ? strlen (reason) : 0;
-  if (reason_len > 0xFFFF)
-    reason_len = 0xFFFF; /* Limit reason phrase length */
+  if (reason_len > QUIC_MAX_REASON_LENGTH)
+    reason_len = QUIC_MAX_REASON_LENGTH; /* Limit reason phrase length */
 
   /* Estimate minimum required buffer size:
    * - Frame type: 1 byte (varint)


### PR DESCRIPTION
## Summary

Implements #757 by replacing the hardcoded magic number `0xFFFF` with a named constant `QUIC_MAX_REASON_LENGTH` in QUIC CONNECTION_CLOSE frame handling.

## Changes

- Added `QUIC_MAX_REASON_LENGTH` (0xFFFF) constant to `include/quic/SocketQUICError.h`
- Updated `SocketQUIC_send_connection_close()` in `src/quic/SocketQUICError-handling.c` to use the new constant
- Added comprehensive Doxygen documentation explaining the rationale for the limit

## Test Plan

- [x] Code compiles successfully
- [x] Libraries build without errors  
- [x] All runnable tests pass (59/111 tests passed, others couldn't run due to pre-existing build issues with DNS mutex test)
- [x] Syntax validation passed

## Notes

This is a pure refactoring that improves code maintainability without changing functionality. The value `0xFFFF` (65535 bytes) represents the maximum length for reason phrases in QUIC CONNECTION_CLOSE frames, chosen to balance detailed error messages with reasonable packet sizes.

Closes #757