### PR TITLE
refactor(http): replace manual overflow checks with SocketSecurity_check_add()

### DIFF
--- a/src/http/SocketHTTP1-compress.c
+++ b/src/http/SocketHTTP1-compress.c
@@ -149,8 +149,7 @@ check_decode_output_limits (size_t total, size_t output_len, size_t max_size)
   if (!SocketSecurity_check_size (output_len))
     return HTTP1_ERROR;
 
-  potential = total + output_len;
-  if (potential < total)
+  if (!SocketSecurity_check_add (total, output_len, &potential))
     return HTTP1_ERROR_BODY_TOO_LARGE; /* Overflow */
 
   if (max_size != SIZE_MAX && potential > max_size)
@@ -179,8 +178,7 @@ check_encode_output_limits (size_t total, size_t output_len, size_t max_size)
   if (!SocketSecurity_check_size (output_len))
     return 0;
 
-  potential = total + output_len;
-  if (potential < total)
+  if (!SocketSecurity_check_add (total, output_len, &potential))
     return 0; /* Overflow */
 
   if (max_size != SIZE_MAX && potential > max_size)


### PR DESCRIPTION
## Summary

Implements #1309

Replaced duplicated manual overflow detection pattern in HTTP compression module with the centralized `SocketSecurity_check_add()` utility function.

## Changes

- **check_decode_output_limits**: Use `SocketSecurity_check_add()` instead of manual `potential < total` check
- **check_encode_output_limits**: Use `SocketSecurity_check_add()` instead of manual `potential < total` check

## Benefits

1. Reduces code duplication
2. Uses battle-tested centralized utility from `SocketSecurity.h`
3. More maintainable and consistent
4. Clearer intent with named function

## Test Plan

- [x] All HTTP-related tests pass with sanitizers (ASan + UBSan)
- [x] No functional changes - same overflow detection logic, just refactored
- [x] Build completes without warnings

Closes #1309