### PR TITLE
fix(quic): add buffer size validation to PATH frame encode functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -807,6 +807,7 @@ set(TEST_SOURCES
     test_quic_frame
     test_quic_stream_frame_encode
     test_quic_new_token_frame
+    test_quic_path_frame
     test_quic_connection
     test_quic_transport_params
     test_quic_pmtu

--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -207,8 +207,8 @@ extern size_t SocketQUICFrame_encode_data_blocked(uint64_t max_data, uint8_t *ou
 extern size_t SocketQUICFrame_encode_stream_data_blocked(uint64_t stream_id, uint64_t max_data, uint8_t *out, size_t out_size);
 extern size_t SocketQUICFrame_encode_streams_blocked(int bidirectional, uint64_t max_streams, uint8_t *out, size_t out_size);
 /* PATH frame encoding/decoding (RFC 9000 §19.17-19.18) */
-extern size_t SocketQUICFrame_encode_path_challenge(const uint8_t data[8], uint8_t *out);
-extern size_t SocketQUICFrame_encode_path_response(const uint8_t data[8], uint8_t *out);
+extern size_t SocketQUICFrame_encode_path_challenge(const uint8_t data[8], uint8_t *out, size_t out_size);
+extern size_t SocketQUICFrame_encode_path_response(const uint8_t data[8], uint8_t *out, size_t out_size);
 extern int SocketQUICFrame_decode_path_challenge(const uint8_t *in, size_t len, uint8_t data[8]);
 extern int SocketQUICFrame_decode_path_response(const uint8_t *in, size_t len, uint8_t data[8]);
 

--- a/src/quic/SocketQUICFrame-path.c
+++ b/src/quic/SocketQUICFrame-path.c
@@ -25,9 +25,14 @@
  */
 
 size_t
-SocketQUICFrame_encode_path_challenge (const uint8_t data[8], uint8_t *out)
+SocketQUICFrame_encode_path_challenge (const uint8_t data[8], uint8_t *out,
+                                        size_t out_size)
 {
   if (!data || !out)
+    return 0;
+
+  /* Need 9 bytes: 1 byte type + 8 bytes data */
+  if (out_size < 9)
     return 0;
 
   /* Frame type */
@@ -53,9 +58,14 @@ SocketQUICFrame_encode_path_challenge (const uint8_t data[8], uint8_t *out)
  */
 
 size_t
-SocketQUICFrame_encode_path_response (const uint8_t data[8], uint8_t *out)
+SocketQUICFrame_encode_path_response (const uint8_t data[8], uint8_t *out,
+                                       size_t out_size)
 {
   if (!data || !out)
+    return 0;
+
+  /* Need 9 bytes: 1 byte type + 8 bytes data */
+  if (out_size < 9)
     return 0;
 
   /* Frame type */

--- a/src/test/test_quic_frame.c
+++ b/src/test/test_quic_frame.c
@@ -214,7 +214,8 @@ TEST (frame_path_challenge_encode)
   uint8_t challenge_data[8] = { 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x00, 0x11 };
   uint8_t encoded[9];
 
-  size_t len = SocketQUICFrame_encode_path_challenge (challenge_data, encoded);
+  size_t len = SocketQUICFrame_encode_path_challenge (challenge_data, encoded,
+                                                       sizeof (encoded));
 
   ASSERT_EQ (9, len);
   ASSERT_EQ (0x1a, encoded[0]);
@@ -226,7 +227,8 @@ TEST (frame_path_response_encode)
   uint8_t response_data[8] = { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0 };
   uint8_t encoded[9];
 
-  size_t len = SocketQUICFrame_encode_path_response (response_data, encoded);
+  size_t len = SocketQUICFrame_encode_path_response (response_data, encoded,
+                                                      sizeof (encoded));
 
   ASSERT_EQ (9, len);
   ASSERT_EQ (0x1b, encoded[0]);
@@ -262,7 +264,8 @@ TEST (frame_path_encode_decode_roundtrip)
   uint8_t decoded[8];
 
   /* Encode */
-  size_t enc_len = SocketQUICFrame_encode_path_challenge (original, encoded);
+  size_t enc_len = SocketQUICFrame_encode_path_challenge (original, encoded,
+                                                           sizeof (encoded));
   ASSERT_EQ (9, enc_len);
 
   /* Decode */
@@ -279,12 +282,14 @@ TEST (frame_path_encode_null_checks)
   uint8_t out[9];
 
   /* Null data pointer */
-  ASSERT_EQ (0, SocketQUICFrame_encode_path_challenge (NULL, out));
-  ASSERT_EQ (0, SocketQUICFrame_encode_path_response (NULL, out));
+  ASSERT_EQ (0, SocketQUICFrame_encode_path_challenge (NULL, out,
+                                                        sizeof (out)));
+  ASSERT_EQ (0, SocketQUICFrame_encode_path_response (NULL, out,
+                                                       sizeof (out)));
 
   /* Null output pointer */
-  ASSERT_EQ (0, SocketQUICFrame_encode_path_challenge (data, NULL));
-  ASSERT_EQ (0, SocketQUICFrame_encode_path_response (data, NULL));
+  ASSERT_EQ (0, SocketQUICFrame_encode_path_challenge (data, NULL, 9));
+  ASSERT_EQ (0, SocketQUICFrame_encode_path_response (data, NULL, 9));
 }
 
 TEST (frame_path_decode_null_checks)

--- a/src/test/test_quic_path_frame.c
+++ b/src/test/test_quic_path_frame.c
@@ -1,0 +1,304 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_quic_path_frame.c
+ * @brief Unit tests for QUIC PATH_CHALLENGE and PATH_RESPONSE frame encoding/decoding (RFC 9000 §19.17-19.18).
+ */
+
+#include "quic/SocketQUICFrame.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * PATH_CHALLENGE Frame Encoding Tests
+ * ============================================================================
+ */
+
+TEST (frame_path_challenge_encode_basic)
+{
+  uint8_t buf[128];
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  size_t len;
+
+  /* Encode basic PATH_CHALLENGE frame */
+  len = SocketQUICFrame_encode_path_challenge (data, buf, sizeof (buf));
+
+  ASSERT_EQ (9, len); /* 1 byte type + 8 bytes data */
+  ASSERT_EQ (QUIC_FRAME_PATH_CHALLENGE, buf[0]); /* Frame type: 0x1a */
+
+  /* Verify data was copied correctly */
+  ASSERT (memcmp (buf + 1, data, 8) == 0);
+}
+
+TEST (frame_path_challenge_encode_roundtrip)
+{
+  uint8_t buf[128];
+  const uint8_t original_data[8]
+      = { 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22 };
+  uint8_t decoded_data[8];
+
+  /* Encode */
+  size_t len = SocketQUICFrame_encode_path_challenge (original_data, buf,
+                                                       sizeof (buf));
+  ASSERT_EQ (9, len);
+
+  /* Decode */
+  int res = SocketQUICFrame_decode_path_challenge (buf, len, decoded_data);
+  ASSERT_EQ (9, res);
+
+  /* Verify roundtrip */
+  ASSERT (memcmp (decoded_data, original_data, 8) == 0);
+}
+
+TEST (frame_path_challenge_encode_buffer_too_small)
+{
+  uint8_t buf[8]; /* Only 8 bytes, need 9 */
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* Try to encode into insufficient buffer */
+  size_t len = SocketQUICFrame_encode_path_challenge (data, buf, sizeof (buf));
+
+  ASSERT_EQ (0, len); /* Should fail gracefully */
+}
+
+TEST (frame_path_challenge_encode_exact_buffer_size)
+{
+  uint8_t buf[9]; /* Exactly 9 bytes */
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* Encode with exact buffer size */
+  size_t len = SocketQUICFrame_encode_path_challenge (data, buf, sizeof (buf));
+
+  ASSERT_EQ (9, len); /* Should succeed */
+  ASSERT_EQ (QUIC_FRAME_PATH_CHALLENGE, buf[0]);
+  ASSERT (memcmp (buf + 1, data, 8) == 0);
+}
+
+TEST (frame_path_challenge_encode_null_data)
+{
+  uint8_t buf[128];
+
+  /* NULL data pointer should fail */
+  size_t len = SocketQUICFrame_encode_path_challenge (NULL, buf, sizeof (buf));
+  ASSERT_EQ (0, len);
+}
+
+TEST (frame_path_challenge_encode_null_buffer)
+{
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* NULL output buffer should fail */
+  size_t len = SocketQUICFrame_encode_path_challenge (data, NULL, 128);
+  ASSERT_EQ (0, len);
+}
+
+TEST (frame_path_challenge_encode_zero_buffer_size)
+{
+  uint8_t buf[128];
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* Zero buffer size should fail */
+  size_t len = SocketQUICFrame_encode_path_challenge (data, buf, 0);
+  ASSERT_EQ (0, len);
+}
+
+/* ============================================================================
+ * PATH_RESPONSE Frame Encoding Tests
+ * ============================================================================
+ */
+
+TEST (frame_path_response_encode_basic)
+{
+  uint8_t buf[128];
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  size_t len;
+
+  /* Encode basic PATH_RESPONSE frame */
+  len = SocketQUICFrame_encode_path_response (data, buf, sizeof (buf));
+
+  ASSERT_EQ (9, len); /* 1 byte type + 8 bytes data */
+  ASSERT_EQ (QUIC_FRAME_PATH_RESPONSE, buf[0]); /* Frame type: 0x1b */
+
+  /* Verify data was copied correctly */
+  ASSERT (memcmp (buf + 1, data, 8) == 0);
+}
+
+TEST (frame_path_response_encode_roundtrip)
+{
+  uint8_t buf[128];
+  const uint8_t original_data[8]
+      = { 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 0x11, 0x22 };
+  uint8_t decoded_data[8];
+
+  /* Encode */
+  size_t len = SocketQUICFrame_encode_path_response (original_data, buf,
+                                                      sizeof (buf));
+  ASSERT_EQ (9, len);
+
+  /* Decode */
+  int res = SocketQUICFrame_decode_path_response (buf, len, decoded_data);
+  ASSERT_EQ (9, res);
+
+  /* Verify roundtrip */
+  ASSERT (memcmp (decoded_data, original_data, 8) == 0);
+}
+
+TEST (frame_path_response_encode_buffer_too_small)
+{
+  uint8_t buf[8]; /* Only 8 bytes, need 9 */
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* Try to encode into insufficient buffer */
+  size_t len = SocketQUICFrame_encode_path_response (data, buf, sizeof (buf));
+
+  ASSERT_EQ (0, len); /* Should fail gracefully */
+}
+
+TEST (frame_path_response_encode_exact_buffer_size)
+{
+  uint8_t buf[9]; /* Exactly 9 bytes */
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* Encode with exact buffer size */
+  size_t len = SocketQUICFrame_encode_path_response (data, buf, sizeof (buf));
+
+  ASSERT_EQ (9, len); /* Should succeed */
+  ASSERT_EQ (QUIC_FRAME_PATH_RESPONSE, buf[0]);
+  ASSERT (memcmp (buf + 1, data, 8) == 0);
+}
+
+TEST (frame_path_response_encode_null_data)
+{
+  uint8_t buf[128];
+
+  /* NULL data pointer should fail */
+  size_t len = SocketQUICFrame_encode_path_response (NULL, buf, sizeof (buf));
+  ASSERT_EQ (0, len);
+}
+
+TEST (frame_path_response_encode_null_buffer)
+{
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* NULL output buffer should fail */
+  size_t len = SocketQUICFrame_encode_path_response (data, NULL, 128);
+  ASSERT_EQ (0, len);
+}
+
+TEST (frame_path_response_encode_zero_buffer_size)
+{
+  uint8_t buf[128];
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+
+  /* Zero buffer size should fail */
+  size_t len = SocketQUICFrame_encode_path_response (data, buf, 0);
+  ASSERT_EQ (0, len);
+}
+
+/* ============================================================================
+ * PATH_CHALLENGE/PATH_RESPONSE Interaction Tests
+ * ============================================================================
+ */
+
+TEST (frame_path_challenge_response_echo)
+{
+  uint8_t challenge_buf[128];
+  uint8_t response_buf[128];
+  const uint8_t challenge_data[8]
+      = { 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0 };
+  uint8_t decoded_data[8];
+
+  /* Encode PATH_CHALLENGE */
+  size_t challenge_len = SocketQUICFrame_encode_path_challenge (
+      challenge_data, challenge_buf, sizeof (challenge_buf));
+  ASSERT_EQ (9, challenge_len);
+
+  /* Decode the challenge */
+  int res = SocketQUICFrame_decode_path_challenge (challenge_buf, challenge_len,
+                                                    decoded_data);
+  ASSERT_EQ (9, res);
+
+  /* Encode PATH_RESPONSE with the same data (echo) */
+  size_t response_len = SocketQUICFrame_encode_path_response (
+      decoded_data, response_buf, sizeof (response_buf));
+  ASSERT_EQ (9, response_len);
+
+  /* Verify frame types are different */
+  ASSERT_EQ (QUIC_FRAME_PATH_CHALLENGE, challenge_buf[0]);
+  ASSERT_EQ (QUIC_FRAME_PATH_RESPONSE, response_buf[0]);
+
+  /* Verify data is the same */
+  ASSERT (memcmp (challenge_buf + 1, response_buf + 1, 8) == 0);
+
+  /* Decode response and verify */
+  uint8_t response_data[8];
+  res = SocketQUICFrame_decode_path_response (response_buf, response_len,
+                                               response_data);
+  ASSERT_EQ (9, res);
+  ASSERT (memcmp (response_data, challenge_data, 8) == 0);
+}
+
+/* ============================================================================
+ * Buffer Size Validation Security Tests (Issue #950)
+ * ============================================================================
+ */
+
+TEST (frame_path_challenge_buffer_validation_issue_950)
+{
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  uint8_t buf[128];
+
+  /* Test all buffer sizes from 0 to 10 */
+  for (size_t buf_size = 0; buf_size < 10; buf_size++)
+    {
+      size_t len = SocketQUICFrame_encode_path_challenge (data, buf, buf_size);
+
+      if (buf_size < 9)
+        {
+          /* Should fail for buffers smaller than 9 bytes */
+          ASSERT_EQ (0, len);
+        }
+      else
+        {
+          /* Should succeed for buffers of 9 or more bytes */
+          ASSERT_EQ (9, len);
+          ASSERT_EQ (QUIC_FRAME_PATH_CHALLENGE, buf[0]);
+        }
+    }
+}
+
+TEST (frame_path_response_buffer_validation_issue_950)
+{
+  const uint8_t data[8] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08 };
+  uint8_t buf[128];
+
+  /* Test all buffer sizes from 0 to 10 */
+  for (size_t buf_size = 0; buf_size < 10; buf_size++)
+    {
+      size_t len = SocketQUICFrame_encode_path_response (data, buf, buf_size);
+
+      if (buf_size < 9)
+        {
+          /* Should fail for buffers smaller than 9 bytes */
+          ASSERT_EQ (0, len);
+        }
+      else
+        {
+          /* Should succeed for buffers of 9 or more bytes */
+          ASSERT_EQ (9, len);
+          ASSERT_EQ (QUIC_FRAME_PATH_RESPONSE, buf[0]);
+        }
+    }
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Implements #950 - Adds missing buffer size validation to `SocketQUICFrame_encode_path_challenge()` and `SocketQUICFrame_encode_path_response()` functions to prevent potential buffer overflows.

## Changes

- Added `size_t out_size` parameter to both encode functions
- Added validation to ensure output buffer is at least 9 bytes before writing
- Updated function signatures in `include/quic/SocketQUICFrame.h`
- Updated all existing callers in `src/test/test_quic_frame.c`
- Added comprehensive test suite in `src/test/test_quic_path_frame.c` with 17 test cases

## Security Impact

This fix addresses a **HIGH severity** security issue where these functions could write 9 bytes to an output buffer without checking if sufficient space exists, potentially causing buffer overflows.

The functions now follow the same safe pattern as all other QUIC frame encode functions (e.g., `SocketQUICFrame_encode_max_data`), which accept an `out_size` parameter and validate before writing.

## Test Plan

- [x] All 113 tests pass with ASan/UBSan enabled
- [x] New test suite (test_quic_path_frame) with 17 tests covering:
  - Basic encoding/decoding
  - Buffer size validation (exact size, too small, zero size)
  - NULL pointer checks
  - Roundtrip encoding/decoding
  - Challenge/response interaction
  - Issue #950 specific validation tests
- [x] Updated existing tests in test_quic_frame.c
- [x] No memory leaks detected by AddressSanitizer

## References

- Fixes #950
- RFC 9000 §19.17-19.18 (PATH_CHALLENGE and PATH_RESPONSE frames)

Closes #950