### PR TITLE
perf(quic): Use compile-time strlen for HKDF labels

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -68,6 +68,9 @@ static const char label_quic_key[] = "quic key";
 static const char label_quic_iv[] = "quic iv";
 static const char label_quic_hp[] = "quic hp";
 
+/* Compile-time string length for performance-critical paths */
+#define STRLEN_LIT(s) (sizeof(s) - 1)
+
 /* ============================================================================
  * Result String Table
  * ============================================================================
@@ -347,21 +350,21 @@ derive_traffic_keys (const uint8_t *secret, size_t secret_len,
 {
   /* Derive key */
   if (hkdf_expand_label (secret, secret_len,
-                          label_quic_key, strlen (label_quic_key),
+                          label_quic_key, STRLEN_LIT (label_quic_key),
                           NULL, 0,
                           key, QUIC_INITIAL_KEY_LEN) < 0)
     return -1;
 
   /* Derive IV */
   if (hkdf_expand_label (secret, secret_len,
-                          label_quic_iv, strlen (label_quic_iv),
+                          label_quic_iv, STRLEN_LIT (label_quic_iv),
                           NULL, 0,
                           iv, QUIC_INITIAL_IV_LEN) < 0)
     return -1;
 
   /* Derive header protection key */
   if (hkdf_expand_label (secret, secret_len,
-                          label_quic_hp, strlen (label_quic_hp),
+                          label_quic_hp, STRLEN_LIT (label_quic_hp),
                           NULL, 0,
                           hp_key, QUIC_INITIAL_HP_KEY_LEN) < 0)
     return -1;
@@ -410,7 +413,7 @@ SocketQUICInitial_derive_keys (const SocketQUICConnectionID_T *dcid,
 
   /* Step 2: Derive client secret */
   if (hkdf_expand_label (initial_secret, 32,
-                          label_client_in, strlen (label_client_in),
+                          label_client_in, STRLEN_LIT (label_client_in),
                           NULL, 0,
                           client_secret, 32) < 0)
     {
@@ -420,7 +423,7 @@ SocketQUICInitial_derive_keys (const SocketQUICConnectionID_T *dcid,
 
   /* Step 3: Derive server secret */
   if (hkdf_expand_label (initial_secret, 32,
-                          label_server_in, strlen (label_server_in),
+                          label_server_in, STRLEN_LIT (label_server_in),
                           NULL, 0,
                           server_secret, 32) < 0)
     {


### PR DESCRIPTION
## Summary

Implements #1169 by replacing runtime `strlen()` calls with compile-time `STRLEN_LIT()` macro for HKDF label operations in QUIC Initial packet key derivation.

## Changes

- Added `STRLEN_LIT(s)` macro for compile-time string length calculation: `sizeof(s) - 1`
- Replaced 5 runtime `strlen()` calls with `STRLEN_LIT()` in the hot path:
  - `label_quic_key` - used in key derivation
  - `label_quic_iv` - used in IV derivation  
  - `label_quic_hp` - used in header protection key derivation
  - `label_client_in` - used in client secret derivation
  - `label_server_in` - used in server secret derivation

## Performance Impact

- Eliminates unnecessary CPU cycles during QUIC handshake
- String lengths are now calculated at compile time instead of runtime
- Follows the performance best practice documented in CLAUDE.md (HTTP Header Lookups section)

## Test Plan

- [x] All QUIC initial packet tests pass (19/19)
- [x] Full test suite passes with sanitizers (112/113, 1 unrelated timeout)
- [x] No functional changes - purely performance optimization
- [x] Build succeeds with ASan/UBSan enabled

## Files Changed

- `src/quic/SocketQUICPacket-initial.c` - Added macro and replaced strlen calls

Closes #1169