### PR TITLE
refactor(quic): replace magic number 16 with QUIC_HP_SAMPLE_LEN constant

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -440,7 +440,7 @@ apply_header_protection (uint8_t *packet, size_t header_len,
                          const uint8_t *sample, const uint8_t *hp_key)
 {
   EVP_CIPHER_CTX *ctx = NULL;
-  uint8_t mask[16];
+  uint8_t mask[QUIC_HP_SAMPLE_LEN];
   int outlen;
   uint8_t pn_length;
   int result = -1;
@@ -455,7 +455,7 @@ apply_header_protection (uint8_t *packet, size_t header_len,
 
   EVP_CIPHER_CTX_set_padding (ctx, 0);
 
-  if (EVP_EncryptUpdate (ctx, mask, &outlen, sample, 16) <= 0)
+  if (EVP_EncryptUpdate (ctx, mask, &outlen, sample, QUIC_HP_SAMPLE_LEN) <= 0)
     goto cleanup;
 
   /* Apply mask to first byte */
@@ -634,7 +634,7 @@ SocketQUICInitial_unprotect (uint8_t *packet, size_t packet_len,
   size_t header_len;
   uint32_t pn;
   const uint8_t *sample;
-  uint8_t mask[16];
+  uint8_t mask[QUIC_HP_SAMPLE_LEN];
   int outlen;
   int result_code = QUIC_INITIAL_ERROR_CRYPTO;
 
@@ -677,7 +677,7 @@ SocketQUICInitial_unprotect (uint8_t *packet, size_t packet_len,
 
   EVP_CIPHER_CTX_set_padding (ctx, 0);
 
-  if (EVP_EncryptUpdate (ctx, mask, &outlen, sample, 16) <= 0)
+  if (EVP_EncryptUpdate (ctx, mask, &outlen, sample, QUIC_HP_SAMPLE_LEN) <= 0)
     goto cleanup;
 
   EVP_CIPHER_CTX_free (ctx);


### PR DESCRIPTION
## Summary

Implements #776 - Replace hardcoded AES block size (16 bytes) with the named constant `QUIC_HP_SAMPLE_LEN` in QUIC header protection implementation.

## Changes

- **src/quic/SocketQUICPacket-initial.c**:
  - Line 443: `uint8_t mask[QUIC_HP_SAMPLE_LEN]` in `apply_header_protection`
  - Line 458: `EVP_EncryptUpdate(..., QUIC_HP_SAMPLE_LEN)` in `apply_header_protection`
  - Line 637: `uint8_t mask[QUIC_HP_SAMPLE_LEN]` in `SocketQUICInitial_unprotect`
  - Line 680: `EVP_EncryptUpdate(..., QUIC_HP_SAMPLE_LEN)` in `SocketQUICInitial_unprotect`

## Impact

- **Code Quality**: Eliminates magic numbers for improved readability
- **Maintainability**: Using named constant makes code intent clearer
- **RFC Compliance**: References RFC 9001 Section 5.4.3 (AES-Based Header Protection)
- **Functional**: No behavior change - pure refactoring

## Technical Details

The constant `QUIC_HP_SAMPLE_LEN` is already defined in `include/quic/SocketQUICPacket.h` (line 563) with value 16, representing the header protection sample length per RFC 9001 Section 5.4.3.

This follows the same pattern as recent PRs:
- #840 - Replaced QUIC ACK delay exponent magic number
- #848 - Replaced DNS config address length magic number

## Test Plan

- [x] Library builds successfully with sanitizers
- [x] No functional changes - pure constant replacement
- [x] Verified constant is already defined in header
- [x] Similar to previously merged refactoring PRs

Closes #776