### PR TITLE
fix(quic): replace memset with SocketCrypto_secure_clear in migration init

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -83,7 +83,7 @@ SocketQUICMigration_init (SocketQUICMigration_T *migration,
   if (migration == NULL)
     return;
 
-  memset (migration, 0, sizeof (*migration));
+  SocketCrypto_secure_clear (migration, sizeof (*migration));
   migration->connection = connection;
   migration->role = role;
   migration->active_path_index = 0;


### PR DESCRIPTION
## Summary

Implements #1171 - Replace memset() with SocketCrypto_secure_clear() in SocketQUICMigration_init() for defense-in-depth security.

## Changes

- Updated `src/quic/SocketQUICMigration.c` line 86 to use `SocketCrypto_secure_clear()` instead of `memset()`
- This prevents compiler optimization from removing the clearing of sensitive path challenge data

## Test Plan

- [x] QUIC migration tests pass with sanitizers
- [x] Full test suite passes (112/113 tests, 1 unrelated timeout)
- [x] Build succeeds with AddressSanitizer and UBSan enabled

Closes #1171