### PR TITLE
refactor(core): add compile-time assertion for error category array bounds

### DIFF
--- a/src/core/SocketError.c
+++ b/src/core/SocketError.c
@@ -152,6 +152,9 @@ static const char *const socket_error_category_names[] = {
   "NETWORK", "PROTOCOL", "APPLICATION", "TIMEOUT", "RESOURCE", "UNKNOWN"
 };
 
+_Static_assert(sizeof(socket_error_category_names) / sizeof(socket_error_category_names[0]) == NUM_ERROR_CATEGORIES,
+               "Category names array size must match NUM_ERROR_CATEGORIES");
+
 SocketErrorCategory
 SocketError_categorize_errno (int err)
 {


### PR DESCRIPTION
## Summary

Implements #1318

Adds a `_Static_assert` to ensure the `socket_error_category_names` array size matches `NUM_ERROR_CATEGORIES` at compile time.

## Changes

- Added compile-time assertion in `src/core/SocketError.c` after the `socket_error_category_names` array declaration
- Validates that the array has exactly 6 elements matching the 6 error categories in the enum
- Prevents silent bugs from array/enum desynchronization

## Test Plan

- [x] Tests pass with sanitizers enabled (`test_socketerror`, `test_except`, `test_arena`, `test_socket`)
- [x] Build succeeds with assertion in place
- [x] The assertion would cause a compile-time error if the array and constant diverge

## Impact

This change:
- Catches potential bugs at compile-time rather than runtime
- Prevents out-of-bounds array access in `SocketError_category_name()`
- Improves code maintainability and safety
- Becomes critical once #1302 is implemented (deriving NUM_ERROR_CATEGORIES from array size)

Closes #1318