### PR TITLE
fix(quic): mark result variable as volatile for exception safety

### DIFF
--- a/src/quic/SocketQUICAddrValidation.c
+++ b/src/quic/SocketQUICAddrValidation.c
@@ -330,7 +330,7 @@ SocketQUICAddrValidation_validate_token (const uint8_t *token,
                                           const struct sockaddr *addr,
                                           const uint8_t *secret)
 {
-  SocketQUICAddrValidation_Result result;
+  volatile SocketQUICAddrValidation_Result result;
   uint64_t token_timestamp;
 
   /* Validate inputs */


### PR DESCRIPTION
## Summary

Implements #1375

Mark the `result` variable in `SocketQUICAddrValidation_validate_token()` as `volatile` to comply with exception handling safety guidelines.

## Changes

- **File**: `src/quic/SocketQUICAddrValidation.c`
- **Line 333**: Changed `SocketQUICAddrValidation_Result result;` to `volatile SocketQUICAddrValidation_Result result;`

## Rationale

The `result` variable is modified multiple times (lines 343, 353, 360, 367) throughout the function and the function calls `compute_and_verify_token_hmac()` which uses `TRY/EXCEPT` blocks internally. According to project exception safety guidelines in CLAUDE.md:

> Variables modified in TRY blocks must be volatile

This ensures correct behavior with the setjmp/longjmp exception mechanism and prevents potential optimization issues.

## Test Plan

- [x] Tests pass with sanitizers enabled (`ENABLE_SANITIZERS=ON`)
- [x] Specifically, `test_quic_addr_validation` passes
- [x] All 115 tests passed (1 timeout unrelated to this change)
- [x] No functional changes, only adding `volatile` qualifier

Closes #1375