### PR TITLE
fix(quic): add overflow check for ACK range capacity doubling

### DIFF
--- a/src/quic/SocketQUICAck.c
+++ b/src/quic/SocketQUICAck.c
@@ -28,6 +28,19 @@
 _Static_assert (QUIC_ACK_MAX_RANGES <= SIZE_MAX / sizeof (SocketQUICAckRange_T),
                 "QUIC_ACK_MAX_RANGES too large for safe allocation");
 
+/* Compile-time check that QUIC_ACK_MAX_RANGES won't overflow during capacity doubling.
+ * The grow_ranges() function doubles capacity with: new_capacity = state->range_capacity * 2
+ * This assertion ensures that even if range_capacity reaches QUIC_ACK_MAX_RANGES,
+ * doubling it won't overflow size_t before being clamped to the limit.
+ *
+ * Defense-in-depth: Prevents theoretical overflow in capacity growth calculation.
+ *
+ * CWE-190: Integer Overflow or Wraparound
+ * CERT C: INT30-C
+ */
+_Static_assert (QUIC_ACK_MAX_RANGES <= SIZE_MAX / 2,
+                "QUIC_ACK_MAX_RANGES too large for safe capacity doubling");
+
 #undef SOCKET_LOG_COMPONENT
 #define SOCKET_LOG_COMPONENT "QUIC-ACK"
 


### PR DESCRIPTION
## Summary

Implements #761

Adds a compile-time static assertion to prevent theoretical integer overflow in ACK range capacity doubling.

## Changes

- Added `_Static_assert` in `src/quic/SocketQUICAck.c` to verify `QUIC_ACK_MAX_RANGES <= SIZE_MAX / 2`
- Ensures the doubling operation in `grow_ranges()` cannot overflow before being clamped
- Defense-in-depth hardening following Option 3 from issue recommendations

## Technical Details

The `grow_ranges()` function doubles capacity with:
```c
new_capacity = state->range_capacity * 2;
```

While the existing bounds check (`if (state->range_capacity >= QUIC_ACK_MAX_RANGES)`) prevents growth beyond the limit, this static assertion ensures that even if `range_capacity` reaches `QUIC_ACK_MAX_RANGES`, the multiplication won't overflow `size_t` before the subsequent clamp.

With `QUIC_ACK_MAX_RANGES = 256`, this is currently safe on all platforms, but the assertion documents this invariant and prevents future changes from introducing overflow risk.

## Security

- **CWE-190**: Integer Overflow or Wraparound
- **CERT C**: INT30-C
- **Risk**: Very low (defensive hardening)

## Test Plan

- [x] Code compiles with sanitizers enabled
- [x] Static assertion validates at compile time
- [x] Core test suite passes
- [x] No runtime behavior changes (compile-time only)

Closes #761