### PR TITLE
refactor(quic): extract frame buffer size estimates to named constants

### DIFF
--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -17,6 +17,13 @@
 #define QUIC_FRAME_ACK_MAX_RANGES 256
 #define QUIC_FRAME_HEADER_MAX_SIZE 32
 
+/* Conservative buffer size estimates for QUIC frame encoding.
+ * These assume maximum varint encoding (8 bytes) for all variable-length fields.
+ * Used for pre-flight buffer size checks in frame encoding functions.
+ */
+#define QUIC_FRAME_MIN_SIZE_RESET_STREAM (1 + 8 + 8 + 8)  /* frame_type + stream_id + error_code + final_size */
+#define QUIC_FRAME_MIN_SIZE_STOP_SENDING (1 + 8 + 8)      /* frame_type + stream_id + error_code */
+
 typedef enum {
   QUIC_FRAME_PADDING = 0x00, QUIC_FRAME_PING = 0x01,
   QUIC_FRAME_ACK = 0x02, QUIC_FRAME_ACK_ECN = 0x03,

--- a/src/quic/SocketQUICError-handling.c
+++ b/src/quic/SocketQUICError-handling.c
@@ -157,7 +157,7 @@ SocketQUIC_send_stream_reset (SocketQUICStream_T stream, uint64_t code,
    * - Application error code: varint
    * - Final size: varint
    */
-  size_t min_size = 1 + 8 + 8 + 8; /* Conservative estimate */
+  size_t min_size = QUIC_FRAME_MIN_SIZE_RESET_STREAM;
   if (out_len < min_size)
     return 0;
 
@@ -211,7 +211,7 @@ SocketQUIC_send_stop_sending (SocketQUICStream_T stream, uint64_t code,
    * - Stream ID: varint
    * - Application error code: varint
    */
-  size_t min_size = 1 + 8 + 8; /* Conservative estimate */
+  size_t min_size = QUIC_FRAME_MIN_SIZE_STOP_SENDING;
   if (out_len < min_size)
     return 0;
 


### PR DESCRIPTION
## Summary

Implements #779

Replaces magic numbers with named constants for better code clarity and maintainability.

## Changes

- Added `QUIC_FRAME_MIN_SIZE_RESET_STREAM` constant (1+8+8+8 bytes)
- Added `QUIC_FRAME_MIN_SIZE_STOP_SENDING` constant (1+8+8 bytes)
- Updated `SocketQUIC_send_stream_reset()` to use the new constant
- Updated `SocketQUIC_send_stop_sending()` to use the new constant

These constants assume maximum varint encoding (8 bytes) for all variable-length fields and are used for pre-flight buffer size checks in frame encoding functions.

## Test Plan

- [x] All QUIC tests pass with sanitizers
- [x] No functional changes, only code clarity improvements
- [x] Constants match the existing calculation logic exactly

Closes #779