### PR TITLE
fix(http): add error check for pthread_key_create in arena cache

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -26,6 +26,7 @@
 #include "http/SocketHTTPClient-private.h"
 
 #include <pthread.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 /**
@@ -66,11 +67,21 @@ arena_cache_destructor (void *ptr)
 
 /**
  * One-time initialization of pthread key.
+ *
+ * Fatal error if pthread_key_create() fails, as TLS is required for
+ * correct operation of the arena cache. Without a valid key, subsequent
+ * pthread_getspecific/setspecific calls will use an invalid key leading
+ * to undefined behavior.
  */
 static void
 arena_cache_init_key (void)
 {
-  pthread_key_create (&arena_cache_key, arena_cache_destructor);
+  int rc = pthread_key_create (&arena_cache_key, arena_cache_destructor);
+  if (rc != 0)
+    {
+      fprintf (stderr, "FATAL: pthread_key_create failed: %d\n", rc);
+      abort ();
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #1293 - Adds missing error check for `pthread_key_create()` in thread-local arena cache initialization.

## Changes

- Added error checking for `pthread_key_create()` return value
- Added `abort()` with descriptive error message if initialization fails
- Added `stdio.h` include for `fprintf`
- Documented fatal error behavior in function comment

## Problem

The `pthread_key_create()` function can fail with:
- `EAGAIN`: System lacks resources to create another TLS key
- `ENOMEM`: Insufficient memory

If initialization failed silently, subsequent calls to `pthread_getspecific()` and `pthread_setspecific()` would use an invalid key, leading to undefined behavior and potential memory corruption.

## Solution

The fix uses the abort approach recommended in the issue, as TLS support is required for correct operation of the arena cache. Without a valid key, the cache cannot function properly.

## Test Plan

- [x] Tests pass with sanitizers enabled (`test_http_client` - 44/44 tests pass)
- [x] Build succeeds with no warnings
- [x] Error handling follows project conventions

Closes #1293