### PR TITLE
refactor(quic): replace magic number with QUIC_STATELESS_RESET_TOKEN_LEN constant

### DIFF
--- a/src/quic/SocketQUICFrame-connid.c
+++ b/src/quic/SocketQUICFrame-connid.c
@@ -27,6 +27,7 @@
 
 #include "quic/SocketQUICFrame.h"
 #include "quic/SocketQUICVarInt.h"
+#include "quic/SocketQUICConstants.h"
 
 #include <string.h>
 
@@ -85,7 +86,7 @@ SocketQUICFrame_encode_new_connection_id (uint64_t sequence,
   size_t type_len = SocketQUICVarInt_size (QUIC_FRAME_NEW_CONNECTION_ID);
   size_t seq_len = SocketQUICVarInt_size (sequence);
   size_t retire_len = SocketQUICVarInt_size (retire_prior_to);
-  size_t total_len = type_len + seq_len + retire_len + 1 + cid_length + 16;
+  size_t total_len = type_len + seq_len + retire_len + 1 + cid_length + QUIC_STATELESS_RESET_TOKEN_LEN;
 
   if (out_size < total_len)
     return 0;
@@ -110,8 +111,8 @@ SocketQUICFrame_encode_new_connection_id (uint64_t sequence,
   pos += cid_length;
 
   /* Encode stateless reset token (16 bytes) */
-  memcpy (out + pos, reset_token, 16);
-  pos += 16;
+  memcpy (out + pos, reset_token, QUIC_STATELESS_RESET_TOKEN_LEN);
+  pos += QUIC_STATELESS_RESET_TOKEN_LEN;
 
   return pos;
 }

--- a/src/test/test_dns_mutex_macros.c
+++ b/src/test/test_dns_mutex_macros.c
@@ -15,8 +15,12 @@
 
 #include "core/Arena.h"
 #include "core/Except.h"
+#include "core/SocketUtil.h"
 #include "dns/SocketDNS-private.h"
 #include "test/Test.h"
+
+/* Declare thread-local exception storage for SocketDNS module */
+SOCKET_DECLARE_MODULE_EXCEPTION (SocketDNS);
 
 /* Suppress longjmp clobbering warnings for test variables used with TRY/EXCEPT
  */

--- a/src/test/test_quic_frame.c
+++ b/src/test/test_quic_frame.c
@@ -1408,7 +1408,7 @@ TEST (frame_new_token_overflow_32bit)
 #endif
 }
 
-TEST (frame_stream_overflow_32bit)
+TEST (frame_stream_with_offset_overflow_32bit)
 {
   /* Test STREAM frame with length > SIZE_MAX on 32-bit */
   uint8_t buf[512];


### PR DESCRIPTION
## Summary

Implements #763 by replacing hardcoded magic number `16` with the existing constant `QUIC_STATELESS_RESET_TOKEN_LEN` in `SocketQUICFrame-connid.c`.

## Changes

### Primary (Issue #763)
- **src/quic/SocketQUICFrame-connid.c**:
  - Added include for `quic/SocketQUICConstants.h`
  - Replaced magic number `16` with `QUIC_STATELESS_RESET_TOKEN_LEN` (line 89 and lines 114-115)

### Additional Fixes (Pre-existing Build Failures)
- **src/test/test_dns_mutex_macros.c**: 
  - Added `SOCKET_DECLARE_MODULE_EXCEPTION(SocketDNS)` declaration
  - Added missing `#include "core/SocketUtil.h"`
  - Fixes compilation error introduced in PR #858
  
- **src/test/test_quic_frame.c**:
  - Renamed duplicate test `frame_stream_overflow_32bit` to `frame_stream_with_offset_overflow_32bit` (line 1411)
  - Fixes duplicate symbol error

## Impact

**Maintainability**: If RFC updates require changing the reset token size, it only needs updating in one location  
**Consistency**: Aligns with existing QUIC module conventions  
**Readability**: Makes the code self-documenting

## Test Plan

- [x] Tests pass with sanitizers: 108/109 (99% pass rate)
- [x] QUIC tests all pass including connection ID frame tests
- [x] DNS mutex tests now compile and pass (6/6)
- [x] Modified file compiles successfully

Single failure: `test_http_integration` (port binding flake, unrelated to changes)

## RFC Reference

RFC 9000 Section 19.15 specifies the Stateless Reset Token as 128 bits (16 bytes) in the NEW_CONNECTION_ID frame format.

Closes #763