### PR TITLE
dns: migrate initialization/cleanup to SocketDNS.c (Phase 2.6c)

### DIFF
--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -322,22 +322,24 @@ extern const Except_T SocketDNS_Failed;
 
 /* Forward Declarations - SocketDNS-internal.c */
 
-/* Synchronization primitives */
-extern void initialize_mutex (struct SocketDNS_T *dns);
-extern void create_completion_pipe (struct SocketDNS_T *dns);
-extern void set_pipe_nonblocking (struct SocketDNS_T *dns);
-extern void initialize_pipe (struct SocketDNS_T *dns);
-extern void initialize_dns_fields (struct SocketDNS_T *dns);
-extern void initialize_dns_components (struct SocketDNS_T *dns);
+/* Synchronization primitives - migrated to SocketDNS.c (Phase 2.6c):
+ * - initialize_mutex()
+ * - create_completion_pipe()
+ * - set_pipe_nonblocking()
+ * - initialize_pipe()
+ * - initialize_dns_fields()
+ * - initialize_dns_components()
+ */
 
-/* Cleanup and shutdown */
-extern void cleanup_mutex_cond (struct SocketDNS_T *dns);
-extern void cleanup_pipe (struct SocketDNS_T *dns);
-extern void cleanup_on_init_failure (struct SocketDNS_T *dns,
-                                     enum DnsCleanupLevel cleanup_level);
-extern void drain_completion_pipe (struct SocketDNS_T *dns);
-extern void reset_dns_state (struct SocketDNS_T *dns);
-extern void destroy_dns_resources (struct SocketDNS_T *dns);
+/* Cleanup and shutdown - migrated to SocketDNS.c (Phase 2.6c):
+ * - cleanup_mutex_cond()
+ * - cleanup_pipe()
+ * - cleanup_on_init_failure()
+ * - drain_completion_pipe()
+ * - reset_dns_state()
+ * - destroy_dns_resources()
+ */
+
 extern void free_request_list (struct SocketDNS_Request_T *head,
                                int use_hash_next);
 extern void free_hash_table_requests (struct SocketDNS_T *dns);
@@ -390,7 +392,7 @@ extern void invoke_callback (struct SocketDNS_T *dns,
 
 /* Forward Declarations - SocketDNS.c */
 extern void validate_resolve_params (const char *host, int port);
-extern struct SocketDNS_T *allocate_dns_resolver (void);
+/* allocate_dns_resolver() migrated to static in SocketDNS.c (Phase 2.6c) */
 
 /* Cache functions - defined in SocketDNS.c, used by SocketDNS-internal.c */
 extern struct SocketDNS_CacheEntry *cache_lookup (struct SocketDNS_T *dns,

--- a/src/dns/SocketDNS-internal.c
+++ b/src/dns/SocketDNS-internal.c
@@ -32,16 +32,7 @@
 
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketDNS);
 
-#define INIT_PTHREAD_PRIMITIVE(dns, init_func, ptr, cleanup_level, error_msg) \
-  do                                                                          \
-    {                                                                         \
-      if (init_func ((ptr), NULL) != 0)                                       \
-        {                                                                     \
-          cleanup_on_init_failure ((dns), (cleanup_level));                   \
-          SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed, (error_msg));        \
-        }                                                                     \
-    }                                                                         \
-  while (0)
+/* INIT_PTHREAD_PRIMITIVE macro migrated to SocketDNS.c (Phase 2.6c) */
 
 static inline void
 mutex_unlock_cleanup (pthread_mutex_t **mutex)
@@ -59,152 +50,18 @@ mutex_unlock_cleanup (pthread_mutex_t **mutex)
 #define SOCKET_CONCAT_INNER(a, b) a##b
 #define SOCKET_CONCAT(a, b) SOCKET_CONCAT_INNER (a, b)
 
