### PR TITLE
refactor(pool): replace manual timespec conversion with socket_util_timespec_add()

### DIFF
--- a/src/pool/SocketPool-health.c
+++ b/src/pool/SocketPool-health.c
@@ -372,13 +372,7 @@ health_worker_thread (void *arg)
           interval_ms = health->config.probe_interval_ms;
           clock_gettime (CLOCK_REALTIME, &ts);
           interval = socket_util_ms_to_timespec ((unsigned long)interval_ms);
-          ts.tv_sec += interval.tv_sec;
-          ts.tv_nsec += interval.tv_nsec;
-          if (ts.tv_nsec >= 1000000000)
-            {
-              ts.tv_sec++;
-              ts.tv_nsec -= 1000000000;
-            }
+          ts = socket_util_timespec_add (ts, interval);
           pthread_cond_timedwait (&health->worker_cond, &health->worker_mutex,
                                   &ts);
         }


### PR DESCRIPTION
## Summary

Implements #1287 - Refactors manual timespec conversion in health worker thread to use new utility function.

## Changes

- **Added** `socket_util_timespec_add()` utility function in `SocketUtil.h`
  - Properly handles nanosecond overflow when adding two timespec structures
  - Returns normalized timespec (tv_nsec always in [0, 999999999])
  - Provides single source of truth for timespec addition
  
- **Refactored** `health_worker_thread()` in `SocketPool-health.c`
  - Replaced manual overflow handling with new utility
  - Simplified from 6 lines to 1 line
  - More maintainable and less error-prone

- **Added** comprehensive test coverage in `test_safe_arithmetic.c`
  - Tests basic addition without overflow
  - Tests nanosecond overflow handling
  - Tests typical interval addition use case
  - Tests edge cases with maximum nanosecond values

## Test Plan

- [x] All new tests pass (`test_safe_arithmetic`)
- [x] Pool health tests pass (`test_pool_health`)
- [x] Build succeeds with sanitizers enabled
- [x] No regressions in health worker functionality

## Impact

- **Code Quality**: Eliminates duplicated timespec overflow logic
- **Maintainability**: Centralized utility is easier to maintain
- **Consistency**: Follows existing pattern of utility functions in SocketUtil.h
- **Safety**: Comprehensive tests prevent future bugs

Closes #1287