### PR TITLE
fix(tls): use raise_system_error() for pthread errors in init_crl_mutex()

### DIFF
--- a/src/tls/SocketTLSContext-core.c
+++ b/src/tls/SocketTLSContext-core.c
@@ -196,18 +196,18 @@ init_crl_mutex (T ctx)
   pthread_mutexattr_t attr;
 
   if (pthread_mutexattr_init (&attr) != 0)
-    ctx_raise_openssl_error ("Failed to initialize CRL mutex attr");
+    raise_system_error ("Failed to initialize CRL mutex attr");
 
   if (pthread_mutexattr_settype (&attr, PTHREAD_MUTEX_RECURSIVE) != 0)
     {
       pthread_mutexattr_destroy (&attr);
-      ctx_raise_openssl_error ("Failed to set recursive mutex type");
+      raise_system_error ("Failed to set recursive mutex type");
     }
 
   if (pthread_mutex_init (&ctx->crl_mutex, &attr) != 0)
     {
       pthread_mutexattr_destroy (&attr);
-      ctx_raise_openssl_error ("Failed to initialize CRL mutex");
+      raise_system_error ("Failed to initialize CRL mutex");
     }
 
   pthread_mutexattr_destroy (&attr);


### PR DESCRIPTION
## Summary

Fixes #992 - Corrects error handling in `init_crl_mutex()` to use the appropriate error function for pthread failures.

## Changes

- Changed `ctx_raise_openssl_error()` to `raise_system_error()` for all three pthread function calls in `init_crl_mutex()`:
  - `pthread_mutexattr_init()`
  - `pthread_mutexattr_settype()`
  - `pthread_mutex_init()`

## Rationale

pthread functions return errno-based error codes, not OpenSSL error codes. Using `ctx_raise_openssl_error()` would:
- Check an empty OpenSSL error queue
- Provide misleading "Unknown TLS error" messages
- Fail to report the actual errno value

`raise_system_error()` correctly:
- Formats errno using `Socket_safe_strerror()`
- Provides meaningful error diagnostics
- Makes mutex initialization failures easier to debug

## Test Plan

- [x] All tests pass with sanitizers enabled (113/113 tests)
- [x] Code builds without warnings
- [x] Changes verified in `/home/tetsuo/git/tetsuo-socket-issue-992/src/tls/SocketTLSContext-core.c`

Closes #992