### PR TITLE
refactor(quic): extract magic buffer size calculation to named constant

### DIFF
--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -24,6 +24,8 @@
  */
 #define QUIC_FRAME_MIN_SIZE_RESET_STREAM (1 + 8 + 8 + 8)  /* frame_type + stream_id + error_code + final_size */
 #define QUIC_FRAME_MIN_SIZE_STOP_SENDING (1 + 8 + 8)      /* frame_type + stream_id + error_code */
+#define QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_TRANSPORT (1 + 8 + 8 + 8)  /* frame_type + error_code + frame_type_field + reason_len */
+#define QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_APP (1 + 8 + 8)           /* frame_type + error_code + reason_len */
 
 typedef enum {
   QUIC_FRAME_PADDING = 0x00, QUIC_FRAME_PING = 0x01,

--- a/src/quic/SocketQUICError-handling.c
+++ b/src/quic/SocketQUICError-handling.c
@@ -79,14 +79,10 @@ SocketQUIC_send_connection_close (SocketQUICConnection_T conn, uint64_t code,
   if (reason_len > QUIC_MAX_REASON_LENGTH)
     reason_len = QUIC_MAX_REASON_LENGTH; /* Limit reason phrase length */
 
-  /* Estimate minimum required buffer size:
-   * - Frame type: 1 byte (varint)
-   * - Error code: up to 8 bytes (varint)
-   * - Frame type field (for transport errors): up to 8 bytes (varint)
-   * - Reason length: up to 8 bytes (varint)
-   * - Reason phrase: reason_len bytes
-   */
-  size_t min_size = 1 + 8 + (is_app_error ? 0 : 8) + 8 + reason_len;
+  /* Check minimum buffer size for frame header plus reason phrase */
+  size_t min_size = (is_app_error ? QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_APP
+                                  : QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_TRANSPORT)
+                    + reason_len;
   if (out_len < min_size)
     return 0;
 


### PR DESCRIPTION
## Summary

Implements #954

Extracts the magic number calculation for CONNECTION_CLOSE frame minimum buffer size to named constants in `SocketQUICFrame.h`, following the existing pattern established for other frame types.

## Changes

- Added `QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_TRANSPORT` constant (1 + 8 + 8 + 8 bytes)
- Added `QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_APP` constant (1 + 8 + 8 bytes)
- Updated `SocketQUIC_send_connection_close()` to use these constants instead of inline calculation

## Consistency

This follows the existing pattern in the codebase:
- `QUIC_FRAME_MIN_SIZE_RESET_STREAM` - for RESET_STREAM frames
- `QUIC_FRAME_MIN_SIZE_STOP_SENDING` - for STOP_SENDING frames

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] All 112 tests pass (100% success rate)
- [x] No functional changes - purely refactoring
- [x] Build completes without warnings

Closes #954