### PR TITLE
refactor(quic): replace manual get_monotonic_ms() with Socket_get_monotonic_ms()

### DIFF
--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -32,21 +32,6 @@ const Except_T SocketQUICAddrValidation_Failed
  */
 
 /**
- * @brief Get current monotonic timestamp in milliseconds.
- */
-static uint64_t
-get_monotonic_ms (void)
-{
-  struct timespec ts;
-  if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0)
-    {
-      return 0;
-    }
-  return (uint64_t)ts.tv_sec * SOCKET_MS_PER_SECOND
-         + (uint64_t)ts.tv_nsec / SOCKET_NS_PER_MS;
-}
-
-/**
  * @brief Hash sockaddr into fixed-size buffer.
  *
  * Creates a deterministic hash of address for token binding.
@@ -181,7 +166,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
     }
 
   /* Get current timestamp */
-  timestamp = get_monotonic_ms ();
+  timestamp = (uint64_t)Socket_get_monotonic_ms ();
 
   /* Hash the address */
   hash_address (addr, addr_hash);
@@ -238,7 +223,7 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
   token_timestamp = socket_util_unpack_be64 (token);
 
   /* Check expiration */
-  current_time = get_monotonic_ms ();
+  current_time = (uint64_t)Socket_get_monotonic_ms ();
   if (current_time > token_timestamp
       && (current_time - token_timestamp)
              > (QUIC_ADDR_VALIDATION_TOKEN_LIFETIME * SOCKET_MS_PER_SECOND))


### PR DESCRIPTION
## Summary
- Remove duplicate implementation of get_monotonic_ms() in SocketQUICAddrValidation.c
- Use the library function Socket_get_monotonic_ms() from SocketUtil.h instead

## Changes
- Remove static get_monotonic_ms() function (was duplicating SocketUtil functionality)
- Replace calls with (uint64_t)Socket_get_monotonic_ms() cast for type compatibility
- Eliminates code duplication and maintenance burden

## Test plan
- [x] Build passes with sanitizers enabled
- [x] No functional change - only refactoring

Fixes #971