### PR TITLE
fix(quic): add inet_ntop() error handling in SocketQUICMigration

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -709,13 +709,21 @@ sockaddr_to_string (const struct sockaddr_storage *addr, char *buf,
   if (addr->ss_family == AF_INET)
     {
       addr4 = (const struct sockaddr_in *)addr;
-      inet_ntop (AF_INET, &addr4->sin_addr, ip, sizeof (ip));
+      if (inet_ntop (AF_INET, &addr4->sin_addr, ip, sizeof (ip)) == NULL)
+        {
+          snprintf (buf, size, "invalid:0");
+          return;
+        }
       snprintf (buf, size, "%s:%u", ip, ntohs (addr4->sin_port));
     }
   else if (addr->ss_family == AF_INET6)
     {
       addr6 = (const struct sockaddr_in6 *)addr;
-      inet_ntop (AF_INET6, &addr6->sin6_addr, ip, sizeof (ip));
+      if (inet_ntop (AF_INET6, &addr6->sin6_addr, ip, sizeof (ip)) == NULL)
+        {
+          snprintf (buf, size, "[invalid]:0");
+          return;
+        }
       snprintf (buf, size, "[%s]:%u", ip, ntohs (addr6->sin6_port));
     }
   else


### PR DESCRIPTION
## Summary

Implements #792

Adds proper error handling for `inet_ntop()` calls in `sockaddr_to_string()` function to prevent undefined behavior when address conversion fails.

## Changes

- Added NULL return value checks for `inet_ntop()` in IPv4 case (line 712)
- Added NULL return value checks for `inet_ntop()` in IPv6 case (line 718)  
- Return safe fallback strings: `"invalid:0"` for IPv4, `"[invalid]:0"` for IPv6
- Early return on conversion failure to avoid using uninitialized buffer

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] All passing tests continue to pass with ASan/UBSan
- [x] Function now safely handles corrupted sockaddr_storage structures
- [x] Debug/logging output will show "invalid" instead of garbage data on error

## Technical Details

The `inet_ntop()` function returns NULL when:
- Address family doesn't match the actual address type
- Address structure is corrupted
- Platform-specific implementation issues occur

Without this check, the uninitialized `ip` buffer would be passed to `snprintf()`, causing undefined behavior and potentially leaking stack data into log messages.

Closes #792