### PR TITLE
refactor(quic): replace hardcoded retry integrity tag size with named constant

### DIFF
--- a/include/quic/SocketQUICPacket.h
+++ b/include/quic/SocketQUICPacket.h
@@ -562,6 +562,14 @@ extern uint64_t SocketQUICPacket_decode_pn (uint32_t truncated_pn,
  */
 #define QUIC_HP_SAMPLE_LEN 16
 
+/**
+ * @brief QUIC Retry Integrity Tag length (RFC 9000 Section 17.2.5).
+ *
+ * The Retry packet includes a 16-byte integrity tag to prevent
+ * off-path attackers from injecting Retry packets.
+ */
+#define QUIC_RETRY_INTEGRITY_TAG_LEN 16
+
 /* ============================================================================
  * Initial Packet Key Structure (RFC 9001 Section 5)
  * ============================================================================

--- a/src/quic/SocketQUICPacket.c
+++ b/src/quic/SocketQUICPacket.c
@@ -247,19 +247,19 @@ parse_retry_header (const uint8_t *data, size_t len,
   /* Retry packet has no Length or Packet Number fields */
   /* The Retry Token is everything except the last 16 bytes (integrity tag) */
 
-  if (len - *offset < 16)
+  if (len - *offset < QUIC_RETRY_INTEGRITY_TAG_LEN)
     return QUIC_PACKET_ERROR_TRUNCATED;
 
-  size_t retry_token_len = len - *offset - 16;
+  size_t retry_token_len = len - *offset - QUIC_RETRY_INTEGRITY_TAG_LEN;
 
   header->retry_token = (retry_token_len > 0) ? (data + *offset) : NULL;
   header->retry_token_length = retry_token_len;
   *offset += retry_token_len;
 
   /* Copy the 16-byte Retry Integrity Tag */
-  memcpy (header->retry_integrity_tag, data + *offset, 16);
+  memcpy (header->retry_integrity_tag, data + *offset, QUIC_RETRY_INTEGRITY_TAG_LEN);
   header->has_retry_integrity_tag = 1;
-  *offset += 16;
+  *offset += QUIC_RETRY_INTEGRITY_TAG_LEN;
 
   header->header_length = *offset;
   *consumed = *offset;
@@ -388,7 +388,7 @@ SocketQUICPacketHeader_size (const SocketQUICPacketHeader_T *header)
         case QUIC_PACKET_TYPE_RETRY:
           /* Retry Token + Integrity Tag (16 bytes) */
           size += header->retry_token_length;
-          size += 16;
+          size += QUIC_RETRY_INTEGRITY_TAG_LEN;
           break;
 
         default:
@@ -491,8 +491,8 @@ serialize_long_header (const SocketQUICPacketHeader_T *header,
         }
 
       /* Retry Integrity Tag */
-      memcpy (output + offset, header->retry_integrity_tag, 16);
-      offset += 16;
+      memcpy (output + offset, header->retry_integrity_tag, QUIC_RETRY_INTEGRITY_TAG_LEN);
+      offset += QUIC_RETRY_INTEGRITY_TAG_LEN;
       break;
 
     default:


### PR DESCRIPTION
## Summary

Implements #965 - Replace hardcoded retry integrity tag size (16 bytes) with a named constant `QUIC_RETRY_INTEGRITY_TAG_LEN` throughout the QUIC packet handling code.

## Changes

- **Added constant**: `QUIC_RETRY_INTEGRITY_TAG_LEN` in `include/quic/SocketQUICPacket.h`
  - Documented with RFC 9000 Section 17.2.5 reference
  - Explains purpose: prevents off-path attackers from injecting Retry packets
  
- **Replaced 7 hardcoded instances** in `src/quic/SocketQUICPacket.c`:
  - Line 250: Bounds check in `parse_retry_header()`
  - Line 253: Retry token length calculation
  - Line 260: Integrity tag memcpy operation
  - Line 262: Offset update after tag copy
  - Line 391: Header size calculation in `SocketQUICPacketHeader_size()`
  - Line 494: Integrity tag serialization memcpy
  - Line 495: Offset update in `serialize_long_header()`

## Benefits

1. **Self-documenting**: Constant name clearly indicates purpose and size
2. **Maintainability**: Single source of truth for the integrity tag size
3. **Consistency**: Matches existing patterns (`QUIC_INITIAL_TAG_LEN`, `QUIC_HP_SAMPLE_LEN`)
4. **RFC compliance**: Direct reference to RFC 9000 Section 17.2.5 in documentation
5. **Searchability**: Easy to grep for all retry integrity tag usage

## Test Plan

- [x] All 25 QUIC tests pass with sanitizers enabled
- [x] Build succeeds with ASan/UBSan
- [x] No functional changes - pure refactoring
- [x] Verified constant usage in parsing and serialization paths

Closes #965