### PR TITLE
feat(quic): update stream state flags in transition functions

### DIFF
--- a/src/quic/SocketQUICStream-state.c
+++ b/src/quic/SocketQUICStream-state.c
@@ -224,6 +224,13 @@ SocketQUICStream_transition_send (SocketQUICStream_T stream,
           /* Valid transition found - execute it */
           stream->send_state = send_transitions[i].to_state;
 
+          /* Update flags based on transition */
+          if (event == QUIC_STREAM_EVENT_SEND_FIN)
+            stream->fin_sent = 1;
+          else if (event == QUIC_STREAM_EVENT_SEND_RESET ||
+                   event == QUIC_STREAM_EVENT_RECV_STOP_SENDING)
+            stream->reset_sent = 1;
+
           /* Update legacy combined state for backwards compatibility */
           update_legacy_state_send (stream);
 
@@ -311,6 +318,12 @@ SocketQUICStream_transition_recv (SocketQUICStream_T stream,
           && recv_transitions[i].event == event)
         {
           stream->recv_state = recv_transitions[i].to_state;
+
+          /* Update flags based on transition */
+          if (event == QUIC_STREAM_EVENT_RECV_FIN)
+            stream->fin_received = 1;
+          else if (event == QUIC_STREAM_EVENT_RECV_RESET)
+            stream->reset_received = 1;
 
           /* Update legacy combined state for backwards compatibility */
           update_legacy_state_recv (stream);


### PR DESCRIPTION
## Summary

Implements proper flag updates in RFC 9000 state transition functions for issue #976.

## Changes

- Updated `SocketQUICStream_transition_send()` to set `fin_sent` and `reset_sent` flags
- Updated `SocketQUICStream_transition_recv()` to set `fin_received` and `reset_received` flags
- Flags are now properly synchronized with state machine transitions per RFC 9000 Section 3

## Details

The state transition functions were already implemented in `src/quic/SocketQUICStream-state.c`, but they were not updating the stream flags as recommended in the issue. This PR adds flag updates to ensure that:

1. When `SEND_FIN` event occurs, `fin_sent` is set to 1
2. When `SEND_RESET` or `RECV_STOP_SENDING` events occur, `reset_sent` is set to 1
3. When `RECV_FIN` event occurs, `fin_received` is set to 1
4. When `RECV_RESET` event occurs, `reset_received` is set to 1

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] All 113 tests pass successfully
- [x] QUIC stream state tests verify state machine behavior

Closes #976