### PR TITLE
fix(http): add error check for pthread_key_create in HTTPClient arena

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -26,6 +26,7 @@
 #include "http/SocketHTTPClient-private.h"
 
 #include <pthread.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 /**
@@ -70,7 +71,13 @@ arena_cache_destructor (void *ptr)
 static void
 arena_cache_init_key (void)
 {
-  pthread_key_create (&arena_cache_key, arena_cache_destructor);
+  int rc = pthread_key_create (&arena_cache_key, arena_cache_destructor);
+  if (rc != 0)
+    {
+      /* Fatal error - can't continue without TLS support */
+      fprintf (stderr, "FATAL: pthread_key_create failed: %d\n", rc);
+      abort ();
+    }
 }
 
 /**


### PR DESCRIPTION
## Summary

Implements #1293 - adds error checking for `pthread_key_create()` in HTTPClient arena initialization.

## Changes

- Added error handling in `arena_cache_init_key()` to check the return value of `pthread_key_create()`
- On failure (EAGAIN or ENOMEM), prints error message to stderr and calls `abort()`
- Added `stdio.h` include for `fprintf()`

## Rationale

According to POSIX, `pthread_key_create()` can fail when:
- System lacks resources to create another TLS key (EAGAIN)
- Insufficient memory (ENOMEM)

Silent failure would cause subsequent calls to `pthread_getspecific()` and `pthread_setspecific()` to use an invalid key, leading to undefined behavior, memory corruption, or crashes that are difficult to debug.

Since TLS support is critical for the arena caching mechanism and cannot be gracefully degraded, treating this as a fatal error with `abort()` is the appropriate approach.

## Test Plan

- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] HTTP client tests pass (44/44)
- [x] Thread safety tests pass (17/17)
- [x] Build completes without warnings

Closes #1293