### PR TITLE
fix(pool): add overflow check in pool_alloc calloc path

### DIFF
--- a/src/pool/SocketPool-core.c
+++ b/src/pool/SocketPool-core.c
@@ -210,6 +210,10 @@ pool_alloc (Arena_T arena, size_t count, size_t elem_size, const char *what)
   if (arena != NULL) {
     ptr = CALLOC (arena, count, elem_size);
   } else {
+    /* Check for multiplication overflow before calloc */
+    if (count > 0 && elem_size > SIZE_MAX / count)
+      RAISE_POOL_MSG (SocketPool_Failed,
+                      "Integer overflow in allocation size for %s", what);
     ptr = calloc (count, elem_size);
   }
   if (!ptr)


### PR DESCRIPTION
## Summary

Fixes #940 by adding an explicit overflow check before the `calloc()` call in the non-arena path of the `pool_alloc()` function.

## Changes

- Added overflow check in `src/pool/SocketPool-core.c` at line 213-216
- Check uses pattern: `if (count > 0 && elem_size > SIZE_MAX / count)`
- Raises `SocketPool_Failed` exception with descriptive error message on overflow
- Follows defensive programming pattern already used elsewhere in the codebase

## Security Impact

- **Severity**: HIGH
- **Pattern**: MALLOC_OVERFLOW
- **CWE**: CWE-190 (Integer Overflow)

While many modern `calloc()` implementations check for overflow internally, this behavior is not guaranteed by the C standard (C11 7.22.3.2). This fix provides defense-in-depth protection against potential attackers who could control allocation sizes via `maxconns` or `bufsize` parameters.

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Build completes without warnings
- [x] Overflow check properly validates allocation sizes before calling calloc()

Closes #940