### PR TITLE
fix: memory leaks in DNS resolver and addrinfo handling

### DIFF
--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -279,11 +279,15 @@ destroy_dns_resources (T d)
   cleanup_pipe (d);
   cleanup_mutex_cond (d);
 
-  /* Free resolver backend (Phase 2.2) */
+  /* Free resolver backend - must call _free before Arena_dispose
+   * so it can clean up transport sockets which have their own arenas */
+  if (d->resolver)
+    {
+      SocketDNSResolver_free (&d->resolver);
+    }
   if (d->resolver_arena)
     {
       Arena_dispose (&d->resolver_arena);
-      d->resolver = NULL;
     }
 
   Arena_dispose (&d->arena);

--- a/src/simple/SocketSimple-dns.c
+++ b/src/simple/SocketSimple-dns.c
@@ -63,7 +63,7 @@ Socket_simple_dns_resolve_timeout (const char *hostname,
     /* Cleanup res on exception - normal path handles it below */
     if (exception_occurred && res)
       {
-        freeaddrinfo ((struct addrinfo *)res);
+        SocketCommon_free_addrinfo ((struct addrinfo *)res);
         res = NULL;
       }
   }
@@ -86,7 +86,7 @@ Socket_simple_dns_resolve_timeout (const char *hostname,
 
   if (count == 0)
     {
-      freeaddrinfo ((struct addrinfo *)res);
+      SocketCommon_free_addrinfo ((struct addrinfo *)res);
       simple_set_error (SOCKET_SIMPLE_ERR_DNS, "No addresses found");
       return -1;
     }
@@ -94,7 +94,7 @@ Socket_simple_dns_resolve_timeout (const char *hostname,
   result->addresses = calloc ((size_t)count + 1, sizeof (char *));
   if (!result->addresses)
     {
-      freeaddrinfo ((struct addrinfo *)res);
+      SocketCommon_free_addrinfo ((struct addrinfo *)res);
       simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Memory allocation failed");
       return -1;
     }
@@ -119,7 +119,7 @@ Socket_simple_dns_resolve_timeout (const char *hostname,
 
   result->count = i;
   result->family = ((struct addrinfo *)res)->ai_family;
-  freeaddrinfo ((struct addrinfo *)res);
+  SocketCommon_free_addrinfo ((struct addrinfo *)res);
 
   if (result->count == 0)
     {
@@ -194,7 +194,7 @@ Socket_simple_dns_lookup4 (const char *hostname, char *buf, size_t len)
   {
     if (exception_occurred && res)
       {
-        freeaddrinfo ((struct addrinfo *)res);
+        SocketCommon_free_addrinfo ((struct addrinfo *)res);
         res = NULL;
       }
   }
@@ -224,7 +224,7 @@ Socket_simple_dns_lookup4 (const char *hostname, char *buf, size_t len)
       simple_set_error (SOCKET_SIMPLE_ERR_DNS, "Failed to get address string");
     }
 
-  freeaddrinfo ((struct addrinfo *)res);
+  SocketCommon_free_addrinfo ((struct addrinfo *)res);
   return ret;
 }
 
@@ -264,7 +264,7 @@ Socket_simple_dns_lookup6 (const char *hostname, char *buf, size_t len)
   {
     if (exception_occurred && res)
       {
-        freeaddrinfo ((struct addrinfo *)res);
+        SocketCommon_free_addrinfo ((struct addrinfo *)res);
         res = NULL;
       }
   }
@@ -294,7 +294,7 @@ Socket_simple_dns_lookup6 (const char *hostname, char *buf, size_t len)
       simple_set_error (SOCKET_SIMPLE_ERR_DNS, "Failed to get address string");
     }
 
-  freeaddrinfo ((struct addrinfo *)res);
+  SocketCommon_free_addrinfo ((struct addrinfo *)res);
   return ret;
 }
 
@@ -343,7 +343,7 @@ Socket_simple_dns_reverse (const char *ip, char *hostname, size_t len)
       simple_set_error (SOCKET_SIMPLE_ERR_DNS, "Reverse lookup failed");
     }
 
-  freeaddrinfo (res);
+  SocketCommon_free_addrinfo (res);
   return ret;
 }
 
@@ -446,7 +446,7 @@ simple_dns_callback_wrapper (SocketDNS_Request_T *req, struct addrinfo *result,
   /* Cleanup */
   Socket_simple_dns_result_free (&simple_result);
   if (result)
-    freeaddrinfo (result);
+    SocketCommon_free_addrinfo (result);
   free (ctx);
 }
 
@@ -804,7 +804,7 @@ Socket_simple_dns_request_free (SocketSimple_DNSRequest_T *req)
   struct SocketSimple_DNSRequest *handle = *req;
 
   if (handle->result)
-    freeaddrinfo (handle->result);
+    SocketCommon_free_addrinfo (handle->result);
 
   free (handle);
   *req = NULL;

