### PR TITLE
dns: migrate hash table operations to SocketDNS.c (Phase 2.6a)

### DIFF
--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -343,8 +343,7 @@ extern void free_request_list (struct SocketDNS_Request_T *head,
 extern void free_hash_table_requests (struct SocketDNS_T *dns);
 extern void free_all_requests (struct SocketDNS_T *dns);
 
-/* Request allocation and hash table management */
-extern unsigned request_hash_function (const struct SocketDNS_Request_T *req);
+/* Request allocation and queue management */
 extern struct SocketDNS_Request_T *
 allocate_request_structure (struct SocketDNS_T *dns);
 extern void allocate_request_hostname (struct SocketDNS_T *dns,
@@ -356,10 +355,6 @@ extern void initialize_request_fields (struct SocketDNS_Request_T *req,
 extern struct SocketDNS_Request_T *
 allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
                   int port, SocketDNS_Callback cb, void *data);
-extern void hash_table_insert (struct SocketDNS_T *dns,
-                               struct SocketDNS_Request_T *req);
-extern void hash_table_remove (struct SocketDNS_T *dns,
-                               struct SocketDNS_Request_T *req);
 extern int check_queue_limit (const struct SocketDNS_T *dns);
 extern void cancel_pending_request (struct SocketDNS_T *dns,
                                     struct SocketDNS_Request_T *req);
@@ -391,6 +386,12 @@ extern void invoke_callback (struct SocketDNS_T *dns,
 /* Forward Declarations - SocketDNS.c */
 extern void validate_resolve_params (const char *host, int port);
 extern struct SocketDNS_T *allocate_dns_resolver (void);
+
+/* Hash table operations - defined in SocketDNS.c, used by SocketDNS-internal.c */
+extern void hash_table_insert (struct SocketDNS_T *dns,
+                               struct SocketDNS_Request_T *req);
+extern void hash_table_remove (struct SocketDNS_T *dns,
+                               struct SocketDNS_Request_T *req);
 
 /* Cache functions - defined in SocketDNS.c, used by SocketDNS-internal.c */
 extern struct SocketDNS_CacheEntry *cache_lookup (struct SocketDNS_T *dns,

--- a/src/dns/SocketDNS-internal.c
+++ b/src/dns/SocketDNS-internal.c
@@ -392,12 +392,6 @@ destroy_dns_resources (T d)
   free (d);
 }
 
-unsigned
-request_hash_function (const struct SocketDNS_Request_T *req)
-{
-  return socket_util_hash_ptr (req, SOCKET_DNS_REQUEST_HASH_SIZE);
-}
-
 Request_T
 allocate_request_structure (struct SocketDNS_T *dns)
 {
@@ -468,44 +462,6 @@ allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
   req->dns_resolver = dns;
 
   return req;
-}
-
-void
-hash_table_insert (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
-{
-  unsigned hash;
-
-  hash = request_hash_function (req);
-  req->hash_value = hash;
-  req->hash_next = dns->request_hash[hash];
-  dns->request_hash[hash] = req;
-}
-
-void
-hash_table_remove (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
-{
-  unsigned hash;
-  Request_T *pp;
-
-  hash = req->hash_value;
-
-  if (hash >= SOCKET_DNS_REQUEST_HASH_SIZE)
-    {
-      SOCKET_LOG_DEBUG_MSG (
-          "Invalid hash_value=%u for req=%p in hash_table_remove", hash, req);
-      return;
-    }
-
-  pp = &dns->request_hash[hash];
-  while (*pp)
-    {
-      if (*pp == req)
-        {
-          *pp = req->hash_next;
-          break;
-        }
-      pp = &(*pp)->hash_next;
-    }
 }
 
 void

--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -58,6 +58,51 @@ static int cache_promote_l2_to_l1 (struct SocketDNS_T *dns,
                                    const char *hostname,
                                    const SocketDNSResolver_Result *l2_result);
 
+/* Hash table operations for request tracking */
+static unsigned
+request_hash_function (const struct SocketDNS_Request_T *req)
+{
+  return socket_util_hash_ptr (req, SOCKET_DNS_REQUEST_HASH_SIZE);
+}
+
+void
+hash_table_insert (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
+{
+  unsigned hash;
+
+  hash = request_hash_function (req);
+  req->hash_value = hash;
+  req->hash_next = dns->request_hash[hash];
+  dns->request_hash[hash] = req;
+}
+
+void
+hash_table_remove (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
+{
+  unsigned hash;
+  Request_T *pp;
+
+  hash = req->hash_value;
+
+  if (hash >= SOCKET_DNS_REQUEST_HASH_SIZE)
+    {
+      SOCKET_LOG_DEBUG_MSG (
+          "Invalid hash_value=%u for req=%p in hash_table_remove", hash, req);
+      return;
+    }
+
+  pp = &dns->request_hash[hash];
+  while (*pp)
+    {
+      if (*pp == req)
+        {
+          *pp = req->hash_next;
+          break;
+        }
+      pp = &(*pp)->hash_next;
+    }
+}
+
 void
 validate_resolve_params (const char *host, int port)
 {


### PR DESCRIPTION
## Summary

Implements #1124

Migrates hash table operations from SocketDNS-internal.c to SocketDNS.c as part of the DNS unification effort (Phase 2.6a).

## Changes

- Moved `request_hash_function()` from SocketDNS-internal.c to SocketDNS.c (kept static)
- Moved `hash_table_insert()` from SocketDNS-internal.c to SocketDNS.c  
- Moved `hash_table_remove()` from SocketDNS-internal.c to SocketDNS.c
- Added forward declarations in SocketDNS-private.h for cross-file usage
- Removed function declarations that are no longer needed

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] DNS tests pass (test_dns_resolver: 26/26 passed)
- [x] No undefined references in build
- [x] Hash table symbols correctly exported in libsocket.a

## Notes

This migration is part of the larger DNS unification effort (#1053) and enables future deletion of SocketDNS-internal.c (#1060). The functions maintain their original implementation and behavior, only their location has changed.

Closes #1124