### PR TITLE
fix(poll): use RETURN macro in EXCEPT block to properly unwind exception stack

### DIFF
--- a/src/poll/SocketPoll.c
+++ b/src/poll/SocketPoll.c
@@ -497,7 +497,7 @@ initialize_poll_async (T poll)
   EXCEPT (SocketAsync_Failed)
   {
     poll->async = NULL; /* Graceful degradation - async is optional */
-    return;
+    RETURN;
   }
   END_TRY;
 


### PR DESCRIPTION
## Summary

Fixes #1393 - Exception stack leak in `src/poll/SocketPoll.c` at line 500.

## Changes

- Replaced bare `return` with `RETURN` macro in `initialize_poll_async()` EXCEPT block
- Ensures proper exception stack unwinding when `SocketAsync_new` fails

## Root Cause

The bare `return` statement in the EXCEPT block at line 500 would exit the function before `END_TRY` could pop the exception frame from `Except_stack`. This left the exception stack pointing to deallocated stack memory, creating a use-after-free vulnerability.

## Solution

The `RETURN` macro (defined in `include/core/Except.h` lines 112-115) properly pops the exception frame before returning, maintaining exception stack integrity:

```c
#define RETURN                                                                \
  switch (Except_stack = ((Except_Frame *)Except_stack)->prev, 0)             \
  default:                                                                    \
    return
```

## Impact

- Prevents potential crashes from dereferencing dangling exception stack pointer
- Maintains thread-local exception stack integrity
- No functional change to graceful degradation behavior (async is still optional)

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] 114 of 116 tests pass (2 unrelated intermittent failures: test_socketpool timeout, test_http_integration)
- [x] No new sanitizer errors introduced
- [x] Exception safety improvement verified via code review

Closes #1393