### PR TITLE
refactor(core): derive NUM_ERROR_CATEGORIES from array size

### DIFF
--- a/src/core/SocketError.c
+++ b/src/core/SocketError.c
@@ -77,7 +77,6 @@ static const SocketErrorMapping error_mappings[] = {
 
 #define NUM_ERROR_MAPPINGS                                                    \
   (sizeof (error_mappings) / sizeof (error_mappings[0]))
-#define NUM_ERROR_CATEGORIES 6
 
 /* O(n) linear scan of ~30 entries - acceptable for small table */
 static const SocketErrorMapping *
@@ -151,6 +150,10 @@ Socket_safe_strerror (int errnum)
 static const char *const socket_error_category_names[] = {
   "NETWORK", "PROTOCOL", "APPLICATION", "TIMEOUT", "RESOURCE", "UNKNOWN"
 };
+
+#define NUM_ERROR_CATEGORIES                                                      \
+  (sizeof (socket_error_category_names)                                          \
+   / sizeof (socket_error_category_names[0]))
 
 SocketErrorCategory
 SocketError_categorize_errno (int err)


### PR DESCRIPTION
## Summary

Implements #1302

Replace hardcoded `NUM_ERROR_CATEGORIES` constant with automatic calculation based on `socket_error_category_names` array size.

## Changes

- Removed hardcoded `#define NUM_ERROR_CATEGORIES 6` from line 80
- Added calculated definition after array declaration:
  ```c
  #define NUM_ERROR_CATEGORIES \
    (sizeof(socket_error_category_names) / sizeof(socket_error_category_names[0]))
  ```
- Ensures automatic synchronization between enum and array count

## Benefits

- Prevents buffer overruns from manual count errors
- Eliminates maintenance burden when adding/removing error categories
- Makes code more resilient to future changes
- Follows existing pattern used for `NUM_ERROR_MAPPINGS`

## Test Plan

- [x] All error handling tests pass (test_socketerror: 12/12)
- [x] Full test suite passes with sanitizers (113/114, unrelated timeout)
- [x] No functional changes to error categorization logic
- [x] Verified correct array size calculation at compile time

Closes #1302