### PR TITLE
refactor(quic): replace RTT magic numbers with named constants

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -120,6 +120,38 @@
  */
 #define QUIC_RTT_BETA 0.25
 
+/**
+ * @brief RTT smoothing using integer arithmetic (RFC 6298/RFC 9002).
+ *
+ * Integer-based constants for EWMA smoothing without floating-point arithmetic:
+ * - smoothed_rtt = (1 - 1/8) * smoothed_rtt + 1/8 * rtt_sample
+ *                = (7 * smoothed_rtt + rtt_sample) / 8
+ * - rtt_var = (1 - 1/4) * rtt_var + 1/4 * |smoothed_rtt - rtt_sample|
+ *           = (3 * rtt_var + |smoothed_rtt - rtt_sample|) / 4
+ *
+ * These constants map to floating-point equivalents QUIC_RTT_ALPHA and QUIC_RTT_BETA.
+ */
+
+/**
+ * @brief Numerator for smoothed RTT: (1 - alpha) = 7/8.
+ */
+#define QUIC_RTT_SMOOTH_WEIGHT 7
+
+/**
+ * @brief Denominator for smoothed RTT calculation.
+ */
+#define QUIC_RTT_SMOOTH_DENOM 8
+
+/**
+ * @brief Numerator for RTT variance: (1 - beta) = 3/4.
+ */
+#define QUIC_RTT_VAR_WEIGHT 3
+
+/**
+ * @brief Denominator for RTT variance calculation.
+ */
+#define QUIC_RTT_VAR_DENOM 4
+
 /* ============================================================================
  * Loss Detection Constants (RFC 9002)
  * ============================================================================

--- a/src/quic/SocketQUICLoss.c
+++ b/src/quic/SocketQUICLoss.c
@@ -262,8 +262,10 @@ SocketQUICLoss_update_rtt (SocketQUICLossRTT_T *rtt, uint64_t latest_rtt_us,
   if (diff < 0)
     diff = -diff;
 
-  rtt->rtt_var = (3 * rtt->rtt_var + (uint64_t)diff) / 4;
-  rtt->smoothed_rtt = (7 * rtt->smoothed_rtt + rtt_sample) / 8;
+  rtt->rtt_var = (QUIC_RTT_VAR_WEIGHT * rtt->rtt_var + (uint64_t)diff)
+                 / QUIC_RTT_VAR_DENOM;
+  rtt->smoothed_rtt = (QUIC_RTT_SMOOTH_WEIGHT * rtt->smoothed_rtt + rtt_sample)
+                      / QUIC_RTT_SMOOTH_DENOM;
 }
 
 uint64_t


### PR DESCRIPTION
## Summary

Implements #800 by replacing hardcoded magic numbers in RTT smoothing calculations with named constants.

## Changes

- **SocketQUICConstants.h**: Added integer-based RTT smoothing constants
  - `QUIC_RTT_VAR_WEIGHT` (3) and `QUIC_RTT_VAR_DENOM` (4) for rtt_var calculation
  - `QUIC_RTT_SMOOTH_WEIGHT` (7) and `QUIC_RTT_SMOOTH_DENOM` (8) for smoothed_rtt calculation
  
- **SocketQUICLoss.c**: Updated RTT smoothing calculations to use the new constants
  - Line 265-266: Replaced magic numbers with named constants
  - Maintains identical behavior with improved readability

## Benefits

1. **Self-documenting code** - Constants explain the RFC-mandated smoothing factors
2. **Single source of truth** - All RTT constants now in SocketQUICConstants.h  
3. **Consistency** - Aligns with existing QUIC_RTT_ALPHA/QUIC_RTT_BETA constants
4. **Maintainability** - Easier to adjust if RFC requirements change

## Test Plan

- [x] All 112 tests pass with sanitizers enabled
- [x] No functional changes - identical arithmetic behavior preserved
- [x] Code compiles without warnings

## References

- RFC 9002 Section 5.3 - RTT Estimation
- RFC 6298 - Computing TCP's Retransmission Timer

Closes #800