### PR TITLE
refactor(pool): use specific exception handlers in socketpool_close_socket_safe

### DIFF
--- a/include/pool/SocketPool-private.h
+++ b/include/pool/SocketPool-private.h
@@ -1181,16 +1181,19 @@ socketpool_close_socket_safe (SocketPool_T pool, Socket_T *socket_ptr,
     SocketPool_remove (pool, *socket_ptr);
     Socket_free (socket_ptr);
   }
-  ELSE
+  EXCEPT(SocketPool_Failed)
   {
-    /* Ignore SocketPool_Failed or Socket_Failed during cleanup -
-     * socket may already be removed or closed */
-    if (context)
-      SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
-                       "%s: socket close/remove failed (may be stale)", context);
-    else
-      SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
-                       "Cleanup: socket close/remove failed (may be stale)");
+    /* Expected failures during cleanup - socket may be stale */
+    SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
+                     "%s: socket close/remove failed (may be stale)",
+                     context ? context : "Cleanup");
+  }
+  EXCEPT(Socket_Failed)
+  {
+    /* Expected failures during cleanup - socket may be stale */
+    SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
+                     "%s: socket close/remove failed (may be stale)",
+                     context ? context : "Cleanup");
   }
   END_TRY;
 }


### PR DESCRIPTION
## Summary

Implements #943

Replaces the ELSE catch-all exception handler in `socketpool_close_socket_safe()` with specific EXCEPT handlers for `SocketPool_Failed` and `Socket_Failed`.

## Changes

- **File**: `include/pool/SocketPool-private.h`
- **Function**: `socketpool_close_socket_safe()`
- **Before**: Used `ELSE` block that caught all exceptions
- **After**: Uses two specific `EXCEPT` blocks for expected exceptions only

## Rationale

The ELSE clause catches **all** exceptions, not just the expected `SocketPool_Failed` and `Socket_Failed`. If unexpected exceptions occur (e.g., `Arena_Failed`, memory corruption exceptions, or assertion failures), they would be silently suppressed and only logged at DEBUG level. This could hide serious errors during cleanup operations.

With specific exception handling, only expected failures are suppressed while unexpected exceptions propagate correctly to callers for proper error handling.

## Test Plan

- [x] All tests pass with sanitizers enabled (112/112 tests passed)
- [x] Build completes without errors or warnings
- [x] No behavior change for expected exceptions
- [x] Unexpected exceptions now propagate correctly

Closes #943