### PR TITLE
security(pool): use SocketCrypto_random_uint32() for hash collision DoS protection

### DIFF
--- a/src/pool/SocketPool-health.c
+++ b/src/pool/SocketPool-health.c
@@ -24,6 +24,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "core/SocketCrypto.h"
 #include "pool/SocketPool-private.h"
 #include "pool/SocketPoolHealth-private.h"
 
@@ -450,8 +451,8 @@ health_create (struct SocketPool_T *pool, Arena_T arena)
   health->arena = arena;
 
   /* Security: Initialize hash seed for hash collision DoS prevention.
-   * Uses time + pid for per-instance uniqueness. */
-  health->hash_seed = (unsigned int)time (NULL) ^ (unsigned int)getpid ();
+   * Uses cryptographically secure random number generator. */
+  health->hash_seed = SocketCrypto_random_uint32 ();
 
   if (pthread_mutex_init (&health->circuit_mutex, NULL) != 0)
     return NULL;


### PR DESCRIPTION
## Summary

Implements #937 - Replace predictable hash seed with cryptographically secure random number.

## Changes

- Add `SocketCrypto.h` include to `SocketPool-health.c`
- Replace `time(NULL) ^ getpid()` with `SocketCrypto_random_uint32()`
- Update comment to reflect use of cryptographic RNG

## Problem

The hash seed for circuit breaker's DJB2 hash function was initialized using `time(NULL) ^ getpid()`, which is predictable and insufficient for preventing hash collision DoS attacks.

## Solution

Use `SocketCrypto_random_uint32()` which provides cryptographically secure randomness via:
- RAND_bytes() when OpenSSL/LibreSSL is available
- /dev/urandom fallback otherwise

This ensures the hash seed is unpredictable, making it infeasible for attackers to craft colliding host:port keys.

## Test Plan

- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] All 112 tests pass
- [x] No functional changes to circuit breaker logic

Closes #937