### PR TITLE
dns: rename socketcommon_perform_getaddrinfo() to socketcommon_perform_dns_resolution() (Phase 3.3)

### DIFF
--- a/src/socket/SocketCommon.c
+++ b/src/socket/SocketCommon.c
@@ -1276,7 +1276,7 @@ socketcommon_resolve_ip_direct (const char *host, const char *port_str,
 }
 
 /**
- * socketcommon_perform_getaddrinfo - Perform DNS resolution with timeout
+ * socketcommon_perform_dns_resolution - Perform DNS resolution with timeout
  * @host: Hostname or IP address (NULL for wildcard)
  * @port_str: Port number as string
  * @hints: Address resolution hints
@@ -1287,15 +1287,14 @@ socketcommon_resolve_ip_direct (const char *host, const char *port_str,
  * Returns: 0 on success, -1 on failure
  * Thread-safe: Yes
  *
- * Uses the global DNS resolver with timeout guarantees. This prevents
- * unbounded blocking on DNS failures (which could block for 30+ seconds
- * with direct getaddrinfo calls).
+ * Uses SocketDNS_resolve_sync() exclusively for hostname resolution.
+ * IP literals and NULL hosts use fast path with direct getaddrinfo().
  */
 static int
-socketcommon_perform_getaddrinfo (const char *host, const char *port_str,
-                                  const struct addrinfo *hints,
-                                  struct addrinfo **res, int use_exceptions,
-                                  Except_T exception_type)
+socketcommon_perform_dns_resolution (const char *host, const char *port_str,
+                                     const struct addrinfo *hints,
+                                     struct addrinfo **res, int use_exceptions,
+                                     Except_T exception_type)
 {
   SocketDNS_T dns;
   volatile int port;
@@ -1439,8 +1438,8 @@ SocketCommon_resolve_address (const char *host, int port,
       != 0)
     return -1;
 
-  if (socketcommon_perform_getaddrinfo (host, port_str, hints, res,
-                                        use_exceptions, exception_type)
+  if (socketcommon_perform_dns_resolution (host, port_str, hints, res,
+                                           use_exceptions, exception_type)
       != 0)
     return -1;
 


### PR DESCRIPTION
## Summary

Implements #1063 - Phase 3.3 of DNS Unification

Renames `socketcommon_perform_getaddrinfo()` to `socketcommon_perform_dns_resolution()` to better reflect its role in the DNS architecture.

## Changes

- Renamed function from `socketcommon_perform_getaddrinfo()` to `socketcommon_perform_dns_resolution()`
- Updated documentation to clarify exclusive use of `SocketDNS_resolve_sync()` for hostname resolution
- IP literals and NULL hosts continue using fast path with direct `getaddrinfo()`

## Files Modified

- `src/socket/SocketCommon.c` - Function rename and documentation update

## Test Plan

- All 299 socket tests pass with sanitizers enabled
- DNS resolution continues to work correctly
- IP address resolution uses fast path
- Proper exception handling maintained

## Dependencies

- Depends on #1061 (Phase 3.1) - Completed
- Depends on #1062 (Phase 3.2) - Completed

Closes #1063