### PR TITLE
dns: migrate request management to SocketDNS.c (Phase 2.6b)

### DIFF
--- a/src/dns/SocketDNS-internal.c
+++ b/src/dns/SocketDNS-internal.c
@@ -134,126 +134,17 @@ shutdown_workers (T d)
 
 /* drain_completion_pipe() migrated to SocketDNS.c (Phase 2.6c) */
 
-static void
-secure_clear_memory (void *ptr, size_t len)
-{
-  if (!ptr || len == 0)
-    return;
-
-#ifdef __linux__
-  explicit_bzero (ptr, len);
-#else
-  volatile unsigned char *vptr = (volatile unsigned char *)ptr;
-  while (len--)
-    *vptr++ = 0;
-#endif
-}
-
-static void
-free_request_list_results (Request_T head, size_t next_offset)
-{
-  Request_T curr = head;
-
-  while (curr)
-    {
-      Request_T next = *(Request_T *)((char *)curr + next_offset);
-
-      if (curr->host)
-        {
-          secure_clear_memory (curr->host, strlen (curr->host));
-        }
-
-      if (curr->result)
-        {
-          SocketCommon_free_addrinfo (curr->result);
-          curr->result = NULL;
-        }
-      curr = next;
-    }
-}
-
-void
-free_all_requests (T d)
-{
-  /* No queue_head anymore - only free hash table requests */
-  for (int i = 0; i < SOCKET_DNS_REQUEST_HASH_SIZE; i++)
-    free_request_list_results (
-        d->request_hash[i], offsetof (struct SocketDNS_Request_T, hash_next));
-}
+/* Request management functions migrated to SocketDNS.c (Phase 2.6b):
+ * - secure_clear_memory()
+ * - free_request_list_results()
+ * - free_all_requests()
+ * - allocate_request_structure()
+ * - allocate_request_hostname()
+ * - initialize_request_fields()
+ * - allocate_request()
+ */
 
 /* reset_dns_state() and destroy_dns_resources() migrated to SocketDNS.c (Phase 2.6c) */
-
-Request_T
-allocate_request_structure (struct SocketDNS_T *dns)
-{
-  Request_T req;
-
-  req = ALLOC (dns->arena, sizeof (*req));
-  if (!req)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate DNS request");
-    }
-
-  return req;
-}
-
-void
-allocate_request_hostname (struct SocketDNS_T *dns,
-                           struct SocketDNS_Request_T *req, const char *host,
-                           size_t host_len)
-{
-  if (host == NULL)
-    {
-      req->host = NULL;
-      return;
-    }
-
-  /* Check for overflow: host_len == SIZE_MAX would cause host_len + 1 to wrap to 0 */
-  if (host_len >= SIZE_MAX || host_len > 255)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        "Hostname length overflow or exceeds DNS maximum (255)");
-    }
-
-  req->host = ALLOC (dns->arena, host_len + 1);
-  if (!req->host)
-    {
-      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
-                        SOCKET_ENOMEM ": Cannot allocate hostname");
-    }
-
-  memcpy (req->host, host, host_len);
-  req->host[host_len] = '\0';
-}
-
-void
-initialize_request_fields (struct SocketDNS_Request_T *req, int port,
-                           SocketDNS_Callback callback, void *data)
-{
-  req->port = port;
-  req->callback = callback;
-  req->callback_data = data;
-  req->state = REQ_PENDING;
-  req->result = NULL;
-  req->error = 0;
-  req->queue_next = NULL;
-  req->hash_next = NULL;
-  req->submit_time_ms = Socket_get_monotonic_ms ();
-  req->timeout_override_ms = -1;
-}
-
-Request_T
-allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
-                  int port, SocketDNS_Callback callback, void *data)
-{
-  Request_T req = allocate_request_structure (dns);
-  allocate_request_hostname (dns, req, host, host_len);
-  initialize_request_fields (req, port, callback, data);
-  req->dns_resolver = dns;
-
-  return req;
-}
 
 void
 queue_append (struct SocketDNS_T *dns, struct SocketDNS_Request_T *req)

--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -291,6 +291,127 @@ destroy_dns_resources (T d)
   free (d);
 }
 
