### PR TITLE
refactor(quic): replace hardcoded 8 with sizeof(uint64_t) in packet number XOR

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -542,8 +542,8 @@ construct_nonce (const uint8_t *iv, uint64_t pn, uint8_t *nonce)
 {
   memcpy (nonce, iv, QUIC_INITIAL_IV_LEN);
 
-  /* XOR packet number into last 8 bytes of IV (big-endian) */
-  for (int i = 0; i < 8; i++)
+  /* XOR packet number into last bytes of IV (big-endian) */
+  for (int i = 0; i < (int)sizeof(uint64_t); i++)
     nonce[QUIC_INITIAL_IV_LEN - 1 - i] ^= (uint8_t)((pn >> (8 * i)) & 0xFF);
 }
 


### PR DESCRIPTION
## Summary

Implements #1388 - Replace hardcoded magic number 8 with sizeof(uint64_t) for clarity in packet number nonce construction.

## Changes

- Updated `construct_nonce()` in `src/quic/SocketQUICPacket-initial.c` to use `sizeof(uint64_t)` instead of hardcoded 8
- Updated comment to reflect the change ("last bytes" instead of "last 8 bytes")

## Benefits

- Makes the relationship to uint64_t packet number type explicit
- Self-documenting code
- More robust if packet number type ever changes

## Test Plan

- [x] All QUIC tests pass (test_quic_initial, test_quic_packet, test_quic_crypto_frame_encode)
- [x] Full test suite passes with sanitizers (114/114 tests, excluding pre-existing flaky test_socketpool)
- [x] Build succeeds with ASan/UBSan enabled

Closes #1388