### PR TITLE
refactor(socket-iov): use centralized SocketTimeout_remaining_ms helper

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -676,18 +676,6 @@ Socket_recvvall (T socket, struct iovec *iov, int iovcnt)
 /* ==================== I/O Operations with Timeout ==================== */
 
 /**
- * get_remaining_timeout_ms - Get remaining time until deadline
- * @deadline_ms: Deadline timestamp from SocketTimeout_deadline_ms()
- *
- * Returns: Remaining milliseconds (may be negative if past deadline)
- */
-static int64_t
-get_remaining_timeout_ms (int64_t deadline_ms)
-{
-  return deadline_ms - Socket_get_monotonic_ms ();
-}
-
-/**
  * socket_wait_with_timeout - Wait for socket readiness with timeout handling
  * @fd: File descriptor to wait on
  * @events: Poll events (POLLIN or POLLOUT)
@@ -708,7 +696,7 @@ socket_wait_with_timeout (int fd, short events, int timeout_ms,
 
   if (timeout_ms > 0)
     {
-      remaining_ms = get_remaining_timeout_ms (deadline_ms);
+      remaining_ms = SocketTimeout_remaining_ms (deadline_ms);
       if (remaining_ms <= 0)
         return 0; /* Timeout */
 


### PR DESCRIPTION
## Summary

Implements #1358

Replaces the local `get_remaining_timeout_ms()` function in Socket-iov.c with the centralized `SocketTimeout_remaining_ms()` helper from SocketUtil.h.

## Changes

- **Removed**: Local `get_remaining_timeout_ms()` function (lines 679-688)
- **Updated**: Call site at line 711 to use `SocketTimeout_remaining_ms()`

## Benefits

1. **Consistency**: Uses standard timeout utilities across codebase
2. **Correctness**: Handles edge cases (deadline=0, negative remaining)
3. **Maintainability**: Single source of truth for timeout calculations
4. **DRY**: Eliminates 13 lines of duplicate logic

## Test Plan

- [x] Tests pass with sanitizers (ASan/UBSan)
- [x] All timeout-related tests pass
- [x] Socket I/O operations tested
- [x] Build successful with -Werror

## Impact

- Reduces code by 13 lines
- Improves timeout calculation correctness
- No functional change for normal cases
- Better edge case handling (no deadline, expired deadlines)

Closes #1358