### PR TITLE
refactor(quic): extract HKDF TLS 1.3 prefix length to named constant

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -50,6 +50,14 @@
  */
 
 /**
+ * @brief TLS 1.3 label prefix length.
+ *
+ * Per RFC 8446 Section 7.1, all HKDF-Expand-Label operations use the
+ * "tls13 " prefix (6 bytes including the space).
+ */
+#define QUIC_HKDF_TLS13_PREFIX_LEN 6
+
+/**
  * @brief Maximum size of HKDF label buffer.
  *
  * Per RFC 8446 Section 7.1, the HkdfLabel structure is:

--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -256,14 +256,14 @@ build_hkdf_label (const char *label, size_t label_len,
   hkdf_label[(*hkdf_label_len)++] = (uint8_t)(output_len & 0xFF);
 
   /* Label length and "tls13 " prefix + actual label */
-  size_t full_label_len = 6 + label_len;
+  size_t full_label_len = QUIC_HKDF_TLS13_PREFIX_LEN + label_len;
   hkdf_label[(*hkdf_label_len)++] = (uint8_t)full_label_len;
 
   /* Check space for "tls13 " prefix */
-  if (*hkdf_label_len + 6 > QUIC_HKDF_LABEL_MAX_SIZE)
+  if (*hkdf_label_len + QUIC_HKDF_TLS13_PREFIX_LEN > QUIC_HKDF_LABEL_MAX_SIZE)
     return -1;
-  memcpy (hkdf_label + *hkdf_label_len, "tls13 ", 6);
-  *hkdf_label_len += 6;
+  memcpy (hkdf_label + *hkdf_label_len, "tls13 ", QUIC_HKDF_TLS13_PREFIX_LEN);
+  *hkdf_label_len += QUIC_HKDF_TLS13_PREFIX_LEN;
 
   /* Check space for label */
   if (*hkdf_label_len + label_len > QUIC_HKDF_LABEL_MAX_SIZE)


### PR DESCRIPTION
## Summary

Implements #979

Replaces hardcoded magic number `6` with named constant `QUIC_HKDF_TLS13_PREFIX_LEN` in the HKDF-Expand-Label implementation.

## Changes

- Added `QUIC_HKDF_TLS13_PREFIX_LEN` constant to `include/quic/SocketQUICConstants.h`
- Replaced all three occurrences of magic number `6` in `src/quic/SocketQUICPacket-initial.c`:
  - Line 259: `full_label_len` calculation
  - Line 263: Buffer size check
  - Line 265: `memcpy` length parameter

## Context

The value `6` represents the length of the "tls13 " prefix used in TLS 1.3 HKDF-Expand-Label construction per RFC 8446 Section 7.1. This is a protocol constant that should be clearly named.

## Test Plan

- [x] All tests pass with sanitizers enabled (113/113)
- [x] Build completes successfully with `-Wall -Wextra -Werror`
- [x] No functional changes - purely a refactoring

Closes #979