### PR TITLE
refactor(http): remove unused eof variable in sync_recv_fallback

### DIFF
--- a/src/http/SocketHTTPClient-async.c
+++ b/src/http/SocketHTTPClient-async.c
@@ -134,12 +134,11 @@ static ssize_t
 sync_recv_fallback (Socket_T socket, void *buf, size_t len)
 {
   volatile ssize_t recvd = 0;
-  volatile int eof = 0;
 
   TRY { recvd = Socket_recv (socket, buf, len); }
   EXCEPT (Socket_Closed)
   {
-    eof = 1;
+    recvd = 0; /* EOF - graceful close */
   }
   EXCEPT (Socket_Failed)
   {
@@ -147,7 +146,7 @@ sync_recv_fallback (Socket_T socket, void *buf, size_t len)
   }
   END_TRY;
 
-  return eof ? 0 : recvd;
+  return recvd;
 }
 
 int


### PR DESCRIPTION
## Summary

Implements #1335

Removed the awkward unused variable suppression pattern in `sync_recv_fallback()` by eliminating the unnecessary `eof` variable.

## Changes

- **File**: `src/http/SocketHTTPClient-async.c`
- **Function**: `sync_recv_fallback()`
- Removed `volatile int eof = 0;` declaration
- Changed EXCEPT(Socket_Closed) handler to set `recvd = 0` directly
- Simplified return statement from `return eof ? 0 : recvd;` to `return recvd;`
- Added clarifying comment `/* EOF - graceful close */`

## Benefits

- **Code clarity**: Removes confusing suppression pattern
- **Maintainability**: Simpler code is easier to understand
- **Consistency**: Aligns with typical exception handling patterns in the codebase

## Test Plan

- [x] Tests pass with sanitizers (ASan/UBSan)
- [x] HTTP client tests pass (44/44)
- [x] HTTP integration tests pass (8/8)
- [x] No functional changes - only refactoring

Closes #1335