### PR TITLE
refactor(pool): consolidate duplicate logging in socketpool_close_socket_safe

### DIFF
--- a/include/pool/SocketPool-private.h
+++ b/include/pool/SocketPool-private.h
@@ -1183,14 +1183,10 @@ socketpool_close_socket_safe (SocketPool_T pool, Socket_T *socket_ptr,
   }
   ELSE
   {
-    /* Ignore SocketPool_Failed or Socket_Failed during cleanup -
-     * socket may already be removed or closed */
-    if (context)
-      SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
-                       "%s: socket close/remove failed (may be stale)", context);
-    else
-      SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
-                       "Cleanup: socket close/remove failed (may be stale)");
+    /* Expected failures during cleanup - socket may be stale */
+    SocketLog_emitf (SOCKET_LOG_DEBUG, SOCKET_LOG_COMPONENT,
+                     "%s: socket close/remove failed (may be stale)",
+                     context ? context : "Cleanup");
   }
   END_TRY;
 }


### PR DESCRIPTION
## Summary

Implements #945 - consolidates duplicate logging code in the `socketpool_close_socket_safe()` inline function.

## Changes

- Replaced two nearly identical `SocketLog_emitf()` calls with a single call using a ternary operator
- The calls differed only in whether they included the `context` parameter in the message
- Updated comment to be more concise

## Benefits

- Reduces code from 9 lines to 5 lines (4 lines removed)
- Single source of truth for log message format
- Improved readability with clearer intent
- Same functionality with identical output

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] No functional changes - purely code cleanup
- [x] Log output remains identical

Closes #945