### PR TITLE
refactor(log): replace magic number NUM_LOG_LEVELS with sizeof calculation

### DIFF
--- a/src/core/SocketLog.c
+++ b/src/core/SocketLog.c
@@ -27,7 +27,7 @@ static void *socketlog_structured_userdata = NULL;
 static const char *const default_level_names[]
     = { "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL" };
 
-#define NUM_LOG_LEVELS 6
+#define NUM_LOG_LEVELS (sizeof(default_level_names)/sizeof(default_level_names[0]))
 
 static const char *
 socketlog_format_timestamp (char *buf, size_t bufsize)


### PR DESCRIPTION
## Summary

Implements #1290

Replaces hardcoded `NUM_LOG_LEVELS` constant (value 6) with compile-time `sizeof` calculation based on the `default_level_names` array size.

## Changes

- Modified `src/core/SocketLog.c` line 30:
  - Before: `#define NUM_LOG_LEVELS 6`
  - After: `#define NUM_LOG_LEVELS (sizeof(default_level_names)/sizeof(default_level_names[0]))`

## Benefits

1. **Automatic synchronization**: Array size and constant stay in sync automatically
2. **Reduced maintenance**: No manual update needed when adding log levels
3. **Compile-time calculation**: Zero runtime overhead
4. **Standard C idiom**: Well-understood pattern for array size

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] 113/114 tests pass (1 known flaky timeout unrelated to this change)
- [x] Verified logging functionality works correctly (level names display properly)
- [x] No behavioral changes - purely a refactoring for maintainability

Closes #1290