### PR TITLE
docs(quic): document ACK range limit rationale

### DIFF
--- a/src/quic/SocketQUICFrame.c
+++ b/src/quic/SocketQUICFrame.c
@@ -207,6 +207,8 @@ parse_ack_ranges (const uint8_t *data, size_t len, size_t *pos,
   if (ack->range_count == 0)
     return QUIC_FRAME_OK;
 
+  /* RFC 9000 allows arbitrary ACK ranges, but we limit to 256 to prevent
+   * DoS attacks via excessive memory allocation and parsing overhead */
   if (ack->range_count > QUIC_FRAME_ACK_MAX_RANGES)
     return QUIC_FRAME_ERROR_ACK_RANGE;
 


### PR DESCRIPTION
## Summary

Implements #1304

Adds inline documentation explaining the rationale for the `QUIC_FRAME_ACK_MAX_RANGES` constant (256) in the ACK range validation code.

## Changes

- Added comment before ACK range count check in `src/quic/SocketQUICFrame.c`
- Comment explains that while RFC 9000 allows arbitrary ACK ranges, we limit to 256 to prevent DoS attacks via excessive memory allocation and parsing overhead

## Test Plan

- [x] All tests pass with sanitizers (113/114 passed, 1 timeout unrelated to change)
- [x] Code compiles without warnings
- [x] Documentation-only change, no functional modifications

Closes #1304