### PR TITLE
perf(quic): optimize hash modulo to bitwise AND in connection ID pool

### DIFF
--- a/src/quic/SocketQUICConnectionID-pool.c
+++ b/src/quic/SocketQUICConnectionID-pool.c
@@ -61,7 +61,7 @@ hash_cid_bytes (const uint8_t *id, size_t len, uint32_t seed)
   for (size_t i = 0; i < len; i++)
     hash = QUIC_HASH_FNV1A_STEP (hash, id[i]);
 
-  return hash % QUIC_CONNID_POOL_HASH_SIZE;
+  return hash & (QUIC_CONNID_POOL_HASH_SIZE - 1);
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Optimizes hash function in `SocketQUICConnectionID-pool.c` by replacing modulo operation with bitwise AND.

## Changes

- **File**: `src/quic/SocketQUICConnectionID-pool.c`
- **Line 64**: Changed `hash % QUIC_CONNID_POOL_HASH_SIZE` to `hash & (QUIC_CONNID_POOL_HASH_SIZE - 1)`

## Rationale

Since `QUIC_CONNID_POOL_HASH_SIZE` is defined as 32 (a power of 2), the modulo operation `x % 32` is mathematically equivalent to `x & 31`. The bitwise AND:
- Avoids division circuitry, typically faster on most architectures
- Maintains identical hash distribution
- No functional changes - purely a performance optimization

This aligns with the header file comment at line 51 which explicitly states the hash size "Should be a power of 2 for efficient modulo via bitmask".

## Test Plan

- [x] All QUIC connection ID pool tests pass (20/20 tests)
- [x] Full test suite passes with sanitizers (114/115 tests, 1 unrelated timeout)
- [x] No functional changes - mathematically equivalent operation
- [x] Build completes successfully with ASan and UBSan enabled

Closes #1331