### PR TITLE
refactor(quic): replace hardcoded 0x1F with QUIC_HP_SHORT_HEADER_MASK

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -515,7 +515,7 @@ apply_header_protection (uint8_t *packet, size_t header_len,
   else
     {
       /* Short header: mask bottom 5 bits */
-      packet[0] ^= (mask[0] & 0x1F);
+      packet[0] ^= (mask[0] & QUIC_HP_SHORT_HEADER_MASK);
     }
 
   /* Get packet number length from first byte */


### PR DESCRIPTION
## Summary

Implements #1387

## Changes

- Replaced hardcoded hex constant `0x1F` with `QUIC_HP_SHORT_HEADER_MASK` in `src/quic/SocketQUICPacket-initial.c` (line 518)
- The constant is already defined in `include/quic/SocketQUICConstants.h` (line 258)

## Benefits

- Improves code clarity by using semantic constant name
- Aligns with project's constant organization pattern
- Makes the code more maintainable and self-documenting

## Test Plan

- [x] Tests pass with sanitizers (115/116 tests passed, 1 unrelated timeout)
- [x] All QUIC-related tests passed successfully
- [x] Build completes without warnings

Closes #1387