### PR TITLE
refactor(quic): replace magic buffer size 64 with QUIC_SOCKADDR_STRING_MAX constant

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -222,6 +222,25 @@
 #define QUIC_STATELESS_RESET_MIN_SIZE 38
 
 /* ============================================================================
+ * String Formatting Constants
+ * ============================================================================
+ */
+
+/**
+ * @brief Maximum length for formatted socket address string.
+ *
+ * Format: "[IPv6]:port"
+ * - IPv6 address: up to INET6_ADDRSTRLEN (46 bytes including null)
+ * - Brackets for IPv6: 2 characters '[' ']'
+ * - Port separator: 1 character ':'
+ * - Port number: up to 5 characters (65535)
+ * - Null terminator: 1 character
+ *
+ * Total: 46 + 2 + 1 + 5 + 1 = 55 bytes minimum, rounded to 64 for alignment.
+ */
+#define QUIC_SOCKADDR_STRING_MAX 64
+
+/* ============================================================================
  * Utility Macros
  * ============================================================================
  */

--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -570,9 +570,9 @@ int
 SocketQUICMigration_path_to_string (const SocketQUICPath_T *path, char *buf,
                                     size_t size)
 {
-  char local_str[64];
-  char peer_str[64];
-  char cid_str[64];
+  char local_str[QUIC_SOCKADDR_STRING_MAX];
+  char peer_str[QUIC_SOCKADDR_STRING_MAX];
+  char cid_str[QUIC_SOCKADDR_STRING_MAX];
   int written;
 
   if (path == NULL || buf == NULL || size == 0)


### PR DESCRIPTION
## Summary

Implements #784 

Replace hardcoded buffer size 64 in `SocketQUICMigration.c` with named constant `QUIC_SOCKADDR_STRING_MAX` to improve code clarity and maintainability.

## Changes

- Add `QUIC_SOCKADDR_STRING_MAX` constant to `include/quic/SocketQUICConstants.h`
- Document buffer size calculation in detail:
  - IPv6 address: INET6_ADDRSTRLEN (46 bytes including null)
  - Brackets for IPv6: 2 characters `[` `]`
  - Port separator: 1 character `:`
  - Port number: up to 5 characters (65535)
  - Null terminator: 1 character
  - Total: 55 bytes minimum, rounded to 64 for alignment
- Replace magic number 64 with constant in `SocketQUICMigration_path_to_string()`

## Test Plan

- [x] Tests pass: `test_quic_migration` runs successfully with sanitizers
- [x] Build verification: Socket objects compile without warnings
- [x] No functional changes: This is a pure refactoring with same buffer size

## Benefits

- Makes buffer sizing rationale explicit and documented
- Ensures consistency if address formatting changes in the future
- Follows project pattern of eliminating magic numbers
- Single source of truth for socket address string buffer size

Closes #784