### PR TITLE
feat(quic): add O(1) sequence number lookup to SocketQUICConnectionIDPool

### DIFF
--- a/include/quic/SocketQUICConnectionID-pool.h
+++ b/include/quic/SocketQUICConnectionID-pool.h
@@ -77,9 +77,10 @@ typedef struct SocketQUICConnectionIDEntry
   int is_used;      /**< Non-zero if currently in use for a path */
   uint64_t used_at; /**< Monotonic timestamp when last used (ms) */
 
-  struct SocketQUICConnectionIDEntry *hash_next; /**< Hash chain pointer */
-  struct SocketQUICConnectionIDEntry *list_next; /**< Sequence list pointer */
-  struct SocketQUICConnectionIDEntry *list_prev; /**< Sequence list pointer */
+  struct SocketQUICConnectionIDEntry *hash_next;     /**< CID hash chain pointer */
+  struct SocketQUICConnectionIDEntry *seq_hash_next; /**< Sequence hash chain ptr */
+  struct SocketQUICConnectionIDEntry *list_next;     /**< Sequence list pointer */
+  struct SocketQUICConnectionIDEntry *list_prev;     /**< Sequence list pointer */
 
 } SocketQUICConnectionIDEntry_T;
 
@@ -94,7 +95,10 @@ typedef struct SocketQUICConnectionIDPool
   Arena_T arena; /**< Memory arena for allocations */
 
   SocketQUICConnectionIDEntry_T *hash_table[QUIC_CONNID_POOL_HASH_SIZE];
-  /**< Hash table for CID lookup */
+  /**< Hash table for O(1) CID byte lookup */
+
+  SocketQUICConnectionIDEntry_T *sequence_table[QUIC_CONNID_POOL_HASH_SIZE];
+  /**< Hash table for O(1) sequence number lookup */
 
   SocketQUICConnectionIDEntry_T *list_head; /**< First entry by sequence */
   SocketQUICConnectionIDEntry_T *list_tail; /**< Last entry by sequence */


### PR DESCRIPTION
## Summary
- Optimize `SocketQUICConnectionIDPool_lookup_sequence()` from O(n) linear search to O(1) hash table lookup
- Memory overhead: ~256 bytes (32 pointers) per pool

## Changes
- **Added sequence hash table**: New `sequence_table[32]` for O(1) sequence lookups
- **Entry structure**: Added `seq_hash_next` pointer for sequence hash chain
- **Hash function**: Implemented `hash_sequence()` using multiplicative hash with seed mixing
- **Index maintenance**: Added `sequence_hash_insert()` and `sequence_hash_remove()` helpers
- **Updated operations**: `add_with_sequence()`, `remove()`, and `purge_retired()` maintain sequence index
- **DoS protection**: Chain length checks prevent hash collision attacks

## Performance
| Operation | Before | After |
|-----------|--------|-------|
| lookup_sequence() | O(n) | O(1) |
| Memory overhead | 0 | ~256 bytes |

## Test plan
- [x] All 20 QUIC connection ID pool tests pass
- [x] Full test suite passes with ASan/UBSan
- [x] Sequence lookup test validates O(1) behavior

Fixes #1340