### PR TITLE
refactor(quic): fix misleading comment about error_code storage

### DIFF
--- a/src/quic/SocketQUICConnection-termination.c
+++ b/src/quic/SocketQUICConnection-termination.c
@@ -198,8 +198,9 @@ SocketQUICConnection_initiate_close(SocketQUICConnection_T conn,
   uint64_t timeout = calculate_termination_timeout(pto_ms);
   conn->closing_deadline_ms = safe_add_timeout(now_ms, timeout);
 
-  /* Store error code in user_data for CONNECTION_CLOSE frame generation */
-  /* Note: Actual frame sending is caller's responsibility */
+  /* Error code handling is caller's responsibility */
+  /* Caller must send CONNECTION_CLOSE frame with appropriate error_code */
+  /* This function only manages connection state transition */
   (void)error_code;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1168 - Corrects a misleading comment in `SocketQUICConnection_initiate_close()`.

## Problem

The function comment stated "Store error code in user_data for CONNECTION_CLOSE frame generation", but:
- The `error_code` parameter was actually unused (cast to void)
- The `SocketQUICConnection` struct has no fields for storing error codes
- CONNECTION_CLOSE frame encoding functions take error_code as a direct parameter

## Changes

Updated the comment to accurately reflect the actual behavior:
```c
/* Error code handling is caller's responsibility */
/* Caller must send CONNECTION_CLOSE frame with appropriate error_code */
/* This function only manages connection state transition */
(void)error_code;
```

## Test Plan

- [x] All QUIC termination tests pass (`test_quic_termination`)
- [x] Full test suite passes with sanitizers (112/113, 1 unrelated timeout)
- [x] Build succeeds with `-Wall -Wextra -Werror`

## Files Changed

- `src/quic/SocketQUICConnection-termination.c` - Updated comment to reflect reality

Closes #1168