### PR TITLE
refactor(pool): replace manual DJB2 hash with socket_util_hash_djb2_seeded()

### DIFF
--- a/include/pool/SocketPoolHealth-private.h
+++ b/include/pool/SocketPoolHealth-private.h
@@ -416,12 +416,16 @@ int health_make_host_key(const char *host, int port, char *buf, size_t len);
  * DJB2 hash for string keys with per-instance seed randomization.
  * The seed prevents hash collision DoS attacks.
  *
+ * Delegates to socket_util_hash_djb2_seeded() from SocketUtil.h.
+ *
  * @param key  Host key string.
  * @param seed Hash seed from health context (health->hash_seed).
+ * @param table_size Hash table size (SOCKET_HEALTH_HASH_SIZE).
  *
- * @return Hash value (use % SOCKET_HEALTH_HASH_SIZE for bucket).
+ * @return Hash value in range [0, table_size).
  */
-unsigned int health_hash_key(const char *key, unsigned int seed);
+unsigned int health_hash_key(const char *key, unsigned int seed,
+                             unsigned int table_size);
 
 /**
  * @brief Check if circuit should transition OPEN -> HALF_OPEN.


### PR DESCRIPTION
## Summary

Implements #938 - Replaces manual DJB2 hash implementation in SocketPool-health.c with the library function socket_util_hash_djb2_seeded() from SocketUtil.h.

## Changes

- **src/pool/SocketPool-health.c**: 
  - Replaced manual DJB2 hash implementation in `health_hash_key()` with call to `socket_util_hash_djb2_seeded()`
  - Added `table_size` parameter to function signature
  - Updated call site to pass `SOCKET_HEALTH_HASH_SIZE` directly
  
- **include/pool/SocketPoolHealth-private.h**: 
  - Updated `health_hash_key()` declaration to match new signature
  - Updated documentation to note delegation to library function

## Benefits

1. **Eliminates code duplication** - Removes 7 lines of manual hash implementation
2. **Uses tested library function** - Relies on documented, tested implementation
3. **Maintains consistency** - All hash operations now use standardized library functions
4. **Reduces maintenance burden** - One implementation to maintain instead of two

## Implementation Notes

The library function uses XOR for character mixing instead of addition (minor algorithmic difference), but provides equivalent hash distribution properties. This is an improvement as the XOR variant is more widely used in modern DJB2 implementations.

## Test Plan

- [x] All tests pass with sanitizers enabled (ASan + UBSan)
- [x] Pre-commit hook validation passed
- [x] Build completes without warnings

Closes #938