### PR TITLE
refactor(dtls): replace magic number with named constant for shutdown poll timeout

### DIFF
--- a/include/tls/SocketDTLSConfig.h
+++ b/include/tls/SocketDTLSConfig.h
@@ -291,6 +291,16 @@
 #define SOCKET_DTLS_DEFAULT_SHUTDOWN_TIMEOUT_MS 5000
 #endif
 
+/**
+ * @brief Poll interval during DTLS shutdown (ms).
+ * @details Interval between poll() calls when waiting for close_notify
+ * during graceful shutdown. Shorter intervals provide faster response
+ * but increase CPU usage.
+ */
+#ifndef SOCKET_DTLS_SHUTDOWN_POLL_INTERVAL_MS
+#define SOCKET_DTLS_SHUTDOWN_POLL_INTERVAL_MS 1000
+#endif
+
 /* Maximum number of retransmissions before giving up */
 #ifndef SOCKET_DTLS_MAX_RETRANSMITS
 #define SOCKET_DTLS_MAX_RETRANSMITS 12

--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -1186,7 +1186,7 @@ static int
 dtls_shutdown_poll_wait (int fd, int64_t deadline_ms)
 {
   struct pollfd pfd = { .fd = fd, .events = POLLIN | POLLOUT };
-  int poll_tmo = SocketTimeout_poll_timeout (1000, deadline_ms);
+  int poll_tmo = SocketTimeout_poll_timeout (SOCKET_DTLS_SHUTDOWN_POLL_INTERVAL_MS, deadline_ms);
   int pr = poll (&pfd, 1, poll_tmo);
 
   if (pr < 0 && errno != EINTR)


### PR DESCRIPTION
## Summary

Implements #1404 - Replaces hardcoded magic number `1000` with named constant `SOCKET_DTLS_SHUTDOWN_POLL_INTERVAL_MS` in DTLS shutdown poll timeout.

## Changes

- Added `SOCKET_DTLS_SHUTDOWN_POLL_INTERVAL_MS` constant (1000ms) following existing pattern
- Replaced magic number in `dtls_shutdown_poll_wait` function with the new constant
- Improved code readability and maintainability

## Test Plan

- [x] Tests pass with sanitizers (99% pass rate, 1 known flaky timeout)
- [x] DTLS tests specifically passed successfully
- [x] Build completes without warnings or errors

Closes #1404