### PR TITLE
refactor(socket-iov): extract duplicated timeout calculation logic

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -595,6 +595,47 @@ get_remaining_timeout_ms (int64_t deadline_ms)
   return deadline_ms - Socket_get_monotonic_ms ();
 }
 
+/**
+ * socket_wait_with_timeout - Wait for socket readiness with timeout handling
+ * @fd: File descriptor to wait on
+ * @events: Poll events (POLLIN or POLLOUT)
+ * @timeout_ms: Original timeout value (>0 for deadline, -1 for block, 0 for none)
+ * @deadline_ms: Deadline timestamp from SocketTimeout_deadline_ms()
+ * @op_name: Operation name for error messages ("send" or "recv")
+ *
+ * Returns: 1 if ready, 0 if timeout occurred
+ * Raises: Socket_Failed if poll fails in blocking mode
+ *
+ * Centralizes timeout calculation and wait logic to eliminate duplication.
+ */
+static int
+socket_wait_with_timeout (int fd, short events, int timeout_ms,
+                          int64_t deadline_ms, const char *op_name)
+{
+  int64_t remaining_ms;
+
+  if (timeout_ms > 0)
+    {
+      remaining_ms = get_remaining_timeout_ms (deadline_ms);
+      if (remaining_ms <= 0)
+        return 0; /* Timeout */
+
+      if (SocketCommon_wait_for_fd (fd, events, (int)remaining_ms) <= 0)
+        return 0; /* Timeout or error */
+    }
+  else if (timeout_ms == -1)
+    {
+      /* Block indefinitely */
+      if (SocketCommon_wait_for_fd (fd, events, -1) < 0)
+        {
+          SOCKET_ERROR_FMT ("poll() failed during %s", op_name);
+          RAISE_MODULE_ERROR (Socket_Failed);
+        }
+    }
+
+  return 1; /* Ready */
+}
+
 
 /**
  * socket_send_with_timeout - Send with timeout helper
@@ -615,7 +656,6 @@ socket_send_with_timeout (T socket, const void *buf, size_t len, int timeout_ms)
   const char *ptr;
   int fd;
   volatile int64_t deadline_ms;
-  int64_t remaining_ms;
   ssize_t result;
 
   assert (socket);
@@ -632,25 +672,9 @@ socket_send_with_timeout (T socket, const void *buf, size_t len, int timeout_ms)
   {
     while (total_sent < len)
       {
-        /* Check remaining time */
-        if (timeout_ms > 0)
-          {
-            remaining_ms = get_remaining_timeout_ms (deadline_ms);
-            if (remaining_ms <= 0)
-              break; /* Timeout */
-
-            if (SocketCommon_wait_for_fd (fd, POLLOUT, (int)remaining_ms) <= 0)
-              break; /* Timeout or error */
-          }
-        else if (timeout_ms == -1)
-          {
-            /* Block indefinitely */
-            if (SocketCommon_wait_for_fd (fd, POLLOUT, -1) < 0)
-              {
-                SOCKET_ERROR_FMT ("poll() failed during send");
-                RAISE_MODULE_ERROR (Socket_Failed);
-              }
-          }
+        /* Wait for socket to be ready with timeout handling */
+        if (!socket_wait_with_timeout (fd, POLLOUT, timeout_ms, deadline_ms, "send"))
+          break; /* Timeout */
 
         result = Socket_send (socket, ptr + total_sent, len - total_sent);
         if (result > 0)
@@ -687,7 +711,6 @@ socket_recv_with_timeout (T socket, void *buf, size_t len, int timeout_ms)
   char *ptr;
   int fd;
   volatile int64_t deadline_ms;
-  int64_t remaining_ms;
   ssize_t result;
 
   assert (socket);
@@ -704,25 +727,9 @@ socket_recv_with_timeout (T socket, void *buf, size_t len, int timeout_ms)
   {
     while (total_received < len)
       {
-        /* Check remaining time */
-        if (timeout_ms > 0)
-          {
-            remaining_ms = get_remaining_timeout_ms (deadline_ms);
-            if (remaining_ms <= 0)
-              break; /* Timeout */
-
-            if (SocketCommon_wait_for_fd (fd, POLLIN, (int)remaining_ms) <= 0)
-              break; /* Timeout or error */
-          }
-        else if (timeout_ms == -1)
-          {
-            /* Block indefinitely */
-            if (SocketCommon_wait_for_fd (fd, POLLIN, -1) < 0)
-              {
-                SOCKET_ERROR_FMT ("poll() failed during recv");
-                RAISE_MODULE_ERROR (Socket_Failed);
-              }
-          }
+        /* Wait for socket to be ready with timeout handling */
+        if (!socket_wait_with_timeout (fd, POLLIN, timeout_ms, deadline_ms, "recv"))
+          break; /* Timeout */
 
         result = Socket_recv (socket, ptr + total_received, len - total_received);
         if (result > 0)


### PR DESCRIPTION
## Summary

Implements #1355

Eliminates code duplication by introducing a `socket_wait_with_timeout()` helper function that centralizes timeout handling logic previously duplicated between `socket_send_with_timeout()` and `socket_recv_with_timeout()`.

## Changes

- Added `socket_wait_with_timeout()` helper function to handle timeout calculation and fd waiting logic
- Refactored `socket_send_with_timeout()` to use the new helper
- Refactored `socket_recv_with_timeout()` to use the new helper
- Removed duplicate `timeout_ms > 0` and `timeout_ms == -1` handling code
- Removed unused `remaining_ms` local variables from both functions

## Benefits

- Reduces code duplication (~20 lines eliminated)
- Improves maintainability by having single source of truth for timeout logic
- Makes timeout behavior easier to test and debug
- Follows DRY principles

## Test Plan

- [x] Tests pass with sanitizers (114 of 115 tests passed)
- [x] test_socket: 299/299 tests passed
- [x] test_socketio: 21/21 tests passed
- [x] Build succeeds with -Wall -Wextra -Werror
- [x] No new compiler warnings
- [x] Code follows project conventions (function naming, documentation)

Note: test_socketpool timeout is a pre-existing issue unrelated to this refactoring.

Closes #1355