### PR TITLE
refactor(socket): remove unnecessary volatile cast in Socket-convenience.c

### DIFF
--- a/src/socket/Socket-convenience.c
+++ b/src/socket/Socket-convenience.c
@@ -361,12 +361,12 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
         result = connect (fd, (struct sockaddr *)&addr, sizeof (addr));
 
         if (result == 0 || errno == EISCONN) {
-                with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
+                with_nonblocking_scope (fd, 0, &original_flags, &need_restore);
                 return;
         }
 
         if (!is_connect_in_progress_error (errno)) {
-                with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
+                with_nonblocking_scope (fd, 0, &original_flags, &need_restore);
                 SOCKET_ERROR_FMT ("Unix connect to %.*s failed",
                                   SOCKET_ERROR_MAX_HOSTNAME, path);
                 RAISE_MODULE_ERROR (Socket_Failed);
@@ -391,7 +391,7 @@ Socket_connect_unix_timeout (T socket, const char *path, int timeout_ms)
                 check_connect_result (fd, path);
         }
         FINALLY {
-                with_nonblocking_scope (fd, 0, (int *)&original_flags, &need_restore);
+                with_nonblocking_scope (fd, 0, &original_flags, &need_restore);
         }
         END_TRY;
 }


### PR DESCRIPTION
## Summary

Implements #927

## Changes

Remove redundant `(int *)` casts when calling `with_nonblocking_scope()` in Socket-convenience.c. The function already accepts `volatile int *` parameters, making the casts unnecessary and potentially harmful to type safety.

**Modified lines:**
- Line 364: Removed `(int *)` cast for `&original_flags`
- Line 369: Removed `(int *)` cast for `&original_flags`  
- Line 394: Removed `(int *)` cast for `&original_flags`

## Rationale

The function signature on line 122 declares:
```c
static void with_nonblocking_scope (int fd, int enable, volatile int *original_flags, volatile int *need_restore)
```

The variables are correctly declared as volatile on line 324:
```c
volatile int original_flags = 0;
volatile int need_restore = 0;
```

The casts strip away the `volatile` qualifier, which can lead to incorrect compiler optimizations in exception handling contexts within TRY/EXCEPT blocks.

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] No functional changes - pure refactoring for type safety
- [x] Maintains proper volatile semantics for exception handling

Closes #927