### PR TITLE
fix(dns): add missing SocketUtil.h include to SocketDNSTransport

### DIFF
--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -37,6 +37,7 @@
 
 #include "core/Arena.h"
 #include "core/SocketTimer.h"
+#include "core/SocketUtil.h"
 #include "dns/SocketDNSDeadServer.h"
 #include "dns/SocketDNSTransport.h"
 #include "dns/SocketDNSWire.h"


### PR DESCRIPTION
## Summary

Fixes #1351 by adding the missing `#include "core/SocketUtil.h"` to SocketDNSTransport.c.

## Problem

The SocketDNSTransport module uses `Socket_get_monotonic_ms()` via the `get_monotonic_ms()` macro (line 131), but was missing the required include for `core/SocketUtil.h` where the function is declared and defined. This caused undefined symbol errors during linking.

## Solution

Added `#include "core/SocketUtil.h"` to the includes section of `src/dns/SocketDNSTransport.c`.

The function `Socket_get_monotonic_ms()` already exists:
- Declared in `include/core/SocketUtil.h` at line 334
- Implemented in `src/core/SocketUtil.c` starting at line 83
- Used throughout the codebase (SocketTimer, SocketRateLimit, SocketSYNProtect, etc.)

This is a simple missing include fix - no new code was needed.

## Changes

- Added `#include "core/SocketUtil.h"` to `src/dns/SocketDNSTransport.c`

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All DNS tests pass (15/15)
- [x] All timer tests pass
- [x] Full test suite passes (114/115 - unrelated timeout)
- [x] Function properly resolves at link time

Closes #1351