### PR TITLE
refactor(dns): replace custom TTL logic with SocketUtil helpers

### DIFF
--- a/src/dns/SocketDNSDeadServer.c
+++ b/src/dns/SocketDNSDeadServer.c
@@ -99,19 +99,8 @@ entry_expired (const struct DeadServerEntry *entry, int64_t now_ms)
   if (entry->marked_dead_ms == 0)
     return false; /* Not marked dead */
 
-  /* Guard against time wraparound */
-  if (now_ms < entry->marked_dead_ms)
-    return false; /* Clock jumped backwards */
-
-  int64_t age_ms = now_ms - entry->marked_dead_ms;
-
-  /* Safe multiplication: DNS_DEAD_SERVER_MAX_TTL is 300 seconds max */
-  if (DNS_DEAD_SERVER_MAX_TTL > INT64_MAX / 1000)
-    return false; /* Overflow would occur */
-
-  int64_t max_ttl_ms = (int64_t)DNS_DEAD_SERVER_MAX_TTL * 1000;
-
-  return age_ms >= max_ttl_ms;
+  return socket_util_ttl_expired (entry->marked_dead_ms,
+                                   DNS_DEAD_SERVER_MAX_TTL, now_ms);
 }
 
 /**
@@ -123,28 +112,8 @@ entry_ttl_remaining (const struct DeadServerEntry *entry, int64_t now_ms)
   if (entry->marked_dead_ms == 0)
     return 0;
 
-  /* Guard against time wraparound */
-  if (now_ms < entry->marked_dead_ms)
-    return 0; /* Clock jumped backwards */
-
-  int64_t age_ms = now_ms - entry->marked_dead_ms;
-
-  /* Safe multiplication check */
-  if (DNS_DEAD_SERVER_MAX_TTL > INT64_MAX / 1000)
-    return 0;
-
-  int64_t max_ttl_ms = (int64_t)DNS_DEAD_SERVER_MAX_TTL * 1000;
-
-  /* Guard against overflow in subtraction */
-  if (age_ms > max_ttl_ms)
-    return 0;
-
-  int64_t remaining_ms = max_ttl_ms - age_ms;
-
-  if (remaining_ms <= 0)
-    return 0;
-
-  return (uint32_t)(remaining_ms / 1000);
+  return socket_util_ttl_remaining (entry->marked_dead_ms,
+                                     DNS_DEAD_SERVER_MAX_TTL, now_ms);
 }
 
 /* Public API */


### PR DESCRIPTION
## Summary

Implements #1182

Refactored `SocketDNSDeadServer.c` to use existing SocketUtil helper functions for TTL calculations instead of duplicating the logic.

## Changes

- Replaced custom `entry_expired()` implementation with call to `socket_util_ttl_expired()`
- Replaced custom `entry_ttl_remaining()` implementation with call to `socket_util_ttl_remaining()`
- Removed ~40 lines of redundant TTL calculation logic
- Removed unnecessary overflow checks (DNS_DEAD_SERVER_MAX_TTL is only 300 seconds)

## Benefits

- **Reduced code duplication** - eliminates redundant TTL calculation logic
- **Improved maintainability** - single source of truth for TTL operations
- **Consistency** - aligns with other DNS modules using SocketUtil helpers
- **Simpler code** - removes unnecessary overflow checks

## Test Plan

- [x] All DNS tests pass with sanitizers enabled
- [x] Dead server test specifically verified (test_dns_deadserver)
- [x] Full test suite passes (112/113 tests, 1 unrelated flaky test timeout)

Closes #1182