### PR TITLE
refactor(quic): replace magic number 9 with named constants in PATH frame functions

### DIFF
--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -18,6 +18,10 @@
 #define QUIC_FRAME_ACK_MAX_RANGES 256
 #define QUIC_FRAME_HEADER_MAX_SIZE 32
 
+/* PATH frame size constants (RFC 9000 §19.17-19.18) */
+#define QUIC_PATH_DATA_SIZE 8
+#define QUIC_PATH_FRAME_SIZE (1 + QUIC_PATH_DATA_SIZE)
+
 /* Conservative buffer size estimates for QUIC frame encoding.
  * These assume maximum varint encoding (8 bytes) for all variable-length fields.
  * Used for pre-flight buffer size checks in frame encoding functions.

--- a/src/quic/SocketQUICFrame-path.c
+++ b/src/quic/SocketQUICFrame-path.c
@@ -33,10 +33,10 @@ SocketQUICFrame_encode_path_challenge (const uint8_t data[8], uint8_t *out)
   /* Frame type */
   out[0] = QUIC_FRAME_PATH_CHALLENGE;
 
-  /* Copy 8-byte challenge data */
-  memcpy (out + 1, data, 8);
+  /* Copy challenge data */
+  memcpy (out + 1, data, QUIC_PATH_DATA_SIZE);
 
-  return 9; /* 1 byte type + 8 bytes data */
+  return QUIC_PATH_FRAME_SIZE;
 }
 
 /* ============================================================================
@@ -61,10 +61,10 @@ SocketQUICFrame_encode_path_response (const uint8_t data[8], uint8_t *out)
   /* Frame type */
   out[0] = QUIC_FRAME_PATH_RESPONSE;
 
-  /* Copy 8-byte response data (echoed from challenge) */
-  memcpy (out + 1, data, 8);
+  /* Copy response data (echoed from challenge) */
+  memcpy (out + 1, data, QUIC_PATH_DATA_SIZE);
 
-  return 9; /* 1 byte type + 8 bytes data */
+  return QUIC_PATH_FRAME_SIZE;
 }
 
 /* ============================================================================
@@ -79,7 +79,7 @@ int
 SocketQUICFrame_decode_path_challenge (const uint8_t *in, size_t len,
                                        uint8_t data[8])
 {
-  if (!in || !data || len < 9)
+  if (!in || !data || len < QUIC_PATH_FRAME_SIZE)
     return -1;
 
   /* Verify frame type */
@@ -87,9 +87,9 @@ SocketQUICFrame_decode_path_challenge (const uint8_t *in, size_t len,
     return -1;
 
   /* Copy challenge data */
-  memcpy (data, in + 1, 8);
+  memcpy (data, in + 1, QUIC_PATH_DATA_SIZE);
 
-  return 9; /* 1 byte type + 8 bytes data */
+  return QUIC_PATH_FRAME_SIZE;
 }
 
 /* ============================================================================
@@ -104,7 +104,7 @@ int
 SocketQUICFrame_decode_path_response (const uint8_t *in, size_t len,
                                       uint8_t data[8])
 {
-  if (!in || !data || len < 9)
+  if (!in || !data || len < QUIC_PATH_FRAME_SIZE)
     return -1;
 
   /* Verify frame type */
@@ -112,7 +112,7 @@ SocketQUICFrame_decode_path_response (const uint8_t *in, size_t len,
     return -1;
 
   /* Copy response data */
-  memcpy (data, in + 1, 8);
+  memcpy (data, in + 1, QUIC_PATH_DATA_SIZE);
 
-  return 9; /* 1 byte type + 8 bytes data */
+  return QUIC_PATH_FRAME_SIZE;
 }


### PR DESCRIPTION
## Summary

Implements #962 by replacing hardcoded magic number `9` with self-documenting named constants in PATH frame encoding/decoding functions.

## Changes

- Added `QUIC_PATH_DATA_SIZE` constant (8 bytes)
- Added `QUIC_PATH_FRAME_SIZE` constant (1 + QUIC_PATH_DATA_SIZE = 9 bytes)
- Updated all four PATH frame functions to use the new constants:
  - `SocketQUICFrame_encode_path_challenge()`
  - `SocketQUICFrame_encode_path_response()`
  - `SocketQUICFrame_decode_path_challenge()`
  - `SocketQUICFrame_decode_path_response()`

## Benefits

- Self-documenting code: relationship between frame type byte and data size is explicit
- Improved maintainability: single point of change if frame format evolves
- Consistency with RFC 9000 §19.17-19.18 specification

## Test Plan

- [x] All 112 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Build successful with no warnings
- [x] No behavioral changes - purely refactoring

Closes #962