### PR TITLE
refactor(dns): replace magic number with TIMEOUT_BACKOFF_MULTIPLIER constant

### DIFF
--- a/src/dns/SocketDNSResolver.c
+++ b/src/dns/SocketDNSResolver.c
@@ -1153,7 +1153,7 @@ SocketDNSResolver_load_resolv_conf (T resolver)
   /* Propagate to transport layer */
   SocketDNSTransport_Config transport_config = { 0 };
   transport_config.initial_timeout_ms = resolver->timeout_ms;
-  transport_config.max_timeout_ms = resolver->timeout_ms * 4;
+  transport_config.max_timeout_ms = resolver->timeout_ms * TIMEOUT_BACKOFF_MULTIPLIER;
   transport_config.max_retries = resolver->max_retries;
   transport_config.rotate_nameservers = SocketDNSConfig_has_rotate (&config);
   SocketDNSTransport_configure (resolver->transport, &transport_config);


### PR DESCRIPTION
## Summary

Implements #1280

## Changes

- Replaced hardcoded literal `4` with `TIMEOUT_BACKOFF_MULTIPLIER` constant at line 1156 in `src/dns/SocketDNSResolver.c`
- This improves code maintainability and ensures consistency across the codebase
- The constant was already defined at line 66 but not used in this location

## Test Plan

- [x] All DNS tests pass with sanitizers (14/14 tests passed)
- [x] Full test suite passes (113/114 tests passed - 1 pre-existing timeout in test_socketpool unrelated to this change)
- [x] Build succeeds with ASan and UBSan enabled

Closes #1280