### PR TITLE
refactor(dns): split generate_client_cookie into HMAC and FNV variants

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -68,6 +68,18 @@ struct T
 };
 
 /* Forward declarations */
+#ifdef SOCKET_HAS_TLS
+static int generate_client_cookie_hmac (T cache,
+                                        const struct sockaddr *server_addr,
+                                        const struct sockaddr *client_addr,
+                                        socklen_t client_len, uint8_t *cookie);
+#else
+static int generate_client_cookie_fnv (T cache,
+                                       const struct sockaddr *server_addr,
+                                       socklen_t addr_len,
+                                       const struct sockaddr *client_addr,
+                                       socklen_t client_len, uint8_t *cookie);
+#endif
 static int generate_client_cookie (T cache, const struct sockaddr *server_addr,
                                    socklen_t addr_len,
                                    const struct sockaddr *client_addr,
@@ -675,15 +687,14 @@ constant_time_compare (const uint8_t *a, const uint8_t *b, size_t len)
 }
 
 /*
- * Generate client cookie using HMAC-SHA256
+ * Generate client cookie using HMAC-SHA256 (TLS available)
  */
-static int
-generate_client_cookie (T cache, const struct sockaddr *server_addr,
-                        socklen_t addr_len __attribute__ ((unused)),
-                        const struct sockaddr *client_addr,
-                        socklen_t client_len, uint8_t *cookie)
-{
 #ifdef SOCKET_HAS_TLS
+static int
+generate_client_cookie_hmac (T cache, const struct sockaddr *server_addr,
+                             const struct sockaddr *client_addr,
+                             socklen_t client_len, uint8_t *cookie)
+{
   unsigned char data[256];
   size_t data_len = 0;
 
@@ -747,8 +758,19 @@ generate_client_cookie (T cache, const struct sockaddr *server_addr,
 
   memcpy (cookie, hmac_out, DNS_CLIENT_COOKIE_SIZE);
   return 0;
+}
+#endif
 
-#else
+/*
+ * Generate client cookie using FNV-1a hash (TLS not available)
+ */
+#ifndef SOCKET_HAS_TLS
+static int
+generate_client_cookie_fnv (T cache, const struct sockaddr *server_addr,
+                            socklen_t addr_len,
+                            const struct sockaddr *client_addr,
+                            socklen_t client_len, uint8_t *cookie)
+{
   /* Fallback: FNV-1a 64-bit (RFC 7873 Appendix A.1) */
   uint64_t hash = 14695981039346656037ULL; /* FNV offset basis */
   const uint64_t prime = 1099511628211ULL; /* FNV prime */
@@ -790,6 +812,25 @@ generate_client_cookie (T cache, const struct sockaddr *server_addr,
   cookie[7] = hash & 0xFF;
 
   return 0;
+}
+#endif
+
+/*
+ * Generate client cookie (RFC 7873 §4.1) - dispatcher
+ */
+static int
+generate_client_cookie (T cache, const struct sockaddr *server_addr,
+                        socklen_t addr_len,
+                        const struct sockaddr *client_addr,
+                        socklen_t client_len, uint8_t *cookie)
+{
+#ifdef SOCKET_HAS_TLS
+  (void)addr_len; /* Unused in HMAC path */
+  return generate_client_cookie_hmac (cache, server_addr, client_addr,
+                                      client_len, cookie);
+#else
+  return generate_client_cookie_fnv (cache, server_addr, addr_len, client_addr,
+                                     client_len, cookie);
 #endif
 }
 


### PR DESCRIPTION
## Summary

Implements #1195

Refactored the 113-line `generate_client_cookie()` function in `src/dns/SocketDNSCookie.c` into three separate functions for better maintainability.

## Changes

- **generate_client_cookie_hmac()**: TLS-enabled HMAC-SHA256 implementation (69 lines)
  - Contains all the address serialization logic for IPv4/IPv6
  - Uses OpenSSL's HMAC-SHA256 for cryptographic cookie generation
  
- **generate_client_cookie_fnv()**: Non-TLS FNV-1a fallback implementation (40 lines)
  - Implements RFC 7873 Appendix A.1 hash-based cookie generation
  - Used when TLS support is not available
  
- **generate_client_cookie()**: Dispatcher function (14 lines)
  - Simple `#ifdef SOCKET_HAS_TLS` dispatcher
  - Calls the appropriate implementation based on build configuration

## Benefits

- Each function is now under 70 lines (well below the 100-line threshold)
- Clearer separation of TLS vs non-TLS code paths
- Easier to understand, test, and maintain each implementation independently
- No functional changes - behavior remains identical

## Test Plan

- [x] All 22 DNS cookie tests pass
- [x] Full test suite passes (112/113, pre-existing timeout unrelated to changes)
- [x] Tests run with AddressSanitizer and UBSanitizer enabled
- [x] No memory leaks or undefined behavior detected

Closes #1195