### PR TITLE
refactor(http): replace manual strncpy with socket_util_safe_strncpy

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -562,8 +562,7 @@ connection_set_client_addr (ServerConnection *conn)
   const char *addr = Socket_getpeeraddr (conn->socket);
   if (addr != NULL)
     {
-      strncpy (conn->client_addr, addr, sizeof (conn->client_addr) - 1);
-      conn->client_addr[sizeof (conn->client_addr) - 1] = '\0';
+      socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #1288

Replaces the manual `strncpy` + null termination pattern in `connection_set_client_addr()` with the centralized `socket_util_safe_strncpy()` utility.

## Changes

- Replaced two-line manual pattern (lines 565-566) with single-line `socket_util_safe_strncpy()` call
- Maintains identical behavior (guaranteed null termination, same truncation)
- Improves code consistency with other modules

## Test Plan

- [x] Tests pass with sanitizers (ASAN/UBSAN)
- [x] All 27 HTTP server tests pass
- [x] No functional changes to behavior

Closes #1288