### PR TITLE
refactor(socket): remove orphaned socket_shutdown_mode_valid documentation

### DIFF
--- a/src/socket/Socket-options.c
+++ b/src/socket/Socket-options.c
@@ -340,14 +340,6 @@ Socket_timeouts_get_extended (const T socket,
  * ============================================================================
  */
 
-/**
- * socket_shutdown_mode_valid - Validate shutdown mode argument
- * @how: Shutdown mode (SHUT_RD, SHUT_WR, or SHUT_RDWR)
- *
- * Returns: Non-zero if valid, 0 if invalid
- */
-
-
 void
 Socket_shutdown (T socket, int how)
 {


### PR DESCRIPTION
## Summary

Removes orphaned documentation for `socket_shutdown_mode_valid` function that was never implemented.

## Changes

- Removed orphaned documentation comment (lines 343-348) in `src/socket/Socket-options.c`
- The validation is already performed inline within `Socket_shutdown` function

## Test Plan

- [x] Tests pass with sanitizers
- [x] Build succeeds without warnings
- [x] No functional changes, documentation cleanup only

Closes #933