### PR TITLE
docs(dns): verify IP literal resolution is optimal (Phase 3.2)

### DIFF
--- a/docs/DNS_IP_LITERAL_VERIFICATION.md
+++ b/docs/DNS_IP_LITERAL_VERIFICATION.md
@@ -1,0 +1,93 @@
+# DNS IP Literal Resolution Verification
+
+**Issue**: #1062
+**Date**: 2025-12-27
+**Status**: VERIFIED - No changes needed
+
+## Summary
+
+Verified that IP literal (direct IP address) resolution is correctly implemented and optimally designed for the tetsuo-socket library.
+
+## Decision
+
+**KEEP the current inet_pton() fast-path for IP literals.**
+
+Rationale:
+1. SocketDNS is designed for async DNS resolution with thread pools
+2. Using it for IP literals adds unnecessary overhead
+3. inet_pton() provides instant validation
+4. Current implementation is already optimal
+
+## Implementation Review
+
+### IP Detection (`socketcommon_is_ip_address`)
+**Location**: `src/socket/SocketCommon.c:586-590`
+
+```c
+bool
+socketcommon_is_ip_address (const char *host)
+{
+  int dummy_family;
+  return SocketCommon_parse_ip (host, &dummy_family) != 0;
+}
+```
+
+Fast IP address detection using parse_ip validation.
+
+### IP Direct Resolution (`socketcommon_resolve_ip_direct`)
+**Location**: `src/socket/SocketCommon.c:1290-1329`
+
+```c
+static int
+socketcommon_resolve_ip_direct (const char *host, const char *port_str,
+                                const struct addrinfo *hints,
+                                struct addrinfo **res, int use_exceptions,
+                                Except_T exception_type)
+{
+  struct addrinfo *tmp_res = NULL;
+  int gai_err = getaddrinfo (host, port_str, hints, &tmp_res);
+  // ... error handling ...
+  *res = SocketCommon_copy_addrinfo (tmp_res);
+  freeaddrinfo (tmp_res);
+  return 0;
+}
+```
+
+Uses getaddrinfo() with AI_NUMERICHOST for synchronous IP literal resolution.
+
+### Fast Path Integration
+**Location**: `src/socket/SocketCommon.c:1369-1374`
+
+```c
+/* Fast path for IP addresses and NULL host: direct getaddrinfo with copy */
+if (host == NULL || socketcommon_is_ip_address (host))
+  {
+    return socketcommon_resolve_ip_direct (host, port_str, hints, res,
+                                           use_exceptions, exception_type);
+  }
+```
+
+IP literals bypass the async DNS resolver completely, using synchronous getaddrinfo() directly.
+
+## Verification Tests
+
+The following scenarios are verified by existing tests:
+
+1. **IPv4 literal resolution**: `127.0.0.1`
+2. **IPv6 literal resolution**: `::1`, `2001:db8::1`
+3. **NULL host handling**: Wildcard bind operations
+4. **Hostname vs IP distinction**: Proper routing to DNS resolver or fast-path
+
+All tests pass with sanitizers enabled (ASan + UBSan).
+
+## Performance Characteristics
+
+- **IP literals**: O(1) - instant validation with inet_pton()
+- **Hostnames**: Async with timeout guarantees via SocketDNS
+- **NULL host**: Direct handling for wildcard binds
+
+## Conclusion
+
+The current implementation is **correct and optimal**. No code changes are required.
+
+IP literals correctly use the fast synchronous path, while hostnames properly use the async DNS resolver with timeout protection.


### PR DESCRIPTION
## Summary

Implements #1062 (DNS Unification Phase 3.2) - Verification of IP literal resolution.

## Decision

**KEEP current inet_pton() fast-path for IP literals.** No code changes needed.

## Changes

- Added `docs/DNS_IP_LITERAL_VERIFICATION.md` documenting the verification

## Rationale

1. SocketDNS is designed for async DNS resolution with thread pools
2. Using it for IP literals would add unnecessary overhead  
3. inet_pton() provides instant O(1) validation
4. Current implementation is already optimal

## Implementation Verified

- `socketcommon_is_ip_address()` (line 586): IP detection using parse_ip
- `socketcommon_resolve_ip_direct()` (line 1290): Direct resolution with getaddrinfo
- Fast-path integration (line 1370): Bypasses async DNS resolver for IP literals

## Test Plan

- [x] All tests pass with sanitizers (ASan + UBSan)
- [x] IPv4 literals (127.0.0.1) resolve correctly
- [x] IPv6 literals (::1, 2001:db8::1) resolve correctly  
- [x] NULL host (wildcard bind) handled correctly
- [x] Hostname vs IP distinction working properly

## Verification

This is a **documentation-only change** that verifies the existing implementation is correct and optimal. No functional changes were made.

Closes #1062