--- a/src/socket/SocketCommon.c
+++ b/src/socket/SocketCommon.c
@@ -91,6 +91,7 @@ init_global_dns_resolver (void)
   {
     g_dns_resolver = SocketDNS_new ();
     SocketDNS_settimeout (g_dns_resolver, g_dns_timeout_ms);
+    atexit (SocketCommon_shutdown_globals);
   }
   EXCEPT (SocketDNS_Failed)
   {

--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -260,7 +260,7 @@ SocketDgram_sendto (T socket, const void *buf, size_t len, const char *host,
   resolve_sendto_address (host, port, &res);
 
   TRY sent = perform_sendto (socket, buf, len, res);
-  FINALLY freeaddrinfo (res);
+  FINALLY SocketCommon_free_addrinfo (res);
   END_TRY;
 
   return (ssize_t)sent;

--- a/src/test/test_socket.c
+++ b/src/test/test_socket.c
@@ -2617,7 +2617,7 @@ TEST (socket_bind_with_addrinfo_ipv4)
   if (result == 0 && res)
     {
       Socket_bind_with_addrinfo (socket, res);
-      freeaddrinfo (res);
+      freeaddrinfo (res);  /* From direct getaddrinfo */
     }
   EXCEPT (Socket_Failed) (void) 0;
   FINALLY
@@ -2651,7 +2651,7 @@ TEST (socket_connect_with_addrinfo_ipv4)
   if (result == 0 && res)
     {
       Socket_connect_with_addrinfo (client, res);
-      freeaddrinfo (res);
+      freeaddrinfo (res);  /* From direct getaddrinfo */
     }
   EXCEPT (Socket_Failed) (void) 0;
   FINALLY
@@ -4608,7 +4608,7 @@ TEST (socketcommon_resolve_address_invalid_host)
 
   ASSERT_EQ (1, raised);
   if (res)
-    freeaddrinfo (res);
+    SocketCommon_free_addrinfo (res);
 }
 
 TEST (socketcommon_resolve_address_family_mismatch)
@@ -4634,7 +4634,7 @@ TEST (socketcommon_resolve_address_family_mismatch)
   /* May or may not raise depending on system - just covers code path */
   (void)raised;
   if (res)
-    freeaddrinfo (res);
+    SocketCommon_free_addrinfo (res);
 }
 
 TEST (socketcommon_resolve_address_no_exceptions)
@@ -4651,7 +4651,7 @@ TEST (socketcommon_resolve_address_no_exceptions)
       Socket_Failed, AF_UNSPEC, 0);
   ASSERT_EQ (-1, result);
   if (res)
-    freeaddrinfo (res);
+    SocketCommon_free_addrinfo (res);
 }
 
 TEST (socketcommon_reverse_lookup_failure)
@@ -5136,7 +5136,7 @@ TEST (socketcommon_try_bind_resolved_addresses_all_fail)
     int port = ntohs (((struct sockaddr_in *)&local)->sin_port);
 
     /* Create new resolution for same port */
-    freeaddrinfo (res);
+    freeaddrinfo (res);  /* From direct getaddrinfo */
     res = NULL;
     char port_str[16];
     snprintf (port_str, sizeof (port_str), "%d", port);
@@ -5160,7 +5160,7 @@ TEST (socketcommon_try_bind_resolved_addresses_all_fail)
   (void)raised;
 
   if (res)
-    freeaddrinfo (res);
+    freeaddrinfo (res);  /* From direct getaddrinfo */
   if (base2)
     SocketCommon_free_base (&base2);
   if (base1)
@@ -5187,7 +5187,7 @@ TEST (socketcommon_resolve_address_family_strict_mismatch)
 
   ASSERT_EQ (1, raised);
   if (res)
-    freeaddrinfo (res);
+    SocketCommon_free_addrinfo (res);
 }
 
 TEST (socketcommon_copy_addrinfo_empty_addr)
@@ -6383,7 +6383,7 @@ TEST (socket_bind_with_addrinfo_failure)
   /* Cleanup */
   (void)raised;
   if (res)
-    freeaddrinfo (res);
+    freeaddrinfo (res);  /* From direct getaddrinfo, not copy */
   Socket_free (&socket1);
   Socket_free (&socket2);
 }

--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -132,7 +132,7 @@ free_dtls_resources (SocketDgram_T socket)
   /* Invalidate peer cache */
   if (socket->dtls_peer_res)
     {
-      freeaddrinfo (socket->dtls_peer_res);
+      SocketCommon_free_addrinfo (socket->dtls_peer_res);
       socket->dtls_peer_res = NULL;
     }
   socket->dtls_peer_host = NULL;
@@ -274,7 +274,7 @@ finalize_dtls_state (SocketDgram_T socket, SSL *ssl, SocketDTLSContext_T ctx)
  * @host: Hostname or IP
  * @port: Port number
  *
- * Returns: Resolved addrinfo list (caller must freeaddrinfo)
+ * Returns: Resolved addrinfo list (caller must SocketCommon_free_addrinfo)
  * Raises: SocketDTLS_Failed on resolution failure
  * Thread-safe: Yes
  */
@@ -319,7 +319,7 @@ dtls_invalidate_peer_cache (SocketDgram_T socket)
 {
   if (socket->dtls_peer_res)
     {
-      freeaddrinfo (socket->dtls_peer_res);
+      SocketCommon_free_addrinfo (socket->dtls_peer_res);
       socket->dtls_peer_res = NULL;
     }
   socket->dtls_peer_host = NULL;
@@ -344,7 +344,7 @@ dtls_cache_peer_resolution (SocketDgram_T socket, const char *host, int port,
   socket->dtls_peer_host = socket_util_arena_strdup (arena, host);
   if (!socket->dtls_peer_host)
     {
-      freeaddrinfo (result);
+      SocketCommon_free_addrinfo (result);
       RAISE_DTLS_ERROR_MSG (SocketDTLS_Failed, "Failed to cache peer hostname");
     }
   socket->dtls_peer_port = port;


### PR DESCRIPTION
## Summary
- Add atexit handler to clean up global DNS resolver on program exit
- Fix SocketDNSResolver transport socket leak by calling _free before arena dispose
- Fix freeaddrinfo misuse for addrinfo created by SocketCommon_copy_addrinfo

Fixes #1142

## Test plan
- [x] All tests pass with sanitizers (112/113 - socketpool timeout is pre-existing)
- [x] No memory leaks detected by AddressSanitizer
- [x] Verified fixes address all leak patterns in original failure