### PR TITLE
refactor(websocket): replace magic number with SOCKETWS_MAX_PATH_SIZE constant

### DIFF
--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -1380,7 +1380,7 @@ SocketWS_close (SocketWS_T ws, int code, const char *reason)
  * @param url The WebSocket URL (ws:// or wss://)
  * @param[out] host Buffer for hostname (size NI_MAXHOST)
  * @param[out] port Port number (default 80/443)
- * @param[out] path Buffer for path (size 1024)
+ * @param[out] path Buffer for path (size SOCKETWS_MAX_PATH_SIZE)
  * @param[out] use_tls TLS flag (1 for wss://, 0 for ws://)
  * @return 0 on success, -1 on error
  */
@@ -1450,8 +1450,8 @@ ws_parse_url (const char *url, char *host, int *port, char *path, int *use_tls)
 
   if (path_start)
     {
-      strncpy (path, path_start, 1024 - 1);
-      path[1024 - 1] = '\0';
+      strncpy (path, path_start, SOCKETWS_MAX_PATH_SIZE - 1);
+      path[SOCKETWS_MAX_PATH_SIZE - 1] = '\0';
     }
   else
     {


### PR DESCRIPTION
## Summary

Implements #1339 - Replace hardcoded magic number `1024` with the existing `SOCKETWS_MAX_PATH_SIZE` constant in WebSocket URL parsing.

## Changes

- Updated `ws_parse_url()` function documentation to reference `SOCKETWS_MAX_PATH_SIZE` instead of hardcoded `1024`
- Replaced magic numbers in `strncpy()` calls (lines 1453-1454) with `SOCKETWS_MAX_PATH_SIZE - 1`
- Ensures consistency with the buffer declaration on line 1547 which already uses the constant

## Impact

- Improves code maintainability - buffer size can be changed in one place
- Enhances code clarity - self-documenting constant instead of magic number
- Reduces bug risk - eliminates inconsistency between declaration and usage

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] All WebSocket tests pass (test_websocket, test_ws_integration, test_websocket_h2)
- [x] Full test suite passes (114/115 tests, 1 unrelated timeout in test_socketpool)
- [x] No new sanitizer warnings
- [x] Verified no other occurrences of magic number 1024 in path-related code

Closes #1339