### PR TITLE
refactor(http): Centralize max decompression size to SocketSecurity.h

### DIFF
--- a/include/core/SocketSecurity.h
+++ b/include/core/SocketSecurity.h
@@ -52,6 +52,17 @@
 #endif
 
 /**
+ * @brief Maximum size for decompressed HTTP content (zip bomb protection).
+ *
+ * Default: 100 MiB (104857600 bytes). Used by HTTP/1.1 decompression to
+ * prevent resource exhaustion from malicious compressed payloads. Override
+ * via compile-time definition.
+ */
+#ifndef SOCKET_SECURITY_MAX_DECOMPRESSED_SIZE
+#define SOCKET_SECURITY_MAX_DECOMPRESSED_SIZE (100 * 1024 * 1024)
+#endif
+
+/**
  * @brief Maximum allowed request timeout value in milliseconds.
  *
  * Default: 60 seconds (60000 ms). Override by defining before inclusion.

--- a/src/http/SocketHTTP1-compress.c
+++ b/src/http/SocketHTTP1-compress.c
@@ -198,14 +198,11 @@ update_encode_total (size_t *total, size_t produced, size_t max_size)
   return 1;
 }
 
-/* Default maximum decompressed size (100MB) for zip bomb protection */
-#define HTTP1_DEFAULT_MAX_DECOMPRESSED_SIZE (100 * 1024 * 1024)
-
 static size_t
 get_effective_max_decompressed_size (const SocketHTTP1_Config *cfg)
 {
   if (cfg == NULL || cfg->max_decompressed_size == 0)
-    return HTTP1_DEFAULT_MAX_DECOMPRESSED_SIZE;
+    return SOCKET_SECURITY_MAX_DECOMPRESSED_SIZE;
   return cfg->max_decompressed_size;
 }
 


### PR DESCRIPTION
## Summary

Implements #1306

- Moved `HTTP1_DEFAULT_MAX_DECOMPRESSED_SIZE` from `SocketHTTP1-compress.c` to `SocketSecurity.h` as `SOCKET_SECURITY_MAX_DECOMPRESSED_SIZE`
- Provides centralized security configuration
- Enables compile-time override capability (`-DSOCKET_SECURITY_MAX_DECOMPRESSED_SIZE=...`)
- Maintains consistency with existing security limits

## Changes

- **include/core/SocketSecurity.h**: Added `SOCKET_SECURITY_MAX_DECOMPRESSED_SIZE` constant (100 MiB)
- **src/http/SocketHTTP1-compress.c**: Removed local constant, now uses centralized definition

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] HTTP/1.1 parser tests pass
- [x] HTTP integration tests pass
- [x] Build succeeds with compression enabled

Closes #1306