### PR TITLE
style(websocket): use int instead of bool for consistency in ws_recv_frame

### DIFF
--- a/src/socket/SocketWS-frame.c
+++ b/src/socket/SocketWS-frame.c
@@ -836,7 +836,7 @@ ws_recv_frame (SocketWS_T ws, SocketWS_FrameParse *frame_out)
     }
 
   *frame_out = ws->frame;
-  bool is_control_frame = ws_is_control_opcode (ws->frame.opcode);
+  int is_control_frame = ws_is_control_opcode (ws->frame.opcode);
 
   /* Validate masking:
    * RFC 6455 (TCP): Client -> Server MUST be masked, Server -> Client MUST NOT


### PR DESCRIPTION
## Summary

Implements #925 - Replace `bool` type with `int` at line 839 of `SocketWS-frame.c` for consistency with codebase conventions.

## Changes

- Changed `bool is_control_frame` to `int is_control_frame` in `ws_recv_frame()` function
- Aligns with existing code style where helper functions return `int` and local boolean variables use `int` type throughout the file

## Test Plan

- [x] Tests pass with sanitizers enabled (all 112 tests passed)
- [x] Build succeeds with no warnings
- [x] No behavioral changes - purely a style consistency fix

Closes #925