### PR TITLE
fix(dns): handle EINTR and partial reads in getrandom()

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -655,11 +655,19 @@ get_entropy (uint8_t *buf, size_t len)
 #endif
 
   /* Fallback to getrandom() */
-  ssize_t ret = getrandom (buf, len, 0);
-  if (ret == (ssize_t)len)
-    return 0;
-
-  return -1;
+  size_t offset = 0;
+  while (offset < len)
+    {
+      ssize_t ret = getrandom (buf + offset, len - offset, 0);
+      if (ret < 0)
+        {
+          if (errno == EINTR)
+            continue;
+          return -1;
+        }
+      offset += (size_t)ret;
+    }
+  return 0;
 }
 
 /*


### PR DESCRIPTION
## Summary

Implements #1192 - Fixes incomplete error handling in `getrandom()` call within DNS Cookie module.

## Changes

- Added retry loop to handle `EINTR` interruptions from signals
- Implemented proper handling of partial reads from `getrandom()`
- Ensures entropy buffer is fully initialized before returning success

## Problem Fixed

The original implementation in `src/dns/SocketDNSCookie.c:658-662` had the following issues:

1. Did not retry on `EINTR` - if interrupted by a signal, it would fail instead of retrying
2. Did not handle partial reads - `getrandom()` may return fewer bytes than requested
3. Could leave buffer partially uninitialized on failure

This affected cryptographic security since the function is used to generate client secrets and rotate secrets for DNS cookies.

## Test Plan

- [x] Tests pass with sanitizers (112/113 tests pass, 1 pre-existing timeout)
- [x] DNS cookie tests pass (22/22 tests)
- [x] Build completes without warnings
- [x] Code follows project conventions (matching brace style, naming)

## Security Impact

This fix prevents potential security issues where DNS cookie secrets could contain uninitialized memory or have reduced entropy due to incomplete random data gathering.

Closes #1192