### PR TITLE
fix(dns): add explicit void cast for TCP_NODELAY setsockopt

### DIFF
--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -910,9 +910,9 @@ tcp_socket_create (int family)
       return -1;
     }
 
-  /* Disable Nagle for lower latency */
+  /* Disable Nagle for lower latency (non-fatal optimization) */
   int nodelay = 1;
-  setsockopt (fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof (nodelay));
+  (void)setsockopt (fd, IPPROTO_TCP, TCP_NODELAY, &nodelay, sizeof (nodelay));
 
   return fd;
 }


### PR DESCRIPTION
## Summary

Implements #1186

## Changes

- Added explicit `(void)` cast to `setsockopt()` call for `TCP_NODELAY` in `tcp_socket_create()`
- Updated comment to clarify this is a non-fatal optimization
- Prevents static analysis warnings about unchecked return values

## Rationale

The `TCP_NODELAY` option is a performance optimization for reducing DNS query latency. Failure to set it is acceptable and should not prevent socket creation. The explicit `(void)` cast documents this intentional behavior.

## Test Plan

- [x] All tests pass with sanitizers (112/113, timeout unrelated to change)
- [x] DNS transport tests pass (22/22)
- [x] Build succeeds with no warnings

Closes #1186