### PR TITLE
refactor(tls): extract sharded session cache cleanup into separate function

### DIFF
--- a/src/tls/SocketTLSContext-core.c
+++ b/src/tls/SocketTLSContext-core.c
@@ -695,6 +695,30 @@ SocketTLSContext_new_client (const char *ca_file)
   return ctx;
 }
 
+/**
+ * free_sharded_session_cache - Free sharded session cache resources
+ * @ctx: Context with sharded cache to free
+ *
+ * Iterates through all shards, freeing hash tables and destroying mutexes.
+ * Resets sharded_enabled flag after cleanup.
+ */
+static void
+free_sharded_session_cache (T ctx)
+{
+  if (!ctx->sharded_enabled)
+    return;
+
+  for (size_t i = 0; i < ctx->sharded_session_cache.num_shards; i++)
+    {
+      TLSSessionShard_T *shard = &ctx->sharded_session_cache.shards[i];
+      if (shard->session_table)
+        HashTable_free (&shard->session_table);
+      pthread_mutex_destroy (&shard->mutex);
+    }
+
+  ctx->sharded_enabled = 0;
+}
+
 void
 SocketTLSContext_free (T *ctx)
 {
@@ -712,19 +736,7 @@ SocketTLSContext_free (T *ctx)
     }
 
   secure_clear_sensitive_data (c);
-
-  /* Cleanup sharded session cache if enabled */
-  if (c->sharded_enabled)
-    {
-      for (size_t i = 0; i < c->sharded_session_cache.num_shards; i++)
-        {
-          TLSSessionShard_T *shard = &c->sharded_session_cache.shards[i];
-          if (shard->session_table)
-            HashTable_free (&shard->session_table);
-          pthread_mutex_destroy (&shard->mutex);
-        }
-      c->sharded_enabled = 0;
-    }
+  free_sharded_session_cache (c);
 
   if (c->arena)
     Arena_dispose (&c->arena);


### PR DESCRIPTION
## Summary

Implements #999

Extracted the sharded session cache cleanup logic from `SocketTLSContext_free()` into a dedicated helper function `free_sharded_session_cache()` to improve code organization and consistency with other cleanup helpers in the same file.

## Changes

- Added `free_sharded_session_cache()` static helper function in `src/tls/SocketTLSContext-core.c`
- Simplified `SocketTLSContext_free()` by calling the new helper instead of inline cleanup
- Follows the established pattern used by other cleanup functions (`free_sni_arrays`, `free_sni_objects`, `secure_clear_sensitive_data`, `destroy_context_mutexes`)

## Benefits

- **Consistency**: Matches the established pattern of specialized cleanup functions
- **Readability**: Reduces complexity of `SocketTLSContext_free()`
- **Maintainability**: Changes to sharded cache cleanup isolated to one function
- **No functional changes**: Purely organizational refactor

## Test Plan

- [x] All TLS context tests pass (19/19 in `test_tls_context`)
- [x] All TLS session tests pass (12/12 in `test_tls_session`)
- [x] All TLS integration tests pass (44/44 in `test_tls_integration`)
- [x] No memory leaks detected with AddressSanitizer
- [x] Built successfully with `-DENABLE_SANITIZERS=ON`

Closes #999