-void
-initialize_mutex (struct SocketDNS_T *dns)
-{
-  INIT_PTHREAD_PRIMITIVE (dns, pthread_mutex_init, &dns->mutex, DNS_CLEAN_NONE,
-                          "Failed to initialize DNS resolver mutex");
-}
-
-void
-initialize_queue_condition (struct SocketDNS_T *dns)
-{
-  /* TODO(Phase 2.x): Removed - no queue condition needed without worker threads */
-  (void)dns;
-}
-
-void
-initialize_result_condition (struct SocketDNS_T *dns)
-{
-  /* TODO(Phase 2.x): Removed - no result condition needed without worker threads */
-  (void)dns;
-}
-
-void
-initialize_synchronization (struct SocketDNS_T *dns)
-{
-  initialize_mutex (dns);
-  initialize_queue_condition (dns);
-  initialize_result_condition (dns);
-}
-
-void
-create_completion_pipe (struct SocketDNS_T *dns)
-{
-  if (pipe (dns->pipefd) < 0)
-    {
-      cleanup_on_init_failure (dns, DNS_CLEAN_MUTEX);
-      SOCKET_RAISE_FMT (SocketDNS, SocketDNS_Failed,
-                        "Failed to create completion pipe");
-    }
-
-  if (SocketCommon_setcloexec (dns->pipefd[0], 1) < 0
-      || SocketCommon_setcloexec (dns->pipefd[1], 1) < 0)
-    {
-      int saved_errno = errno;
-      cleanup_pipe (dns);
-      cleanup_on_init_failure (dns, DNS_CLEAN_MUTEX);
-      errno = saved_errno;
-      SOCKET_RAISE_FMT (SocketDNS, SocketDNS_Failed,
-                        "Failed to set close-on-exec flag on pipe");
-    }
-}
-
-void
-set_pipe_nonblocking (struct SocketDNS_T *dns)
-{
-  int flags = fcntl (dns->pipefd[0], F_GETFL);
-  if (flags < 0)
-    {
-      cleanup_on_init_failure (dns, DNS_CLEAN_ARENA);
-      SOCKET_RAISE_FMT (SocketDNS, SocketDNS_Failed,
-                        "Failed to get pipe flags");
-    }
-
-  if (fcntl (dns->pipefd[0], F_SETFL, flags | O_NONBLOCK) < 0)
-    {
-      cleanup_on_init_failure (dns, DNS_CLEAN_ARENA);
-      SOCKET_RAISE_FMT (SocketDNS, SocketDNS_Failed,
-                        "Failed to set pipe to non-blocking");
-    }
-}
-
-void
-initialize_pipe (struct SocketDNS_T *dns)
-{
-  create_completion_pipe (dns);
-  set_pipe_nonblocking (dns);
-}
-
-T
-allocate_dns_resolver (void)
-{
-  struct SocketDNS_T *dns;
-
-  dns = calloc (1, sizeof (*dns));
-  if (!dns)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate DNS resolver");
-    }
-
-  return dns;
-}
-
-void
-initialize_dns_fields (struct SocketDNS_T *dns)
-{
-  /* num_workers removed - no worker threads in new architecture */
-  dns->max_pending = SOCKET_DNS_MAX_PENDING;
-  dns->request_timeout_ms = SOCKET_DEFAULT_DNS_TIMEOUT_MS;
-
-  dns->cache_max_entries = SOCKET_DNS_DEFAULT_CACHE_MAX_ENTRIES;
-  dns->cache_ttl_seconds = SOCKET_DNS_DEFAULT_CACHE_TTL_SECONDS;
-
-  dns->prefer_ipv6 = 1;
-
-  /* Initialize resolver fields to NULL (Phase 2.2) */
-  dns->resolver = NULL;
-  dns->resolver_arena = NULL;
-}
-
-void
-initialize_dns_components (struct SocketDNS_T *dns)
-{
-  dns->arena = Arena_new ();
-  if (!dns->arena)
-    {
-      free (dns);
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate DNS resolver arena");
-    }
-
-  initialize_synchronization (dns);
-  initialize_pipe (dns);
-
-  /* Initialize SocketDNSResolver backend (Phase 2.2) */
-  dns->resolver_arena = Arena_new ();
-  if (!dns->resolver_arena)
-    {
-      cleanup_on_init_failure (dns, DNS_CLEAN_PIPE);
-      SOCKET_RAISE_MSG (
-          SocketDNS, SocketDNS_Failed,
-          SOCKET_ENOMEM ": Cannot allocate resolver arena");
-    }
-
-  TRY
-    {
-      dns->resolver = SocketDNSResolver_new (dns->resolver_arena);
-      SocketDNSResolver_load_resolv_conf (dns->resolver);
-    }
-  EXCEPT (SocketDNSResolver_Failed)
-    {
-      Arena_dispose (&dns->resolver_arena);
-      cleanup_on_init_failure (dns, DNS_CLEAN_PIPE);
-      RERAISE;
-    }
-  END_TRY;
-}
+/* Initialization functions migrated to SocketDNS.c (Phase 2.6c):
+ * - initialize_mutex()
+ * - initialize_queue_condition()
+ * - initialize_result_condition()
+ * - initialize_synchronization()
+ * - create_completion_pipe()
+ * - set_pipe_nonblocking()
+ * - initialize_pipe()
+ * - allocate_dns_resolver()
+ * - initialize_dns_fields()
+ * - initialize_dns_components()
+ */
 
 void
 setup_thread_attributes (pthread_attr_t *attr)
@@ -262,37 +119,11 @@ start_dns_workers (struct SocketDNS_T *dns)
   (void)dns;
 }
 
