### PR TITLE
refactor(dns): centralize monotonic time utility

### DIFF
--- a/src/dns/SocketDNSResolver.c
+++ b/src/dns/SocketDNSResolver.c
@@ -133,14 +133,8 @@ static void cache_insert (T resolver, const char *hostname,
                           size_t count, uint32_t ttl);
 static struct CacheEntry *cache_lookup (T resolver, const char *hostname);
 
-/* Utility: get monotonic time in milliseconds */
-static int64_t
-get_monotonic_ms (void)
-{
-  struct timespec ts;
-  clock_gettime (CLOCK_MONOTONIC, &ts);
-  return ((int64_t)ts.tv_sec * 1000) + (ts.tv_nsec / 1000000);
-}
+/* Use centralized monotonic time utility from SocketUtil.h */
+#define get_monotonic_ms() Socket_get_monotonic_ms()
 
 /* Utility: DJB2 case-insensitive hash */
 static unsigned

--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -127,14 +127,8 @@ struct T
 const Except_T SocketDNSTransport_Failed
     = { &SocketDNSTransport_Failed, "DNS transport operation failed" };
 
-/* Get monotonic time in milliseconds */
-static int64_t
-get_monotonic_ms (void)
-{
-  struct timespec ts;
-  clock_gettime (CLOCK_MONOTONIC, &ts);
-  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-}
+/* Use centralized monotonic time utility from SocketUtil.h */
+#define get_monotonic_ms() Socket_get_monotonic_ms()
 
 /* Detect address family from string */
 static int

--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -114,14 +114,8 @@ struct T
 const Except_T SocketDNSoverHTTPS_Failed
     = { &SocketDNSoverHTTPS_Failed, "DNS-over-HTTPS operation failed" };
 
-/* Get monotonic time in milliseconds */
-static int64_t
-get_monotonic_ms (void)
-{
-  struct timespec ts;
-  clock_gettime (CLOCK_MONOTONIC, &ts);
-  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-}
+/* Use centralized monotonic time utility from SocketUtil.h */
+#define get_monotonic_ms() Socket_get_monotonic_ms()
 
 /**
  * Convert standard Base64 to Base64URL (RFC 4648 Section 5).

--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -174,14 +174,8 @@ struct T
 const Except_T SocketDNSoverTLS_Failed
     = { &SocketDNSoverTLS_Failed, "DNS-over-TLS operation failed" };
 
-/* Get monotonic time in milliseconds */
-static int64_t
-get_monotonic_ms (void)
-{
-  struct timespec ts;
-  clock_gettime (CLOCK_MONOTONIC, &ts);
-  return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
-}
+/* Use centralized monotonic time utility from SocketUtil.h */
+#define get_monotonic_ms() Socket_get_monotonic_ms()
 
 /* Detect address family from string */
 static int


### PR DESCRIPTION
## Summary

Implements #1204

Replaces 4 duplicate implementations of `get_monotonic_ms()` in DNS modules with the centralized `Socket_get_monotonic_ms()` utility from SocketUtil.h.

## Changes

- **src/dns/SocketDNSResolver.c**: Replace local `get_monotonic_ms()` with macro wrapper
- **src/dns/SocketDNSoverHTTPS.c**: Replace local `get_monotonic_ms()` with macro wrapper
- **src/dns/SocketDNSTransport.c**: Replace local `get_monotonic_ms()` with macro wrapper
- **src/dns/SocketDNSoverTLS.c**: Replace local `get_monotonic_ms()` with macro wrapper

All 4 local implementations were identical and performed the same manual conversion:
```c
return (int64_t)ts.tv_sec * 1000 + ts.tv_nsec / 1000000;
```

## Benefits

1. **DRY principle**: Single source of truth - fix bugs once
2. **Better error handling**: Centralized version handles `clock_gettime()` failures
3. **Platform support**: Fallback to `CLOCK_REALTIME` if `CLOCK_MONOTONIC` unavailable
4. **Overflow safety**: Cast before multiplication to prevent overflow
5. **Consistency**: All modules use same time source

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All DNS tests pass: 14/14 tests
  - test_socketdns
  - test_dns_wire
  - test_dns_transport
  - test_dns_config
  - test_dns_cache
  - test_dns_resolver
  - test_dnssec
  - test_dnscookie
  - test_dnserror
  - test_dns_negcache
  - test_dns_servfailcache
  - test_dns_deadserver
  - test_dns_over_tls
  - test_dns_over_https
- [x] No memory leaks with ASan
- [x] No undefined behavior with UBSan

Closes #1204