### PR TITLE
refactor(quic): standardize buffer validation in flow control frame encoding

### DIFF
--- a/src/quic/SocketQUICFrame-flow.c
+++ b/src/quic/SocketQUICFrame-flow.c
@@ -37,16 +37,22 @@ size_t
 SocketQUICFrame_encode_max_data (uint64_t max_data, uint8_t *out,
                                   size_t out_size)
 {
-  size_t pos;
-
   if (!out)
     return 0;
 
-  /* Need at least 1 byte for type + 1 byte for minimum varint */
-  if (out_size < 2)
-    return 0;
+  /* Calculate required size: type (1 byte) + max_data (varint) */
+  size_t type_len = 1;
+  size_t max_data_len = SocketQUICVarInt_size (max_data);
 
-  pos = 0;
+  if (max_data_len == 0)
+    return 0; /* max_data exceeds varint maximum */
+
+  size_t total_len = type_len + max_data_len;
+
+  if (out_size < total_len)
+    return 0; /* Buffer too small */
+
+  size_t pos = 0;
 
   /* Type: 0x10 */
   out[pos++] = QUIC_FRAME_MAX_DATA;
@@ -72,16 +78,23 @@ size_t
 SocketQUICFrame_encode_max_stream_data (uint64_t stream_id, uint64_t max_data,
                                          uint8_t *out, size_t out_size)
 {
-  size_t pos;
-
   if (!out)
     return 0;
 
-  /* Need at least 1 byte for type + 2 bytes for minimum varints */
-  if (out_size < 3)
-    return 0;
+  /* Calculate required size: type + stream_id + max_data (all varints) */
+  size_t type_len = 1;
+  size_t stream_id_len = SocketQUICVarInt_size (stream_id);
+  size_t max_data_len = SocketQUICVarInt_size (max_data);
 
-  pos = 0;
+  if (stream_id_len == 0 || max_data_len == 0)
+    return 0; /* Value exceeds varint maximum */
+
+  size_t total_len = type_len + stream_id_len + max_data_len;
+
+  if (out_size < total_len)
+    return 0; /* Buffer too small */
+
+  size_t pos = 0;
 
   /* Type: 0x11 */
   out[pos++] = QUIC_FRAME_MAX_STREAM_DATA;
@@ -110,16 +123,22 @@ size_t
 SocketQUICFrame_encode_max_streams (int bidirectional, uint64_t max_streams,
                                      uint8_t *out, size_t out_size)
 {
-  size_t pos;
-
   if (!out)
     return 0;
 
-  /* Need at least 1 byte for type + 1 byte for minimum varint */
-  if (out_size < 2)
-    return 0;
+  /* Calculate required size: type (1 byte) + max_streams (varint) */
+  size_t type_len = 1;
+  size_t max_streams_len = SocketQUICVarInt_size (max_streams);
 
-  pos = 0;
+  if (max_streams_len == 0)
+    return 0; /* max_streams exceeds varint maximum */
+
+  size_t total_len = type_len + max_streams_len;
+
+  if (out_size < total_len)
+    return 0; /* Buffer too small */
+
+  size_t pos = 0;
 
   /* Type: 0x12 (bidi) or 0x13 (uni) */
   out[pos++] = bidirectional ? QUIC_FRAME_MAX_STREAMS_BIDI


### PR DESCRIPTION
## Summary

Implements #1150 by standardizing buffer validation across all six flow control frame encoding functions in `src/quic/SocketQUICFrame-flow.c`.

## Changes

Previously, the file used two different validation approaches:
- **First 3 functions** (MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS): Hardcoded minimum sizes
- **Last 3 functions** (DATA_BLOCKED, STREAM_DATA_BLOCKED, STREAMS_BLOCKED): Calculated exact sizes

This PR standardizes all functions to use the **calculated exact sizes** approach, matching the pattern used in related QUIC frame encoding files:
- `src/quic/SocketQUICFrame-stream.c`
- `src/quic/SocketQUICFrame-close.c`

### Modified Functions
1. `SocketQUICFrame_encode_max_data`
2. `SocketQUICFrame_encode_max_stream_data`
3. `SocketQUICFrame_encode_max_streams`

### Validation Pattern (Before)
```c
/* Need at least 1 byte for type + 1 byte for minimum varint */
if (out_size < 2)
  return 0;
```

### Validation Pattern (After)
```c
/* Calculate required size: type (1 byte) + max_data (varint) */
size_t type_len = 1;
size_t max_data_len = SocketQUICVarInt_size (max_data);

if (max_data_len == 0)
  return 0; /* max_data exceeds varint maximum */

size_t total_len = type_len + max_data_len;

if (out_size < total_len)
  return 0; /* Buffer too small */
```

## Benefits

- **Consistency**: All 6 functions now use identical validation logic
- **Explicitness**: Varint overflow is explicitly checked via `SocketQUICVarInt_size`
- **Alignment**: Matches the pattern used in other QUIC frame encoding files
- **Self-documenting**: The validation logic is more readable and maintainable

## Test Plan

- [x] All existing tests pass with sanitizers enabled
- [x] `test_quic_flow` passes (35/35 tests)
- [x] Build succeeds with `-Wall -Wextra -Werror`
- [x] No functional behavior changes (refactoring only)

## RFC Reference

RFC 9000 Sections 19.9-19.14 (Flow Control Frames)

Closes #1150