### PR TITLE
refactor(tls-ktls): fix overflow check logic in sendfile fallback

### DIFF
--- a/src/tls/SocketTLS-ktls.c
+++ b/src/tls/SocketTLS-ktls.c
@@ -317,9 +317,12 @@ SocketTLS_sendfile (Socket_T socket, int file_fd, off_t offset, size_t size)
       size_t sent_chunk = 0;
       while (sent_chunk < (size_t)nread)
         {
-          int to_send = (int)(nread - sent_chunk);
-          if (to_send > INT_MAX)
+          ssize_t remaining = nread - sent_chunk;
+          int to_send;
+          if (remaining > INT_MAX)
             to_send = INT_MAX;
+          else
+            to_send = (int)remaining;
 
           int ret_raw = SSL_write (ssl, buf + sent_chunk, to_send);
           ssize_t ret = tls_handle_ssl_write_result (ssl, ret_raw, "SSL_write in sendfile fallback");


### PR DESCRIPTION
## Summary

Fixes #993

## Changes

- Fixed overflow check in `SocketTLS_sendfile()` fallback implementation
- Now performs overflow check BEFORE casting to `int`, not after
- Prevents silent truncation when `(nread - sent_chunk) > INT_MAX`

## Details

**Before:**
```c
int to_send = (int)(nread - sent_chunk);
if (to_send > INT_MAX)
  to_send = INT_MAX;
```

**After:**
```c
ssize_t remaining = nread - sent_chunk;
int to_send;
if (remaining > INT_MAX)
  to_send = INT_MAX;
else
  to_send = (int)remaining;
```

## Impact

This is a code quality fix. While unlikely to trigger in practice (buffer size is 64KB, INT_MAX is 2GB+), the logic is now correct and prevents potential silent truncation bugs.

## Test Plan

- [x] All tests pass with sanitizers enabled (113/113 tests passed)
- [x] Verified overflow check occurs before cast
- [x] No functional behavior change for normal operations

Closes #993