### PR TITLE
fix(quic): use constant-time comparison for stateless reset token verification

### DIFF
--- a/src/quic/SocketQUICConnection-termination.c
+++ b/src/quic/SocketQUICConnection-termination.c
@@ -29,6 +29,7 @@
 #include <stdint.h>
 #include "quic/SocketQUICConnection.h"
 #include "quic/SocketQUICConstants.h"
+#include "core/SocketCrypto.h"
 
 /**
  * @brief Safely add two uint64_t values with overflow protection.
@@ -321,6 +322,8 @@ SocketQUICConnection_set_stateless_reset_token(SocketQUICConnection_T conn,
  * RFC 9000 Section 10.3: A stateless reset is a packet whose final 16 bytes
  * match the stateless reset token. Minimum packet size is 38 bytes to avoid
  * false positives with short packets.
+ *
+ * Uses constant-time comparison to prevent timing attacks (CWE-208).
  */
 int
 SocketQUICConnection_verify_stateless_reset(const uint8_t *packet,
@@ -334,7 +337,8 @@ SocketQUICConnection_verify_stateless_reset(const uint8_t *packet,
   if (packet_len < QUIC_STATELESS_RESET_MIN_SIZE)
     return 0;
 
-  /* Compare final 16 bytes with expected token */
+  /* Compare final 16 bytes with expected token using constant-time comparison */
   const uint8_t *actual_token = packet + packet_len - QUIC_STATELESS_RESET_TOKEN_LEN;
-  return memcmp(actual_token, expected_token, QUIC_STATELESS_RESET_TOKEN_LEN) == 0;
+  return SocketCrypto_secure_compare(actual_token, expected_token,
+                                     QUIC_STATELESS_RESET_TOKEN_LEN) == 0;
 }


### PR DESCRIPTION
## Summary

Fixes #1324 - Replaces timing-vulnerable `memcmp()` with constant-time comparison for stateless reset token verification.

## Changes

- Modified `SocketQUICConnection_verify_stateless_reset()` to use `SocketCrypto_secure_compare()`
- Added include for `core/SocketCrypto.h`
- Updated function documentation to note constant-time comparison and CWE-208 mitigation

## Security Impact

**Before**: The function used standard `memcmp()` which returns early on the first differing byte, potentially leaking timing information about where tokens differ.

**After**: Uses constant-time comparison that:
- Uses `CRYPTO_memcmp()` when TLS is enabled (OpenSSL implementation)
- Falls back to custom constant-time implementation when TLS is unavailable
- Prevents timing side-channel attacks per CWE-208

## Test Plan

- [x] All QUIC tests pass (26/26)
- [x] Crypto tests pass
- [x] `test_quic_termination` specifically validates stateless reset verification
- [x] Tests run with AddressSanitizer + UBSanitizer enabled
- [x] No functional changes - only security hardening

## References

- RFC 9000 Section 10.3: Stateless Reset
- CWE-208: Observable Timing Discrepancy
- Existing `SocketCrypto_secure_compare()` implementation (lines 758-779 in `src/core/SocketCrypto.c`)

Closes #1324