### PR TITLE
refactor(quic): add defensive default cases to switch statements in SocketQUICWire

### DIFF
--- a/src/quic/SocketQUICWire.c
+++ b/src/quic/SocketQUICWire.c
@@ -11,6 +11,8 @@
  * Based on the pseudocode in RFC 9000 Appendix A.2 and A.3.
  */
 
+#include <assert.h>
+
 #include "quic/SocketQUICWire.h"
 #include "quic/SocketQUICConstants.h"
 
@@ -242,6 +244,11 @@ SocketQUICWire_pn_read (const uint8_t *data, size_t len, unsigned pn_len,
       *value = ((uint64_t)data[0] << 24) | ((uint64_t)data[1] << 16)
                | ((uint64_t)data[2] << 8) | (uint64_t)data[3];
       break;
+
+    default:
+      /* Should never reach here due to validation above */
+      assert (0 && "Invalid pn_len passed validation");
+      return QUIC_PN_ERROR_BITS;
     }
 
   return QUIC_PN_OK;
@@ -284,6 +291,11 @@ SocketQUICWire_pn_write (uint64_t value, unsigned pn_len, uint8_t *output,
       output[2] = (uint8_t)((value >> 8) & 0xFF);
       output[3] = (uint8_t)(value & 0xFF);
       break;
+
+    default:
+      /* Should never reach here due to validation above */
+      assert (0 && "Invalid pn_len passed validation");
+      return 0;
     }
 
   return pn_len;


### PR DESCRIPTION
## Summary

Implements #752 by adding defensive default cases to switch statements in `SocketQUICWire_pn_read()` and `SocketQUICWire_pn_write()`.

## Changes

- Added `#include <assert.h>` to `src/quic/SocketQUICWire.c`
- Added default case to `pn_read()` switch statement with assert and error return
- Added default case to `pn_write()` switch statement with assert and error return

## Rationale

While both functions validate that `pn_len` is in the range [1, 4] before the switch statements, adding default cases provides:

- Runtime detection of logic errors if validation is accidentally bypassed
- Improved compiler warnings for incomplete switch coverage
- Defensive programming best practice
- Consistency with other QUIC modules (e.g., `SocketQUICVarInt.c`)

## Test Plan

- [x] Code compiles cleanly with `-Wall -Wextra -Werror`
- [x] All 58 tests in `test_quic_wire` pass with AddressSanitizer and UBSanitizer
- [x] No new compiler warnings introduced
- [x] Pattern follows existing project conventions (see `SocketQUICVarInt.c`)

## Notes

Build failures in `test_dns_mutex_macros` and `test_quic_frame` are pre-existing issues unrelated to this change and also fail on main branch.

Closes #752