### PR TITLE
fix(dns): replace unsafe strcpy() with memcpy() in SocketDNSoverHTTPS.c

### DIFF
--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -300,7 +300,7 @@ SocketDNSoverHTTPS_configure (T transport,
         return -1;
     }
 
-  strcpy (s->url, config->url);
+  memcpy (s->url, config->url, url_len + 1); /* Include null terminator */
   s->method = config->method;
   s->prefer_http2 = config->prefer_http2 ? 1 : 1; /* Default to HTTP/2 */
   s->timeout_ms


### PR DESCRIPTION
## Summary

Implements #1281 - Replaces unsafe `strcpy()` with safer `memcpy()` in `src/dns/SocketDNSoverHTTPS.c` line 303.

## Security Issue

The code used `strcpy()` without explicit bounds, violating defense-in-depth security principles:
- **CWE-120**: Buffer Copy without Checking Size of Input
- **CERT STR31-C**: Must guarantee storage space for strings
- **Static Analysis**: Flagged by CodeQL, Coverity as security issue

## Changes

- **Before**: `strcpy(s->url, config->url);`
- **After**: `memcpy(s->url, config->url, url_len + 1); /* Include null terminator */`

The existing length validation at line 288 is preserved. This change:
- Makes buffer bounds explicit in the copy operation
- Eliminates unsafe function usage
- Prevents future bugs if validation logic changes
- No functional changes - behavior remains identical

## Test Plan

- [x] Build with sanitizers (`ENABLE_SANITIZERS=ON`)
- [x] DNS over HTTPS tests pass (`test_dns_over_https`)
- [x] All DNS/HTTP tests pass with ASAN
- [x] No memory leaks detected
- [x] Verified null terminator inclusion (url_len + 1)

## Test Results

```bash
cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest -R dns_over_https
Test #114: test_dns_over_https ..............   Passed    0.01 sec
100% tests passed, 0 tests failed out of 1
```

All related DNS and HTTP tests pass successfully.

Closes #1281