### PR TITLE
refactor(tls): eliminate volatile variable in try_load_user_ca() using RETURN macro

### DIFF
--- a/src/tls/SocketTLSContext-core.c
+++ b/src/tls/SocketTLSContext-core.c
@@ -534,25 +534,23 @@ tls_context_get_from_ssl (const SSL *ssl)
 static int
 try_load_user_ca (T ctx, const char *ca_file)
 {
-  volatile int loaded = 0;
-
   TRY
   {
     SocketTLSContext_load_ca (ctx, ca_file);
     SOCKET_LOG_INFO_MSG ("Loaded user-provided CA '%s' for client context %p",
                          ca_file, (void *)ctx);
-    loaded = 1;
+    RETURN 1;
   }
   EXCEPT (SocketTLS_Failed)
   {
     SOCKET_LOG_WARN_MSG ("Failed to load user-provided CA '%s' for client "
                          "context %p - attempting system CA fallback",
                          ca_file, (void *)ctx);
-    loaded = 0;
+    RETURN 0;
   }
   END_TRY;
 
-  return loaded;
+  return 0;  /* Unreachable, but required for -Werror=return-type */
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #995

Refactors `try_load_user_ca()` to use the `RETURN` macro instead of a volatile variable, eliminating unnecessary volatile qualification while maintaining proper exception stack unwinding.

## Changes

- Removed `volatile int loaded` variable
- Replaced with direct `RETURN` statements in TRY/EXCEPT blocks
- Added unreachable return statement for compiler compatibility

## Rationale

The original issue proposed simply removing `volatile`, but this caused:
1. Compiler warning `-Wclobbered` (variable might be clobbered by longjmp)
2. AddressSanitizer error (stack-use-after-return when using bare `return`)

The solution uses the `RETURN` macro (defined in `Except.h`), which properly unwinds the exception stack before returning, avoiding both issues.

## Test Plan

- [x] All TLS tests pass with sanitizers (test_tls_phase4, test_mtls, test_tls_context)
- [x] Tests run multiple times to ensure stability
- [x] No AddressSanitizer errors
- [x] No memory leaks detected
- [x] Build succeeds with -Werror

Closes #995