### PR TITLE
docs(quic): document struct padding safety in SocketQUICConnectionID_copy

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -160,6 +160,9 @@ SocketQUICConnectionID_copy (SocketQUICConnectionID_T *dst,
   if (dst == NULL || src == NULL)
     return QUIC_CONNID_ERROR_NULL;
 
+  /* Safe: struct padding (3 bytes between len and sequence, 4 bytes at end)
+   * is always zeroed by SocketQUICConnectionID_init() before use, ensuring
+   * deterministic memcpy behavior and avoiding uninitialized memory issues. */
   memcpy (dst, src, sizeof (*dst));
   return QUIC_CONNID_OK;
 }


### PR DESCRIPTION
## Summary

Implements #991

Documents the safety invariant that makes `memcpy()` safe for copying `SocketQUICConnectionID_T` structures including their padding bytes.

## Changes

- Added inline comment to `SocketQUICConnectionID_copy()` documenting that struct padding (3 bytes between `len` and `sequence`, 4 bytes at end) is always zeroed by `SocketQUICConnectionID_init()` before use
- This ensures deterministic `memcpy()` behavior and avoids uninitialized memory issues

## Analysis

The struct layout includes:
- 3 bytes of padding between `uint8_t len` (offset 20) and `uint64_t sequence` (offset 24)
- 4 bytes of padding at the end (offset 52-56)

The current implementation is safe because `SocketQUICConnectionID_init()` (line 55) uses `memset()` to zero the entire struct before use, ensuring all padding bytes are deterministic.

## Test Plan

- [x] All QUIC connection ID tests pass with sanitizers
- [x] Full test suite passes in worktree (113/113 tests)
- [x] No functional changes, documentation only

Closes #991