### PR TITLE
refactor(quic): use consistent C99 loop variable declaration style

### DIFF
--- a/src/quic/SocketQUICStream-state.c
+++ b/src/quic/SocketQUICStream-state.c
@@ -201,7 +201,6 @@ SocketQUICStream_transition_send (SocketQUICStream_T stream,
                                   SocketQUICStreamEvent event)
 {
   SocketQUICStreamState current;
-  size_t i;
 
   if (stream == NULL)
     return QUIC_STREAM_ERROR_NULL;
@@ -216,7 +215,7 @@ SocketQUICStream_transition_send (SocketQUICStream_T stream,
     }
 
   /* Search transition table for valid transition */
-  for (i = 0; i < SEND_TRANSITIONS_COUNT; i++)
+  for (size_t i = 0; i < SEND_TRANSITIONS_COUNT; i++)
     {
       if (send_transitions[i].from_state == current
           && send_transitions[i].event == event)


### PR DESCRIPTION
## Summary

Implements #1164

Fixes inconsistent loop variable declaration style in `SocketQUICStream-state.c` by converting the send-side state transition function to use C99-style inline variable declaration, matching the receive-side function.

## Changes

- **File**: `src/quic/SocketQUICStream-state.c`
- Removed standalone `size_t i;` declaration at function start (line 204)
- Changed `for (i = 0; ...)` to `for (size_t i = 0; ...)` (line 218)

**Before** (C89 style):
```c
size_t i;
// ...
for (i = 0; i < SEND_TRANSITIONS_COUNT; i++)
```

**After** (C99 style):
```c
for (size_t i = 0; i < SEND_TRANSITIONS_COUNT; i++)
```

This makes both transition functions consistent and follows the project's C11 standard.

## Test Plan

- [x] All QUIC stream state tests pass (39/39)
- [x] Full test suite passes with ASan/UBSan (112/113, 1 unrelated timeout)
- [x] Build completes without warnings
- [x] No functional changes - pure refactoring

Closes #1164