### PR TITLE
feat(issue-processor): add visibility into claimed vs available issues

### DIFF
--- a/.claude/skills/issue-processor/scripts/check_status.py
+++ b/.claude/skills/issue-processor/scripts/check_status.py
@@ -4,7 +4,7 @@ Check pipeline status by reading status.txt and manifest.json.
 Prints a simple status line for the skill to parse.
 
 Usage:
-    python check_status.py --state-dir DIR
+    python check_status.py --state-dir DIR [--verbose]
 
 Output (one of):
     READY:5/20                              - Setup complete, ready to start
@@ -12,6 +12,11 @@ Output (one of):
     STALLED:3/20:no_progress_for_120s       - No results for 120+ seconds
     COMPLETED:20/20:18_success:2_fail       - All issues processed
     ERROR:message                           - Error occurred
+
+With --verbose, also shows:
+    - Current batch issue numbers
+    - Completed issue numbers
+    - Failed issue numbers
 
 Note: STALLED indicates agents may have failed without writing result files.
 Check agent logs or manually inspect issues with wip:* labels.
@@ -26,6 +31,8 @@ from pathlib import Path
 def main():
     parser = argparse.ArgumentParser(description="Check pipeline status")
     parser.add_argument("--state-dir", required=True, help="State directory path")
+    parser.add_argument("--verbose", "-v", action="store_true",
+                        help="Show detailed batch information")
     args = parser.parse_args()
 
     state_dir = Path(args.state_dir)
@@ -37,12 +44,14 @@ def main():
 
     # Read status.txt if it exists
     status_file = state_dir / "status.txt"
+    status_line = None
     if status_file.exists():
-        status = status_file.read_text().strip()
-        print(status)
-        sys.exit(0)
+        status_line = status_file.read_text().strip()
+        if not args.verbose:
+            print(status_line)
+            sys.exit(0)
 
-    # Fall back to reading manifest
+    # Read manifest for details
     manifest_file = state_dir / "manifest.json"
     if not manifest_file.exists():
         print("ERROR:manifest_not_found")
@@ -52,18 +61,57 @@ def main():
         manifest = json.load(f)
 
     total = manifest.get("total_issues", 0)
-    completed = len(manifest.get("completed", []))
-    failed = len(manifest.get("failed", []))
-    in_progress = len(manifest.get("in_progress", []))
+    completed = manifest.get("completed", [])
+    failed = manifest.get("failed", [])
+    in_progress = manifest.get("in_progress", [])
+    current_batch = manifest.get("current_batch", [])
+    ready = manifest.get("ready", [])
 
-    if completed + failed == total and total > 0:
-        print(f"COMPLETED:{total}/{total}:{completed}_success:{failed}_failed")
-    elif in_progress > 0:
-        done = completed + failed
-        print(f"RUNNING:{done}/{total}")
-    else:
-        ready = len(manifest.get("ready", []))
-        print(f"READY:{ready}/{total}")
+    # Determine status if we don't have status.txt
+    if not status_line:
+        if len(completed) + len(failed) == total and total > 0:
+            status_line = f"COMPLETED:{total}/{total}:{len(completed)}_success:{len(failed)}_failed"
+        elif len(in_progress) > 0 or len(current_batch) > 0:
+            done = len(completed) + len(failed)
+            status_line = f"RUNNING:{done}/{total}"
+        else:
+            status_line = f"READY:{len(ready)}/{total}"
+
+    if not args.verbose:
+        print(status_line)
+        sys.exit(0)
+
+    # Verbose output
+    print(f"Status: {status_line}")
+    print(f"Run ID: {manifest.get('run_id', 'unknown')}")
+    print(f"Repository: {manifest.get('repository', 'unknown')}")
+    print()
+
+    if current_batch:
+        print(f"Current batch ({len(current_batch)} issues):")
+        print(f"  {', '.join(f'#{n}' for n in sorted(current_batch))}")
+        print()
+
+    if completed:
+        print(f"Completed ({len(completed)} issues):")
+        # Show in groups of 10
+        sorted_completed = sorted(completed)
+        for i in range(0, len(sorted_completed), 10):
+            chunk = sorted_completed[i:i+10]
+            print(f"  {', '.join(f'#{n}' for n in chunk)}")
+        print()
+
+    if failed:
+        print(f"Failed ({len(failed)} issues):")
+        print(f"  {', '.join(f'#{n}' for n in sorted(failed))}")
+        print()
+
+    remaining_ready = [n for n in ready if n not in completed and n not in failed and n not in current_batch]
+    if remaining_ready:
+        print(f"Remaining ready ({len(remaining_ready)} issues):")
+        print(f"  First 10: {', '.join(f'#{n}' for n in sorted(remaining_ready)[:10])}")
+        if len(remaining_ready) > 10:
+            print(f"  ... and {len(remaining_ready) - 10} more")
 
 
 if __name__ == "__main__":

