### PR TITLE
refactor(quic): replace magic offset 24 with symbolic constant

### DIFF
--- a/include/quic/SocketQUICAddrValidation.h
+++ b/include/quic/SocketQUICAddrValidation.h
@@ -36,6 +36,10 @@
 #define QUIC_TOKEN_ADDR_HASH_SIZE 16  /**< Address hash field size */
 #define QUIC_TOKEN_HMAC_SIZE 32       /**< HMAC-SHA256 field size */
 
+/** @brief Token field offsets */
+#define QUIC_TOKEN_HMAC_OFFSET \
+  (QUIC_TOKEN_TIMESTAMP_SIZE + QUIC_TOKEN_ADDR_HASH_SIZE)  /**< HMAC field offset */
+
 /** @brief Actual token size: 8 (timestamp) + 16 (addr hash) + 32 (HMAC) */
 #define QUIC_ADDR_VALIDATION_TOKEN_SIZE \
   (QUIC_TOKEN_TIMESTAMP_SIZE + QUIC_TOKEN_ADDR_HASH_SIZE + QUIC_TOKEN_HMAC_SIZE)

--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -262,7 +262,8 @@ compute_and_verify_token_hmac (const uint8_t *token, uint64_t token_timestamp,
   }
   END_TRY;
 
-  if (SocketCrypto_secure_compare (token + 24, hmac_output, 32) != 0)
+  if (SocketCrypto_secure_compare (token + QUIC_TOKEN_HMAC_OFFSET, hmac_output,
+                                    QUIC_TOKEN_HMAC_SIZE) != 0)
     {
       return QUIC_ADDR_VALIDATION_ERROR_INVALID;
     }
@@ -317,7 +318,7 @@ SocketQUICAddrValidation_generate_token (const struct sockaddr *addr,
   /* Build token: timestamp || addr_hash || HMAC */
   socket_util_pack_be64 (token, timestamp);
   memcpy (token + QUIC_TOKEN_TIMESTAMP_SIZE, addr_hash, QUIC_TOKEN_ADDR_HASH_SIZE);
-  memcpy (token + 24, hmac_output, 32);
+  memcpy (token + QUIC_TOKEN_HMAC_OFFSET, hmac_output, QUIC_TOKEN_HMAC_SIZE);
 
   *token_len = QUIC_ADDR_VALIDATION_TOKEN_SIZE;
   return QUIC_ADDR_VALIDATION_OK;


### PR DESCRIPTION
## Summary

Replaces hardcoded magic number `24` with symbolic constant `QUIC_TOKEN_HMAC_OFFSET` in QUIC address validation token operations. Also replaces hardcoded `32` with `QUIC_TOKEN_HMAC_SIZE` for consistency.

## Changes

- Added `QUIC_TOKEN_HMAC_OFFSET` constant to `include/quic/SocketQUICAddrValidation.h`
- Replaced `token + 24` with `token + QUIC_TOKEN_HMAC_OFFSET` in two locations
- Replaced hardcoded `32` with `QUIC_TOKEN_HMAC_SIZE` for consistency

## Test Plan

- [x] Tests pass with sanitizers (ASAN + UBSAN)
- [x] QUIC address validation tests pass
- [x] All module tests pass (114/115, 1 unrelated timeout)

## Token Format Reference

```
0-7:   timestamp (QUIC_TOKEN_TIMESTAMP_SIZE = 8)
8-23:  address hash (QUIC_TOKEN_ADDR_HASH_SIZE = 16)
24-55: HMAC (QUIC_TOKEN_HMAC_SIZE = 32)
```

The offset 24 is where the HMAC field starts: `8 + 16 = 24`

Closes #1334