### PR TITLE
fix(happyeyeballs): check snprintf return value in DNS error callback

### DIFF
--- a/src/socket/SocketHappyEyeballs.c
+++ b/src/socket/SocketHappyEyeballs.c
@@ -301,8 +301,16 @@ he_dns_callback (SocketDNSResolver_Query_T query,
           return;
         }
 
-      snprintf (he->error_buf, sizeof (he->error_buf),
-                "DNS resolution failed: %s", SocketDNSResolver_strerror (error));
+      int written = snprintf (he->error_buf, sizeof (he->error_buf),
+                              "DNS resolution failed: %s",
+                              SocketDNSResolver_strerror (error));
+      if (written >= (int)sizeof (he->error_buf))
+        {
+          SocketLog_emitf (SOCKET_LOG_WARN, SOCKET_LOG_COMPONENT,
+                           "DNS error message truncated (%d bytes needed, %zu "
+                           "available)",
+                           written, sizeof (he->error_buf));
+        }
       he->dns_error = error;
       he->dns_complete = 1;
       he->dns_query = NULL;


### PR DESCRIPTION
## Summary

Implements #1332 - adds return value checking for `snprintf()` call in `he_dns_callback()` when formatting DNS resolution error messages.

## Changes

- Added `snprintf` return value check in DNS error callback (line 304)
- Log warning when DNS error message is truncated
- Helps debugging by making truncation visible in logs

## Technical Details

When `SocketDNSResolver_strerror(error)` returns a long error message that exceeds the 256-byte `error_buf`, the `snprintf` call will truncate it. This change:

1. Captures the return value from `snprintf`
2. Compares it against the buffer size
3. Logs a warning with `SocketLog_emitf` when truncation occurs

The warning includes both the bytes needed and bytes available to help diagnose buffer sizing issues.

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] `test_happy_eyeballs` passes
- [x] Build succeeds without warnings
- [x] No change in behavior (only adds diagnostic logging)

## Impact

Low - This is a defensive programming improvement that only adds logging. No functional changes to error handling or user-facing behavior.

Closes #1332