### PR TITLE
refactor(http): replace manual strncpy with socket_util_safe_strncpy

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -562,8 +562,7 @@ connection_set_client_addr (ServerConnection *conn)
   const char *addr = Socket_getpeeraddr (conn->socket);
   if (addr != NULL)
     {
-      strncpy (conn->client_addr, addr, sizeof (conn->client_addr) - 1);
-      conn->client_addr[sizeof (conn->client_addr) - 1] = '\0';
+      socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #1288 by replacing the manual `strncpy` + null termination pattern in `connection_set_client_addr()` with the centralized `socket_util_safe_strncpy()` utility function.

## Changes

- **File**: `src/http/SocketHTTPServer-connections.c`
- **Lines**: 565-566 (now line 565)
- Replaced two-line manual pattern with single function call
- Uses existing `socket_util_safe_strncpy()` from `core/SocketUtil.h`
- Maintains identical behavior (guaranteed null termination, same truncation)

## Before

```c
strncpy (conn->client_addr, addr, sizeof (conn->client_addr) - 1);
conn->client_addr[sizeof (conn->client_addr) - 1] = '\0';
```

## After

```c
socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
```

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All 27 HTTP server tests pass
- [x] 113/114 total tests pass (1 unrelated timeout on test_socketpool)
- [x] No functional changes - maintains identical behavior

Closes #1288