### PR TITLE
refactor(http): Replace manual overflow checks with SocketSecurity_check_add()

### DIFF
--- a/src/http/SocketHTTP1-compress.c
+++ b/src/http/SocketHTTP1-compress.c
@@ -149,8 +149,7 @@ check_decode_output_limits (size_t total, size_t output_len, size_t max_size)
   if (!SocketSecurity_check_size (output_len))
     return HTTP1_ERROR;
 
-  potential = total + output_len;
-  if (potential < total)
+  if (!SocketSecurity_check_add (total, output_len, &potential))
     return HTTP1_ERROR_BODY_TOO_LARGE; /* Overflow */
 
   if (max_size != SIZE_MAX && potential > max_size)
@@ -179,8 +178,7 @@ check_encode_output_limits (size_t total, size_t output_len, size_t max_size)
   if (!SocketSecurity_check_size (output_len))
     return 0;
 
-  potential = total + output_len;
-  if (potential < total)
+  if (!SocketSecurity_check_add (total, output_len, &potential))
     return 0; /* Overflow */
 
   if (max_size != SIZE_MAX && potential > max_size)


### PR DESCRIPTION
## Summary

Refactors HTTP compression module to use centralized overflow detection utility instead of duplicated manual checks.

## Changes

- **check_decode_output_limits**: Replaced manual `if (potential < total)` overflow check with `SocketSecurity_check_add()`
- **check_encode_output_limits**: Replaced manual `if (potential < total)` overflow check with `SocketSecurity_check_add()`

## Benefits

1. **Reduces code duplication** - Eliminates repeated overflow detection pattern
2. **Uses battle-tested utility** - `SocketSecurity_check_add()` is already used throughout the codebase
3. **More maintainable** - Changes to overflow detection logic only need to happen in one place
4. **Clearer intent** - Named function makes the purpose immediately obvious

## Test Plan

- [x] All HTTP-related tests pass with sanitizers enabled
- [x] HTTP/1.1 parser tests pass (34/34)
- [x] No new warnings or errors
- [x] Sanitizer tests pass (ASan + UBSan)

Closes #1309