### PR TITLE
dns: migrate request management to SocketDNS.c (Phase 2.6b)

### DIFF
--- a/src/dns/SocketDNS-internal.c
+++ b/src/dns/SocketDNS-internal.c
@@ -317,53 +317,6 @@ drain_completion_pipe (struct SocketDNS_T *dns)
   while (n > 0);
 }
 
-static void
-secure_clear_memory (void *ptr, size_t len)
-{
-  if (!ptr || len == 0)
-    return;
-
-#ifdef __linux__
-  explicit_bzero (ptr, len);
-#else
-  volatile unsigned char *vptr = (volatile unsigned char *)ptr;
-  while (len--)
-    *vptr++ = 0;
-#endif
-}
-
-static void
-free_request_list_results (Request_T head, size_t next_offset)
-{
-  Request_T curr = head;
-
-  while (curr)
-    {
-      Request_T next = *(Request_T *)((char *)curr + next_offset);
-
-      if (curr->host)
-        {
-          secure_clear_memory (curr->host, strlen (curr->host));
-        }
-
-      if (curr->result)
-        {
-          SocketCommon_free_addrinfo (curr->result);
-          curr->result = NULL;
-        }
-      curr = next;
-    }
-}
-
-void
-free_all_requests (T d)
-{
-  /* No queue_head anymore - only free hash table requests */
-  for (int i = 0; i < SOCKET_DNS_REQUEST_HASH_SIZE; i++)
-    free_request_list_results (
-        d->request_hash[i], offsetof (struct SocketDNS_Request_T, hash_next));
-}
-
 void
 reset_dns_state (T d)
 {
@@ -396,78 +349,6 @@ unsigned
 request_hash_function (const struct SocketDNS_Request_T *req)
 {
   return socket_util_hash_ptr (req, SOCKET_DNS_REQUEST_HASH_SIZE);
-}
-
-Request_T
-allocate_request_structure (struct SocketDNS_T *dns)
-{
-  Request_T req;
-
-  req = ALLOC (dns->arena, sizeof (*req));
-  if (!req)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate DNS request");
-    }
-
-  return req;
-}
-
-void
-allocate_request_hostname (struct SocketDNS_T *dns,
-                           struct SocketDNS_Request_T *req, const char *host,
-                           size_t host_len)
-{
-  if (host == NULL)
-    {
-      req->host = NULL;
-      return;
-    }
-
-  /* Check for overflow: host_len == SIZE_MAX would cause host_len + 1 to wrap to 0 */
-  if (host_len >= SIZE_MAX || host_len > 255)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        "Hostname length overflow or exceeds DNS maximum (255)");
-    }
-
-  req->host = ALLOC (dns->arena, host_len + 1);
-  if (!req->host)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate hostname");
-    }
-
-  memcpy (req->host, host, host_len);
-  req->host[host_len] = '\0';
-}
-
-void
-initialize_request_fields (struct SocketDNS_Request_T *req, int port,
-                           SocketDNS_Callback callback, void *data)
-{
-  req->port = port;
-  req->callback = callback;
-  req->callback_data = data;
-  req->state = REQ_PENDING;
-  req->result = NULL;
-  req->error = 0;
-  req->queue_next = NULL;
-  req->hash_next = NULL;
-  req->submit_time_ms = Socket_get_monotonic_ms ();
-  req->timeout_override_ms = -1;
-}
-
-Request_T
-allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
-                  int port, SocketDNS_Callback callback, void *data)
-{
-  Request_T req = allocate_request_structure (dns);
-  allocate_request_hostname (dns, req, host, host_len);
-  initialize_request_fields (req, port, callback, data);
-  req->dns_resolver = dns;
-
-  return req;
 }
 
 void

--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -58,6 +58,127 @@ static int cache_promote_l2_to_l1 (struct SocketDNS_T *dns,
                                    const char *hostname,
                                    const SocketDNSResolver_Result *l2_result);
 
