### PR TITLE
refactor(quic): replace magic number 1000 with SOCKET_MS_PER_SECOND constant

### DIFF
--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -42,7 +42,8 @@ get_monotonic_ms (void)
     {
       return 0;
     }
-  return (uint64_t)ts.tv_sec * 1000 + (uint64_t)ts.tv_nsec / 1000000;
+  return (uint64_t)ts.tv_sec * SOCKET_MS_PER_SECOND
+         + (uint64_t)ts.tv_nsec / SOCKET_NS_PER_MS;
 }
 
 /**
@@ -268,7 +269,7 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
   current_time = get_monotonic_ms ();
   if (current_time > token_timestamp
       && (current_time - token_timestamp)
-             > (QUIC_ADDR_VALIDATION_TOKEN_LIFETIME * 1000))
+             > (QUIC_ADDR_VALIDATION_TOKEN_LIFETIME * SOCKET_MS_PER_SECOND))
     {
       return QUIC_ADDR_VALIDATION_ERROR_EXPIRED;
     }


### PR DESCRIPTION
## Summary

Implements #980 - Replaces hardcoded `1000` magic numbers with named constants `SOCKET_MS_PER_SECOND` and `SOCKET_NS_PER_MS` from SocketConfig.h in SocketQUICAddrValidation.c.

## Changes

- **Line 45**: Replace `1000` with `SOCKET_MS_PER_SECOND` for seconds to milliseconds conversion
- **Line 45**: Replace `1000000` with `SOCKET_NS_PER_MS` for nanoseconds to milliseconds conversion
- **Line 271**: Replace `1000` with `SOCKET_MS_PER_SECOND` for token lifetime calculation

## Benefits

- **Self-documenting code**: Intent is immediately clear from constant names
- **Single source of truth**: Time conversion constants centralized in SocketConfig.h
- **Maintainability**: Easier to update if conversion logic changes
- **Consistency**: Aligns with existing constant naming patterns (e.g., `QUIC_ADDR_VALIDATION_TOKEN_LIFETIME`)

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All QUIC address validation tests pass (13/13)
- [x] No new compiler warnings
- [x] Code review for correctness

Closes #980