### PR TITLE
refactor(reconnect): remove unused variable 'buf' in default_health_check

### DIFF
--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -666,7 +666,6 @@ default_health_check (const T conn, const Socket_T socket, int timeout_ms,
 {
   struct pollfd pfd;
   int fd, result;
-  char buf;
   int poll_timeout
       = (timeout_ms > 0) ? timeout_ms : SOCKET_RECONNECT_MIN_HEALTH_POLL_MS;
 


### PR DESCRIPTION
## Summary

Implements #924

## Changes

- Removed unused `char buf` variable from `default_health_check()` function in `src/socket/SocketReconnect.c`
- The function uses a separate `char dummy` variable for the peek operation at line 698, making `buf` redundant

## Test Plan

- [x] Tests pass with sanitizers (112/112 tests passed)
- [x] Build completes without warnings
- [x] No functional changes - pure code cleanup

Closes #924