### PR TITLE
refactor(quic): replace magic number 16 with QUIC_TOKEN_ADDR_HASH_SIZE constant

### DIFF
--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -37,16 +37,16 @@ const Except_T SocketQUICAddrValidation_Failed
  * Creates a deterministic hash of address for token binding.
  *
  * @param[in] addr Socket address.
- * @param[out] hash Output buffer (16 bytes).
+ * @param[out] hash Output buffer (QUIC_TOKEN_ADDR_HASH_SIZE bytes).
  */
 static void
-hash_address (const struct sockaddr *addr, uint8_t hash[16])
+hash_address (const struct sockaddr *addr, uint8_t hash[QUIC_TOKEN_ADDR_HASH_SIZE])
 {
   unsigned char sha256_output[SOCKET_CRYPTO_SHA256_SIZE];
 
   if (!addr)
     {
-      memset (hash, 0, 16);
+      memset (hash, 0, QUIC_TOKEN_ADDR_HASH_SIZE);
       return;
     }
 
@@ -64,12 +64,12 @@ hash_address (const struct sockaddr *addr, uint8_t hash[16])
     }
   else
     {
-      memset (hash, 0, 16);
+      memset (hash, 0, QUIC_TOKEN_ADDR_HASH_SIZE);
       return;
     }
 
-  /* Use first 16 bytes of SHA-256 */
-  memcpy (hash, sha256_output, 16);
+  /* Use first QUIC_TOKEN_ADDR_HASH_SIZE bytes of SHA-256 */
+  memcpy (hash, sha256_output, QUIC_TOKEN_ADDR_HASH_SIZE);
 }
 
 /* ============================================================================
@@ -216,11 +216,11 @@ check_token_expiration (uint64_t token_timestamp)
 static SocketQUICAddrValidation_Result
 verify_token_address (const uint8_t *token, const struct sockaddr *addr)
 {
-  uint8_t addr_hash[16];
+  uint8_t addr_hash[QUIC_TOKEN_ADDR_HASH_SIZE];
 
   hash_address (addr, addr_hash);
 
-  if (SocketCrypto_secure_compare (token + 8, addr_hash, 16) != 0)
+  if (SocketCrypto_secure_compare (token + 8, addr_hash, QUIC_TOKEN_ADDR_HASH_SIZE) != 0)
     {
       return QUIC_ADDR_VALIDATION_ERROR_INVALID;
     }
@@ -242,14 +242,14 @@ compute_and_verify_token_hmac (const uint8_t *token, uint64_t token_timestamp,
                                 const struct sockaddr *addr,
                                 const uint8_t *secret)
 {
-  uint8_t addr_hash[16];
+  uint8_t addr_hash[QUIC_TOKEN_ADDR_HASH_SIZE];
   uint8_t hmac_input[QUIC_TOKEN_HMAC_INPUT_SIZE];
   unsigned char hmac_output[SOCKET_CRYPTO_SHA256_SIZE];
 
   hash_address (addr, addr_hash);
 
   socket_util_pack_be64 (hmac_input, token_timestamp);
-  memcpy (hmac_input + 8, addr_hash, 16);
+  memcpy (hmac_input + 8, addr_hash, QUIC_TOKEN_ADDR_HASH_SIZE);
 
   TRY
   {
@@ -275,7 +275,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
                                           const uint8_t *secret,
                                           uint8_t *token, size_t *token_len)
 {
-  uint8_t addr_hash[16];
+  uint8_t addr_hash[QUIC_TOKEN_ADDR_HASH_SIZE];
   uint8_t hmac_input[QUIC_TOKEN_HMAC_INPUT_SIZE];
   unsigned char hmac_output[SOCKET_CRYPTO_SHA256_SIZE];
   uint64_t timestamp;
@@ -286,7 +286,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
       return QUIC_ADDR_VALIDATION_ERROR_NULL;
     }
 
-  /* Token format: 8 timestamp + 16 addr_hash + 32 HMAC */
+  /* Token format: 8 timestamp + QUIC_TOKEN_ADDR_HASH_SIZE addr_hash + 32 HMAC */
   if (*token_len < QUIC_ADDR_VALIDATION_TOKEN_SIZE)
     {
       return QUIC_ADDR_VALIDATION_ERROR_BUFFER_SIZE;
@@ -300,7 +300,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
 
   /* Build HMAC input: timestamp || addr_hash */
   socket_util_pack_be64 (hmac_input, timestamp);
-  memcpy (hmac_input + 8, addr_hash, 16);
+  memcpy (hmac_input + 8, addr_hash, QUIC_TOKEN_ADDR_HASH_SIZE);
 
   /* Compute HMAC-SHA256 */
   TRY
@@ -316,7 +316,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
 
   /* Build token: timestamp || addr_hash || HMAC */
   socket_util_pack_be64 (token, timestamp);
-  memcpy (token + 8, addr_hash, 16);
+  memcpy (token + 8, addr_hash, QUIC_TOKEN_ADDR_HASH_SIZE);
   memcpy (token + 24, hmac_output, 32);
 
   *token_len = QUIC_ADDR_VALIDATION_TOKEN_SIZE;


### PR DESCRIPTION
## Summary

Implements #1308

Replaces hardcoded magic number `16` with the named constant `QUIC_TOKEN_ADDR_HASH_SIZE` throughout `src/quic/SocketQUICAddrValidation.c` for improved code maintainability and clarity.

## Changes

- Updated `hash_address()` function signature to use `QUIC_TOKEN_ADDR_HASH_SIZE` instead of `16`
- Replaced all magic number `16` instances in `memset()` and `memcpy()` calls with the constant
- Updated array declarations (`uint8_t addr_hash[16]` → `uint8_t addr_hash[QUIC_TOKEN_ADDR_HASH_SIZE]`)
- Updated documentation comments to reference the constant instead of literal value

## Locations Changed

- Line 40: Function documentation comment
- Line 43: Function signature `hash_address()`
- Line 49: `memset()` call (error path)
- Line 67: `memset()` call (unsupported address family)
- Line 71-72: Comment and `memcpy()` call
- Line 219: Array declaration in `verify_token_address()`
- Line 223: `SocketCrypto_secure_compare()` size parameter
- Line 245: Array declaration in `compute_and_verify_token_hmac()`
- Line 252: `memcpy()` size parameter
- Line 278: Array declaration in `SocketQUICAddrValidation_generate_token()`
- Line 289: Comment describing token format
- Line 303: `memcpy()` size parameter
- Line 319: `memcpy()` size parameter

## Test Plan

- [x] All QUIC address validation tests pass (17/17)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes, only refactoring for code quality

## Benefits

1. Single source of truth: The constant `QUIC_TOKEN_ADDR_HASH_SIZE` is defined once in the header
2. Improved maintainability: If the hash size needs to change, only the constant needs updating
3. Self-documenting code: The constant name clearly indicates its purpose
4. Consistency with existing project patterns

Closes #1308