### PR TITLE
docs(crypto): document BASE64_MAX_SCAN_LENGTH constant rationale

### DIFF
--- a/src/core/SocketCrypto.c
+++ b/src/core/SocketCrypto.c
@@ -434,7 +434,21 @@ base64_decode_char (unsigned char c, unsigned char *buffer, int *buffer_pos,
   return 0;
 }
 
-/* Maximum Base64 scan length to prevent unbounded strlen on untrusted input */
+/*
+ * Maximum Base64 scan length to prevent unbounded strlen on untrusted input.
+ *
+ * 64KB (65536 bytes) chosen to balance security and practical use:
+ * - Security: Prevents unbounded strnlen() scans on potentially malicious or
+ *   non-NUL-terminated input, limiting CPU/memory exposure during validation
+ * - Practical: Supports ~48KB of decoded data (base64 expands by ~4/3), which
+ *   covers common use cases like API keys, tokens, certificates, and small
+ *   embedded resources
+ * - Conservative: Much smaller than SOCKET_SECURITY_MAX_ALLOCATION (256MB) as
+ *   this is a preliminary scan limit, not the final allocation limit
+ *
+ * Larger base64 inputs must provide explicit length via the input_len parameter
+ * rather than relying on NUL-termination scanning.
+ */
 #define BASE64_MAX_SCAN_LENGTH 65536
 
 static int


### PR DESCRIPTION
## Summary

Implements #1284 by documenting the rationale for the `BASE64_MAX_SCAN_LENGTH` constant in `src/core/SocketCrypto.c`.

## Changes

- Enhanced documentation for `BASE64_MAX_SCAN_LENGTH` constant
- Explains the security benefits (prevents unbounded scans on untrusted input)
- Clarifies practical use cases (supports ~48KB of decoded data)
- Documents the conservative design (smaller than max allocation for preliminary scans)
- No code changes - documentation only

## Rationale

The constant value of 64KB (65536 bytes) balances:
1. **Security**: Limits CPU/memory exposure during validation of potentially malicious input
2. **Practicality**: Covers common use cases (API keys, tokens, certificates, small embedded resources)
3. **Design**: Conservative preliminary scan limit vs final allocation limit (256MB)

## Test Plan

- [x] All base64 tests pass (32+ tests)
- [x] Tests pass with sanitizers enabled
- [x] No functional changes to code

Closes #1284