### PR TITLE
refactor(quic): remove redundant QUIC_PATH_DATA_SIZE definition

### DIFF
--- a/src/quic/SocketQUICFrame.c
+++ b/src/quic/SocketQUICFrame.c
@@ -34,9 +34,6 @@
 /* 1-RTT only */
 #define PKT_1 (QUIC_PKT_1RTT)
 
-/* RFC 9000 Section 12.12-12.13: PATH_CHALLENGE/RESPONSE data size */
-#define QUIC_PATH_DATA_SIZE 8
-
 /* RFC 9000 Section 10.3: Stateless Reset Token size */
 #define QUIC_STATELESS_RESET_TOKEN_SIZE 16
 


### PR DESCRIPTION
## Summary

Implements #1144

## Changes

- Removed redundant `#define QUIC_PATH_DATA_SIZE 8` from `src/quic/SocketQUICFrame.c` line 38
- Definition already exists in `include/quic/SocketQUICFrame.h` line 22
- Header is included by source file at line 12, making the redefinition unnecessary

## Test Plan

- [x] All QUIC tests pass with sanitizers (17/17 PATH frame tests specifically)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - purely removes redundancy

Closes #1144