### PR TITLE
refactor(core): add SOCKET_SNPRINTF_CHECK macro to reduce code duplication

### DIFF
--- a/include/core/SocketUtil.h
+++ b/include/core/SocketUtil.h
@@ -549,6 +549,37 @@ socket_util_round_up_pow2 (size_t n)
 }
 
 /* ============================================================================
+ * SNPRINTF UTILITIES
+ * ============================================================================
+ */
+
+/**
+ * @brief Check snprintf return value for truncation
+ * @ingroup foundation
+ * @param ret Return value from snprintf
+ * @param buflen Buffer size passed to snprintf
+ * @return -1 if truncated or error, ret otherwise
+ * @threadsafe Yes (macro expansion, no shared state)
+ *
+ * Standard pattern for checking snprintf truncation. According to POSIX,
+ * snprintf returns:
+ * - Negative value on encoding error
+ * - Number of characters that would be written (excluding null terminator)
+ * - Truncation occurs when return value >= buflen
+ *
+ * This macro provides a single source of truth for snprintf truncation
+ * checking, reducing code duplication and improving consistency.
+ *
+ * Usage:
+ *   int ret = snprintf(buf, buflen, "format %s", str);
+ *   return SOCKET_SNPRINTF_CHECK(ret, buflen);
+ *
+ * @see snprintf(3) for return value semantics
+ */
+#define SOCKET_SNPRINTF_CHECK(ret, buflen) \
+  ((ret) < 0 || (size_t)(ret) >= (buflen) ? -1 : (ret))
+
+/* ============================================================================
  * MIN/MAX UTILITIES
  * ============================================================================
  */

--- a/src/dns/SocketDNSError.c
+++ b/src/dns/SocketDNSError.c
@@ -426,7 +426,7 @@ SocketDNS_ede_format (const SocketDNS_ExtendedError *ede, char *buf,
   if (!ede->present)
     {
       int ret = snprintf (buf, buflen, "(no extended error)");
-      return (ret < 0 || (size_t)ret >= buflen) ? -1 : ret;
+      return SOCKET_SNPRINTF_CHECK (ret, buflen);
     }
 
   const char *name = SocketDNS_ede_code_name (ede->info_code);
@@ -438,7 +438,7 @@ SocketDNS_ede_format (const SocketDNS_ExtendedError *ede, char *buf,
   else
     ret = snprintf (buf, buflen, "%s (%u)", name, ede->info_code);
 
-  return (ret < 0 || (size_t)ret >= buflen) ? -1 : ret;
+  return SOCKET_SNPRINTF_CHECK (ret, buflen);
 }
 
 int

--- a/src/quic/SocketQUICMigration.c
+++ b/src/quic/SocketQUICMigration.c
@@ -586,7 +586,7 @@ SocketQUICMigration_path_to_string (const SocketQUICPath_T *path, char *buf,
                       (unsigned long)path->cwnd,
                       (unsigned long)path->rtt_us);
 
-  return (written < 0 || (size_t)written >= size) ? -1 : written;
+  return SOCKET_SNPRINTF_CHECK (written, size);
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #1307

This PR adds a centralized `SOCKET_SNPRINTF_CHECK` macro to reduce code duplication in snprintf truncation checking across the codebase.

## Changes

- **include/core/SocketUtil.h**: Added `SOCKET_SNPRINTF_CHECK` macro with comprehensive documentation
- **src/dns/SocketDNSError.c**: Updated 2 instances to use the new macro
- **src/quic/SocketQUICMigration.c**: Updated 1 instance to use the new macro

## Pattern Replaced

Before:
```c
int ret = snprintf(buf, buflen, "format");
return (ret < 0 || (size_t)ret >= buflen) ? -1 : ret;
```

After:
```c
int ret = snprintf(buf, buflen, "format");
return SOCKET_SNPRINTF_CHECK(ret, buflen);
```

## Benefits

- Single source of truth for snprintf truncation checking
- Improved readability with clear semantic meaning
- Easier to maintain and update (change once, apply everywhere)
- Consistent with codebase pattern of utility macros
- Reduced cognitive load when reading error-checking code

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All DNS tests pass (test code using SocketDNSError.c)
- [x] All QUIC tests pass (test code using SocketQUICMigration.c)
- [x] No new compiler warnings
- [x] Macro follows project conventions (documented, thread-safe)

## Additional Notes

The pattern `(ret < 0 || (size_t)ret >= buflen) ? -1 : ret` appears in multiple other files as well, but this PR focuses on the instances mentioned in the issue. Future work can migrate additional instances to use this macro for consistency.

Closes #1307