### PR TITLE
refactor(quic): remove duplicate QUIC_STATELESS_RESET_MIN_PACKET_LEN constant

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -28,9 +28,6 @@
 /* RFC 9000 Section 10.2: Closing/draining timeout = 3 * PTO */
 #define QUIC_TERMINATION_PTO_MULTIPLIER 3
 
-/* RFC 9000 Section 10.3.1: Minimum packet size to avoid false positives */
-#define QUIC_STATELESS_RESET_MIN_PACKET_LEN 38
-
 typedef struct SocketQUICConnection *SocketQUICConnection_T;
 typedef struct SocketQUICConnTable *SocketQUICConnTable_T;
 

--- a/src/quic/SocketQUICConnection-termination.c
+++ b/src/quic/SocketQUICConnection-termination.c
@@ -28,6 +28,7 @@
 #include <string.h>
 #include <stdint.h>
 #include "quic/SocketQUICConnection.h"
+#include "quic/SocketQUICConstants.h"
 
 /**
  * @brief Safely add two uint64_t values with overflow protection.
@@ -326,7 +327,7 @@ SocketQUICConnection_verify_stateless_reset(const uint8_t *packet,
     return 0;
 
   /* RFC 9000 Section 10.3.1: Minimum size to avoid collisions */
-  if (packet_len < QUIC_STATELESS_RESET_MIN_PACKET_LEN)
+  if (packet_len < QUIC_STATELESS_RESET_MIN_SIZE)
     return 0;
 
   /* Compare final 16 bytes with expected token */


### PR DESCRIPTION
## Summary

Implements #1161 by removing the duplicate constant definition for stateless reset minimum packet size.

## Changes

- Removed `QUIC_STATELESS_RESET_MIN_PACKET_LEN` from `include/quic/SocketQUICConnection.h`
- Added `#include "quic/SocketQUICConstants.h"` to `src/quic/SocketQUICConnection-termination.c`
- Updated usage to reference `QUIC_STATELESS_RESET_MIN_SIZE` (the canonical constant in SocketQUICConstants.h)

## Benefits

- Single source of truth for QUIC constants
- Reduced maintenance burden
- Eliminates risk of value divergence between duplicate definitions
- Better code organization (all QUIC constants centralized in SocketQUICConstants.h)

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] All tests pass (except pre-existing timeout in test_socketpool)
- [x] No functional changes - both constants had the same value (38 bytes)
- [x] Verified the constant is used correctly in stateless reset verification

Closes #1161