### PR TITLE
refactor(uring): improve fd validation consistency in CQE processing

### DIFF
--- a/src/poll/SocketPoll_uring.c
+++ b/src/poll/SocketPoll_uring.c
@@ -430,6 +430,13 @@ backend_wait (PollBackend_T backend, int timeout_ms)
     if (fd <= 0)
       continue;
 
+    /* Defense-in-depth: validate fd is within reasonable bounds.
+     * While io_uring user_data corruption is unlikely under normal operation,
+     * this prevents processing invalid fds from corrupted CQEs. Follows the
+     * same pattern as kqueue backend (SocketPoll_kqueue.c:331). */
+    if ((uintptr_t)fd > (uintptr_t)INT_MAX)
+      continue;
+
     if (cqe->res < 0)
       {
         /* Error on this fd */


### PR DESCRIPTION
## Summary

Implements #947

Adds upper bound validation for file descriptors extracted from io_uring completion queue entries (CQEs) to match the defensive programming pattern already used in the kqueue backend.

## Changes

- Add `INT_MAX` validation check after extracting fd from `user_data` in CQE processing loop
- Skip processing of fds that exceed `INT_MAX` to prevent potential truncation issues
- Follows the same defensive pattern as `SocketPoll_kqueue.c:331`
- Improves consistency across polling backends (epoll, kqueue, io_uring)

## Implementation Details

**Location**: `src/poll/SocketPoll_uring.c:437-438`

```c
/* Defense-in-depth: validate fd is within reasonable bounds.
 * While io_uring user_data corruption is unlikely under normal operation,
 * this prevents processing invalid fds from corrupted CQEs. Follows the
 * same pattern as kqueue backend (SocketPoll_kqueue.c:331). */
if ((uintptr_t)fd > (uintptr_t)INT_MAX)
  continue;
```

## Rationale

While io_uring `user_data` corruption is unlikely under normal kernel operation, this defensive check:

1. Prevents array overruns if fd is used as an index elsewhere
2. Provides early detection of bugs in poll submission logic
3. Makes debugging easier if unexpected values appear in CQEs
4. Aligns with defensive programming principles for data from external sources (kernel)

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] io_uring backend builds successfully (`-DENABLE_IO_URING=ON`)
- [x] No performance impact (validation is a simple integer comparison)
- [x] Code compiles without warnings under `-Wall -Wextra -Werror`

Closes #947