### PR TITLE
dns: migrate utility functions to SocketDNS.c (Phase 2.6d)

### DIFF
--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -358,8 +358,6 @@ extern struct SocketDNS_Request_T *
 allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
                   int port, SocketDNS_Callback cb, void *data);
 extern int check_queue_limit (const struct SocketDNS_T *dns);
-extern void cancel_pending_request (struct SocketDNS_T *dns,
-                                    struct SocketDNS_Request_T *req);
 
 /* Timeout handling */
 extern int
@@ -374,11 +372,9 @@ extern void handle_request_timeout (struct SocketDNS_T *dns,
 
 /* Resolution helpers */
 extern void initialize_addrinfo_hints (struct addrinfo *hints);
-extern void signal_completion (struct SocketDNS_T *dns);
 extern void store_resolution_result (struct SocketDNS_T *dns,
                                      struct SocketDNS_Request_T *req,
                                      struct addrinfo *result, int error);
-extern int dns_cancellation_error (void);
 extern int perform_dns_resolution (const struct SocketDNS_Request_T *req,
                                    const struct addrinfo *hints,
                                    struct addrinfo **result);
@@ -394,6 +390,12 @@ extern void hash_table_insert (struct SocketDNS_T *dns,
                                struct SocketDNS_Request_T *req);
 extern void hash_table_remove (struct SocketDNS_T *dns,
                                struct SocketDNS_Request_T *req);
+
+/* Utility functions - migrated to SocketDNS.c (Phase 2.6d) */
+extern void signal_completion (struct SocketDNS_T *dns);
+extern int dns_cancellation_error (void);
+extern void cancel_pending_request (struct SocketDNS_T *dns,
+                                    struct SocketDNS_Request_T *req);
 
 /* Cache functions - defined in SocketDNS.c, used by SocketDNS-internal.c */
 extern struct SocketDNS_CacheEntry *cache_lookup (struct SocketDNS_T *dns,

--- a/src/dns/SocketDNS-internal.c
+++ b/src/dns/SocketDNS-internal.c
@@ -305,14 +305,7 @@ submit_dns_request (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
   /* No queue_append or cond signal - worker threads removed */
 }
 
-void
-cancel_pending_request (struct SocketDNS_T *dns,
-                        struct SocketDNS_Request_T *req)
-{
-  /* No queue_remove - queue removed */
-  hash_table_remove (dns, req);
-  req->state = REQ_CANCELLED;
-}
+/* cancel_pending_request() migrated to SocketDNS.c (Phase 2.6d) */
 
 int
 request_effective_timeout_ms (const struct SocketDNS_T *dns,
@@ -392,25 +385,9 @@ wait_for_request (struct SocketDNS_T *dns)
   return NULL;
 }
 
-void
-signal_completion (struct SocketDNS_T *dns)
-{
-  char byte = COMPLETION_SIGNAL_BYTE;
-  ssize_t n;
+/* signal_completion() migrated to SocketDNS.c (Phase 2.6d) */
 
-  n = write (dns->pipefd[1], &byte, 1);
-  (void)n;
-}
-
-int
-dns_cancellation_error (void)
-{
-#ifdef EAI_CANCELLED
-  return EAI_CANCELLED;
-#else
-  return EAI_AGAIN;
-#endif
-}
+/* dns_cancellation_error() migrated to SocketDNS.c (Phase 2.6d) */
 
 int
 perform_dns_resolution (const struct SocketDNS_Request_T *req,

--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -352,6 +352,37 @@ hash_table_remove (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)
     }
 }
 
+/* Utility Functions (migrated from SocketDNS-internal.c - Phase 2.6d) */
+
+void
+signal_completion (struct SocketDNS_T *dns)
+{
+  char byte = COMPLETION_SIGNAL_BYTE;
+  ssize_t n;
+
+  n = write (dns->pipefd[1], &byte, 1);
+  (void)n;
+}
+
+int
+dns_cancellation_error (void)
+{
+#ifdef EAI_CANCELLED
+  return EAI_CANCELLED;
+#else
+  return EAI_AGAIN;
+#endif
+}
+
+void
+cancel_pending_request (struct SocketDNS_T *dns,
+                        struct SocketDNS_Request_T *req)
+{
+  /* No queue_remove - queue removed */
+  hash_table_remove (dns, req);
+  req->state = REQ_CANCELLED;
+}
+
 void
 validate_resolve_params (const char *host, int port)
 {


### PR DESCRIPTION
## Summary

Migrates utility functions from `SocketDNS-internal.c` to `SocketDNS.c` as part of Phase 2.6d of the DNS unification effort.

## Changes

### Functions Migrated
- `signal_completion()` - Signals completion pipe for async notification
- `dns_cancellation_error()` - Returns platform-specific cancellation error code
- `cancel_pending_request()` - Cancels in-flight DNS requests and removes from hash table

### Not Migrated
- `secure_clear_memory()` - Remains in `SocketDNS-internal.c` as it is still used locally by `free_request_list_results()`

### Files Modified
- `src/dns/SocketDNS.c` - Added migrated utility functions
- `src/dns/SocketDNS-internal.c` - Removed migrated functions, added migration notes
- `include/dns/SocketDNS-private.h` - Updated forward declarations to reflect new locations

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All DNS tests run (some pre-existing failures related to architecture changes)
- [x] Functions maintain identical signatures and behavior

## Related

Closes #1127
Part of #1053 (DNS Unification)
Enables #1060 (Delete SocketDNS-internal.c)