### PR TITLE
refactor(quic): extract duplicated stream initialization logic

### DIFF
--- a/src/quic/SocketQUICStream.c
+++ b/src/quic/SocketQUICStream.c
@@ -122,6 +122,24 @@ SocketQUICStream_sequence (uint64_t stream_id)
  * ============================================================================
  */
 
+/**
+ * stream_set_defaults - Initialize stream fields to default values
+ * @stream: Stream structure to initialize
+ * @stream_id: Stream ID to assign
+ *
+ * Sets the stream's ID, type, and initial states. Should be called after
+ * memset() to zero the structure.
+ */
+static void
+stream_set_defaults (SocketQUICStream_T stream, uint64_t stream_id)
+{
+  stream->id = stream_id;
+  stream->type = SocketQUICStream_type (stream_id);
+  stream->state = QUIC_STREAM_STATE_READY; /* Legacy */
+  stream->send_state = QUIC_STREAM_STATE_READY;
+  stream->recv_state = QUIC_STREAM_STATE_RECV;
+}
+
 SocketQUICStream_T
 SocketQUICStream_new (Arena_T arena, uint64_t stream_id)
 {
@@ -153,12 +171,7 @@ SocketQUICStream_init (SocketQUICStream_T stream, uint64_t stream_id)
     return QUIC_STREAM_ERROR_INVALID_ID;
 
   memset (stream, 0, sizeof (*stream));
-
-  stream->id = stream_id;
-  stream->type = SocketQUICStream_type (stream_id);
-  stream->state = QUIC_STREAM_STATE_READY; /* Legacy */
-  stream->send_state = QUIC_STREAM_STATE_READY;
-  stream->recv_state = QUIC_STREAM_STATE_RECV;
+  stream_set_defaults (stream, stream_id);
 
   return QUIC_STREAM_OK;
 }
@@ -173,11 +186,7 @@ SocketQUICStream_reset (SocketQUICStream_T stream)
 
   id = stream->id;
   memset (stream, 0, sizeof (*stream));
-  stream->id = id;
-  stream->type = SocketQUICStream_type (id);
-  stream->state = QUIC_STREAM_STATE_READY; /* Legacy */
-  stream->send_state = QUIC_STREAM_STATE_READY;
-  stream->recv_state = QUIC_STREAM_STATE_RECV;
+  stream_set_defaults (stream, id);
 
   return QUIC_STREAM_OK;
 }


### PR DESCRIPTION
## Summary

Implements #974

Extracted common stream initialization logic from SocketQUICStream_init() and SocketQUICStream_reset() into a private helper function stream_set_defaults().

## Changes

- Added stream_set_defaults() static helper function
- Refactored SocketQUICStream_init() to use the helper
- Refactored SocketQUICStream_reset() to use the helper
- Eliminated 10 lines of duplicated code

## Benefits

- Reduces code duplication
- Improves maintainability
- Ensures consistent initialization logic

## Test Plan

- [x] All tests pass with sanitizers (109/109 in worktree)
- [x] No behavior changes - purely refactoring
- [x] Code builds cleanly

Closes #974