### PR TITLE
cleanup(happyeyeballs): remove unused legacy DNS helper functions

### DIFF
--- a/src/socket/SocketHappyEyeballs.c
+++ b/src/socket/SocketHappyEyeballs.c
@@ -478,29 +478,6 @@ he_start_dns_resolution (T he)
   return 0;
 }
 
-static void
-he_setup_dns_hints (struct addrinfo *hints)
-{
-  memset (hints, 0, sizeof (*hints));
-  hints->ai_family = AF_UNSPEC;
-  hints->ai_socktype = SOCK_STREAM;
-  hints->ai_flags = AI_ADDRCONFIG;
-}
-
-static void
-he_format_port_string (const int port, char *port_str, const size_t port_str_size)
-{
-  snprintf (port_str, port_str_size, "%d", port);
-}
-
-static void
-he_set_dns_error (T he, const int error)
-{
-  snprintf (he->error_buf, sizeof (he->error_buf), "DNS resolution failed: %s",
-            gai_strerror (error));
-  he->dns_error = error;
-}
-
 /* REMOVED: DNS error handling unified in he_handle_dns_error; no separate getaddrinfo error handler. */
 
 /* REMOVED: DNS resolution unified with async path in process(); no separate blocking resolve needed.


### PR DESCRIPTION
## Summary

Implements #932

Removes three unused helper functions from the legacy getaddrinfo()-based DNS implementation that were never removed during the migration to the async SocketDNSResolver.

## Changes

- Removed `he_setup_dns_hints()` - configured addrinfo for blocking DNS lookup
- Removed `he_format_port_string()` - formatted port for getaddrinfo()
- Removed `he_set_dns_error()` - set error from gai_strerror()

## Test Plan

- [x] Tests pass with sanitizers (108/108 tests passed)
- [x] Verified functions are not called anywhere in codebase
- [x] Code compiles cleanly with no warnings

## Context

These functions were part of the legacy DNS resolution implementation and are no longer used. The current DNS resolution path uses:
- `he_start_dns_resolution()` - uses SocketDNSResolver
- `he_dns_callback()` - handles async results
- `he_process_dns_completion()` - drives resolver

Closes #932