### PR TITLE
refactor(quic): replace magic number with QUIC_PMTU_PROBE_INCREMENT constant

### DIFF
--- a/include/quic/SocketQUICPMTU.h
+++ b/include/quic/SocketQUICPMTU.h
@@ -91,6 +91,15 @@
  */
 #define QUIC_MAX_PMTU_PROBES_IN_FLIGHT 3
 
+/**
+ * @brief PMTU probe increment in bytes.
+ *
+ * RFC 8899 Section 5.3: Probe size should increase incrementally.
+ * 100 bytes provides reasonable granularity for path MTU discovery
+ * between the minimum (1200) and typical maximum (1500) PMTU values.
+ */
+#define QUIC_PMTU_PROBE_INCREMENT 100
+
 /* ============================================================================
  * DPLPMTUD States (RFC 8899 Section 5.2)
  * ============================================================================

--- a/src/quic/SocketQUICPMTU.c
+++ b/src/quic/SocketQUICPMTU.c
@@ -147,8 +147,8 @@ SocketQUICPMTU_start_discovery (SocketQUICPMTU_T pmtu)
   /* Transition to SEARCHING */
   pmtu->state = QUIC_PMTU_STATE_SEARCHING;
 
-  /* Start with current PMTU + 100 bytes as initial probe target */
-  pmtu->target_pmtu = pmtu->current_pmtu + 100;
+  /* Start with current PMTU + increment as initial probe target */
+  pmtu->target_pmtu = pmtu->current_pmtu + QUIC_PMTU_PROBE_INCREMENT;
   if (pmtu->target_pmtu > pmtu->max_pmtu)
     pmtu->target_pmtu = pmtu->max_pmtu;
 
@@ -261,7 +261,7 @@ SocketQUICPMTU_probe_acked (SocketQUICPMTU_T pmtu, uint64_t packet_number)
   /* Prepare next probe (binary search approach) */
   if (pmtu->state == QUIC_PMTU_STATE_SEARCHING)
     {
-      size_t next_target = pmtu->current_pmtu + 100;
+      size_t next_target = pmtu->current_pmtu + QUIC_PMTU_PROBE_INCREMENT;
       if (next_target > pmtu->max_pmtu)
         next_target = pmtu->max_pmtu;
 

--- a/src/test/test_dns_mutex_macros.c
+++ b/src/test/test_dns_mutex_macros.c
@@ -27,6 +27,9 @@
 /* Test exception type */
 static const Except_T TestException = { &TestException, "Test exception" };
 
+/* Thread-local exception storage required by SOCKET_RAISE_FMT macro */
+static __thread Except_T SocketDNS_DetailedException;
+
 /* Helper to create a minimal DNS resolver structure for testing */
 static struct SocketDNS_T *
 create_test_dns_resolver (Arena_T arena)


### PR DESCRIPTION
## Summary

Implements #786 - Replaces hardcoded magic number `100` with named constant `QUIC_PMTU_PROBE_INCREMENT` in PMTU discovery code.

## Changes

- **Header**: Add `QUIC_PMTU_PROBE_INCREMENT` constant (100 bytes) with RFC 8899 reference
- **src/quic/SocketQUICPMTU.c:151**: Replace `100` with constant in `SocketQUICPMTU_start_discovery()`
- **src/quic/SocketQUICPMTU.c:264**: Replace `100` with constant in `SocketQUICPMTU_probe_acked()`
- **Fix**: Add missing `SocketDNS_DetailedException` declaration in test_dns_mutex_macros.c

## Benefits

- Single source of truth for probe increment value
- Easier to tune PMTU discovery behavior
- More self-documenting code  
- Consistent with existing constant definitions (e.g., `QUIC_PMTU_PROBE_TIMEOUT_MS`, `QUIC_MAX_PMTU_PROBES_IN_FLIGHT`)

## Test Plan

- [x] All QUIC PMTU tests pass (19/19) with AddressSanitizer + UBSanitizer
- [x] Library builds successfully with sanitizers enabled
- [x] Fixed test_dns_mutex_macros compilation issue (pre-existing bug)
- [x] test_dns_mutex_macros tests pass (6/6)

Closes #786