### PR TITLE
refactor(websocket): replace magic number 2 with SOCKETWS_EXTENDED_LEN_16_SIZE constant

### DIFF
--- a/src/socket/SocketWS-frame.c
+++ b/src/socket/SocketWS-frame.c
@@ -280,7 +280,7 @@ static SocketWS_Error
 ws_parse_extended_length (SocketWS_FrameParse *frame)
 {
   size_t offset = SOCKETWS_BASE_HEADER_SIZE;
-  int bytes = (frame->payload_len == SOCKETWS_EXTENDED_LEN_16) ? 2 : SOCKETWS_EXTENDED_LEN_64_SIZE;
+  int bytes = (frame->payload_len == SOCKETWS_EXTENDED_LEN_16) ? SOCKETWS_EXTENDED_LEN_16_SIZE : SOCKETWS_EXTENDED_LEN_64_SIZE;
   frame->payload_len = 0;
   for (int i = 0; i < bytes; i++)
     {
@@ -420,7 +420,7 @@ ws_encode_extended_length (unsigned char *header, size_t offset, uint64_t len, u
   unsigned char len_indicator = code & 0x7F;
 
   header[offset++] = code;
-  int bytes = (len_indicator == SOCKETWS_EXTENDED_LEN_16) ? 2 : SOCKETWS_EXTENDED_LEN_64_SIZE;
+  int bytes = (len_indicator == SOCKETWS_EXTENDED_LEN_16) ? SOCKETWS_EXTENDED_LEN_16_SIZE : SOCKETWS_EXTENDED_LEN_64_SIZE;
   for (int i = 0; i < bytes; i++)
     {
       header[offset++] = (len >> ((bytes - 1 - i) * 8)) & 0xFF;


### PR DESCRIPTION
## Summary

Implements #915

## Changes

- Replaced magic number `2` with `SOCKETWS_EXTENDED_LEN_16_SIZE` constant in `ws_parse_extended_length()` (line 283)
- Replaced magic number `2` with `SOCKETWS_EXTENDED_LEN_16_SIZE` constant in `ws_encode_extended_length()` (line 423)

## Benefits

- Improves code maintainability
- Eliminates redundancy (constant already exists)
- Makes the code self-documenting
- Consistent with existing pattern (already uses `SOCKETWS_EXTENDED_LEN_64_SIZE`)

## Test Plan

- [x] Tests pass with sanitizers (all 112 tests passed)
- [x] Build succeeds with no warnings
- [x] No functional changes, purely refactoring

Closes #915