### PR TITLE
refactor(quic): add derivation comments to varint max value constants

### DIFF
--- a/src/quic/SocketQUICVarInt.c
+++ b/src/quic/SocketQUICVarInt.c
@@ -34,10 +34,10 @@
 #define VARINT_VALUE_MASK_8BYTE 0x3F /* 62 bits total */
 
 /* Maximum values per encoding length */
-#define VARINT_MAX_1BYTE 63ULL
-#define VARINT_MAX_2BYTE 16383ULL
-#define VARINT_MAX_4BYTE 1073741823ULL
-#define VARINT_MAX_8BYTE SOCKETQUICVARINT_MAX
+#define VARINT_MAX_1BYTE 63ULL              /* (1ULL << 6) - 1 = 63 */
+#define VARINT_MAX_2BYTE 16383ULL           /* (1ULL << 14) - 1 = 16383 */
+#define VARINT_MAX_4BYTE 1073741823ULL      /* (1ULL << 30) - 1 = 1073741823 */
+#define VARINT_MAX_8BYTE SOCKETQUICVARINT_MAX /* (1ULL << 62) - 1 = 4611686018427387903 */
 
 /* ============================================================================
  * Exception Definition


### PR DESCRIPTION
## Summary

Implements #770

Adds inline comments to QUIC varint maximum value constants showing their mathematical derivation from bit counts, improving code maintainability and making verification easier.

## Changes

- Added derivation comments to `VARINT_MAX_1BYTE` (2^6 - 1 = 63)
- Added derivation comments to `VARINT_MAX_2BYTE` (2^14 - 1 = 16383)  
- Added derivation comments to `VARINT_MAX_4BYTE` (2^30 - 1 = 1073741823)
- Added derivation comments to `VARINT_MAX_8BYTE` (2^62 - 1 = 4611686018427387903)

## Benefits

1. Self-documenting code - derivation is immediately clear
2. Easier to verify correctness against RFC 9000 Section 16
3. Helps future maintainers understand the relationship between encoding length and max value
4. Reduces risk of copy-paste errors if similar code is written elsewhere

## Test Plan

- [x] All 39 QUIC varint tests pass
- [x] Tests pass without sanitizers
- [x] No behavioral changes - documentation only

## References

- RFC 9000 Section 16: Variable-Length Integer Encoding
- Header documentation: `include/quic/SocketQUICVarInt.h` lines 11-16

Closes #770