### PR TITLE
refactor(quic): clarify SocketQUICConnectionID_set null data behavior

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -61,9 +61,13 @@ SocketQUICConnectionID_set (SocketQUICConnectionID_T *cid, const uint8_t *data,
   if (len > QUIC_CONNID_MAX_LEN)
     return QUIC_CONNID_ERROR_LENGTH;
 
+  /* Fail fast if caller passes len > 0 but data == NULL (programmer error) */
+  if (len > 0 && data == NULL)
+    return QUIC_CONNID_ERROR_NULL;
+
   SocketQUICConnectionID_init (cid);
 
-  if (len > 0 && data != NULL)
+  if (len > 0)
     memcpy (cid->data, data, len);
 
   cid->len = (uint8_t)len;

--- a/src/test/test_quic_connid.c
+++ b/src/test/test_quic_connid.c
@@ -130,6 +130,17 @@ TEST (quic_connid_set_null)
   ASSERT_EQ (res, QUIC_CONNID_ERROR_NULL);
 }
 
+TEST (quic_connid_set_null_data_nonzero_len)
+{
+  SocketQUICConnectionID_T cid;
+
+  /* len > 0 but data == NULL should return error (not create zero-filled CID) */
+  SocketQUICConnectionID_Result res
+      = SocketQUICConnectionID_set (&cid, NULL, 8);
+
+  ASSERT_EQ (res, QUIC_CONNID_ERROR_NULL);
+}
+
 /* ============================================================================
  * Generation Tests
  * ============================================================================


### PR DESCRIPTION
## Summary

Implements #1338 - Clarifies behavior when `len > 0` but `data == NULL` in `SocketQUICConnectionID_set()`.

## Changes

- **Validation**: Return `QUIC_CONNID_ERROR_NULL` when `len > 0` but `data == NULL`
- **Logic simplification**: Removed redundant null check from memcpy (data is now guaranteed non-NULL when `len > 0`)
- **Test coverage**: Added `quic_connid_set_null_data_nonzero_len` test case

## Rationale

Previously, calling `SocketQUICConnectionID_set(&cid, NULL, 8)` would:
1. Skip the memcpy (line 70)
2. Set `cid->len = 8` (line 72)
3. Return `QUIC_CONNID_OK`

This created a connection ID with non-zero length but zero data (from `SocketQUICConnectionID_init()`), which is almost certainly a programmer error rather than an intentional zero-filled CID.

The new behavior fails fast on this invalid input, making debugging easier. Zero-length CIDs (`len=0, data=NULL`) remain valid per QUIC spec.

## Test Plan

- [x] All QUIC tests pass (25/25)
- [x] New test validates error return for `len > 0 && data == NULL`
- [x] Existing test confirms zero-length CIDs still work
- [x] Built and tested with sanitizers enabled

Closes #1338