### PR TITLE
fix(quic): use constant-time comparison for PATH_CHALLENGE validation

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -12,6 +12,7 @@
 #include "quic/SocketQUICMigration.h"
 #include "quic/SocketQUICConstants.h"
 #include "core/SocketUtil.h"
+#include "core/SocketCrypto.h"
 #include <string.h>
 #include <stdio.h>
 #include <arpa/inet.h>
@@ -788,8 +789,8 @@ find_path_by_challenge (SocketQUICMigration_T *migration,
 
   for (i = 0; i < migration->path_count; i++)
     {
-      if (memcmp (migration->paths[i].challenge, challenge,
-                 QUIC_PATH_CHALLENGE_SIZE)
+      if (SocketCrypto_secure_compare (migration->paths[i].challenge, challenge,
+                                       QUIC_PATH_CHALLENGE_SIZE)
           == 0)
         {
           return &migration->paths[i];


### PR DESCRIPTION
## Summary

Implements #1153

## Changes

- Replaced timing-unsafe `memcmp()` with `SocketCrypto_secure_compare()` in `find_path_by_challenge()`
- Added `#include "core/SocketCrypto.h"` to SocketQUICMigration.c

## Security Impact

While PATH_CHALLENGE is already protected by QUIC packet encryption and authentication, this change implements defense-in-depth by preventing timing side-channel attacks (CWE-208) against the challenge validation.

## Test Plan

- [x] All QUIC migration tests pass (19/19)
- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] No regressions in other QUIC modules

Closes #1153