### PR TITLE
refactor(quic): add constants for preferred address protocol field sizes

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -274,6 +274,41 @@
 #define QUIC_STATELESS_RESET_MIN_SIZE 38
 
 /* ============================================================================
+ * Preferred Address Field Sizes (RFC 9000 Section 18.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief IPv4 address length in bytes.
+ *
+ * Standard IPv4 address size for preferred address encoding.
+ */
+#define QUIC_IPV4_ADDR_LEN 4
+
+/**
+ * @brief IPv6 address length in bytes.
+ *
+ * Standard IPv6 address size for preferred address encoding.
+ */
+#define QUIC_IPV6_ADDR_LEN 16
+
+/**
+ * @brief Port number length in bytes.
+ *
+ * Port encoded as big-endian uint16_t.
+ */
+#define QUIC_PORT_LEN 2
+
+/**
+ * @brief Minimum preferred address size in bytes.
+ *
+ * Minimum size when connection_id.len = 0:
+ * IPv4 (4) + IPv4 port (2) + IPv6 (16) + IPv6 port (2) +
+ * CID length (1) + CID (0) + Stateless Reset Token (16) = 41 bytes
+ */
+#define QUIC_PREFERRED_ADDR_MIN_SIZE 41
+
+/* ============================================================================
  * String Formatting Constants
  * ============================================================================
  */

--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -259,7 +259,9 @@ encode_preferred_address (uint8_t *buf, size_t buf_size,
   size_t len;
 
   /* Calculate content size */
-  size_t content_size = 4 + 2 + 16 + 2 + 1 + paddr->connection_id.len + 16;
+  size_t content_size = QUIC_IPV4_ADDR_LEN + QUIC_PORT_LEN +
+                        QUIC_IPV6_ADDR_LEN + QUIC_PORT_LEN + 1 +
+                        paddr->connection_id.len + QUIC_STATELESS_RESET_TOKEN_LEN;
 
   /* Encode parameter ID */
   len = SocketQUICVarInt_encode (QUIC_TP_PREFERRED_ADDRESS, buf + pos,
@@ -344,7 +346,9 @@ empty_param_size (uint64_t id)
 static size_t
 preferred_address_size (const SocketQUICPreferredAddress_T *paddr)
 {
-  size_t content_size = 4 + 2 + 16 + 2 + 1 + paddr->connection_id.len + 16;
+  size_t content_size = QUIC_IPV4_ADDR_LEN + QUIC_PORT_LEN +
+                        QUIC_IPV6_ADDR_LEN + QUIC_PORT_LEN + 1 +
+                        paddr->connection_id.len + QUIC_STATELESS_RESET_TOKEN_LEN;
   size_t id_size = SocketQUICVarInt_size (QUIC_TP_PREFERRED_ADDRESS);
   size_t len_size = SocketQUICVarInt_size (content_size);
   return id_size + len_size + content_size;
@@ -678,8 +682,8 @@ decode_preferred_address (const uint8_t *data, size_t len,
 {
   size_t pos = 0;
 
-  /* Minimum size: 4+2+16+2+1+0+16 = 41 bytes */
-  if (len < 41)
+  /* Minimum size when CID length is 0 */
+  if (len < QUIC_PREFERRED_ADDR_MIN_SIZE)
     return QUIC_TP_ERROR_INCOMPLETE;
 
   /* IPv4 address */


### PR DESCRIPTION
## Summary

Implements #985

Replaces hardcoded magic numbers for preferred address field sizes with named constants to improve code clarity and maintainability.

## Changes

- Added constants to `include/quic/SocketQUICConstants.h`:
  - `QUIC_IPV4_ADDR_LEN` (4 bytes)
  - `QUIC_IPV6_ADDR_LEN` (16 bytes)
  - `QUIC_PORT_LEN` (2 bytes)
  - `QUIC_PREFERRED_ADDR_MIN_SIZE` (41 bytes)

- Updated three locations in `src/quic/SocketQUICTransportParams.c`:
  - `encode_preferred_address()` - line 262
  - `preferred_address_size()` - line 347
  - `decode_preferred_address()` - line 681

## Test Plan

- [x] Tests pass with sanitizers
- [x] All QUIC transport params tests pass
- [x] Build successful with no warnings

Closes #985