### PR TITLE
refactor(tls-verify): remove redundant OCSP response size check

### DIFF
--- a/src/tls/SocketTLSContext-verify.c
+++ b/src/tls/SocketTLSContext-verify.c
@@ -858,8 +858,8 @@ status_cb_wrapper (SSL *ssl, void *arg)
   len = encode_ocsp_response (resp, &der);
   OCSP_RESPONSE_free (resp);
 
-  /* Combined check: encoding failed OR response too large */
-  if (len == 0 || len > SOCKET_TLS_MAX_OCSP_RESPONSE_LEN)
+  /* Check encoding result (encode_ocsp_response validates size internally) */
+  if (len == 0)
     {
       if (der)
         OPENSSL_free (der);


### PR DESCRIPTION
## Summary

Implements #1001

Removes redundant OCSP response size validation in `status_cb_wrapper` function. The size check is already performed inside the `encode_ocsp_response` helper function, making the duplicate check at the call site unnecessary.

## Changes

- **File**: `src/tls/SocketTLSContext-verify.c`
- **Line 862**: Simplified check from `len == 0 || len > SOCKET_TLS_MAX_OCSP_RESPONSE_LEN` to just `len == 0`
- **Rationale**: `encode_ocsp_response` already validates size at line 821 and returns 0 on failure

## Benefits

- Eliminates code redundancy
- Maintains single source of truth for size validation
- Improves code maintainability
- Makes intent clearer (helper function handles all validation)

## Test Plan

- [x] All OCSP tests pass (test_tls_ocsp - 16/16 tests)
- [x] Coverage tests pass including `cov_tls_ocsp_response_too_large`
- [x] Full test suite passes with sanitizers enabled (113/113 tests)
- [x] No functional changes - purely refactoring

Closes #1001