### PR TITLE
fix(websocket): replace magic number with SOCKETWS_MAX_PATH_SIZE constant

### DIFF
--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -1380,7 +1380,7 @@ SocketWS_close (SocketWS_T ws, int code, const char *reason)
  * @param url The WebSocket URL (ws:// or wss://)
  * @param[out] host Buffer for hostname (size NI_MAXHOST)
  * @param[out] port Port number (default 80/443)
- * @param[out] path Buffer for path (size 1024)
+ * @param[out] path Buffer for path (size SOCKETWS_MAX_PATH_SIZE)
  * @param[out] use_tls TLS flag (1 for wss://, 0 for ws://)
  * @return 0 on success, -1 on error
  */
@@ -1450,8 +1450,8 @@ ws_parse_url (const char *url, char *host, int *port, char *path, int *use_tls)
 
   if (path_start)
     {
-      strncpy (path, path_start, 1024 - 1);
-      path[1024 - 1] = '\0';
+      strncpy (path, path_start, SOCKETWS_MAX_PATH_SIZE - 1);
+      path[SOCKETWS_MAX_PATH_SIZE - 1] = '\0';
     }
   else
     {


### PR DESCRIPTION
## Summary

Implements #1330

Replaces hardcoded `1024` magic number with `SOCKETWS_MAX_PATH_SIZE` constant in `ws_parse_url()` for better maintainability and code consistency.

## Changes

- Updated `strncpy()` buffer size from hardcoded `1024` to `SOCKETWS_MAX_PATH_SIZE` constant
- Updated NULL termination index to use `SOCKETWS_MAX_PATH_SIZE`
- Updated function documentation to reference constant instead of literal value

## Context

The automated security audit flagged missing NULL termination, but upon investigation, the NULL termination was already present on line 1454. However, the code was using a magic number `1024` instead of the defined constant `SOCKETWS_MAX_PATH_SIZE` (defined in `include/socket/SocketWS-private.h` line 126).

This change improves code quality by:
1. Eliminating magic number anti-pattern
2. Ensuring consistency with the rest of the codebase
3. Making the code more maintainable (changing the buffer size only requires updating one constant)

## Test Plan

- [x] All WebSocket tests pass with sanitizers (`test_websocket`, `test_ws_integration`, `test_websocket_h2`)
- [x] Full test suite passes (114/115 tests - one pre-existing flaky test timeout unrelated to this change)
- [x] Built with ASan and UBSan enabled
- [x] No new warnings or errors

Closes #1330