### PR TITLE
fix(dns): fail loudly on global resolver initialization failure

### DIFF
--- a/src/socket/SocketCommon.c
+++ b/src/socket/SocketCommon.c
@@ -96,7 +96,7 @@ init_global_dns_resolver (void)
   {
     SOCKET_LOG_ERROR_MSG ("Failed to initialize global DNS resolver: %s",
                           Except_frame.exception->reason);
-    g_dns_resolver = NULL;
+    RERAISE;
   }
   END_TRY;
 }


### PR DESCRIPTION
## Summary

Implements #1064 - DNS Unification Phase 3.4: Update global resolver initialization

Changed `init_global_dns_resolver()` to propagate exceptions via `RERAISE` instead of silently falling back to `NULL` resolver.

## Changes

- Modified `src/socket/SocketCommon.c` line 99
- Changed from `g_dns_resolver = NULL;` to `RERAISE;`
- This ensures DNS resolver initialization failures are caught early rather than causing delayed failures during DNS resolution attempts

## Test Plan

- [x] All 113 tests pass with sanitizers enabled
- [x] Build succeeds with ASan and UBSan
- [x] No regressions detected

Fixes #1064