### PR TITLE
refactor(quic): improve enum boundary check robustness in result_string function

### DIFF
--- a/src/quic/SocketQUICVarInt.c
+++ b/src/quic/SocketQUICVarInt.c
@@ -60,11 +60,20 @@ static const char *result_strings[] = {
   [QUIC_VARINT_ERROR_NULL] = "NULL pointer argument",
 };
 
+/* Compile-time check: ensure array size matches enum count */
+_Static_assert (sizeof (result_strings) / sizeof (result_strings[0])
+                    == QUIC_VARINT_ERROR_NULL + 1,
+                "result_strings array size must match enum count");
+
 const char *
 SocketQUICVarInt_result_string (SocketQUICVarInt_Result result)
 {
-  if (result < 0 || result > QUIC_VARINT_ERROR_NULL)
+  const size_t num_results
+      = sizeof (result_strings) / sizeof (result_strings[0]);
+
+  if (result < 0 || (size_t)result >= num_results)
     return "Unknown error";
+
   return result_strings[result];
 }
 


### PR DESCRIPTION
## Summary

Implements #762

Replaces fragile enum-based boundary check in `SocketQUICVarInt_result_string()` with robust array-size based validation.

## Changes

- Added `_Static_assert` to verify array size matches enum count at compile time
- Replaced enum-based boundary check (`result > QUIC_VARINT_ERROR_NULL`) with array size calculation
- Changed comparison to use `>=` instead of `>` for correctness with `size_t`

## Benefits

- Automatically adapts if enum values are added/removed
- Catches array/enum mismatch at compile time  
- More maintainable and self-documenting
- Prevents potential out-of-bounds array access

## Test Plan

- [x] Library builds successfully with sanitizers
- [x] Manual test of function with all enum values passes
- [x] Out-of-bounds values correctly return "Unknown error"
- [x] Compile-time assertion ensures array/enum consistency

## Verification

```bash
# Build with sanitizers
cmake -B build -DENABLE_SANITIZERS=ON
cmake --build build -j$(nproc)

# Test program verified all enum values work correctly
# and out-of-bounds values return "Unknown error"
```

Closes #762