### PR TITLE
refactor(proxy): use htons() for network byte order in SOCKS5 port encoding

### DIFF
--- a/src/socket/SocketProxy-socks5.c
+++ b/src/socket/SocketProxy-socks5.c
@@ -573,8 +573,9 @@ proxy_socks5_send_connect (struct SocketProxy_Conn_T *conn)
     }
 
   /* Port (network byte order) */
-  buf[len++] = (unsigned char)((conn->target_port >> 8) & 0xFF);
-  buf[len++] = (unsigned char)(conn->target_port & 0xFF);
+  uint16_t port_nbo = htons(conn->target_port);
+  memcpy(buf + len, &port_nbo, sizeof(port_nbo));
+  len += sizeof(port_nbo);
 
   conn->send_len = len;
   conn->send_offset = 0;


### PR DESCRIPTION
## Summary

Implements #1346

Replaces manual bit-shift port encoding with standard `htons()` for better portability and idiomatic network programming.

## Changes

- Replaced manual bit-shift operations with `htons()` for network byte order conversion
- Used `memcpy()` for safe buffer write instead of individual byte assignments
- More readable and maintainable code while being functionally equivalent

## Location

**File**: `src/socket/SocketProxy-socks5.c`
**Function**: `proxy_socks5_send_connect()`

## Before

```c
buf[len++] = (unsigned char)((conn->target_port >> 8) & 0xFF);
buf[len++] = (unsigned char)(conn->target_port & 0xFF);
```

## After

```c
uint16_t port_nbo = htons(conn->target_port);
memcpy(buf + len, &port_nbo, sizeof(port_nbo));
len += sizeof(port_nbo);
```

## Test Plan

- [x] All proxy tests pass (84/84)
- [x] Proxy integration tests pass
- [x] Tests run with sanitizers enabled (ASan + UBSan)
- [x] Functionally equivalent - no behavior changes

Closes #1346