### PR TITLE
fix(dns): add bounds checking for CNAME and hostname snprintf

### DIFF
--- a/src/dns/SocketDNSResolver.c
+++ b/src/dns/SocketDNSResolver.c
@@ -754,6 +754,10 @@ parse_response (T resolver, struct SocketDNSResolver_Query *q,
           if (q->cname_depth >= RESOLVER_MAX_CNAME_DEPTH)
             return RESOLVER_ERROR_CNAME_LOOP;
 
+          /* Validate CNAME target length before copy */
+          if (strlen (cname_target) >= DNS_MAX_NAME_LEN)
+            return RESOLVER_ERROR_INVALID;
+
           /* Store CNAME target for re-query */
           snprintf (q->current_name, DNS_MAX_NAME_LEN, "%s", cname_target);
           q->cname_depth++;
@@ -925,6 +929,12 @@ transport_callback (SocketDNSQuery_T query, const unsigned char *response,
                   >= 0)
                 {
                   if (q->cname_depth >= RESOLVER_MAX_CNAME_DEPTH)
+                    {
+                      q->state = QUERY_STATE_FAILED;
+                      return;
+                    }
+                  /* Validate CNAME target length before copy */
+                  if (strlen (cname_target) >= DNS_MAX_NAME_LEN)
                     {
                       q->state = QUERY_STATE_FAILED;
                       return;
@@ -1396,6 +1406,13 @@ SocketDNSResolver_resolve (T resolver, const char *hostname, int flags,
   if (SocketDNSTransport_nameserver_count (resolver->transport) == 0)
     {
       callback (NULL, NULL, RESOLVER_ERROR_NO_NS, userdata);
+      return NULL;
+    }
+
+  /* Validate hostname length before allocation */
+  if (strlen (hostname) >= DNS_MAX_NAME_LEN)
+    {
+      callback (NULL, NULL, RESOLVER_ERROR_INVALID, userdata);
       return NULL;
     }
 


### PR DESCRIPTION
## Summary

Implements #1189 - adds bounds checking for CNAME and hostname copies in DNS resolver to prevent silent truncation.

## Changes

- Added `strlen()` validation before all `snprintf()` calls copying untrusted DNS data
- Returns `RESOLVER_ERROR_INVALID` when source exceeds `DNS_MAX_NAME_LEN` (255 bytes)
- Fixes three vulnerable instances:
  - Line 758: `parse_response()` CNAME target copy
  - Line 933: `transport_callback()` CNAME target copy
  - Lines 1412-1413: `SocketDNSResolver_resolve()` hostname copy

## Security Impact

Prevents potential cache poisoning attacks via truncated hostnames:
- CNAME `www.example.com.malicious.com` → truncated to `www.example.com.malicio`
- Could match legitimate cached domains after truncation
- Validates against RFC 1035 domain name size limits (255 octets max)

## Test Plan

- [x] All DNS resolver tests pass (26/26)
- [x] All DNS-related tests pass (14/14)
- [x] Full test suite passes (111/113, 2 pre-existing failures)
- [x] Builds successfully with sanitizers enabled
- [x] No memory leaks detected

## References

- RFC 1035 Section 2.3.4: Domain name size limits
- RFC 5452: Cache poisoning prevention

Closes #1189