### PR TITLE
fix(issue-processor): improve diagnostics for stalled agents

### DIFF
--- a/.claude/agents/issue-implementer.md
+++ b/.claude/agents/issue-implementer.md
@@ -36,6 +36,19 @@ You receive:
 
 ## Execution Protocol
 
+### -1. Write Started Marker (IMMEDIATE FIRST ACTION)
+
+**Before anything else**, write a started marker so the system knows you're alive:
+
+```bash
+echo '{"issue": {ISSUE_NUMBER}, "started_at": "'$(date -Iseconds)'"}' > {STATE_DIR}/started/{ISSUE_NUMBER}.json
+```
+
+Create the `started/` directory if it doesn't exist:
+```bash
+mkdir -p {STATE_DIR}/started
+```
+
 ### 0. Claim the Issue (REQUIRED FIRST STEP)
 
 Before doing ANY work, claim the issue to prevent other instances from working on it:

--- a/.claude/skills/issue-processor/SKILL.md
+++ b/.claude/skills/issue-processor/SKILL.md
@@ -105,8 +105,14 @@ python3 .claude/skills/issue-processor/scripts/check_status.py --state-dir {STAT
 |--------|--------|
 | `READY:N/M` | Coordinator hasn't started yet |
 | `RUNNING:N/M` | In progress, report to user |
+| `STALLED:N/M:no_progress_for_Xs` | No results for 120+ seconds - agents may have failed |
 | `COMPLETED:N/M:X_success:Y_failed` | Done, go to summary |
 | `ERROR:message` | Report error |
+
+**STALLED handling**: If you see STALLED, check:
+1. `started/` directory - which agents wrote started markers
+2. `wip:*` labels on issues - which are claimed but not progressing
+3. Consider respawning coordinator or releasing stuck claims
 
 **IMPORTANT**: Do NOT use TaskOutput to check coordinator status. Only read status.txt.
 
@@ -197,6 +203,8 @@ If user says "continue":
 ├── frontier.json    # Ready/blocked lists
 ├── worktrees.json   # Worktree paths (if --create-worktrees used)
 ├── issues/          # Issue details
+│   └── 391.json
+├── started/         # Agent start markers (for debugging)
 │   └── 391.json
 └── results/         # Implementation results
     └── 391.json

--- a/.claude/skills/issue-processor/scripts/check_status.py
+++ b/.claude/skills/issue-processor/scripts/check_status.py
@@ -7,13 +7,14 @@ Usage:
     python check_status.py --state-dir DIR
 
 Output (one of):
-    READY:5/20                        - Setup complete, ready to start
-    RUNNING:5/20                      - Processing in progress
-    COMPLETED:20/20:18_success:2_fail - All issues processed
-    ERROR:message                     - Error occurred
+    READY:5/20                              - Setup complete, ready to start
+    RUNNING:5/20                            - Processing in progress
+    STALLED:3/20:no_progress_for_120s       - No results for 120+ seconds
+    COMPLETED:20/20:18_success:2_fail       - All issues processed
+    ERROR:message                           - Error occurred
 
-Note: CHECKPOINT status was removed as coordinator respawn is handled
-via manifest.json state rather than status.txt signaling.
+Note: STALLED indicates agents may have failed without writing result files.
+Check agent logs or manually inspect issues with wip:* labels.
 """
 
 import argparse

--- a/.claude/skills/issue-processor/scripts/next_batch.py
+++ b/.claude/skills/issue-processor/scripts/next_batch.py
@@ -53,8 +53,8 @@ def create_worktree(repo_root: Path, issue_num: int, branch_name: str) -> Path |
     # Check if worktree already exists
     if worktree_dir.exists():
         # Verify it's a valid worktree
-        success, _ = run_git(["worktree", "list", "--porcelain"], cwd=str(repo_root))
-        if str(worktree_dir) in _:
+        success, worktree_list = run_git(["worktree", "list", "--porcelain"], cwd=str(repo_root))
+        if success and str(worktree_dir) in worktree_list:
             return worktree_dir
         # Directory exists but not a worktree - remove it
         import shutil


### PR DESCRIPTION
## Summary

When agents fail early without writing result files, the status gets stuck at `0/N` with no indication of the problem. This adds proper diagnostics.

## Changes

1. **STALLED detection** (`poll_results.py`):
   - After 120s of no progress, changes status to `STALLED:0/10:no_progress_for_120s`
   - Reports which issues are pending
   - Checks `started/` directory to differentiate "started but failed" vs "never started"

2. **Started markers** (`issue-implementer.md`):
   - Agents now write to `started/{ISSUE_NUMBER}.json` as their first action
   - Allows debugging which agents started but crashed before writing results

3. **Bug fix** (`next_batch.py`):
   - Line 57 was using `_` variable incorrectly - now properly checks `worktree_list`

4. **Documentation** (`SKILL.md`, `check_status.py`):
   - Added STALLED status to status meanings table
   - Added `started/` to state files documentation

## Example Output on Stall

```
WARNING: No progress for 125s. Agents may have failed.
Pending issues: [391, 392, 393]
Started but no result: [391, 392]
Never started: [393]
```

## Test Plan

- [x] Verified poll_results.py logic with manual testing
- [x] Updated documentation

Fixes #1421