### PR TITLE
refactor(quic): expand transport params duplicate detection to 64 parameter IDs

### DIFF
--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -1039,7 +1039,7 @@ SocketQUICTransportParams_decode (const uint8_t *data, size_t len,
 {
   size_t pos = 0;
   SocketQUICTransportParams_Result result;
-  uint32_t seen_params = 0; /* Bitmap for duplicate detection */
+  uint64_t seen_params = 0; /* Bitmap for duplicate detection (up to param ID 63) */
 
   if (data == NULL || params == NULL || consumed == NULL)
     return QUIC_TP_ERROR_NULL;
@@ -1072,9 +1072,9 @@ SocketQUICTransportParams_decode (const uint8_t *data, size_t len,
         return QUIC_TP_ERROR_INCOMPLETE;
 
       /* Check for duplicates (for known parameters) */
-      if (param_id <= 31)
+      if (param_id <= 63)
         {
-          uint32_t mask = 1u << param_id;
+          uint64_t mask = 1ULL << param_id;
           if (seen_params & mask)
             return QUIC_TP_ERROR_DUPLICATE;
           seen_params |= mask;


### PR DESCRIPTION
## Summary

Implements #988

Expands the QUIC transport parameter duplicate detection from 32 to 64 parameter IDs by upgrading the bitmap from uint32_t to uint64_t.

## Changes

- Changed `seen_params` from `uint32_t` to `uint64_t` in `SocketQUICTransportParams_decode()`
- Extended range check from `<= 31` to `<= 63`
- Updated shift operation to use `1ULL` for proper 64-bit arithmetic

## Rationale

The previous 32-bit bitmap could only track duplicate detection for parameter IDs 0-31. QUIC defines parameter 0x20 (DATAGRAM) at ID 32, which was beyond the tracking range. This meant duplicates of higher-numbered parameters could not be detected.

This implementation follows Option 1 from the issue analysis as the simplest and most appropriate solution for near-term needs, doubling the coverage range while maintaining minimal code changes.

## Test Plan

- [x] All QUIC tests pass (25/25 tests, 100% success rate)
- [x] Specific test `test_quic_transport_params` passes with sanitizers
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] No memory leaks detected by ASan
- [x] No undefined behavior detected by UBSan

Closes #988