### PR TITLE
feat(dns): add compile-time array size validation in SocketDNSError.c

### DIFF
--- a/src/dns/SocketDNSError.c
+++ b/src/dns/SocketDNSError.c
@@ -47,6 +47,10 @@ static const char *ede_code_names[] = {
   "Invalid Data"                   /* 24 */
 };
 
+_Static_assert (sizeof (ede_code_names) / sizeof (ede_code_names[0])
+                  == DNS_EDE_MAX_DEFINED + 1,
+                "ede_code_names array size must match DNS_EDE_MAX_DEFINED + 1");
+
 /**
  * @brief Error code description table.
  */
@@ -78,6 +82,12 @@ static const char *ede_code_descriptions[] = {
   /* 24 */ "Zone data is too old or has expired"
 };
 
+_Static_assert (sizeof (ede_code_descriptions)
+                    / sizeof (ede_code_descriptions[0])
+                  == DNS_EDE_MAX_DEFINED + 1,
+                "ede_code_descriptions array size must match "
+                "DNS_EDE_MAX_DEFINED + 1");
+
 /**
  * @brief Category name table.
  */
@@ -89,6 +99,11 @@ static const char *ede_category_names[] = {
   "Server State",
   "Network"
 };
+
+_Static_assert (sizeof (ede_category_names) / sizeof (ede_category_names[0])
+                  == DNS_EDE_CATEGORY_NETWORK + 1,
+                "ede_category_names array size must match "
+                "DNS_EDE_CATEGORY_NETWORK + 1");
 
 /**
  * @brief Validate UTF-8 byte sequence.


### PR DESCRIPTION
## Summary

Implements #1179 by adding `_Static_assert` compile-time checks to verify that static arrays in `src/dns/SocketDNSError.c` match their corresponding enum definitions.

## Changes

- Added `_Static_assert` after `ede_code_names[]` to verify it has `DNS_EDE_MAX_DEFINED + 1` elements
- Added `_Static_assert` after `ede_code_descriptions[]` to verify it has `DNS_EDE_MAX_DEFINED + 1` elements  
- Added `_Static_assert` after `ede_category_names[]` to verify it has `DNS_EDE_CATEGORY_NETWORK + 1` elements

## Benefits

- **Compile-time safety**: If someone extends the enums in `include/dns/SocketDNSError.h` without updating the arrays, the build will fail with a clear error message
- **Prevents runtime crashes**: Catches array size mismatches before they can cause out-of-bounds access in functions like `SocketDNS_ede_code_name()`, `SocketDNS_ede_code_description()`, and `SocketDNS_ede_category_name()`
- **Zero runtime cost**: Assertions are evaluated at compile-time only

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All DNS-related tests pass (test_dnserror, test_dns_*, test_dnssec, test_dnscookie)
- [x] Verified assertions compile correctly with current array sizes
- [x] Future enum extensions will trigger compile-time errors if arrays are not updated

Fixes #1179