### PR TITLE
refactor(dns): simplify SocketDNSResolver_resolve by extracting query initialization

### DIFF
--- a/src/dns/SocketDNSResolver.c
+++ b/src/dns/SocketDNSResolver.c
@@ -165,6 +165,9 @@ static void cache_insert (T resolver, const char *hostname,
                           const SocketDNSResolver_Address *addresses,
                           size_t count, uint32_t ttl);
 static struct CacheEntry *cache_lookup (T resolver, const char *hostname);
+static struct SocketDNSResolver_Query *initialize_query (
+    T resolver, const char *hostname, int flags,
+    SocketDNSResolver_Callback callback, void *userdata);
 
 /* Use centralized monotonic time utility from SocketUtil.h */
 #define get_monotonic_ms() Socket_get_monotonic_ms()
@@ -1349,6 +1352,47 @@ try_cache (T resolver, const char *hostname, int flags,
   return 1;
 }
 
+/**
+ * Initialize a new DNS query structure.
+ *
+ * Allocates and initializes a query for the given hostname and parameters.
+ * The query is added to the resolver's pending list.
+ *
+ * @param resolver  Resolver instance.
+ * @param hostname  Hostname to query (already validated).
+ * @param flags     Resolution flags.
+ * @param callback  User callback for results.
+ * @param userdata  User data for callback.
+ * @return Initialized query on success, NULL on allocation failure.
+ */
+static struct SocketDNSResolver_Query *
+initialize_query (T resolver, const char *hostname, int flags,
+                  SocketDNSResolver_Callback callback, void *userdata)
+{
+  struct SocketDNSResolver_Query *q;
+
+  /* Allocate query */
+  q = Arena_alloc (resolver->arena, sizeof (*q), __FILE__, __LINE__);
+  if (!q)
+    return NULL;
+
+  /* Initialize query structure */
+  memset (q, 0, sizeof (*q));
+  q->id = generate_unique_id (resolver);
+  snprintf (q->hostname, DNS_MAX_NAME_LEN, "%s", hostname);
+  snprintf (q->current_name, DNS_MAX_NAME_LEN, "%s", hostname);
+  q->flags = flags;
+  q->state = QUERY_STATE_INIT;
+  q->callback = callback;
+  q->userdata = userdata;
+  q->resolver = resolver; /* Set back-pointer for transport callback */
+
+  /* Add to pending list */
+  query_list_add (resolver, q);
+
+  return q;
+}
+
 SocketDNSResolver_Query_T
 SocketDNSResolver_resolve (T resolver, const char *hostname, int flags,
                            SocketDNSResolver_Callback callback, void *userdata)
@@ -1387,26 +1431,13 @@ SocketDNSResolver_resolve (T resolver, const char *hostname, int flags,
       return NULL;
     }
 
-  /* Allocate query */
-  q = Arena_alloc (resolver->arena, sizeof (*q), __FILE__, __LINE__);
+  /* Initialize query */
+  q = initialize_query (resolver, hostname, flags, callback, userdata);
   if (!q)
     {
       callback (NULL, NULL, RESOLVER_ERROR_NOMEM, userdata);
       return NULL;
     }
-
-  memset (q, 0, sizeof (*q));
-  q->id = generate_unique_id (resolver);
-  snprintf (q->hostname, DNS_MAX_NAME_LEN, "%s", hostname);
-  snprintf (q->current_name, DNS_MAX_NAME_LEN, "%s", hostname);
-  q->flags = flags;
-  q->state = QUERY_STATE_INIT;
-  q->callback = callback;
-  q->userdata = userdata;
-  q->resolver = resolver; /* Set back-pointer for transport callback */
-
-  /* Add to pending list */
-  query_list_add (resolver, q);
 
   /* Send initial query */
   if (send_query (resolver, q) != 0)


### PR DESCRIPTION
## Summary

Implements #1289 - Refactors `SocketDNSResolver_resolve()` to improve readability and maintainability by extracting query initialization logic into a separate helper function.

## Changes

- **Added `initialize_query()` helper function**: Encapsulates query allocation, initialization, and list management (lines 1365-1391)
- **Simplified `SocketDNSResolver_resolve()`**: Reduced from 67 to 54 lines by extracting initialization logic
- **Added forward declaration**: Included `initialize_query()` in forward declarations section
- **Preserved all functionality**: Fast-path checks, error handling, and query sending remain unchanged

## Benefits

- **Improved readability**: Main function is now more declarative and easier to follow
- **Better separation of concerns**: Fast-path logic separated from query initialization
- **Enhanced testability**: Initialization logic can be tested independently if needed
- **Easier maintenance**: Future modifications to query initialization are now localized

## Test Plan

- [x] All DNS resolver tests pass (26/26)
- [x] Full test suite passes with sanitizers (112/114 - 2 pre-existing failures unrelated to DNS)
- [x] Build successful with ASan and UBSan enabled
- [x] No behavioral changes - identical functionality to original implementation

## Performance Impact

No performance impact - this is a pure refactoring with identical code paths and logic flow.

Closes #1289