### PR TITLE
refactor(quic): replace magic numbers with named constants in SocketQUICTransportParams_set_defaults

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -297,6 +297,64 @@
  * ============================================================================
  */
 
+/* ============================================================================
+ * Transport Parameters: Typical/Recommended Defaults
+ * ============================================================================
+ *
+ * These values represent sensible production defaults for transport parameters,
+ * distinct from the RFC 9000 protocol defaults (which are mostly 0).
+ * Used by SocketQUICTransportParams_set_defaults() to configure a typical
+ * connection with reasonable limits.
+ */
+
+/**
+ * @brief Typical idle timeout in milliseconds (30 seconds).
+ *
+ * RFC 9000 default is 0 (disabled), but 30 seconds is a reasonable
+ * production value to detect dead connections while allowing for
+ * temporary network issues.
+ */
+#define QUIC_TP_TYPICAL_IDLE_TIMEOUT_MS 30000
+
+/**
+ * @brief Typical initial max data (1 MB).
+ *
+ * RFC 9000 default is 0 (no data allowed), but 1 MB provides a
+ * good starting point for connection-level flow control.
+ */
+#define QUIC_TP_TYPICAL_INITIAL_MAX_DATA (1024 * 1024)
+
+/**
+ * @brief Typical initial max stream data (256 KB).
+ *
+ * RFC 9000 default is 0 (no data allowed), but 256 KB allows
+ * reasonable stream buffering for both bidirectional and
+ * unidirectional streams.
+ */
+#define QUIC_TP_TYPICAL_INITIAL_MAX_STREAM_DATA (256 * 1024)
+
+/**
+ * @brief Typical initial max streams limit (100 streams).
+ *
+ * RFC 9000 default is 0 (no streams allowed), but 100 concurrent
+ * streams is sufficient for most applications while preventing
+ * resource exhaustion.
+ */
+#define QUIC_TP_TYPICAL_INITIAL_MAX_STREAMS 100
+
+/**
+ * @brief Typical active connection ID limit (8 CIDs).
+ *
+ * RFC 9000 default is 2 (minimum), but 8 provides flexibility for
+ * connection migration and load balancing scenarios.
+ */
+#define QUIC_TP_TYPICAL_ACTIVE_CONNID_LIMIT 8
+
+/* ============================================================================
+ * Utility Macros
+ * ============================================================================
+ */
+
 /**
  * @brief Compute FNV-1a hash step.
  *

--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -119,14 +119,14 @@ SocketQUICTransportParams_set_defaults (SocketQUICTransportParams_T *params,
   SocketQUICTransportParams_init (params);
 
   /* Set reasonable defaults for a typical connection */
-  params->max_idle_timeout = 30000;               /* 30 seconds */
-  params->initial_max_data = 1048576;             /* 1 MB */
-  params->initial_max_stream_data_bidi_local = 262144;  /* 256 KB */
-  params->initial_max_stream_data_bidi_remote = 262144; /* 256 KB */
-  params->initial_max_stream_data_uni = 262144;         /* 256 KB */
-  params->initial_max_streams_bidi = 100;
-  params->initial_max_streams_uni = 100;
-  params->active_connection_id_limit = 8;
+  params->max_idle_timeout = QUIC_TP_TYPICAL_IDLE_TIMEOUT_MS;
+  params->initial_max_data = QUIC_TP_TYPICAL_INITIAL_MAX_DATA;
+  params->initial_max_stream_data_bidi_local = QUIC_TP_TYPICAL_INITIAL_MAX_STREAM_DATA;
+  params->initial_max_stream_data_bidi_remote = QUIC_TP_TYPICAL_INITIAL_MAX_STREAM_DATA;
+  params->initial_max_stream_data_uni = QUIC_TP_TYPICAL_INITIAL_MAX_STREAM_DATA;
+  params->initial_max_streams_bidi = QUIC_TP_TYPICAL_INITIAL_MAX_STREAMS;
+  params->initial_max_streams_uni = QUIC_TP_TYPICAL_INITIAL_MAX_STREAMS;
+  params->active_connection_id_limit = QUIC_TP_TYPICAL_ACTIVE_CONNID_LIMIT;
 
   (void)role; /* May be used for role-specific defaults in future */
 }


### PR DESCRIPTION
## Summary

Implements #984

Replaces hardcoded magic numbers in `SocketQUICTransportParams_set_defaults()` with named constants defined in `SocketQUICConstants.h`.

## Changes

- **Added constants** in `include/quic/SocketQUICConstants.h`:
  - `QUIC_TP_TYPICAL_IDLE_TIMEOUT_MS` (30000 ms = 30 seconds)
  - `QUIC_TP_TYPICAL_INITIAL_MAX_DATA` (1 MB)
  - `QUIC_TP_TYPICAL_INITIAL_MAX_STREAM_DATA` (256 KB)
  - `QUIC_TP_TYPICAL_INITIAL_MAX_STREAMS` (100)
  - `QUIC_TP_TYPICAL_ACTIVE_CONNID_LIMIT` (8)

- **Updated** `src/quic/SocketQUICTransportParams.c`:
  - Replaced magic numbers with named constants in `SocketQUICTransportParams_set_defaults()`

## Benefits

- Improves code maintainability
- Makes values easier to tune and document
- Prevents inconsistency if multiple places need these values
- Clear distinction between RFC 9000 defaults (mostly 0) and typical production values

## Test Plan

- [x] All 113 tests pass with sanitizers (ASan + UBSan)
- [x] QUIC transport params tests pass (36/36)
- [x] No functional changes - only constant extraction

Closes #984