### PR TITLE
refactor(dns): extract DNS cookie rollover period constant

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -31,6 +31,9 @@ const Except_T SocketDNSCookie_Failed
 /* Client secret size (256 bits for HMAC-SHA256) */
 #define SECRET_SIZE 32
 
+/* Previous secret validity during rollover (RFC 7873 Section 5.3) */
+#define DNS_COOKIE_ROLLOVER_PERIOD 150
+
 /* Internal cache entry with LRU tracking */
 typedef struct CacheNode
 {
@@ -202,7 +205,7 @@ SocketDNSCookie_rotate_secret (T cache)
   /* Save previous secret for rollover */
   memcpy (cache->prev_secret, cache->secret, SECRET_SIZE);
   cache->prev_secret_valid_until
-      = time (NULL) + 150; /* 150 seconds per RFC 7873 */
+      = time (NULL) + DNS_COOKIE_ROLLOVER_PERIOD;
 
   /* Generate new secret */
   if (get_entropy (cache->secret, SECRET_SIZE) != 0)


### PR DESCRIPTION
## Summary

Implements #1194 by extracting the hardcoded 150-second rollover period into a named constant.

## Changes

- Added `DNS_COOKIE_ROLLOVER_PERIOD` constant with RFC 7873 Section 5.3 reference
- Replaced magic number 150 at line 205 with the named constant
- Improves code maintainability and documentation

## Test Plan

- [x] Tests pass with sanitizers (112/113, timeout unrelated to change)
- [x] DNS cookie test suite passes (22/22)
- [x] Code builds successfully

Closes #1194