### PR TITLE
feat(http): add static assertions for HPACK Huffman encode table safety

### DIFF
--- a/src/http/SocketHPACK-huffman.c
+++ b/src/http/SocketHPACK-huffman.c
@@ -310,6 +310,12 @@ const HPACK_HuffmanSymbol hpack_huffman_encode[HPACK_HUFFMAN_SYMBOLS] = {
 };
 /* clang-format on */
 
+/* Verify table size matches expected symbol count */
+_Static_assert(sizeof(hpack_huffman_encode) / sizeof(hpack_huffman_encode[0]) == 257,
+               "Huffman encode table must have exactly 257 entries");
+_Static_assert(HPACK_HUFFMAN_SYMBOLS == 257,
+               "HPACK_HUFFMAN_SYMBOLS must be 257 for unsigned char safety");
+
 /* ============================================================================
  * Decode Tables
  *


### PR DESCRIPTION
## Summary

Implements #1369 - adds compile-time verification for HPACK Huffman encode table safety invariants.

## Changes

- Added `_Static_assert` to verify `hpack_huffman_encode` array has exactly 257 entries
- Added `_Static_assert` to verify `HPACK_HUFFMAN_SYMBOLS == 257` for unsigned char safety
- Assertions placed in `/home/tetsuo/git/tetsuo-socket-issue-1369/src/http/SocketHPACK-huffman.c` after the table definition (line 314-317)

## Security Impact

These assertions prevent potential buffer overflow vulnerabilities by ensuring:
1. The encode table covers all possible `unsigned char` values (0-255)
2. The EOS symbol (256) is properly included
3. Any future modifications that break these invariants will fail at compile time

## Test Plan

- [x] Tests pass with sanitizers (`test_hpack`, `test_http2*`)
- [x] Verified assertion triggers on intentional breakage (changed 257 to 256)
- [x] Compilation succeeds with correct values
- [x] No behavioral changes - purely compile-time safety hardening

Closes #1369