### PR TITLE
refactor(quic): add socket_util_pack/unpack_be64() to eliminate manual implementations

### DIFF
--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -1289,6 +1289,48 @@ socket_util_pack_be32 (unsigned char *p, uint32_t v)
   p[3] = (unsigned char)(v & 0xFF);
 }
 
+/**
+ * @brief Unpack 64-bit big-endian value.
+ * @ingroup foundation
+ * @param p Pointer to 8-byte buffer.
+ * @return Decoded 64-bit value in host byte order.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 8 bytes from big-endian (network) byte order to host byte order.
+ * Used for parsing network protocols (DNS, HTTP/2, QUIC).
+ */
+static inline uint64_t
+socket_util_unpack_be64 (const unsigned char *p)
+{
+  return ((uint64_t)p[0] << 56) | ((uint64_t)p[1] << 48)
+         | ((uint64_t)p[2] << 40) | ((uint64_t)p[3] << 32)
+         | ((uint64_t)p[4] << 24) | ((uint64_t)p[5] << 16)
+         | ((uint64_t)p[6] << 8) | (uint64_t)p[7];
+}
+
+/**
+ * @brief Pack 64-bit value to big-endian.
+ * @ingroup foundation
+ * @param p Pointer to 8-byte buffer.
+ * @param v 64-bit value in host byte order.
+ * @threadsafe Yes (pure function)
+ *
+ * Converts 64-bit value from host byte order to big-endian (network) byte order.
+ * Used for serializing network protocols (DNS, HTTP/2, QUIC).
+ */
+static inline void
+socket_util_pack_be64 (unsigned char *p, uint64_t v)
+{
+  p[0] = (unsigned char)((v >> 56) & 0xFF);
+  p[1] = (unsigned char)((v >> 48) & 0xFF);
+  p[2] = (unsigned char)((v >> 40) & 0xFF);
+  p[3] = (unsigned char)((v >> 32) & 0xFF);
+  p[4] = (unsigned char)((v >> 24) & 0xFF);
+  p[5] = (unsigned char)((v >> 16) & 0xFF);
+  p[6] = (unsigned char)((v >> 8) & 0xFF);
+  p[7] = (unsigned char)(v & 0xFF);
+}
+
 /* ============================================================================
  * IP ADDRESS UTILITY FUNCTIONS
  * ============================================================================

--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -86,34 +86,6 @@ hash_address (const struct sockaddr *addr, uint8_t hash[16])
   memcpy (hash, sha256_output, 16);
 }
 
-/**
- * @brief Write uint64 in network byte order.
- */
-static void
-write_uint64_be (uint8_t *buf, uint64_t value)
-{
-  buf[0] = (value >> 56) & 0xFF;
-  buf[1] = (value >> 48) & 0xFF;
-  buf[2] = (value >> 40) & 0xFF;
-  buf[3] = (value >> 32) & 0xFF;
-  buf[4] = (value >> 24) & 0xFF;
-  buf[5] = (value >> 16) & 0xFF;
-  buf[6] = (value >> 8) & 0xFF;
-  buf[7] = value & 0xFF;
-}
-
-/**
- * @brief Read uint64 in network byte order.
- */
-static uint64_t
-read_uint64_be (const uint8_t *buf)
-{
-  return ((uint64_t)buf[0] << 56) | ((uint64_t)buf[1] << 48)
-         | ((uint64_t)buf[2] << 40) | ((uint64_t)buf[3] << 32)
-         | ((uint64_t)buf[4] << 24) | ((uint64_t)buf[5] << 16)
-         | ((uint64_t)buf[6] << 8) | (uint64_t)buf[7];
-}
-
 /* ============================================================================
  * Amplification Limit Functions
  * ============================================================================
@@ -214,7 +186,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
   hash_address (addr, addr_hash);
 
   /* Build HMAC input: timestamp || addr_hash */
-  write_uint64_be (hmac_input, timestamp);
+  socket_util_pack_be64 (hmac_input, timestamp);
   memcpy (hmac_input + 8, addr_hash, 16);
 
   /* Compute HMAC-SHA256 */
@@ -229,7 +201,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
   END_TRY;
 
   /* Build token: timestamp || addr_hash || HMAC */
-  write_uint64_be (token, timestamp);
+  socket_util_pack_be64 (token, timestamp);
   memcpy (token + 8, addr_hash, 16);
   memcpy (token + 24, hmac_output, 32);
 
@@ -262,7 +234,7 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
     }
 
   /* Extract timestamp */
-  token_timestamp = read_uint64_be (token);
+  token_timestamp = socket_util_unpack_be64 (token);
 
   /* Check expiration */
   current_time = get_monotonic_ms ();
@@ -283,7 +255,7 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
     }
 
   /* Rebuild HMAC input */
-  write_uint64_be (hmac_input, token_timestamp);
+  socket_util_pack_be64 (hmac_input, token_timestamp);
   memcpy (hmac_input + 8, addr_hash, 16);
 
   /* Compute expected HMAC */


### PR DESCRIPTION
## Summary

Implements #978

Adds `socket_util_pack_be64()` and `socket_util_unpack_be64()` helper functions to `SocketUtil.h`, completing the pattern established by be16, be24, and be32 variants.

## Changes

- Added `socket_util_pack_be64()` and `socket_util_unpack_be64()` inline functions to `include/core/SocketUtil.h`
- Removed local `write_uint64_be()` and `read_uint64_be()` implementations from `src/quic/SocketQUICAddrValidation.c`
- Updated all call sites in address validation code to use the new helpers

## Benefits

- Eliminates code duplication across modules
- Provides consistent API for all byte sizes (16, 24, 32, 64)
- Improves code discoverability and maintainability
- Single source of truth for endianness conversions

## Test Plan

- [x] All QUIC tests pass with sanitizers (test_quic_addr_validation verified)
- [x] Address validation functionality unchanged (token generation/validation working)
- [x] No memory leaks detected by AddressSanitizer

Closes #978