### PR TITLE
fix(uring): add missing SocketUtil.h include for helper functions

### DIFF
--- a/src/poll/SocketPoll_uring.c
+++ b/src/poll/SocketPoll_uring.c
@@ -25,6 +25,7 @@
 
 #include "core/Arena.h"
 #include "core/SocketConfig.h"
+#include "core/SocketUtil.h" /* For socket_util_ms_to_timespec and other utilities */
 #include "poll/SocketPoll_backend.h"
 #include "socket/Socket.h" /* For Socket_get_monotonic_ms */
 


### PR DESCRIPTION
## Summary

Implements #946

## Changes

- Add missing `core/SocketUtil.h` include to `src/poll/SocketPoll_uring.c`
- Ensures consistency with epoll backend which already includes this header
- Provides access to utility functions like `socket_util_ms_to_timespec()` and other shared helpers

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] Build succeeds with `-DENABLE_IO_URING=ON`
- [x] All 112 tests pass in 19.77 seconds

Closes #946