### PR TITLE
fix(quic): add integer overflow protection to CONNECTION_CLOSE frame encoding

### DIFF
--- a/src/quic/SocketQUICFrame-close.c
+++ b/src/quic/SocketQUICFrame-close.c
@@ -99,8 +99,13 @@ SocketQUICFrame_encode_connection_close_transport (uint64_t error_code,
   if (error_code_len == 0 || frame_type_len == 0 || reason_len_size == 0)
     return 0; /* Value exceeds varint maximum */
 
-  size_t total_len
-      = type_len + error_code_len + frame_type_len + reason_len_size + reason_len;
+  /* Check for integer overflow in total_len calculation.
+   * Prevent SIZE_MAX wraparound that could bypass buffer size check. */
+  size_t fixed_size = type_len + error_code_len + frame_type_len + reason_len_size;
+  if (reason_len > SIZE_MAX - fixed_size)
+    return 0; /* Overflow would occur */
+
+  size_t total_len = fixed_size + reason_len;
 
   if (out_len < total_len)
     return 0; /* Buffer too small */
@@ -186,7 +191,13 @@ SocketQUICFrame_encode_connection_close_app (uint64_t error_code,
   if (error_code_len == 0 || reason_len_size == 0)
     return 0; /* Value exceeds varint maximum */
 
-  size_t total_len = type_len + error_code_len + reason_len_size + reason_len;
+  /* Check for integer overflow in total_len calculation.
+   * Prevent SIZE_MAX wraparound that could bypass buffer size check. */
+  size_t fixed_size = type_len + error_code_len + reason_len_size;
+  if (reason_len > SIZE_MAX - fixed_size)
+    return 0; /* Overflow would occur */
+
+  size_t total_len = fixed_size + reason_len;
 
   if (out_len < total_len)
     return 0; /* Buffer too small */


### PR DESCRIPTION
## Summary

Fixes #1149 - Integer overflow vulnerability in CONNECTION_CLOSE frame encoding

## Changes

Added overflow protection to both `SocketQUICFrame_encode_connection_close_transport()` and `SocketQUICFrame_encode_connection_close_app()` functions.

The fix prevents SIZE_MAX wraparound by checking if `reason_len` would cause overflow before performing the addition:

```c
size_t fixed_size = type_len + error_code_len + reason_len_size;
if (reason_len > SIZE_MAX - fixed_size)
    return 0; /* Overflow would occur */
```

## Vulnerability Details

**Severity**: HIGH  
**Category**: Integer Overflow leading to Buffer Overflow

An attacker could provide a malicious reason phrase with length close to SIZE_MAX, causing:
1. Integer overflow in `total_len` calculation
2. Bypass of buffer size check
3. Buffer overflow during `memcpy()` operation

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] Existing QUIC frame tests pass
- [x] Manual verification of overflow check logic

Closes #1149