### PR TITLE
refactor(core): flatten nested preprocessor conditionals in generate_hash_seed()

### DIFF
--- a/src/core/SocketIPTracker.c
+++ b/src/core/SocketIPTracker.c
@@ -261,6 +261,32 @@ init_tracker_fields (T tracker, Arena_T arena, int max_per_ip)
   tracker->initialized = SOCKET_MUTEX_UNINITIALIZED;
 }
 
+/* Platform-specific random seed helpers - flattened from nested conditionals */
+
+#ifdef __linux__
+#ifndef SYS_getrandom
+#define SYS_getrandom 318
+#endif
+#ifndef GRND_NONBLOCK
+#define GRND_NONBLOCK 0x0001
+#endif
+
+static int
+try_getrandom (unsigned char *seed_bytes, size_t size)
+{
+  ssize_t n = syscall (SYS_getrandom, seed_bytes, size, GRND_NONBLOCK);
+  return (n == (ssize_t)size) ? 0 : -1;
+}
+#endif
+
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
+static int
+try_getentropy (unsigned char *seed_bytes, size_t size)
+{
+  return getentropy (seed_bytes, size);
+}
+#endif
+
 /* Generate secure random seed with fallback hierarchy for DoS resistance */
 static unsigned
 generate_hash_seed (void)
@@ -276,17 +302,9 @@ generate_hash_seed (void)
       return seed;
     }
 
-  /* Try getrandom() on Linux (kernel 3.17+) */
+  /* Try platform-specific secure random sources */
 #ifdef __linux__
-#ifndef SYS_getrandom
-#define SYS_getrandom 318
-#endif
-#ifndef GRND_NONBLOCK
-#define GRND_NONBLOCK 0x0001
-#endif
-  ssize_t n = syscall (SYS_getrandom, seed_bytes, sizeof (seed_bytes),
-                       GRND_NONBLOCK);
-  if (n == (ssize_t)sizeof (seed_bytes))
+  if (try_getrandom (seed_bytes, sizeof (seed_bytes)) == 0)
     {
       memcpy (&seed, seed_bytes, sizeof (seed));
       SOCKET_LOG_WARN_MSG (
@@ -297,9 +315,8 @@ generate_hash_seed (void)
     }
 #endif
 
-  /* Try getentropy() on BSD/macOS */
 #if defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__APPLE__)
-  if (getentropy (seed_bytes, sizeof (seed_bytes)) == 0)
+  if (try_getentropy (seed_bytes, sizeof (seed_bytes)) == 0)
     {
       memcpy (&seed, seed_bytes, sizeof (seed));
       SOCKET_LOG_WARN_MSG (


### PR DESCRIPTION
## Summary

Implements #1282

Refactored `generate_hash_seed()` in `src/core/SocketIPTracker.c` to reduce deeply nested preprocessor conditionals from 4 levels to 2 levels by extracting platform-specific random source logic into separate helper functions.

## Changes

- **Added `try_getrandom()` helper**: Encapsulates Linux getrandom() syscall logic
- **Added `try_getentropy()` helper**: Encapsulates BSD/macOS getentropy() logic  
- **Moved preprocessor defines**: Platform-specific constants now defined outside main function
- **Simplified main logic**: Uniform interface for calling platform-specific helpers

## Impact

- Improves code readability by reducing cognitive complexity
- Makes it easier to add new platform-specific fallbacks in the future
- No behavioral changes - fallback hierarchy remains identical:
  1. SocketCrypto_random_bytes (OpenSSL/LibreSSL RAND_bytes)
  2. Platform-specific secure random (getrandom on Linux, getentropy on BSD/macOS)
  3. Weak fallback (time + pid) with critical warnings

## Test Plan

- [x] Builds successfully with sanitizers enabled
- [x] All SocketIPTracker-related tests pass (test_synprotect: 36/36)
- [x] Integration tests pass (39/39)
- [x] No behavior changes - refactoring only

Note: Two unrelated flaky tests in CI (test_socketpool timeout, test_happy_eyeballs abort) exist on main and are not caused by this change.

Closes #1282