### PR TITLE
security(happyeyeballs): add defensive overflow check in addrinfo allocation

### DIFF
--- a/src/socket/SocketHappyEyeballs.c
+++ b/src/socket/SocketHappyEyeballs.c
@@ -23,6 +23,7 @@
 #include <netdb.h>
 #include <netinet/in.h>
 #include <poll.h>
+#include <stdint.h> /* For SIZE_MAX */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -315,6 +316,10 @@ he_convert_resolver_result (const SocketDNSResolver_Result *result, int port)
         addrlen = sizeof (struct sockaddr_in6);
       else
         continue; /* Skip unsupported families */
+
+      /* Defensive overflow check - should never happen with AF_INET/AF_INET6 */
+      if (addrlen > SIZE_MAX - sizeof (struct addrinfo))
+        continue; /* Skip this address if allocation would overflow */
 
       ai = calloc (1, sizeof (struct addrinfo) + addrlen);
       if (!ai)


### PR DESCRIPTION
## Summary

Implements #929 by adding a defensive overflow check before allocating addrinfo structures in the Happy Eyeballs implementation.

## Changes

- Added `stdint.h` include for SIZE_MAX constant
- Added overflow check `if (addrlen > SIZE_MAX - sizeof(struct addrinfo))` before allocation
- Gracefully skips addresses that would overflow instead of risking memory corruption

## Risk Assessment

**Practical Risk: Very Low**
- The check protects against theoretical overflow in `sizeof(struct addrinfo) + addrlen`
- Currently `addrlen` is limited to AF_INET (~16 bytes) and AF_INET6 (~28 bytes)
- Total allocation is ~76 bytes maximum, far from SIZE_MAX
- No attacker-controlled input affects this calculation

**Benefit: Defense-in-Depth**
- Protects against future code modifications that might add larger address families
- Documents the assumption about addrlen bounds in code
- Negligible performance cost (single comparison before allocation)
- Fail-safe behavior: skip invalid address instead of memory corruption

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Happy Eyeballs specific test passes (test_happy_eyeballs)
- [x] Build successful with -Wall -Wextra -Werror
- [x] No new warnings introduced

Closes #929