### PR TITLE
security(http): Add defensive assertions for size_t to uInt casts in zlib

### DIFF
--- a/src/http/SocketHTTP1-compress.c
+++ b/src/http/SocketHTTP1-compress.c
@@ -286,6 +286,9 @@ decode_zlib (SocketHTTP1_Decoder_T decoder, const unsigned char *input,
   int ret;
   z_stream *s = &decoder->state.zlib;
 
+  assert (input_len <= UINT_MAX);  /* Document precondition */
+  assert (output_len <= UINT_MAX); /* Document precondition */
+
   s->next_in = (Bytef *)input;
   s->avail_in = (uInt)input_len;
   s->next_out = output;
@@ -314,6 +317,8 @@ finish_zlib_decode (SocketHTTP1_Decoder_T decoder, unsigned char *output,
 {
   int ret;
   z_stream *s = &decoder->state.zlib;
+
+  assert (output_len <= UINT_MAX); /* Document precondition */
 
   s->next_in = NULL;
   s->avail_in = 0;
@@ -345,6 +350,9 @@ encode_zlib (SocketHTTP1_Encoder_T encoder, const unsigned char *input,
   int zlib_flush = flush ? Z_SYNC_FLUSH : Z_NO_FLUSH;
   z_stream *s = &encoder->state.zlib;
 
+  assert (input_len <= UINT_MAX);  /* Document precondition */
+  assert (output_len <= UINT_MAX); /* Document precondition */
+
   s->next_in = (Bytef *)input;
   s->avail_in = (uInt)input_len;
   s->next_out = output;
@@ -365,6 +373,8 @@ finish_zlib_encode (SocketHTTP1_Encoder_T encoder, unsigned char *output,
   int ret;
   size_t produced;
   z_stream *s = &encoder->state.zlib;
+
+  assert (output_len <= UINT_MAX); /* Document precondition */
 
   s->next_in = NULL;
   s->avail_in = 0;


### PR DESCRIPTION
## Summary

Implements #1312 by adding defensive assertions at cast sites where `size_t` is cast to `uInt` for zlib operations.

## Changes

- Added `assert(input_len <= UINT_MAX)` and `assert(output_len <= UINT_MAX)` in `decode_zlib()`
- Added `assert(output_len <= UINT_MAX)` in `finish_zlib_decode()`
- Added `assert(input_len <= UINT_MAX)` and `assert(output_len <= UINT_MAX)` in `encode_zlib()`
- Added `assert(output_len <= UINT_MAX)` in `finish_zlib_encode()`

## Defense-in-Depth Rationale

While `check_buffer_limits()` already validates these values before the casts are reached, the assertions provide:

1. **Self-documenting code**: Makes preconditions explicit at the cast site
2. **Early detection**: Catches violations immediately in debug builds
3. **Future-proofing**: Protects against refactoring errors or call path changes
4. **Zero runtime cost**: Assertions are compiled out in release builds

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All tests pass (113/114, 1 timeout unrelated to changes)
- [x] HTTP compression tests pass
- [x] No new warnings or errors

Closes #1312