### PR TITLE
fix(quic): validate reason string length in SocketQUIC_send_connection_close

### DIFF
--- a/include/quic/SocketQUICError.h
+++ b/include/quic/SocketQUICError.h
@@ -376,20 +376,26 @@ extern int SocketQUIC_error_is_connection_fatal (uint64_t code);
  * code and reason phrase. This closes the entire connection and all
  * associated streams.
  *
- * @param conn   Connection to close.
- * @param code   Error code (transport or application).
- * @param reason Human-readable reason phrase (may be NULL).
- * @param out    Output buffer for encoded frame.
- * @param out_len Size of output buffer.
+ * @param conn       Connection to close.
+ * @param code       Error code (transport or application).
+ * @param reason     Human-readable reason phrase (may be NULL).
+ * @param reason_len Length of reason phrase in bytes (0 if reason is NULL).
+ *                   If reason_len exceeds QUIC_MAX_REASON_LENGTH, it will
+ *                   be clamped to the maximum allowed length.
+ * @param out        Output buffer for encoded frame.
+ * @param out_len    Size of output buffer.
  *
  * @return Number of bytes written to out, or 0 on error.
  *
  * @note The connection state should be set to CLOSING after calling this.
  *       Transport errors use frame type 0x1c, application errors use 0x1d.
+ *       The reason parameter does NOT need to be null-terminated, as the
+ *       length is explicitly provided via reason_len.
  */
 extern size_t SocketQUIC_send_connection_close (SocketQUICConnection_T conn,
                                                  uint64_t code,
                                                  const char *reason,
+                                                 size_t reason_len,
                                                  uint8_t *out,
                                                  size_t out_len);
 


### PR DESCRIPTION
## Summary

Implements #948

Fixes a security vulnerability where `SocketQUIC_send_connection_close()` called `strlen()` on an untrusted `reason` parameter without validating null-termination. This could lead to buffer over-read if a caller passed a non-null-terminated string.

## Changes

### API Change
- Added `reason_len` parameter to `SocketQUIC_send_connection_close()`
- Function signature now requires explicit length instead of relying on null-termination
- Allows safe handling of binary data and non-null-terminated strings

### Security Improvements
- Removed unsafe `strlen()` call
- Added validation: NULL reason pointer requires zero length
- Length is clamped to `QUIC_MAX_REASON_LENGTH` (65535 bytes)
- No buffer over-read possible with untrusted input

### Updated Files
- `include/quic/SocketQUICError.h` - Updated function signature and documentation
- `src/quic/SocketQUICError-handling.c` - Implemented safe length-based logic
- `src/test/test_quic_error.c` - Updated existing tests + added security tests

### New Tests
1. **Non-null-terminated string handling** - Verifies function correctly handles strings without null terminators
2. **NULL pointer validation** - Ensures NULL reason with non-zero length is rejected
3. **Length clamping** - Confirms oversized reasons are clamped to maximum

## Test Plan

- [x] All 112 tests pass with ASan/UBSan enabled
- [x] New security tests verify fix prevents buffer over-read
- [x] Existing QUIC error tests updated and passing
- [x] Zero test failures

## Security Impact

- **Before**: Potential information disclosure or crash from buffer over-read
- **After**: Safe handling of all string inputs, regardless of null-termination

Closes #948