### PR TITLE
fix(dns): prevent memory leak in cache_insert when strdup fails

### DIFF
--- a/src/dns/SocketDNSResolver.c
+++ b/src/dns/SocketDNSResolver.c
@@ -554,9 +554,13 @@ cache_insert (T resolver, const char *hostname,
   if (!entry)
     return;
 
-  entry->hostname = strdup (hostname);
+  /* Allocate hostname from arena to prevent leak */
+  size_t hostname_len = strlen (hostname) + 1;
+  entry->hostname = Arena_alloc (resolver->arena, hostname_len, __FILE__,
+                                 __LINE__);
   if (!entry->hostname)
     return;
+  memcpy (entry->hostname, hostname, hostname_len);
 
   /* Copy addresses */
   size_t copy_count = count > RESOLVER_MAX_ADDRESSES ? RESOLVER_MAX_ADDRESSES


### PR DESCRIPTION
## Summary

Implements #1185

## Changes

- Replaced `strdup()` with `Arena_alloc()` + `memcpy()` in `cache_insert()` function
- This ensures all allocations for a cache entry are on the same arena
- Prevents memory leak when `Arena_alloc` succeeds but `strdup` fails

## Test Plan

- [x] All DNS tests pass with sanitizers enabled
- [x] Build succeeds with ASan/UBSan
- [x] No new memory leaks detected

Closes #1185