### PR TITLE
refactor(quic): replace Arena_alloc+memset with Arena_calloc in SocketQUICPMTU

### DIFF
--- a/src/quic/SocketQUICPMTU.c
+++ b/src/quic/SocketQUICPMTU.c
@@ -58,11 +58,9 @@ SocketQUICPMTU_new (Arena_T arena, size_t initial_pmtu, size_t max_pmtu)
     max_pmtu = QUIC_MAX_PMTU;
 
   /* Allocate context */
-  pmtu = Arena_alloc (arena, sizeof (*pmtu), __FILE__, __LINE__);
+  pmtu = Arena_calloc (arena, 1, sizeof (*pmtu), __FILE__, __LINE__);
   if (!pmtu)
     return NULL;
-
-  memset (pmtu, 0, sizeof (*pmtu));
 
   /* Initialize state */
   pmtu->arena = arena;


### PR DESCRIPTION
## Summary

Implements #970

## Changes

- Replaced `Arena_alloc` followed by `memset` with `Arena_calloc` in `SocketQUICPMTU_new`
- Eliminates redundant `memset` call by using Arena's zero-initialization function
- Improves code clarity by using the appropriate Arena API function for zero-initialized allocation

## Test Plan

- [x] All PMTU tests pass with sanitizers (21/21 tests, verified 5 times)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - `Arena_calloc` provides the same zero-initialization behavior as `Arena_alloc` + `memset`

## Implementation Details

**Before:**
```c
pmtu = Arena_alloc (arena, sizeof (*pmtu), __FILE__, __LINE__);
if (!pmtu)
  return NULL;

memset (pmtu, 0, sizeof (*pmtu));
```

**After:**
```c
pmtu = Arena_calloc (arena, 1, sizeof (*pmtu), __FILE__, __LINE__);
if (!pmtu)
  return NULL;
```

This change follows the Arena API design where `Arena_calloc` is specifically intended for zero-initialized allocations, eliminating the need for a separate `memset` call.

Closes #970