-void
-cleanup_mutex_cond (struct SocketDNS_T *dns)
-{
-  /* condition variables removed - only destroy mutex */
-  pthread_mutex_destroy (&dns->mutex);
-}
-
-void
-cleanup_pipe (struct SocketDNS_T *dns)
-{
-  for (int i = 0; i < 2; i++)
-    {
-      SAFE_CLOSE (dns->pipefd[i]);
-      dns->pipefd[i] = -1;
-    }
-}
-
-void
-cleanup_on_init_failure (struct SocketDNS_T *dns,
-                         enum DnsCleanupLevel cleanup_level)
-{
-  if (cleanup_level >= DNS_CLEAN_ARENA)
-    Arena_dispose (&dns->arena);
-  if (cleanup_level >= DNS_CLEAN_PIPE)
-    cleanup_pipe (dns);
-  if (cleanup_level >= DNS_CLEAN_MUTEX)
-    {
-      pthread_mutex_destroy (&dns->mutex);
-    }
-  free (dns);
-}
+/* Cleanup functions migrated to SocketDNS.c (Phase 2.6c):
+ * - cleanup_mutex_cond()
+ * - cleanup_pipe()
+ * - cleanup_on_init_failure()
+ */
 
 void
 shutdown_workers (T d)
@@ -301,21 +132,7 @@ shutdown_workers (T d)
   signal_shutdown_and_broadcast (d);
 }
 
-void
-drain_completion_pipe (struct SocketDNS_T *dns)
-{
-  char buffer[SOCKET_DNS_PIPE_BUFFER_SIZE];
-  ssize_t n;
-
-  if (dns->pipefd[0] < 0)
-    return;
-
-  do
-    {
-      n = read (dns->pipefd[0], buffer, sizeof (buffer));
-    }
-  while (n > 0);
-}
+/* drain_completion_pipe() migrated to SocketDNS.c (Phase 2.6c) */
 
 static void
 secure_clear_memory (void *ptr, size_t len)
@@ -364,33 +181,7 @@ free_all_requests (T d)
         d->request_hash[i], offsetof (struct SocketDNS_Request_T, hash_next));
 }
 
-void
-reset_dns_state (T d)
-{
-  SCOPED_MUTEX_LOCK (&d->mutex);
-  free_all_requests (d);
-  cache_clear_locked (d); /* Free cache entries' malloc'd addrinfo results */
-  /* queue fields removed - no queue in new architecture */
-  for (int i = 0; i < SOCKET_DNS_REQUEST_HASH_SIZE; i++)
-    d->request_hash[i] = NULL;
-}
-
-void
-destroy_dns_resources (T d)
-{
-  cleanup_pipe (d);
-  cleanup_mutex_cond (d);
-
-  /* Free resolver backend (Phase 2.2) */
-  if (d->resolver_arena)
-    {
-      Arena_dispose (&d->resolver_arena);
-      d->resolver = NULL;
-    }
-
-  Arena_dispose (&d->arena);
-  free (d);
-}
+/* reset_dns_state() and destroy_dns_resources() migrated to SocketDNS.c (Phase 2.6c) */
 
 unsigned
 request_hash_function (const struct SocketDNS_Request_T *req)


### PR DESCRIPTION
## Summary

Implements #1126 - Migrates initialization and cleanup functions from SocketDNS-internal.c to SocketDNS.c as part of Phase 2.6c of the DNS unification effort.

## Changes

Migrated the following functions from `src/dns/SocketDNS-internal.c` to `src/dns/SocketDNS.c` as static functions:

### Initialization Functions
- `allocate_dns_resolver()` - Allocate resolver structure
- `initialize_dns_fields()` - Initialize DNS config fields
- `initialize_mutex()` - Initialize mutex primitive
- `initialize_synchronization()` - Set up synchronization primitives
- `initialize_pipe()` - Create completion pipe
- `initialize_dns_components()` - Main initialization orchestrator
- `cleanup_on_init_failure()` - Rollback on init failure

### Cleanup Functions
- `cleanup_pipe()` - Close completion pipe
- `cleanup_mutex_cond()` - Destroy mutex/cond
- `drain_completion_pipe()` - Drain pending completions
- `reset_dns_state()` - Reset DNS state
- `destroy_dns_resources()` - Main cleanup orchestrator

### Helper Functions
- `create_completion_pipe()` - Create pipe with cloexec
- `set_pipe_nonblocking()` - Set pipe non-blocking
- `initialize_queue_condition()` - Initialize queue condition (removed in Phase 2.x)
- `initialize_result_condition()` - Initialize result condition (removed in Phase 2.x)
- `INIT_PTHREAD_PRIMITIVE` macro - Pthread initialization helper

## Implementation Notes

- All functions maintain identical signatures and implementation
- Functions are now static in SocketDNS.c
- Updated `include/dns/SocketDNS-private.h` to remove extern declarations
- Added forward declarations for functions used before definition
- Added missing includes (fcntl.h, unistd.h) to SocketDNS.c

## Test Plan

- [x] Build succeeds with sanitizers (`-DENABLE_SANITIZERS=ON`)
- [x] No undefined references during linking
- [x] SocketDNS_new() and SocketDNS_free() work correctly
- [x] Core DNS tests pass (test_socketdns)

## Related Issues

Closes #1126
Part of #1053 (DNS Unification)
Enables #1060 (Delete SocketDNS-internal.c)