### PR TITLE
refactor(quic): use llabs() instead of manual absolute value calculation

### DIFF
--- a/src/quic/SocketQUICLoss.c
+++ b/src/quic/SocketQUICLoss.c
@@ -258,9 +258,7 @@ SocketQUICLoss_update_rtt (SocketQUICLossRTT_T *rtt, uint64_t latest_rtt_us,
    * rttvar = (1 - 1/4) * rttvar + 1/4 * |smoothed_rtt - rtt_sample|
    * smoothed_rtt = (1 - 1/8) * smoothed_rtt + 1/8 * rtt_sample
    */
-  diff = (int64_t)rtt->smoothed_rtt - (int64_t)rtt_sample;
-  if (diff < 0)
-    diff = -diff;
+  diff = llabs((int64_t)rtt->smoothed_rtt - (int64_t)rtt_sample);
 
   rtt->rtt_var = (3 * rtt->rtt_var + (uint64_t)diff) / 4;
   rtt->smoothed_rtt = (7 * rtt->smoothed_rtt + rtt_sample) / 8;


### PR DESCRIPTION
## Summary

Implements #801

Refactors the RTT variance calculation in `SocketQUICLoss_update_rtt()` to use the standard library function `llabs()` instead of manual absolute value computation.

## Changes

- **File**: `src/quic/SocketQUICLoss.c`
- **Line 261**: Changed from manual `if (diff < 0) diff = -diff;` to `diff = llabs(...)`
- Removed 3 lines, added 1 line

## Rationale

- **Code clarity**: Using `llabs()` makes the intent immediately clear
- **Standard library usage**: Prefer standard library functions over manual reimplementations
- **Consistency**: Aligns with C standard library best practices
- **No functional change**: The behavior remains identical

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] No functional changes - pure refactoring
- [x] Build succeeds with all warnings enabled

Closes #801