### PR TITLE
refactor(log): Replace magic number NUM_LOG_LEVELS with sizeof calculation

### DIFF
--- a/src/core/SocketLog.c
+++ b/src/core/SocketLog.c
@@ -27,7 +27,7 @@ static void *socketlog_structured_userdata = NULL;
 static const char *const default_level_names[]
     = { "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" };
 
-#define NUM_LOG_LEVELS 6
+#define NUM_LOG_LEVELS (sizeof(default_level_names)/sizeof(default_level_names[0]))
 
 static const char *
 socketlog_format_timestamp (char *buf, size_t bufsize)


### PR DESCRIPTION
## Summary

Implements #1290 - Replaces hardcoded `NUM_LOG_LEVELS` constant with automatic compile-time sizeof calculation.

## Changes

- **File**: `src/core/SocketLog.c`
- **Change**: `#define NUM_LOG_LEVELS 6` → `#define NUM_LOG_LEVELS (sizeof(default_level_names)/sizeof(default_level_names[0]))`

## Benefits

1. **Automatic synchronization**: Array size and constant stay in sync
2. **Reduced maintenance burden**: One less thing to remember when adding log levels  
3. **Compile-time calculation**: No runtime overhead
4. **Common C idiom**: Well-understood pattern for array size calculation

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All tests pass (113/114 passed, 1 timeout unrelated to change)
- [x] SocketLog_levelname() bounds check still works correctly with the calculated constant
- [x] No runtime behavior changes

Closes #1290