### PR TITLE
refactor(tls): move DTLS shutdown timeout to config header

### DIFF
--- a/include/tls/SocketDTLSConfig.h
+++ b/include/tls/SocketDTLSConfig.h
@@ -277,6 +277,20 @@
 #define SOCKET_DTLS_DEFAULT_HANDSHAKE_TIMEOUT_MS 30000
 #endif
 
+/* Default shutdown timeout (total time allowed for graceful shutdown) */
+/**
+ * @brief Default timeout for DTLS shutdown operation (ms).
+ * @ingroup dtls_config
+ * @details Timeout for graceful close_notify exchange during shutdown.
+ * Conservative 5000ms (5 seconds) accounts for network latency and
+ * retransmissions. Used by SocketDTLS_shutdown() internal timeout.
+ * @see SocketDTLS_shutdown() for shutdown operation details.
+ * @see SOCKET_DTLS_MAX_TIMEOUT_MS for maximum retransmission timeout.
+ */
+#ifndef SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS
+#define SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS 5000
+#endif
+
 /* Maximum number of retransmissions before giving up */
 #ifndef SOCKET_DTLS_MAX_RETRANSMITS
 #define SOCKET_DTLS_MAX_RETRANSMITS 12

--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -54,11 +54,6 @@ const Except_T SocketDTLS_TimeoutExpired
 const Except_T SocketDTLS_ShutdownFailed
     = { .type = &SocketDTLS_ShutdownFailed, .reason = "DTLS shutdown failed" };
 
-#ifndef SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS
-#define SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS                               \
-  5000 /* ms, configurable via compile-time override */
-#endif
-
 SOCKET_DECLARE_MODULE_EXCEPTION (SocketDTLS);
 
 /**


### PR DESCRIPTION
## Summary

Implements #1400

Moves the hardcoded `SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS` constant from the source file to the public configuration header for better maintainability and consistency.

## Changes

- **Added** `SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS` to `include/tls/SocketDTLSConfig.h` with full Doxygen documentation
- **Removed** local definition from `src/tls/SocketDTLS.c`
- **Preserved** timeout value of 5000ms (5 seconds) for graceful shutdown
- **Follows** existing pattern for DTLS timeout constants (handshake, retransmission, etc.)

## Test Plan

- [x] All DTLS tests pass with sanitizers enabled
- [x] Build succeeds without warnings
- [x] Constant is properly accessible and used in shutdown implementation
- [x] Follows project conventions for configuration headers

## Location

The constant is now defined in `include/tls/SocketDTLSConfig.h` alongside other DTLS timeout constants:
- `SOCKET_DTLS_INITIAL_TIMEOUT_MS` (1000ms)
- `SOCKET_DTLS_MAX_TIMEOUT_MS` (60000ms)
- `SOCKET_DTLS_DEFAULT_HANDSHAKE_TIMEOUT_MS` (30000ms)
- `SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS` (5000ms) ← **NEW**

Closes #1400