### PR TITLE
fix(http): add error check for pthread_setspecific in arena cache

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -88,7 +88,14 @@ httpclient_get_arena_cache (void)
     {
       cache = calloc (1, sizeof (*cache));
       if (cache)
-        pthread_setspecific (arena_cache_key, cache);
+        {
+          if (pthread_setspecific (arena_cache_key, cache) != 0)
+            {
+              /* Failed to store in TLS - free and continue without cache */
+              free (cache);
+              cache = NULL;
+            }
+        }
     }
 
   return cache;


### PR DESCRIPTION
## Summary

Fixes #1305 by adding missing error handling for `pthread_setspecific()` in the HTTP client arena cache.

## Changes

- Added error check for `pthread_setspecific()` return value in `httpclient_get_arena_cache()`
- On failure (ENOMEM or EINVAL), the allocated cache is freed to prevent memory leak
- Function correctly returns NULL, allowing graceful fallback to non-cached arena allocation

## Impact

- Prevents memory leak if `pthread_setspecific()` consistently fails under resource exhaustion
- Maintains correct behavior with existing fallback mechanisms
- No functional change under normal conditions

## Test Plan

- [x] All existing tests pass with sanitizers enabled
- [x] HTTP client test suite passes (44 tests)
- [x] Build succeeds with ASan/UBSan

Closes #1305