### PR TITLE
refactor(quic): remove unused stdio.h include from SocketQUICConnectionID.c

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -11,7 +11,6 @@
  * and utility functions.
  */
 
-#include <stdio.h>
 #include <string.h>
 
 #include "quic/SocketQUICConnectionID.h"


### PR DESCRIPTION
## Summary

Implements #990

## Changes

- Removed unused `<stdio.h>` include from `src/quic/SocketQUICConnectionID.c`
- The file does not use any stdio.h functions (no printf, fprintf, sprintf, FILE operations)

## Benefits

- Reduces compilation dependencies
- Makes actual dependencies clearer
- Slightly faster compilation
- Follows principle of minimal includes

## Test Plan

- [x] All 113 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Build succeeds with ENABLE_SANITIZERS=ON
- [x] No functionality changed - pure refactoring

Closes #990