### PR TITLE
docs(pool): Document nanosleep EINTR behavior in drain_wait

### DIFF
--- a/src/pool/SocketPool-drain.c
+++ b/src/pool/SocketPool-drain.c
@@ -610,7 +610,10 @@ SocketPool_drain_wait (T pool, int timeout_ms)
   /* Poll with exponential backoff */
   while ((result = SocketPool_drain_poll (pool)) > 0)
     {
-      /* Sleep with exponential backoff */
+      /* Sleep with exponential backoff
+       * Note: nanosleep() may return early on signal (EINTR), which is
+       * acceptable here as the loop will simply poll sooner. The backoff
+       * is for efficiency, not correctness. */
       ts = socket_util_ms_to_timespec (backoff_ms);
       nanosleep (&ts, NULL);
 


### PR DESCRIPTION
## Summary

Implements #1175 - adds documentation explaining the nanosleep() EINTR behavior in `SocketPool_drain_wait()`.

## Changes

- Added multi-line comment in `src/pool/SocketPool-drain.c` explaining that nanosleep() may return early on signal (EINTR)
- Documents that this behavior is intentional and acceptable for this polling loop context
- Clarifies that the backoff is for efficiency, not correctness

## Test Plan

- [x] Tests pass with sanitizers (112/113 - existing test_socketpool timeout unrelated to this change)
- [x] Documentation-only change, no code logic modified
- [x] Comment follows project conventions for multi-line documentation

Closes #1175