### PR TITLE
security(quic): use constant-time comparison for address matching

### DIFF
--- a/src/quic/SocketQUICConnection-demux.c
+++ b/src/quic/SocketQUICConnection-demux.c
@@ -12,6 +12,7 @@
 #include <unistd.h>
 #include "core/Arena.h"
 #include "core/Except.h"
+#include "core/SocketCrypto.h"
 #include "quic/SocketQUICConnection.h"
 #include "quic/SocketQUICConnectionID.h"
 #include "quic/SocketQUICConstants.h"
@@ -211,7 +212,7 @@ SocketQUICConnection_T SocketQUICConnTable_lookup_by_addr(SocketQUICConnTable_T 
       pthread_mutex_unlock(&table->mutex);
       return NULL;
     }
-    if (conn->local_port == local_port && conn->peer_port == peer_port && conn->is_ipv6 == is_ipv6 && memcmp(conn->local_addr, local_addr, addr_len) == 0 && memcmp(conn->peer_addr, peer_addr, addr_len) == 0) { pthread_mutex_unlock(&table->mutex); return conn; }
+    if (conn->local_port == local_port && conn->peer_port == peer_port && conn->is_ipv6 == is_ipv6 && SocketCrypto_secure_compare(conn->local_addr, local_addr, addr_len) == 0 && SocketCrypto_secure_compare(conn->peer_addr, peer_addr, addr_len) == 0) { pthread_mutex_unlock(&table->mutex); return conn; }
     conn = conn->hash_next;
   }
   pthread_mutex_unlock(&table->mutex);


### PR DESCRIPTION
## Summary

Implements #964 - Replace timing-vulnerable `memcmp()` with constant-time `SocketCrypto_secure_compare()` in QUIC connection demultiplexing.

## Changes

- **File**: `src/quic/SocketQUICConnection-demux.c`
- Added include for `core/SocketCrypto.h`
- Replaced two `memcmp()` calls with `SocketCrypto_secure_compare()` in `SocketQUICConnTable_lookup_by_addr()` for address comparison
  - `local_addr` comparison (line 215)
  - `peer_addr` comparison (line 215)

## Security Impact

- **Defense-in-depth**: Prevents potential timing side-channel attacks during QUIC connection lookup
- **Best practices**: Aligns with secure coding standards for security-sensitive protocol implementations
- **Performance**: Minimal impact - constant-time comparison has same order of magnitude as `memcmp()`

## Test Plan

- [x] All QUIC tests pass (24/24 tests)
- [x] Build succeeds with sanitizers enabled
- [x] No functional regressions

## Pattern

This change follows the `TIMING_ATTACK_MEMCMP` security pattern, using constant-time comparison for IP address matching in the QUIC connection table lookup path.

Closes #964