### PR TITLE
fix(quic): add error checking for SocketCrypto_random_bytes in path validation retry

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -309,8 +309,15 @@ SocketQUICMigration_check_timeouts (SocketQUICMigration_T *migration,
               path->challenge_sent_time = current_time_ms;
 
               /* Regenerate challenge data */
-              SocketCrypto_random_bytes (path->challenge,
-                                        QUIC_PATH_CHALLENGE_SIZE);
+              if (SocketCrypto_random_bytes (path->challenge,
+                                            QUIC_PATH_CHALLENGE_SIZE)
+                  != 0)
+                {
+                  /* RNG failure - mark path as permanently failed */
+                  path->state = QUIC_PATH_FAILED;
+                  timeout_count++;
+                  continue;
+                }
 
               /* Caller must resend PATH_CHALLENGE frame */
             }


### PR DESCRIPTION
## Summary

Fixes #1297 - Critical security issue: Missing error check for `SocketCrypto_random_bytes()` in QUIC path validation retry logic.

## Changes

- Added proper error handling for `SocketCrypto_random_bytes()` call at line 312 in `src/quic/SocketQUICMigration.c`
- On RNG failure, path is now marked as `QUIC_PATH_FAILED` to prevent security vulnerabilities
- Follows the existing error handling pattern at line 207

## Security Impact

Without this fix, RNG failures during path validation retries could lead to:
- **Predictable challenges**: Attacker could predict challenge values
- **Challenge reuse**: Same challenge sent multiple times enables replay attacks  
- **Path validation bypass**: Compromises the security of QUIC path migration
- **RFC 9000 violation**: Section 8.2.1 requires PATH_CHALLENGE frames to contain unpredictable bytes

## Test Plan

- [x] Tests pass with sanitizers (`ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest`)
- [x] QUIC migration tests pass (19/19 tests)
- [x] No memory leaks detected by AddressSanitizer
- [x] Build succeeds with `-Werror` enabled

Closes #1297