### PR TITLE
refactor(quic): replace magic number with sizeof in SocketQUICConnectionID_to_hex

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -314,13 +314,13 @@ SocketQUICConnectionID_to_hex (const SocketQUICConnectionID_T *cid, char *buf,
 
   if (cid == NULL || cid->len == 0)
     {
-      if (size < 6)
+      if (size < sizeof ("empty"))
         {
           buf[0] = '\0';
           return -1;
         }
-      memcpy (buf, "empty", 6);
-      return 5;
+      memcpy (buf, "empty", sizeof ("empty"));
+      return sizeof ("empty") - 1;
     }
 
   /* Format: "XX:XX:XX..." requires 3*len-1 chars + null terminator.


### PR DESCRIPTION
## Summary

Implements #989

## Changes

- Replaced hardcoded magic number `6` with `sizeof("empty")` in `SocketQUICConnectionID_to_hex()`
- Updated size check to use `sizeof("empty")` for consistency
- Return value now uses `sizeof("empty") - 1` for clarity

## Test Plan

- [x] All QUIC connection ID tests pass (56/56 tests in test_quic_connid)
- [x] Full test suite passes with sanitizers enabled
- [x] No functional changes - purely refactoring for maintainability

Closes #989