### PR TITLE
refactor(quic): add snprintf truncation checks to sockaddr_to_string

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -44,8 +44,8 @@ const Except_T SocketQUICMigration_Failed = { &SocketQUICMigration_Failed,
 static int generate_random_bytes (uint8_t *buf, size_t len);
 static int sockaddr_equal (const struct sockaddr_storage *a,
                           const struct sockaddr_storage *b);
-static void sockaddr_to_string (const struct sockaddr_storage *addr, char *buf,
-                                size_t size);
+static int sockaddr_to_string (const struct sockaddr_storage *addr, char *buf,
+                               size_t size);
 static SocketQUICPath_T *find_path_by_challenge (
     SocketQUICMigration_T *migration, const uint8_t challenge[8]);
 static SocketQUICPath_T *allocate_path_slot (SocketQUICMigration_T *migration);
@@ -583,8 +583,11 @@ SocketQUICMigration_path_to_string (const SocketQUICPath_T *path, char *buf,
   if (path == NULL || buf == NULL || size == 0)
     return -1;
 
-  sockaddr_to_string (&path->local_addr, local_str, sizeof (local_str));
-  sockaddr_to_string (&path->peer_addr, peer_str, sizeof (peer_str));
+  if (sockaddr_to_string (&path->local_addr, local_str, sizeof (local_str))
+      != 0)
+    return -1;
+  if (sockaddr_to_string (&path->peer_addr, peer_str, sizeof (peer_str)) != 0)
+    return -1;
   SocketQUICConnectionID_to_hex (&path->cid, cid_str, sizeof (cid_str));
 
   written = snprintf (buf, size,
@@ -718,20 +721,22 @@ sockaddr_equal (const struct sockaddr_storage *a,
  * @param addr Address to convert.
  * @param buf  Output buffer.
  * @param size Size of output buffer.
+ * @return 0 on success, -1 on error or truncation.
  */
-static void
+static int
 sockaddr_to_string (const struct sockaddr_storage *addr, char *buf,
                     size_t size)
 {
   const struct sockaddr_in *addr4;
   const struct sockaddr_in6 *addr6;
   char ip[INET6_ADDRSTRLEN];
+  int written;
 
   if (addr == NULL || buf == NULL || size == 0)
     {
       if (buf != NULL && size > 0)
         buf[0] = '\0';
-      return;
+      return -1;
     }
 
   if (addr->ss_family == AF_INET)
@@ -739,24 +744,27 @@ sockaddr_to_string (const struct sockaddr_storage *addr, char *buf,
       addr4 = (const struct sockaddr_in *)addr;
       if (inet_ntop (AF_INET, &addr4->sin_addr, ip, sizeof (ip)) == NULL)
         {
-          snprintf (buf, size, "invalid:0");
-          return;
+          written = snprintf (buf, size, "invalid:0");
+          return (written < 0 || (size_t)written >= size) ? -1 : 0;
         }
-      snprintf (buf, size, "%s:%u", ip, ntohs (addr4->sin_port));
+      written = snprintf (buf, size, "%s:%u", ip, ntohs (addr4->sin_port));
+      return (written < 0 || (size_t)written >= size) ? -1 : 0;
     }
   else if (addr->ss_family == AF_INET6)
     {
       addr6 = (const struct sockaddr_in6 *)addr;
       if (inet_ntop (AF_INET6, &addr6->sin6_addr, ip, sizeof (ip)) == NULL)
         {
-          snprintf (buf, size, "[invalid]:0");
-          return;
+          written = snprintf (buf, size, "[invalid]:0");
+          return (written < 0 || (size_t)written >= size) ? -1 : 0;
         }
-      snprintf (buf, size, "[%s]:%u", ip, ntohs (addr6->sin6_port));
+      written = snprintf (buf, size, "[%s]:%u", ip, ntohs (addr6->sin6_port));
+      return (written < 0 || (size_t)written >= size) ? -1 : 0;
     }
   else
     {
-      snprintf (buf, size, "unknown");
+      written = snprintf (buf, size, "unknown");
+      return (written < 0 || (size_t)written >= size) ? -1 : 0;
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #793

## Changes

- Changed `sockaddr_to_string()` function signature from `void` to `int` to return success/error status
- Added truncation checks for all 5 `snprintf()` calls in the function (lines 742, 745, 752, 755, 759)
- Returns 0 on success, -1 on error or truncation
- Updated callers in `SocketQUICMigration_path_to_string()` to check return value and propagate errors
- Updated function documentation to reflect return value

## Test Plan

- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] All 108 tests passed successfully
- [x] No memory leaks detected
- [x] Syntax validated with gcc

Closes #793