### PR TITLE
refactor(poll): use LOCKED_INT_GETTER macro to reduce duplication

### DIFF
--- a/src/poll/SocketPoll.c
+++ b/src/poll/SocketPoll.c
@@ -1058,15 +1058,8 @@ SocketPoll_del (T poll, Socket_T socket)
 int
 SocketPoll_getdefaulttimeout (T poll)
 {
-  int current;
-
   assert (poll);
-
-  pthread_mutex_lock (&poll->mutex);
-  current = poll->default_timeout_ms;
-  pthread_mutex_unlock (&poll->mutex);
-
-  return current;
+  return LOCKED_INT_GETTER (poll, default_timeout_ms);
 }
 
 void
@@ -1262,15 +1255,8 @@ socketpoll_get_timer_heap (T poll)
 int
 SocketPoll_getmaxregistered (T poll)
 {
-  int max;
-
   assert (poll);
-
-  pthread_mutex_lock (&poll->mutex);
-  max = poll->max_registered;
-  pthread_mutex_unlock (&poll->mutex);
-
-  return max;
+  return LOCKED_INT_GETTER (poll, max_registered);
 }
 
 void
@@ -1299,15 +1285,8 @@ SocketPoll_setmaxregistered (T poll, int max)
 int
 SocketPoll_getregisteredcount (T poll)
 {
-  int count;
-
   assert (poll);
-
-  pthread_mutex_lock (&poll->mutex);
-  count = poll->registered_count;
-  pthread_mutex_unlock (&poll->mutex);
-
-  return count;
+  return LOCKED_INT_GETTER (poll, registered_count);
 }
 
 /* ==================== New Accessors ==================== */


### PR DESCRIPTION
## Summary

Implements #941 - refactored three getter functions to use the existing `LOCKED_INT_GETTER` macro instead of manually implementing mutex locking patterns.

## Changes

- **SocketPoll_getdefaulttimeout**: Reduced from 11 lines to 4 lines
- **SocketPoll_getmaxregistered**: Reduced from 11 lines to 4 lines  
- **SocketPoll_getregisteredcount**: Reduced from 11 lines to 4 lines

All three functions now use the `LOCKED_INT_GETTER` macro, eliminating code duplication while maintaining identical thread-safety guarantees.

## Implementation Details

The `LOCKED_INT_GETTER` macro was already defined but unused. It uses GNU statement expressions `({ })`, which is consistent with other macros in the codebase like `ALLOCATE_HASH_ENTRY`.

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] No functional changes - identical thread-safety behavior
- [x] Code compiles without warnings

Closes #941