### PR TITLE
refactor(quic): extract duplicate path index lookup into helper function

### DIFF
--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -38,6 +38,8 @@ static int sockaddr_to_string (const struct sockaddr_storage *addr, char *buf,
 static SocketQUICPath_T *find_path_by_challenge (
     SocketQUICMigration_T *migration, const uint8_t challenge[8]);
 static SocketQUICPath_T *allocate_path_slot (SocketQUICMigration_T *migration);
+static size_t find_path_index (const SocketQUICMigration_T *migration,
+                               const SocketQUICPath_T *path);
 
 /* ============================================================================
  * Lifecycle Functions
@@ -252,14 +254,11 @@ SocketQUICMigration_handle_path_response (SocketQUICMigration_T *migration,
   /* If this was the target of migration, complete migration */
   if (migration->migration_in_progress)
     {
-      for (size_t i = 0; i < migration->path_count; i++)
+      size_t path_index = find_path_index (migration, path);
+      if (path_index < migration->path_count)
         {
-          if (&migration->paths[i] == path)
-            {
-              migration->target_path_index = i;
-              /* Caller should invoke SocketQUICMigration_initiate next */
-              break;
-            }
+          migration->target_path_index = path_index;
+          /* Caller should invoke SocketQUICMigration_initiate next */
         }
     }
 
@@ -368,12 +367,7 @@ SocketQUICMigration_initiate (SocketQUICMigration_T *migration,
   SocketQUICMigration_reset_congestion (new_path, old_path);
 
   /* Find index of new path */
-  for (new_path_index = 0; new_path_index < migration->path_count;
-       new_path_index++)
-    {
-      if (&migration->paths[new_path_index] == new_path)
-        break;
-    }
+  new_path_index = find_path_index (migration, new_path);
 
   if (new_path_index >= migration->path_count)
     return QUIC_MIGRATION_ERROR_INVALID_STATE;
@@ -760,4 +754,32 @@ allocate_path_slot (SocketQUICMigration_T *migration)
     }
 
   return NULL;
+}
+
+/**
+ * @brief Find index of path in migration manager.
+ *
+ * Performs linear search to find the array index of a given path.
+ *
+ * @param migration Migration manager.
+ * @param path Path to find.
+ *
+ * @return Path index, or migration->path_count if not found.
+ */
+static size_t
+find_path_index (const SocketQUICMigration_T *migration,
+                 const SocketQUICPath_T *path)
+{
+  size_t i;
+
+  if (migration == NULL || path == NULL)
+    return migration ? migration->path_count : 0;
+
+  for (i = 0; i < migration->path_count; i++)
+    {
+      if (&migration->paths[i] == path)
+        return i;
+    }
+
+  return migration->path_count; /* Not found */
 }


### PR DESCRIPTION
## Summary

Implements #1303

Extracted duplicate linear search pattern for finding path index in the QUIC migration module into a reusable helper function.

## Changes

- Added `find_path_index()` static helper function with proper NULL checking and bounds validation
- Refactored `SocketQUICMigration_handle_path_response()` to use the helper (lines 255-264)
- Refactored `SocketQUICMigration_initiate()` to use the helper (lines 371-376)
- Centralized search logic for easier maintenance and consistency

## Benefits

- Eliminates code duplication (DRY principle)
- Improves readability with descriptive function name
- Centralizes search logic for easier maintenance
- Adds proper NULL checking and bounds validation

## Test Plan

- [x] Built with sanitizers enabled (ASan + UBSan)
- [x] All QUIC migration tests pass (19/19)
- [x] All QUIC module tests pass (25/25)
- [x] No memory leaks detected

Closes #1303