### PR TITLE
fix(websocket): ensure NULL termination after strncpy in ws_parse_url

### DIFF
--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -1445,10 +1445,14 @@ ws_parse_url (const char *url, char *host, int *port, char *path, int *use_tls)
   else
     {
       strncpy (host, url, NI_MAXHOST - 1);
+      host[NI_MAXHOST - 1] = '\0';
     }
 
   if (path_start)
-    strncpy (path, path_start, 1024 - 1);
+    {
+      strncpy (path, path_start, 1024 - 1);
+      path[1024 - 1] = '\0';
+    }
   else
     {
       path[0] = '/';


### PR DESCRIPTION
## Summary

Fixes #1320 - Security vulnerability: Missing NULL termination after strncpy() calls in ws_parse_url()

## Changes

- Added explicit NULL termination after `strncpy(host, url, NI_MAXHOST - 1)` on line 1447
- Added explicit NULL termination after `strncpy(path, path_start, 1024 - 1)` on line 1451
- Added braces for consistency around the path_start block

## Security Impact

**Severity**: HIGH

Without NULL termination, if the source string length is >= buffer size - 1, the destination buffers would not be NULL-terminated. This could lead to:
- Buffer over-read when the buffers are used as C strings
- Information disclosure (exposing sensitive memory contents)
- Potential crashes (segmentation faults)

## Pattern Consistency

This fix follows the same pattern already used elsewhere in the same function:
- Line 1425: `host[host_len] = '\0';` after strncpy
- Line 1443: `host[host_len] = '\0';` after strncpy

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All WebSocket tests pass (test_websocket, test_websocket_h2)
- [x] Full test suite passes (113/114 tests, 1 unrelated timeout)
- [x] No new ASan/UBSan warnings introduced