### PR TITLE
docs(socket-iov): enhance SOCKET_SPLICE_CHUNK_SIZE documentation

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -44,8 +44,21 @@
 #include "socket/SocketIO.h"
 
 /**
- * Default chunk size for splice operations (64KB)
- * This provides good performance for socket-to-socket transfers
+ * Default chunk size for splice operations (64KB = 16 pages)
+ *
+ * This value was chosen because:
+ * - Matches Linux default pipe buffer size (16 * PAGE_SIZE on x86-64)
+ * - Aligns with typical TCP receive window size
+ * - Balances memory usage vs throughput for socket-to-socket transfers
+ * - Minimizes splice() system calls while avoiding excessive memory use
+ *
+ * Performance characteristics:
+ * - Smaller values (<32KB): More syscalls, lower memory, worse throughput
+ * - Larger values (>128KB): Better throughput, higher memory, diminishing returns
+ *
+ * This can be overridden at compile time for specific workloads:
+ *   -DSOCKET_SPLICE_CHUNK_SIZE=131072  (128KB for high-throughput proxies)
+ *   -DSOCKET_SPLICE_CHUNK_SIZE=32768   (32KB for memory-constrained systems)
  */
 #ifndef SOCKET_SPLICE_CHUNK_SIZE
 #define SOCKET_SPLICE_CHUNK_SIZE 65536


### PR DESCRIPTION
## Summary

Implements #1365 - Enhanced documentation for SOCKET_SPLICE_CHUNK_SIZE macro.

## Changes

- Added comprehensive documentation explaining the 64KB default chunk size choice
- Documented performance characteristics and trade-offs
- Provided compile-time override examples for custom workloads
- No functional changes - documentation only

## Benefits

- Helps developers understand the rationale behind the magic constant
- Enables informed performance tuning for specific use cases
- Improves code maintainability

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All tests pass (115/116 - 1 known flaky test timeout)
- [x] Documentation-only change, no functional impact

Closes #1365