### PR TITLE
feat(quic): add NULL pointer validation in encode_token_param() and encode_connid_param()

### DIFF
--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -176,6 +176,10 @@ encode_connid_param (uint8_t *buf, size_t buf_size, uint64_t id,
   size_t pos = 0;
   size_t len;
 
+  /* Validate inputs */
+  if (buf == NULL || cid == NULL)
+    return 0;
+
   /* Encode parameter ID */
   len = SocketQUICVarInt_encode (id, buf + pos, buf_size - pos);
   if (len == 0)
@@ -206,6 +210,10 @@ encode_token_param (uint8_t *buf, size_t buf_size, uint64_t id,
 {
   size_t pos = 0;
   size_t len;
+
+  /* Validate inputs */
+  if (buf == NULL || (token_len > 0 && token == NULL))
+    return 0;
 
   /* Encode parameter ID */
   len = SocketQUICVarInt_encode (id, buf + pos, buf_size - pos);


### PR DESCRIPTION
## Summary

Implements #1360 by adding NULL pointer validation to internal encoding helper functions.

## Changes

- Added NULL validation to `encode_token_param()` in `src/quic/SocketQUICTransportParams.c`
  - Validates `buf` is non-NULL
  - Validates `token` is non-NULL when `token_len > 0`
- Added NULL validation to `encode_connid_param()` in the same file
  - Validates `buf` and `cid` are non-NULL

## Rationale

While current callers always pass valid pointers (QUIC_STATELESS_RESET_TOKEN_LEN), these checks provide defense-in-depth and make the API contract explicit for future callers. This prevents potential NULL pointer dereference vulnerabilities.

## Test Plan

- [x] All existing tests pass with sanitizers enabled (36/36 QUIC transport params tests)
- [x] Full test suite passes (114/116 tests, 2 pre-existing failures unrelated to changes)
- [x] Built with ASan and UBSan enabled
- [x] No memory leaks detected

Closes #1360