+/* Request Management Functions (migrated from SocketDNS-internal.c - Phase 2.6b) */
+
+static void
+secure_clear_memory (void *ptr, size_t len)
+{
+  if (!ptr || len == 0)
+    return;
+
+#ifdef __linux__
+  explicit_bzero (ptr, len);
+#else
+  volatile unsigned char *vptr = (volatile unsigned char *)ptr;
+  while (len--)
+    *vptr++ = 0;
+#endif
+}
+
+static void
+free_request_list_results (Request_T head, size_t next_offset)
+{
+  Request_T curr = head;
+
+  while (curr)
+    {
+      Request_T next = *(Request_T *)((char *)curr + next_offset);
+
+      if (curr->host)
+        {
+          secure_clear_memory (curr->host, strlen (curr->host));
+        }
+
+      if (curr->result)
+        {
+          SocketCommon_free_addrinfo (curr->result);
+          curr->result = NULL;
+        }
+      curr = next;
+    }
+}
+
+void
+free_all_requests (T d)
+{
+  /* No queue_head anymore - only free hash table requests */
+  for (int i = 0; i < SOCKET_DNS_REQUEST_HASH_SIZE; i++)
+    free_request_list_results (
+        d->request_hash[i], offsetof (struct SocketDNS_Request_T, hash_next));
+}
+
+Request_T
+allocate_request_structure (struct SocketDNS_T *dns)
+{
+  Request_T req;
+
+  req = ALLOC (dns->arena, sizeof (*req));
+  if (!req)
+    {
+      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
+                        SOCKET_ENOMEM ": Cannot allocate DNS request");
+    }
+
+  return req;
+}
+
+void
+allocate_request_hostname (struct SocketDNS_T *dns,
+                           struct SocketDNS_Request_T *req, const char *host,
+                           size_t host_len)
+{
+  if (host == NULL)
+    {
+      req->host = NULL;
+      return;
+    }
+
+  /* Check for overflow: host_len == SIZE_MAX would cause host_len + 1 to wrap to 0 */
+  if (host_len >= SIZE_MAX || host_len > 255)
+    {
+      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
+                        "Hostname length overflow or exceeds DNS maximum (255)");
+    }
+
+  req->host = ALLOC (dns->arena, host_len + 1);
+  if (!req->host)
+    {
+      SOCKET_RAISE_MSG (SocketDNS, SocketDNS_Failed,
+                        SOCKET_ENOMEM ": Cannot allocate hostname");
+    }
+
+  memcpy (req->host, host, host_len);
+  req->host[host_len] = '\0';
+}
+
+void
+initialize_request_fields (struct SocketDNS_Request_T *req, int port,
+                           SocketDNS_Callback callback, void *data)
+{
+  req->port = port;
+  req->callback = callback;
+  req->callback_data = data;
+  req->state = REQ_PENDING;
+  req->result = NULL;
+  req->error = 0;
+  req->queue_next = NULL;
+  req->hash_next = NULL;
+  req->submit_time_ms = Socket_get_monotonic_ms ();
+  req->timeout_override_ms = -1;
+}
+
+Request_T
+allocate_request (struct SocketDNS_T *dns, const char *host, size_t host_len,
+                  int port, SocketDNS_Callback callback, void *data)
+{
+  Request_T req = allocate_request_structure (dns);
+  allocate_request_hostname (dns, req, host, host_len);
+  initialize_request_fields (req, port, callback, data);
+  req->dns_resolver = dns;
+
+  return req;
+}
+
 /* Forward declarations for cache coherence functions */
 static struct SocketDNS_CacheEntry *
 cache_lookup_l1_only (struct SocketDNS_T *dns, const char *hostname);


### PR DESCRIPTION
## Summary

Implements #1125 - Migrate request management functions from `SocketDNS-internal.c` to `SocketDNS.c` as part of DNS unification (Phase 2.6).

## Changes

Migrated 7 request management functions:
- `secure_clear_memory()` - Secure memory clearing
- `free_request_list_results()` - Free request list results
- `free_all_requests()` - Cleanup all pending requests
- `allocate_request_structure()` - Allocate request struct
- `allocate_request_hostname()` - Allocate hostname storage
- `initialize_request_fields()` - Initialize request fields
- `allocate_request()` - Main request allocation entry point

### Files Modified
- `src/dns/SocketDNS.c` - Added migrated functions
- `src/dns/SocketDNS-internal.c` - Removed migrated functions

## Implementation Notes

- All functions maintain identical signatures and behavior
- No functional changes - pure code relocation
- Functions added after cleanup section in SocketDNS.c
- Appropriate migration comments added to both files

## Test Plan

- [x] Build succeeds with sanitizers (`-DENABLE_SANITIZERS=ON`)
- [x] All symbols present in library (verified with nm)
- [x] No new compilation errors or warnings
- [x] Code relocation only - no behavior changes

## Related Issues

Part of #1053 (DNS Unification Phase 2.6) - prepares for deletion of SocketDNS-internal.c

Closes #1125