### PR TITLE
refactor: Replace magic number 24 with QUIC_TOKEN_HMAC_INPUT_SIZE

### DIFF
--- a/include/quic/SocketQUICAddrValidation.h
+++ b/include/quic/SocketQUICAddrValidation.h
@@ -40,6 +40,9 @@
 /** @brief Path challenge data size (RFC 9000 §8.2) */
 #define QUIC_PATH_CHALLENGE_SIZE 8
 
+/** @brief HMAC input size: 8 bytes timestamp + 16 bytes address hash */
+#define QUIC_TOKEN_HMAC_INPUT_SIZE 24
+
 /* ============================================================================
  * Exception Types
  * ============================================================================

--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -149,7 +149,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
                                           uint8_t *token, size_t *token_len)
 {
   uint8_t addr_hash[16];
-  uint8_t hmac_input[24]; /* 8 bytes timestamp + 16 bytes addr hash */
+  uint8_t hmac_input[QUIC_TOKEN_HMAC_INPUT_SIZE];
   unsigned char hmac_output[SOCKET_CRYPTO_SHA256_SIZE];
   uint64_t timestamp;
 
@@ -178,7 +178,8 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
   /* Compute HMAC-SHA256 */
   TRY
   {
-    SocketCrypto_hmac_sha256 (secret, 32, hmac_input, 24, hmac_output);
+    SocketCrypto_hmac_sha256 (secret, 32, hmac_input, QUIC_TOKEN_HMAC_INPUT_SIZE,
+                              hmac_output);
   }
   EXCEPT (SocketCrypto_Failed)
   {
@@ -202,7 +203,7 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
                                           const uint8_t *secret)
 {
   uint8_t addr_hash[16];
-  uint8_t hmac_input[24];
+  uint8_t hmac_input[QUIC_TOKEN_HMAC_INPUT_SIZE];
   unsigned char hmac_output[SOCKET_CRYPTO_SHA256_SIZE];
   uint64_t token_timestamp;
   uint64_t current_time;
@@ -247,7 +248,8 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
   /* Compute expected HMAC */
   TRY
   {
-    SocketCrypto_hmac_sha256 (secret, 32, hmac_input, 24, hmac_output);
+    SocketCrypto_hmac_sha256 (secret, 32, hmac_input, QUIC_TOKEN_HMAC_INPUT_SIZE,
+                              hmac_output);
   }
   EXCEPT (SocketCrypto_Failed)
   {


### PR DESCRIPTION
## Summary

Implements #1158

Replaces hardcoded magic number 24 in `SocketQUICAddrValidation.c` with a named constant `QUIC_TOKEN_HMAC_INPUT_SIZE` for improved code clarity and maintainability.

## Changes

- Added `QUIC_TOKEN_HMAC_INPUT_SIZE` constant to `include/quic/SocketQUICAddrValidation.h`
- Replaced all 4 occurrences of magic number 24:
  - Line 152: `hmac_input` buffer declaration in `generate_token`
  - Line 181: HMAC function call in `generate_token`
  - Line 205: `hmac_input` buffer declaration in `validate_token`
  - Line 250: HMAC function call in `validate_token`

The value 24 represents the HMAC input size: 8 bytes (timestamp) + 16 bytes (address hash). This structural constant is now properly documented in the header file.

## Test Plan

- [x] All QUIC tests pass with sanitizers enabled
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] Code compiles without warnings or errors

Closes #1158