### PR TITLE
refactor(pool): simplify timespec construction in health worker

### DIFF
--- a/src/pool/SocketPool-health.c
+++ b/src/pool/SocketPool-health.c
@@ -368,10 +368,13 @@ health_worker_thread (void *arg)
       pthread_mutex_lock (&health->worker_mutex);
       if (!atomic_load (&health->shutdown))
         {
-          struct timespec interval;
           interval_ms = health->config.probe_interval_ms;
           clock_gettime (CLOCK_REALTIME, &ts);
-          interval = socket_util_ms_to_timespec ((unsigned long)interval_ms);
+          struct timespec interval
+              = socket_util_ms_to_timespec ((unsigned long)interval_ms);
+
+          /* Add interval to current time (timespec addition with overflow
+           * handling) */
           ts.tv_sec += interval.tv_sec;
           ts.tv_nsec += interval.tv_nsec;
           if (ts.tv_nsec >= 1000000000)


### PR DESCRIPTION
## Summary

Refactors timespec handling in `health_worker_thread()` for improved code clarity.

## Changes

- Moved `interval` declaration closer to initialization (C99 style)
- Added clarifying comment explaining why overflow handling is still needed
- No functional changes - overflow handling remains necessary when adding two timespec structures

## Technical Details

The `socket_util_ms_to_timespec()` utility returns a normalized timespec, but overflow handling is still required when adding the interval to the current time, since `ts.tv_nsec + interval.tv_nsec` can exceed 1 billion nanoseconds.

## Test Plan

- [x] Tests pass with sanitizers (`test_pool_health`)
- [x] Build completes without warnings
- [x] No functional behavior changes

Closes #1287