+/* Request management functions (Phase 2.6b) */
+
+static void
+secure_clear_memory (void *ptr, size_t len)
+{
+  if (!ptr || len == 0)
+    return;
+
+#ifdef __linux__
+  explicit_bzero (ptr, len);
+#else
+  volatile unsigned char *vptr = (volatile unsigned char *)ptr;
+  while (len--)
+    *vptr++ = 0;
+#endif
+}
+
+static void
+free_request_list_results (Request_T head, size_t next_offset)
+{
+  Request_T curr = head;
+
+  while (curr)
+    {
+      Request_T next = *(Request_T *)((char *)curr + next_offset);
+
+      if (curr->host)
+        {
+          secure_clear_memory (curr->host, strlen (curr->host));
+        }
+
+      if (curr->result)
+        {
+          SocketCommon_free_addrinfo (curr->result);
+          curr->result = NULL;
+        }
+      curr = next;
+    }
+}
+
+void
+free_all_requests (T d)
+{
+  /* No queue_head anymore - only free hash table requests */
+  for (int i = 0; i < SOCKET_DNS_REQUEST_HASH_SIZE; i++)
+    free_request_list_results (
+        d->request_hash[i], offsetof (struct SocketDNS_Request_T, hash_next));
+}
+
+Request_T
+allocate_request_structure (struct SocketDNS_T *dns)
+{
+  Request_T req;
+
+  req = ALLOC (dns->arena, sizeof (*req));
+  if (!req)
+    {
+      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
+                        SOCKET_ENOMEM ": Cannot allocate DNS request");
+    }
+
+  return req;
+}
+
+void
+allocate_request_hostname (struct SocketDNS_T *dns,
+                           struct SocketDNS_Request_T *req, const char *host,
+                           size_t host_len)
+{
+  if (host == NULL)
+    {
+      req->host = NULL;
+      return;
+    }
+
+  /* Check for overflow: host_len == SIZE_MAX would cause host_len + 1 to wrap to 0 */
+  if (host_len >= SIZE_MAX || host_len > 255)
+    {
+      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
+                        "Hostname length overflow or exceeds DNS maximum (255)");
+    }
+
+  req->host = ALLOC (dns->arena, host_len + 1);
+  if (!req->host)
+    {
+      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
+                        SOCKET_ENOMEM ": Cannot allocate hostname");
+    }
+
+  memcpy (req->host, host, host_len);
+  req->host[host_len] = '\0';
+}
+
+void
+initialize_request_fields (struct SocketDNS_Request_T *req, int port,
+                           SocketDNS_Callback callback, void *data)
+{
+  req->port = port;
+  req->callback = callback;
+  req->callback_data = data;
+  req->state = REQ_PENDING;
+  req->result = NULL;
+  req->error = 0;
+  req->queue_next = NULL;
+  req->hash_next = NULL;
+  req->submit_time_ms = Socket_get_monotonic_ms ();
+  req->timeout_override_ms = -1;
+}
+
+Request_T
+allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
+                  int port, SocketDNS_Callback callback, void *data)
+{
+  Request_T req = allocate_request_structure (dns);
+  allocate_request_hostname (dns, req, host, host_len);
+  initialize_request_fields (req, port, callback, data);
+  req->dns_resolver = dns;
+
+  return req;
+}
+
 void
 validate_resolve_params (const char *host, int port)
 {


### PR DESCRIPTION
## Summary

Implements #1125: Migrate request management functions from `SocketDNS-internal.c` to `SocketDNS.c` as part of Phase 2.6b of the DNS unification effort.

## Changes

Moved the following functions from `src/dns/SocketDNS-internal.c` to `src/dns/SocketDNS.c`:

1. `allocate_request_structure()` - Allocate request struct  
2. `allocate_request_hostname()` - Allocate hostname storage
3. `initialize_request_fields()` - Initialize request fields
4. `allocate_request()` - Main request allocation entry point
5. `free_request_list_results()` - Free result list memory
6. `free_all_requests()` - Cleanup all pending requests  
7. `secure_clear_memory()` - Helper for secure memory cleanup

These functions manage `SocketDNS_Request_T` lifecycle and logically belong in the public implementation file alongside other request operations.

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] No undefined references or linker errors
- [x] All non-excluded tests pass with sanitizers (87/87 tests pass)
- [x] Functions successfully relocated from SocketDNS-internal.c to SocketDNS.c
- [x] Verified symbols with `objdump` and `readelf`

**Note**: Some DNS-related tests (test_socketdns, test_dns_transport, test_dns_cache) have pre-existing memory leaks from recent DNS refactoring (#1113-#1123) that will be fixed separately. These are excluded from the pre-commit hook.

## Implementation Details

- Functions maintain identical signatures and behavior
- Static linkage preserved for all internal helper functions
- No changes to function logic - pure code relocation
- `SocketDNS-internal.c` now references these functions as external symbols

## Related Issues

- Part of DNS Unification: #1053
- Enables: #1060 (Delete SocketDNS-internal.c)

Closes #1125