### PR TITLE
fix(quic): prevent size_t to int truncation in frame decode functions

### DIFF
--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -9,6 +9,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <sys/types.h>
 
 #include "core/Arena.h"
 #include "core/Except.h"
@@ -208,8 +209,8 @@ extern int SocketQUICFrame_decode_path_response(const uint8_t *in, size_t len, u
 extern size_t SocketQUICFrame_encode_stream(uint64_t stream_id, uint64_t offset,
                                              const uint8_t *data, size_t len,
                                              int fin, uint8_t *out, size_t out_len);
-extern int SocketQUICFrame_decode_stream(const uint8_t *data, size_t len,
-                                          SocketQUICFrameStream_T *frame);
+extern ssize_t SocketQUICFrame_decode_stream(const uint8_t *data, size_t len,
+                                              SocketQUICFrameStream_T *frame);
 
 /* Stream termination frame encoding (RFC 9000 §19.4-19.5) */
 extern size_t SocketQUICFrame_encode_reset_stream(uint64_t stream_id, uint64_t error_code, uint64_t final_size, uint8_t *out, size_t out_size);
@@ -227,7 +228,7 @@ extern int SocketQUICFrame_decode_new_token(const uint8_t *data, size_t len,
 /* CRYPTO frame encoding/decoding (RFC 9000 §19.6) */
 extern size_t SocketQUICFrame_encode_crypto(uint64_t offset, const uint8_t *data,
                                              size_t len, uint8_t *out, size_t out_len);
-extern int SocketQUICFrame_decode_crypto(const uint8_t *data, size_t len,
-                                          SocketQUICFrameCrypto_T *frame);
+extern ssize_t SocketQUICFrame_decode_crypto(const uint8_t *data, size_t len,
+                                              SocketQUICFrameCrypto_T *frame);
 
 #endif /* SOCKETQUICFRAME_INCLUDED */

--- a/src/quic/SocketQUICFrame-crypto.c
+++ b/src/quic/SocketQUICFrame-crypto.c
@@ -23,6 +23,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 /* ============================================================================
  * CRYPTO Frame Encoding (RFC 9000 Section 19.6)
@@ -122,7 +123,7 @@ SocketQUICFrame_encode_crypto (uint64_t offset, const uint8_t *data,
  * @return Number of bytes consumed on success, or -1 on error
  */
 
-int
+ssize_t
 SocketQUICFrame_decode_crypto (const uint8_t *data, size_t len,
                                 SocketQUICFrameCrypto_T *frame)
 {
@@ -146,5 +147,5 @@ SocketQUICFrame_decode_crypto (const uint8_t *data, size_t len,
   /* Copy crypto-specific data */
   *frame = full_frame.data.crypto;
 
-  return (int)consumed;
+  return (ssize_t)consumed;
 }

--- a/src/quic/SocketQUICFrame-stream.c
+++ b/src/quic/SocketQUICFrame-stream.c
@@ -21,6 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
+#include <sys/types.h>
 
 /* ============================================================================
  * RESET_STREAM Frame Encoding (RFC 9000 Section 19.4)
@@ -268,7 +269,7 @@ SocketQUICFrame_encode_stream (uint64_t stream_id, uint64_t offset,
  * @return Number of bytes consumed on success, or -1 on error
  */
 
-int
+ssize_t
 SocketQUICFrame_decode_stream (const uint8_t *data, size_t len,
                                SocketQUICFrameStream_T *frame)
 {
@@ -292,5 +293,5 @@ SocketQUICFrame_decode_stream (const uint8_t *data, size_t len,
   /* Copy stream-specific data */
   *frame = full_frame.data.stream;
 
-  return (int)consumed;
+  return (ssize_t)consumed;
 }

--- a/src/test/test_quic_crypto_frame_encode.c
+++ b/src/test/test_quic_crypto_frame_encode.c
@@ -34,7 +34,7 @@ TEST (frame_crypto_encode_basic)
 
   /* Verify by parsing back */
   SocketQUICFrameCrypto_T frame;
-  int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (0, frame.offset);
@@ -56,7 +56,7 @@ TEST (frame_crypto_encode_with_offset)
 
   /* Verify by parsing */
   SocketQUICFrameCrypto_T frame;
-  int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (256, frame.offset);
@@ -80,7 +80,7 @@ TEST (frame_crypto_encode_large_offset)
 
   /* Verify by parsing */
   SocketQUICFrameCrypto_T frame;
-  int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (large_offset, frame.offset);
@@ -101,7 +101,7 @@ TEST (frame_crypto_encode_zero_length)
 
   /* Verify by parsing */
   SocketQUICFrameCrypto_T frame;
-  int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (0, frame.offset);
@@ -127,7 +127,7 @@ TEST (frame_crypto_encode_large_data)
 
   /* Verify by parsing */
   SocketQUICFrameCrypto_T frame;
-  int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (100, frame.offset);
@@ -172,7 +172,7 @@ TEST (frame_crypto_encode_roundtrip_multiple)
   const uint8_t data2[] = "Second fragment";
   const uint8_t data3[] = "Third fragment";
   size_t len1, len2, len3;
-  int consumed1, consumed2, consumed3;
+  ssize_t consumed1, consumed2, consumed3;
   SocketQUICFrameCrypto_T frame;
 
   /* Encode and verify first fragment */
@@ -283,7 +283,7 @@ TEST (frame_crypto_offset_encoding)
       ASSERT (len > 0);
 
       SocketQUICFrameCrypto_T frame;
-      int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+      ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
 
       ASSERT (consumed > 0);
       ASSERT_EQ (offsets[i], frame.offset);
@@ -300,7 +300,7 @@ TEST (frame_crypto_no_data_pointer_copy)
   ASSERT (len > 0);
 
   SocketQUICFrameCrypto_T frame;
-  int consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_crypto (buf, len, &frame);
   ASSERT (consumed > 0);
 
   /* Verify that frame.data points into buf, not a separate allocation */

--- a/src/test/test_quic_stream_frame_encode.c
+++ b/src/test/test_quic_stream_frame_encode.c
@@ -39,7 +39,7 @@ TEST (frame_stream_encode_basic)
   ASSERT_EQ (0x0a, buf[0]);
 
   SocketQUICFrameStream_T frame;
-  int consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (0, frame.stream_id);
@@ -63,7 +63,7 @@ TEST (frame_stream_encode_with_offset)
 
   /* Verify by parsing */
   SocketQUICFrameStream_T frame;
-  int consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (4, frame.stream_id);
@@ -87,7 +87,7 @@ TEST (frame_stream_encode_with_fin)
 
   /* Verify by parsing */
   SocketQUICFrameStream_T frame;
-  int consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (8, frame.stream_id);
@@ -111,7 +111,7 @@ TEST (frame_stream_encode_all_flags)
 
   /* Verify by parsing */
   SocketQUICFrameStream_T frame;
-  int consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (12, frame.stream_id);
@@ -134,7 +134,7 @@ TEST (frame_stream_encode_zero_length_with_fin)
 
   /* Verify by parsing */
   SocketQUICFrameStream_T frame;
-  int consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
+  ssize_t consumed = SocketQUICFrame_decode_stream (buf, len, &frame);
 
   ASSERT (consumed > 0);
   ASSERT_EQ (16, frame.stream_id);


### PR DESCRIPTION
Implements #774