### PR TITLE
refactor(quic): replace manual byte-order conversion with socket_util helpers in SocketQUICVersion.c

### DIFF
--- a/src/quic/SocketQUICVersion.c
+++ b/src/quic/SocketQUICVersion.c
@@ -15,6 +15,7 @@
 
 #include "quic/SocketQUICVersion.h"
 #include "quic/SocketQUICConnectionID.h"
+#include "core/SocketUtil.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -103,11 +104,8 @@ SocketQUICVersion_create_negotiation (const SocketQUICConnectionID_T *dcid,
   /* Supported Versions (4 bytes each, network byte order) */
   for (size_t i = 0; i < count; i++)
     {
-      uint32_t version = versions[i];
-      output[pos++] = (version >> 24) & 0xFF;
-      output[pos++] = (version >> 16) & 0xFF;
-      output[pos++] = (version >> 8) & 0xFF;
-      output[pos++] = version & 0xFF;
+      socket_util_pack_be32 (&output[pos], versions[i]);
+      pos += 4;
     }
 
   return (int)pos;
@@ -147,8 +145,7 @@ SocketQUICVersion_parse_negotiation (const uint8_t *data, size_t len,
     return QUIC_VERSION_NEG_ERROR_PARSE;
 
   /* Version field: Must be 0x00000000 */
-  uint32_t version = ((uint32_t)data[pos] << 24) | ((uint32_t)data[pos + 1] << 16)
-                     | ((uint32_t)data[pos + 2] << 8) | data[pos + 3];
+  uint32_t version = socket_util_unpack_be32 (&data[pos]);
   pos += 4;
 
   if (version != QUIC_VERSION_NEGOTIATION)
@@ -204,9 +201,7 @@ SocketQUICVersion_parse_negotiation (const uint8_t *data, size_t len,
 
   for (size_t i = 0; i < versions_to_copy; i++)
     {
-      versions_out[i] = ((uint32_t)data[pos] << 24)
-                        | ((uint32_t)data[pos + 1] << 16)
-                        | ((uint32_t)data[pos + 2] << 8) | data[pos + 3];
+      versions_out[i] = socket_util_unpack_be32 (&data[pos]);
       pos += 4;
     }
 


### PR DESCRIPTION
## Summary

Implements #961

This PR refactors `SocketQUICVersion.c` to use existing `socket_util_pack_be32()` and `socket_util_unpack_be32()` helper functions instead of manual bit-shift byte-order conversions.

## Changes

- Added `#include "core/SocketUtil.h"` to imports
- Replaced manual packing (lines 106-111) with `socket_util_pack_be32()`
- Replaced manual unpacking (lines 150-151) with `socket_util_unpack_be32()`
- Replaced manual unpacking (lines 207-209) with `socket_util_unpack_be32()`

## Benefits

- **Consistency**: Uses the same byte-order conversion functions as DNS, HTTP/2, and other protocol modules
- **Readability**: Intent is clearer with named functions vs manual bit shifts
- **Maintainability**: Single source of truth for byte-order conversion
- **Less error-prone**: Eliminates possibility of typos in bit shift patterns

## Test Plan

- [x] Tests pass with sanitizers enabled (all 112 tests)
- [x] QUIC version-specific tests pass (`test_quic_version`)
- [x] No functional changes - pure refactoring

Closes #961