### PR TITLE
feat(quic): add observability for DoS protection in hash table lookups

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -91,6 +91,7 @@ extern SocketQUICConnection_Result SocketQUICConnTable_remove(SocketQUICConnTabl
 extern size_t SocketQUICConnTable_count(SocketQUICConnTable_T table);
 extern SocketQUICConnection_Result SocketQUICConnTable_add_cid(SocketQUICConnTable_T table, SocketQUICConnection_T conn, const SocketQUICConnectionID_T *new_cid);
 extern SocketQUICConnection_Result SocketQUICConnTable_retire_cid(SocketQUICConnTable_T table, SocketQUICConnection_T conn, uint64_t sequence);
+extern void SocketQUICConnTable_get_stats(SocketQUICConnTable_T table, uint64_t *chain_limit_hits_cid, uint64_t *chain_limit_hits_addr, uint64_t *max_chain_len_seen, size_t *conn_count);
 
 extern SocketQUICConnection_T SocketQUICConnection_new(Arena_T arena, SocketQUICConnection_Role role);
 extern void SocketQUICConnection_init(SocketQUICConnection_T conn, SocketQUICConnection_Role role);


### PR DESCRIPTION
## Summary

Implements #799

Adds statistics tracking to monitor DoS protection events in QUIC connection table hash chain lookups.

## Changes

- Add stats fields to SocketQUICConnTable struct
- Update lookup functions to increment stats on chain limit hit  
- Add SocketQUICConnTable_get_stats() accessor
- Add comprehensive tests

## Test Plan

- All QUIC connection tests pass with sanitizers
- New tests verify stats tracking and chain limit detection

Closes #799