### PR TITLE
fix(quic): add missing overflow check to SocketQUICWire_pn_length

### DIFF
--- a/src/quic/SocketQUICWire.c
+++ b/src/quic/SocketQUICWire.c
@@ -69,6 +69,10 @@ SocketQUICWire_pn_length (uint64_t full_pn, uint64_t largest_acked)
   unsigned min_bits;
   unsigned num_bytes;
 
+  /* Enforce documented promise: return 4 if full_pn exceeds QUIC_PN_MAX */
+  if (full_pn > QUIC_PN_MAX)
+    return QUIC_PN_MAX_SIZE;
+
   /*
    * RFC 9000 Appendix A.2:
    * The number of bits must be at least one more than the base-2 logarithm

--- a/src/test/test_quic_wire.c
+++ b/src/test/test_quic_wire.c
@@ -640,6 +640,53 @@ TEST (quic_wire_pn_encode_max_valid)
   ASSERT_EQ (len, 4);
 }
 
+/* ============================================================================
+ * Overflow Check Tests (Issue #1178)
+ * ============================================================================
+ */
+
+TEST (quic_wire_pn_length_overflow_check_max_plus_one)
+{
+  /* Test case from issue #1178: QUIC_PN_MAX + 1 should return 4 */
+  unsigned len = SocketQUICWire_pn_length (QUIC_PN_MAX + 1, QUIC_PN_NONE);
+  ASSERT_EQ (len, 4);
+}
+
+TEST (quic_wire_pn_length_overflow_check_uint64_max)
+{
+  /* Test case from issue #1178: UINT64_MAX should return 4, not wrap to 1 */
+  unsigned len = SocketQUICWire_pn_length (UINT64_MAX, QUIC_PN_NONE);
+  ASSERT_EQ (len, 4);
+}
+
+TEST (quic_wire_pn_length_overflow_check_max_plus_1000)
+{
+  /* Test case from issue #1178: QUIC_PN_MAX + 1000 should return 4 */
+  unsigned len = SocketQUICWire_pn_length (QUIC_PN_MAX + 1000, QUIC_PN_NONE);
+  ASSERT_EQ (len, 4);
+}
+
+TEST (quic_wire_pn_length_overflow_with_acked)
+{
+  /* Overflow check should work regardless of largest_acked value */
+  unsigned len = SocketQUICWire_pn_length (QUIC_PN_MAX + 1, 100);
+  ASSERT_EQ (len, 4);
+}
+
+TEST (quic_wire_pn_length_at_max_boundary)
+{
+  /* QUIC_PN_MAX itself is valid, should not trigger overflow */
+  unsigned len = SocketQUICWire_pn_length (QUIC_PN_MAX, QUIC_PN_NONE);
+  ASSERT_EQ (len, 4);
+}
+
+TEST (quic_wire_pn_length_just_below_max)
+{
+  /* Just below QUIC_PN_MAX should work normally */
+  unsigned len = SocketQUICWire_pn_length (QUIC_PN_MAX - 1, QUIC_PN_NONE);
+  ASSERT_EQ (len, 4);
+}
+
 int
 main (void)
 {


### PR DESCRIPTION
## Summary

Implements #1178 by adding the missing overflow check documented in SocketQUICWire.h:101.

## Problem

The function `SocketQUICWire_pn_length()` documented that it returns 4 if `full_pn > QUIC_PN_MAX`, but this check was not implemented. This created a security vulnerability where invalid packet numbers could cause unsigned integer overflow.

**Vulnerability scenario:**
```c
// With full_pn = UINT64_MAX, largest_acked = QUIC_PN_NONE
num_unacked = UINT64_MAX + 1  // Wraps to 0
bits_needed(0) = 1
// Returns 1 instead of 4 (incorrect!)
```

## Changes

### Implementation (src/quic/SocketQUICWire.c)
- Added overflow check at start of function (lines 72-74)
- Returns `QUIC_PN_MAX_SIZE` (4) when `full_pn > QUIC_PN_MAX`
- Prevents integer overflow in subsequent calculations

### Tests (src/test/test_quic_wire.c)
Added 6 comprehensive test cases:
- `quic_wire_pn_length_overflow_check_max_plus_one` - Edge case at QUIC_PN_MAX + 1
- `quic_wire_pn_length_overflow_check_uint64_max` - Worst case with UINT64_MAX
- `quic_wire_pn_length_overflow_check_max_plus_1000` - Arbitrary overflow value
- `quic_wire_pn_length_overflow_with_acked` - Works with different largest_acked
- `quic_wire_pn_length_at_max_boundary` - QUIC_PN_MAX itself is valid
- `quic_wire_pn_length_just_below_max` - Just below boundary works normally

## Test Plan

- [x] All 25 QUIC tests pass with sanitizers
- [x] New overflow tests verify fix for all scenarios in issue
- [x] No regression in existing functionality
- [x] Consistent with `SocketQUICWire_pn_encode()` which already validates overflow

## RFC Compliance

This fix ensures compliance with RFC 9000 requirement that packet numbers must be <= 2^62-1.

Closes #1178