### PR TITLE
refactor(quic): improve type clarity in SocketQUIC_error_string cast

### DIFF
--- a/src/quic/SocketQUICError.c
+++ b/src/quic/SocketQUICError.c
@@ -67,7 +67,7 @@ SocketQUIC_error_string (uint64_t code)
   if (QUIC_IS_CRYPTO_ERROR (code))
     {
       int ret = snprintf (crypto_buf, sizeof (crypto_buf), "CRYPTO_ERROR(0x%02x)",
-                          (unsigned int)QUIC_CRYPTO_ALERT (code));
+                          (uint8_t)QUIC_CRYPTO_ALERT (code));
 
       /* Defensive check: should never happen with current format */
       if (ret < 0 || (size_t)ret >= sizeof (crypto_buf))


### PR DESCRIPTION
## Summary

Implements #959

Improved type clarity in `SocketQUIC_error_string()` by changing the cast from `unsigned int` to `uint8_t` when formatting QUIC crypto error codes.

## Changes

- Changed cast in `src/quic/SocketQUICError.c` line 70 from `(unsigned int)` to `(uint8_t)`
- The `QUIC_CRYPTO_ALERT` macro masks values to 0xff (0-255 range)
- Using `uint8_t` makes the 8-bit nature explicit and improves code clarity

## Test Plan

- [x] Build completes successfully
- [x] All 112 tests pass with sanitizers (ASan + UBSan)
- [x] QUIC error tests pass (48/48 tests)
- [x] Output format unchanged
- [x] No functional changes, only improved type clarity

## Impact

- **Severity**: Low
- **Category**: Code clarity / maintainability
- **Type**: Refactoring
- **Benefit**: Improved self-documenting code

Closes #959