### PR TITLE
refactor(dns): consolidate DoH server URL buffer size constant

### DIFF
--- a/include/dns/SocketDNSoverHTTPS.h
+++ b/include/dns/SocketDNSoverHTTPS.h
@@ -81,6 +81,9 @@
 /** Maximum pending queries per transport. */
 #define DOH_MAX_PENDING_QUERIES 100
 
+/** Maximum server URL length in ServerConfig. */
+#define DOH_MAX_SERVER_URL_LENGTH 512
+
 /* Error codes for callback */
 #define DOH_ERROR_SUCCESS 0         /**< Query completed successfully */
 #define DOH_ERROR_TIMEOUT -1        /**< Query timeout */

--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -62,7 +62,7 @@ static const struct
 /* Server configuration entry */
 struct ServerConfig
 {
-  char url[512];
+  char url[DOH_MAX_SERVER_URL_LENGTH];
   SocketDNSoverHTTPS_Method method;
   int prefer_http2;
   int timeout_ms;


### PR DESCRIPTION
## Summary

Consolidates the hardcoded 512 buffer size for DoH server URLs into a named constant for improved maintainability and consistency.

## Changes

- Define `DOH_MAX_SERVER_URL_LENGTH = 512` in `include/dns/SocketDNSoverHTTPS.h`
- Replace magic number in `struct ServerConfig` url field with the constant
- Preserve existing validation logic that checks `url_len >= sizeof(s->url)`

## Test Plan

- [x] All DoH tests pass (15/15)
- [x] Build succeeds with sanitizers enabled
- [x] Size validation still works correctly at line 288
- [x] No functional changes - purely a refactor

Closes #1311