### PR TITLE
fix(pipeline): use rg via Bash for TODO scanning

### DIFF
--- a/.claude/commands/pipeline.md
+++ b/.claude/commands/pipeline.md
@@ -66,17 +66,12 @@ Done
 
 ### Steps
 
-1. **Scan for TODO patterns** using Grep:
+1. **Scan for TODO patterns** using Bash with `rg`:
+   ```bash
+   rg "(TODO|FIXME|HACK|XXX|NOTE)" <directory> -n -g "*.c" -g "*.h"
    ```
-   Use Grep tool with pattern:
-   (TODO|FIXME|HACK|XXX|NOTE)\s*[:\-]?\s*
 
-   Options:
-   - path: <directory>
-   - glob: *.{c,h}
-   - output_mode: content
-   - -n: true (show line numbers)
-   ```
+   This is more reliable than the Grep tool which may fail on certain directories.
 
 2. **Parse results** into structured findings:
    - File path


### PR DESCRIPTION
## Summary
- Fix TODO scanning mode in `/pipeline` command to use `rg` via Bash instead of the Grep tool
- The Grep tool was returning no matches even when TODOs exist in files

Fixes #1507

## Test plan
- [x] Verified `rg` finds TODOs in `src/quic/` (10 matches)
- [ ] Run `/pipeline src/quic/ todo` and verify it finds TODOs