### PR TITLE
refactor(dns): extract DNS cookie rollover period constant

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -37,6 +37,9 @@ const Except_T SocketDNSCookie_Failed
 /* Maximum server cookie TTL (1 day) */
 #define DNS_COOKIE_MAX_SERVER_TTL_SECONDS 86400
 
+/* Previous secret validity during rollover (RFC 7873 §5.3) */
+#define DNS_COOKIE_ROLLOVER_PERIOD 150
+
 /* Internal cache entry with LRU tracking */
 typedef struct CacheNode
 {
@@ -219,8 +222,7 @@ SocketDNSCookie_rotate_secret (T cache)
 
   /* Save previous secret for rollover */
   memcpy (cache->prev_secret, cache->secret, SECRET_SIZE);
-  cache->prev_secret_valid_until
-      = time (NULL) + 150; /* 150 seconds per RFC 7873 */
+  cache->prev_secret_valid_until = time (NULL) + DNS_COOKIE_ROLLOVER_PERIOD;
 
   /* Generate new secret */
   if (get_entropy (cache->secret, SECRET_SIZE) != 0)


### PR DESCRIPTION
## Summary

Implements #1194 - Extracts hardcoded 150 second secret rollover period into a named constant.

## Changes

- Added `DNS_COOKIE_ROLLOVER_PERIOD` constant (150 seconds) with RFC 7873 §5.3 reference
- Replaced hardcoded value in `SocketDNSCookie_rotate_secret()` with the constant
- Improves code maintainability and documentation clarity

## Test Plan

- [x] All DNS cookie tests pass (23/23)
- [x] Full test suite passes with sanitizers (113/114, one unrelated timeout)
- [x] Build succeeds with no warnings

Closes #1194