--- a/.claude/skills/issue-processor/scripts/finish_batch.py
+++ b/.claude/skills/issue-processor/scripts/finish_batch.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""
+Mark the current batch as complete and clear it from the manifest.
+
+This script should be called by the skill after a batch completes (all agents
+have written results). It clears current_batch and updates completed/failed
+lists based on result files.
+
+Usage:
+    python finish_batch.py --state-dir DIR
+
+Output:
+    Summary of batch completion status.
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Mark current batch as complete"
+    )
+    parser.add_argument("--state-dir", required=True, help="State directory path")
+    args = parser.parse_args()
+
+    state_dir = Path(args.state_dir)
+    manifest_file = state_dir / "manifest.json"
+    results_dir = state_dir / "results"
+
+    if not manifest_file.exists():
+        print("ERROR: manifest.json not found", file=sys.stderr)
+        sys.exit(1)
+
+    # Load manifest
+    with open(manifest_file) as f:
+        manifest = json.load(f)
+
+    current_batch = manifest.get("current_batch", [])
+    if not current_batch:
+        print("No current batch to finish")
+        sys.exit(0)
+
+    completed = set(manifest.get("completed", []))
+    failed = set(manifest.get("failed", []))
+
+    # Check result files for each issue in batch
+    new_completed = 0
+    new_failed = 0
+
+    for issue_num in current_batch:
+        result_file = results_dir / f"{issue_num}.json"
+        if result_file.exists():
+            with open(result_file) as f:
+                result = json.load(f)
+
+            if result.get("status") == "success":
+                completed.add(issue_num)
+                new_completed += 1
+            else:
+                failed.add(issue_num)
+                new_failed += 1
+        else:
+            # No result file - assume failed (agent crashed without writing)
+            failed.add(issue_num)
+            new_failed += 1
+
+    # Update manifest
+    manifest["completed"] = list(completed)
+    manifest["failed"] = list(failed)
+    manifest["current_batch"] = []  # Clear the batch
+    manifest.pop("batch_started_at", None)
+
+    # Save manifest
+    with open(manifest_file, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    # Output summary
+    print(f"Batch complete: {new_completed} succeeded, {new_failed} failed")
+    print(f"Total: {len(completed)} completed, {len(failed)} failed")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-processor/scripts/list_available.py
+++ b/.claude/skills/issue-processor/scripts/list_available.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""
+List issues that are available for manual work vs currently claimed by agents.
+
+This helps when running issue-processor in one terminal and wanting to work
+on issues manually in another terminal without conflicts.
+
+Usage:
+    python list_available.py --repo OWNER/REPO [--state-dir DIR] [--limit N]
+
+Output:
+    Shows currently claimed issues (with wip:* labels) and available issues
+    that are safe to work on manually.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_gh(args: list[str], check: bool = True) -> tuple[bool, str]:
+    """Run gh CLI command and return (success, output)."""
+    result = subprocess.run(
+        ["gh"] + args,
+        capture_output=True,
+        text=True
+    )
+    if check and result.returncode != 0:
+        return False, result.stderr.strip()
+    return True, result.stdout.strip()
+
+
+def fetch_open_issues(owner: str, repo: str) -> list[dict]:
+    """Fetch all open issues with their labels."""
+    issues = []
+    cursor = None
+
+    while True:
+        cursor_arg = f', after: "{cursor}"' if cursor else ""
+
+        query = f'''
+        query {{
+          repository(owner: "{owner}", name: "{repo}") {{
+            issues(first: 100, states: OPEN{cursor_arg}) {{
+              pageInfo {{ hasNextPage endCursor }}
+              nodes {{
+                number
+                title
+                labels(first: 10) {{ nodes {{ name }} }}
+              }}
+            }}
+          }}
+        }}
+        '''
+
+        success, output = run_gh(["api", "graphql", "-f", f"query={query}"])
+        if not success:
+            print(f"Error fetching issues: {output}", file=sys.stderr)
+            sys.exit(1)
+
+        result = json.loads(output)
+        page = result.get("data", {}).get("repository", {}).get("issues", {})
+        nodes = page.get("nodes", [])
+
+        for node in nodes:
+            labels = [l["name"] for l in node.get("labels", {}).get("nodes", [])]
+            wip_label = next((l for l in labels if l.startswith("wip:")), None)
+            issues.append({
+                "number": node["number"],
+                "title": node["title"],
+                "labels": labels,
+                "wip_label": wip_label,
+                "claimed": wip_label is not None
+            })
+
+        if not page.get("pageInfo", {}).get("hasNextPage"):
+            break
+        cursor = page["pageInfo"]["endCursor"]
+
+    return issues
+
+
+def load_manifest(state_dir: Path) -> dict | None:
+    """Load manifest.json if it exists."""
+    manifest_file = state_dir / "manifest.json"
+    if manifest_file.exists():
+        with open(manifest_file) as f:
+            return json.load(f)
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="List available issues vs claimed issues"
+    )
+    parser.add_argument("--repo", required=True, help="Repository (owner/repo)")
+    parser.add_argument("--state-dir", help="State directory to check for completed issues")
+    parser.add_argument("--limit", type=int, default=20, help="Max available issues to show")
+    parser.add_argument("--json", action="store_true", help="Output as JSON")
+    args = parser.parse_args()
+
+    owner, repo = args.repo.split("/")
+
+    # Fetch all open issues
+    print("Fetching open issues...", file=sys.stderr)
+    issues = fetch_open_issues(owner, repo)
+
+    # Separate claimed vs available
+    claimed = [i for i in issues if i["claimed"]]
+    available = [i for i in issues if not i["claimed"]]
+
+    # Check manifest for completed/failed issues
+    completed_nums = set()
+    failed_nums = set()
+    current_batch = []
+
+    if args.state_dir:
+        state_dir = Path(args.state_dir)
+        manifest = load_manifest(state_dir)
+        if manifest:
+            completed_nums = set(manifest.get("completed", []))
+            failed_nums = set(manifest.get("failed", []))
+            current_batch = manifest.get("current_batch", [])
+
+            # Filter out completed/failed/current_batch from available
+            current_batch_set = set(current_batch)
+            available = [i for i in available
+                         if i["number"] not in completed_nums
+                         and i["number"] not in failed_nums
+                         and i["number"] not in current_batch_set]
+
+    if args.json:
+        output = {
+            "claimed": [{"number": i["number"], "title": i["title"], "wip_label": i["wip_label"]}
+                        for i in claimed],
+            "available": [{"number": i["number"], "title": i["title"]}
+                          for i in available[:args.limit]],
+            "completed": list(completed_nums),
+            "failed": list(failed_nums),
+            "current_batch": current_batch,
+            "stats": {
+                "total_open": len(issues),
+                "claimed": len(claimed),
+                "available": len(available),
+                "completed": len(completed_nums),
+                "failed": len(failed_nums)
+            }
+        }
+        print(json.dumps(output, indent=2))
+        return
+
+    # Pretty print
+    print()
+    print("=" * 70)
+    print(f"ISSUE STATUS FOR {owner}/{repo}")
+    print("=" * 70)
+
+    # Show claimed issues
+    print()
+    if claimed:
+        print(f"CLAIMED ({len(claimed)} issues being worked on by agents):")
+        print("-" * 50)
+        for issue in sorted(claimed, key=lambda x: x["number"]):
+            label = issue["wip_label"]
+            # Extract timestamp from label like wip:claude-1703847234-12345
+            parts = label.split("-")
+            if len(parts) >= 2:
+                try:
+                    timestamp = int(parts[1])
+                    from datetime import datetime
+                    claimed_at = datetime.fromtimestamp(timestamp).strftime("%H:%M:%S")
+                    print(f"  #{issue['number']:4d}  {issue['title'][:45]:<45}  (since {claimed_at})")
+                except (ValueError, IndexError):
+                    print(f"  #{issue['number']:4d}  {issue['title'][:45]:<45}  ({label})")
+            else:
+                print(f"  #{issue['number']:4d}  {issue['title'][:45]:<45}  ({label})")
+    else:
+        print("CLAIMED: None")
+
+    # Show current batch if available
+    if current_batch:
+        print()
+        print(f"CURRENT BATCH ({len(current_batch)} issues in this batch):")
+        print("-" * 50)
+        for num in current_batch:
+            issue = next((i for i in issues if i["number"] == num), None)
+            if issue:
+                status = "claimed" if issue["claimed"] else "pending"
+                print(f"  #{num:4d}  {issue['title'][:50]:<50}  [{status}]")
+            else:
+                print(f"  #{num:4d}  (issue not found)")
+
+    # Show stats
+    print()
+    print(f"SUMMARY:")
+    print("-" * 50)
+    print(f"  Total open issues:  {len(issues)}")
+    print(f"  Claimed by agents:  {len(claimed)}")
+    print(f"  Completed:          {len(completed_nums)}")
+    print(f"  Failed:             {len(failed_nums)}")
+    print(f"  Available:          {len(available)}")
+
+    # Show available issues
+    print()
+    print(f"AVAILABLE FOR MANUAL WORK (showing first {args.limit}):")
+    print("-" * 50)
+    if available:
+        for issue in sorted(available, key=lambda x: x["number"])[:args.limit]:
+            print(f"  #{issue['number']:4d}  {issue['title'][:60]}")
+    else:
+        print("  (none available)")
+
+    print()
+    print("=" * 70)
+    print("Issues marked 'AVAILABLE' can be safely worked on in another terminal.")
+    print("=" * 70)
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/issue-processor/scripts/start_batch.py
+++ b/.claude/skills/issue-processor/scripts/start_batch.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""
+Claim a batch of issues for processing and update the manifest.
+
+This script should be called by the skill before spawning agents to track
+which issues are currently being worked on. This enables visibility when
+running list_available.py or check_status.py --verbose.
+
+Usage:
+    python start_batch.py --state-dir DIR --batch-size N
+
+Output:
+    JSON list of issue numbers in the claimed batch.
+
+Example:
+    $ python start_batch.py --state-dir .claude/issue-state/run-xxx --batch-size 10
+    [1298, 1299, 1300, 1301, 1302, 1303, 1304, 1305, 1306, 1307]
+"""
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Claim a batch of issues and update manifest"
+    )
+    parser.add_argument("--state-dir", required=True, help="State directory path")
+    parser.add_argument("--batch-size", type=int, default=10,
+                        help="Number of issues to claim")
+    args = parser.parse_args()
+
+    state_dir = Path(args.state_dir)
+    manifest_file = state_dir / "manifest.json"
+
+    if not manifest_file.exists():
+        print("ERROR: manifest.json not found", file=sys.stderr)
+        sys.exit(1)
+
+    # Load manifest
+    with open(manifest_file) as f:
+        manifest = json.load(f)
+
+    # Get lists
+    ready = manifest.get("ready", [])
+    completed = set(manifest.get("completed", []))
+    failed = set(manifest.get("failed", []))
+    claimed_by_others = set(manifest.get("claimed_by_others", []))
+
+    # Filter ready list to exclude already processed issues
+    available = [n for n in ready
+                 if n not in completed
+                 and n not in failed
+                 and n not in claimed_by_others]
+
+    if not available:
+        print("[]")  # Empty batch
+        sys.exit(0)
+
+    # Take the batch
+    batch = available[:args.batch_size]
+
+    # Update manifest with current batch
+    manifest["current_batch"] = batch
+    manifest["batch_started_at"] = datetime.now(timezone.utc).isoformat()
+
+    # Save manifest
+    with open(manifest_file, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    # Output the batch
+    print(json.dumps(batch))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Add scripts to show which issues are currently being worked on by agents and which are safe to work on manually in another terminal:

- **`list_available.py`**: Shows claimed issues (with `wip:*` labels), current batch, and issues available for manual work
- **`start_batch.py`**: Claims a batch and updates manifest with `current_batch` field
- **`finish_batch.py`**: Clears `current_batch` and updates `completed`/`failed` lists
- **`check_status.py --verbose`**: Shows detailed batch information including current batch issues

This solves the problem where users couldn't easily see what the issue-processor was working on when trying to work manually in parallel.

### Example Usage

```bash
# In another tmux window, see what's available:
python3 .claude/skills/issue-processor/scripts/list_available.py \
  --repo 7etsuo/tetsuo-socket \
  --state-dir .claude/issue-state/run-xxx
```

Output:
```
CLAIMED (10 issues being worked on by agents):
  #1298  Use socket_util_safe_add_u64...  (since 21:51:03)
  ...

CURRENT BATCH (5 issues in this batch):
  #1288  Replace manual strncpy...  [pending]
  ...

AVAILABLE FOR MANUAL WORK (showing first 10):
  #1293  Missing error check for pthread_key_create...
  ...
```

Fixes #1443

## Test plan

- [x] `list_available.py` shows correct claimed/available split
- [x] `start_batch.py` correctly updates manifest with `current_batch`
- [x] `finish_batch.py` clears batch and updates completed/failed
- [x] `check_status.py --verbose` shows batch details
- [x] Issues in current_batch are excluded from "available" list