### PR TITLE
dns: update SocketDgram sendto() resolution (Phase 4.2)

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -167,20 +167,10 @@ static int
 resolve_sendto_address (const char *host, int port, struct addrinfo **res)
 {
   struct addrinfo hints;
-  char port_str[SOCKET_PORT_STR_BUFSIZE];
-  int result;
-
-  snprintf (port_str, sizeof (port_str), "%d", port);
 
   SocketCommon_setup_hints (&hints, SOCKET_DGRAM_TYPE, 0);
-  result = getaddrinfo (host, port_str, &hints, res);
-  if (result != 0)
-    {
-      SOCKET_ERROR_MSG ("Invalid host/IP address: %.*s (%s)",
-                        SOCKET_ERROR_MAX_HOSTNAME, host,
-                        gai_strerror (result));
-      RAISE_MODULE_ERROR (SocketDgram_Failed);
-    }
+  SocketCommon_resolve_address (host, port, &hints, res, SocketDgram_Failed,
+                                SOCKET_AF_UNSPEC, 1);
   return 0;
 }
 


### PR DESCRIPTION
## Summary

Implements #1065 (DNS Unification Phase 4.2)

Updates sendto() hostname resolution to use SocketCommon_resolve_address() instead of direct getaddrinfo() calls.

## Changes

- Modified `resolve_sendto_address()` in `src/socket/SocketDgram.c`
- Replaced direct `getaddrinfo()` call with `SocketCommon_resolve_address()`
- Removed manual error handling code (now handled by SocketCommon)
- Reduced function from ~20 lines to ~10 lines

## Benefits

- DNS timeout guarantees now apply to sendto() operations
- Consistent error handling across all socket operations (bind/connect/sendto)
- Simplified code maintenance
- Same functional behavior with improved reliability

## Test Plan

- [x] All 67 socketdgram tests pass
- [x] Verified sendto() resolves hostnames correctly
- [x] Verified sendto() works with IP addresses (fast path)
- [x] Verified invalid hostname handling with proper timeout
- [x] Build succeeds with sanitizers enabled

Closes #1065