### PR TITLE
fix(quic): add integer overflow protection in packet number decoding

### DIFF
--- a/src/quic/SocketQUICPacket.c
+++ b/src/quic/SocketQUICPacket.c
@@ -761,6 +761,11 @@ SocketQUICPacket_decode_pn (uint32_t truncated_pn, uint8_t pn_length,
   uint64_t pn_mask;
   uint64_t candidate_pn;
 
+  /* Validate pn_length to prevent integer overflow in shift operation */
+  if (pn_length < QUIC_PACKET_NUMBER_MIN_LEN
+      || pn_length > QUIC_PACKET_NUMBER_MAX_LEN)
+    return 0;
+
   /* Calculate the expected packet number window */
   expected_pn = largest_pn + 1;
   pn_win = (uint64_t)1 << (pn_length * 8);

--- a/src/test/test_quic_packet.c
+++ b/src/test/test_quic_packet.c
@@ -675,6 +675,28 @@ TEST (quic_packet_pn_roundtrip)
   ASSERT_EQ (decoded, original_pn);
 }
 
+TEST (quic_packet_decode_pn_overflow_protection)
+{
+  /* Test that invalid pn_length values are rejected to prevent overflow */
+  uint64_t result;
+
+  /* pn_length = 0 (too small) */
+  result = SocketQUICPacket_decode_pn (0x42, 0, 0);
+  ASSERT_EQ (result, 0);
+
+  /* pn_length = 5 (too large, would cause 40-bit shift) */
+  result = SocketQUICPacket_decode_pn (0x42, 5, 0);
+  ASSERT_EQ (result, 0);
+
+  /* pn_length = 8 (would cause 64-bit shift - undefined behavior) */
+  result = SocketQUICPacket_decode_pn (0x42, 8, 0);
+  ASSERT_EQ (result, 0);
+
+  /* pn_length = 255 (max uint8_t, would cause massive shift) */
+  result = SocketQUICPacket_decode_pn (0x42, 255, 0);
+  ASSERT_EQ (result, 0);
+}
+
 /* ============================================================================
  * Utility Function Tests
  * ============================================================================


### PR DESCRIPTION
## Summary

Implements #1374 - Adds input validation to `SocketQUICPacket_decode_pn()` to prevent undefined behavior from integer overflow in bit shift operations.

## Changes

- **src/quic/SocketQUICPacket.c**: Added validation at the start of `SocketQUICPacket_decode_pn()` to check that `pn_length` is within the valid RFC 9000 range (1-4 bytes)
- **src/test/test_quic_packet.c**: Added `test_quic_packet_decode_pn_overflow_protection` test case to verify rejection of invalid pn_length values (0, 5, 8, 255)

## Security Impact

Without this fix, an attacker providing a malformed QUIC packet with `pn_length >= 8` could trigger undefined behavior through the shift operation `(uint64_t)1 << (pn_length * 8)`. Per C11 §6.5.7, shifting by 64 or more bits is undefined.

The fix follows the existing pattern used by `validate_pn_length()` helper (called by builder functions) and applies the same validation to the decode path.

## Test Plan

- [x] All 26 QUIC test suites pass
- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] New test verifies overflow protection for edge cases
- [x] Existing packet number encoding/decoding tests still pass

Closes #1374