### PR TITLE
feat(dns): add SocketDNSResolver as backend (Phase 2.2)

### DIFF
--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -140,6 +140,15 @@ struct SocketDNS_CacheEntry
 };
 
 /**
+ * @brief Forward declaration of SocketDNSResolver_T from resolver module.
+ * @ingroup dns
+ *
+ * Used for SocketDNSResolver backend integration.
+ * @see SocketDNSResolver.h for resolver API details.
+ */
+typedef struct SocketDNSResolver_T *SocketDNSResolver_T;
+
+/**
  * @brief Async DNS resolver structure.
  * @ingroup dns
  */
@@ -174,6 +183,10 @@ struct SocketDNS_T
   size_t nameserver_count;  /**< Number of custom nameservers */
   char **search_domains;   /**< Custom search domains (NULL = use system) */
   size_t search_domain_count; /**< Number of search domains */
+
+  /* SocketDNSResolver Backend (Phase 2.2) */
+  SocketDNSResolver_T resolver;    /**< Backend resolver instance */
+  Arena_T resolver_arena;          /**< Separate arena for resolver lifecycle */
 };
 
 /* Internal macros - use centralized constant */


### PR DESCRIPTION
## Summary

Implements #1057 - DNS Unification Phase 2.2

Integrates SocketDNSResolver_T into SocketDNS_T structure as the backend resolver.

## Changes

- Add `SocketDNSResolver_T resolver` field to `SocketDNS_T` struct
- Add `Arena_T resolver_arena` field for independent lifecycle management
- Initialize resolver in `SocketDNS_new()` with proper error handling
- Load `/etc/resolv.conf` during resolver initialization
- Cleanup resolver in `SocketDNS_free()` by disposing resolver_arena
- Add forward declaration of `SocketDNSResolver_T` in private header

## Implementation Details

The resolver is initialized with its own dedicated arena (`resolver_arena`) to:
- Enable independent lifecycle management
- Support proper cleanup on initialization failure
- Isolate resolver memory from main SocketDNS arena

Error handling follows the existing pattern with TRY/EXCEPT/FINALLY blocks
and proper cleanup via `cleanup_on_init_failure()`.

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] DNS resolver tests pass (test_dns_resolver)
- [x] Resolver and resolver_arena are properly initialized
- [x] Cleanup properly disposes resolver_arena and sets fields to NULL
- [x] No memory leaks detected with ASan

## Related Issues

Closes #1057
Part of #1053 (DNS Unification)
Blocked by #1056 (Phase 2.1) - completed