### PR TITLE
dns: migrate request management to SocketDNS.c (Phase 2.6b)

### DIFF
--- a/src/dns/SocketDNS-internal.c
+++ b/src/dns/SocketDNS-internal.c
@@ -134,126 +134,17 @@ shutdown_workers (T d)
 
 /* drain_completion_pipe() migrated to SocketDNS.c (Phase 2.6c) */
 
-static void
-secure_clear_memory (void *ptr, size_t len)
-{
-  if (!ptr || len == 0)
-    return;
-
-#ifdef __linux__
-  explicit_bzero (ptr, len);
-#else
-  volatile unsigned char *vptr = (volatile unsigned char *)ptr;
-  while (len--)
-    *vptr++ = 0;
-#endif
-}
-
-static void
-free_request_list_results (Request_T head, size_t next_offset)
-{
-  Request_T curr = head;
-
-  while (curr)
-    {
-      Request_T next = *(Request_T *)((char *)curr + next_offset);
-
-      if (curr->host)
-        {
-          secure_clear_memory (curr->host, strlen (curr->host));
-        }
-
-      if (curr->result)
-        {
-          SocketCommon_free_addrinfo (curr->result);
-          curr->result = NULL;
-        }
-      curr = next;
-    }
-}
-
-void
-free_all_requests (T d)
-{
-  /* No queue_head anymore - only free hash table requests */
-  for (int i = 0; i < SOCKET_DNS_REQUEST_HASH_SIZE; i++)
-    free_request_list_results (
-        d->request_hash[i], offsetof (struct SocketDNS_Request_T, hash_next));
-}
+/* Request management functions migrated to SocketDNS.c (Phase 2.6b):
+ * - secure_clear_memory()
+ * - free_request_list_results()
+ * - free_all_requests()
+ * - allocate_request_structure()
+ * - allocate_request_hostname()
+ * - initialize_request_fields()
+ * - allocate_request()
+ */
 
 /* reset_dns_state() and destroy_dns_resources() migrated to SocketDNS.c (Phase 2.6c) */
-
-Request_T
-allocate_request_structure (struct SocketDNS_T *dns)
-{
-  Request_T req;
-
-  req = ALLOC (dns->arena, sizeof (*req));
-  if (!req)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate DNS request");
-    }
-
-  return req;
-}
-
-void
-allocate_request_hostname (struct SocketDNS_T *dns,
-                           struct SocketDNS_Request_T *req, const char *host,
-                           size_t host_len)
-{
-  if (host == NULL)
-    {
-      req->host = NULL;
-      return;
-    }
-
-  /* Check for overflow: host_len == SIZE_MAX would cause host_len + 1 to wrap to 0 */
-  if (host_len >= SIZE_MAX || host_len > 255)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        "Hostname length overflow or exceeds DNS maximum (255)");
-    }
-
-  req->host = ALLOC (dns->arena, host_len + 1);
-  if (!req->host)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate hostname");
-    }
-
-  memcpy (req->host, host, host_len);
-  req->host[host_len] = '\0';
-}
-
-void
-initialize_request_fields (struct SocketDNS_Request_T *req, int port,
-                           SocketDNS_Callback callback, void *data)
-{
-  req->port = port;
-  req->callback = callback;
-  req->callback_data = data;
-  req->state = REQ_PENDING;
-  req->result = NULL;
-  req->error = 0;
-  req->queue_next = NULL;
-  req->hash_next = NULL;
-  req->submit_time_ms = Socket_get_monotonic_ms ();
-  req->timeout_override_ms = -1;
-}
-
-Request_T
-allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
-                  int port, SocketDNS_Callback callback, void *data)
-{
-  Request_T req = allocate_request_structure (dns);
-  allocate_request_hostname (dns, req, host, host_len);
-  initialize_request_fields (req, port, callback, data);
-  req->dns_resolver = dns;
-
-  return req;
-}
 
 void
 queue_append (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)


### PR DESCRIPTION
## Summary

Implements #1125

Migrates request management functions from `SocketDNS-internal.c` to `SocketDNS.c` as part of DNS unification (Phase 2.6b).

## Changes

### Migrated Functions (7 total, ~150 lines)

1. **secure_clear_memory()** - Secure memory clearing using explicit_bzero
2. **free_request_list_results()** - Free request result lists with secure hostname clearing
3. **free_all_requests()** - Cleanup all pending requests in hash table
4. **allocate_request_structure()** - Allocate request struct from arena
5. **allocate_request_hostname()** - Allocate hostname storage with overflow checks
6. **initialize_request_fields()** - Initialize request fields (state, callbacks, timeout)
7. **allocate_request()** - Main request allocation entry point

### Modified Files

- `src/dns/SocketDNS.c` - Added migrated functions after hash table operations section
- `src/dns/SocketDNS-internal.c` - Removed migrated functions, added migration marker

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] Core tests pass (arena, except, util, buf, log, timer, etc.)
- [x] No new test failures introduced (verified against main branch baseline)
- [x] Function signatures and behavior preserved identically

## Progress

This completes Phase 2.6b of DNS unification. Next steps:
- Phase 2.6d: Migrate remaining queue/worker functions
- Phase 2.7: Delete SocketDNS-internal.c (#1060)

Closes #1125