### PR TITLE
refactor(reconnect): add INT_MAX overflow check in calculate_backoff_delay

### DIFF
--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <math.h>
 #include <poll.h>
 #include <stdio.h>
@@ -173,6 +174,10 @@ calculate_backoff_delay (T conn)
   /* Ensure minimum 1ms */
   if (delay < 1.0)
     delay = 1.0;
+
+  /* Check for INT_MAX overflow before casting to int */
+  if (delay > (double)INT_MAX)
+    delay = (double)INT_MAX;
 
   return (int)delay;
 }


### PR DESCRIPTION
## Summary

Implements #916

Adds explicit INT_MAX overflow check before casting double to int in calculate_backoff_delay() to prevent potential undefined behavior on systems where max_delay_ms could approach INT_MAX.

## Changes

- Added `limits.h` include for INT_MAX constant
- Added overflow check: `if (delay > (double)INT_MAX) delay = (double)INT_MAX;`
- Ensures delay value is properly bounded before int conversion

## Test Plan

- [x] All tests pass with sanitizers (110/112 - 2 pre-existing DNS leak failures unrelated to this change)
- [x] Build succeeds with sanitizers enabled
- [x] Change is in calculate_backoff_delay() which is tested via test_reconnect

## Security Impact

Prevents potential integer overflow undefined behavior when casting delay from double to int.

Closes #916