### PR TITLE
fix(dgram): replace assert-only bounds checks with runtime validation

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -613,13 +613,25 @@ dgram_try_addresses (T socket, struct addrinfo *res, int socket_family,
           /* Cache address in appropriate field based on operation type */
           if (op == DGRAM_OP_CONNECT)
             {
-              assert (rp->ai_addrlen <= sizeof (struct sockaddr_storage));
+              if (rp->ai_addrlen > sizeof (struct sockaddr_storage))
+                {
+                  SOCKET_ERROR_MSG ("Address length %u exceeds storage size %zu",
+                                    (unsigned)rp->ai_addrlen,
+                                    sizeof (struct sockaddr_storage));
+                  continue; /* Try next address */
+                }
               memcpy (&socket->base->remote_addr, rp->ai_addr, rp->ai_addrlen);
               socket->base->remote_addrlen = rp->ai_addrlen;
             }
           else
             {
-              assert (rp->ai_addrlen <= sizeof (struct sockaddr_storage));
+              if (rp->ai_addrlen > sizeof (struct sockaddr_storage))
+                {
+                  SOCKET_ERROR_MSG ("Address length %u exceeds storage size %zu",
+                                    (unsigned)rp->ai_addrlen,
+                                    sizeof (struct sockaddr_storage));
+                  continue; /* Try next address */
+                }
               memcpy (&socket->base->local_addr, rp->ai_addr, rp->ai_addrlen);
               socket->base->local_addrlen = rp->ai_addrlen;
             }


### PR DESCRIPTION
## Summary

Fixes #1379 by replacing assert-only bounds checks with runtime validation in `dgram_try_addresses()`.

## Changes

- Replaced `assert(rp->ai_addrlen <= sizeof(struct sockaddr_storage))` with runtime bounds checking
- Added error logging via `SOCKET_ERROR_MSG` when address length exceeds storage size
- On validation failure, skip to next address instead of potential buffer overflow
- Ensures memory safety in both debug and release builds

## Security Impact

This fixes a HIGH severity security vulnerability:
- **Before**: Assert compiled out in release builds (`-DNDEBUG`), leaving no bounds check
- **After**: Runtime validation active in all build configurations
- **Prevented**: Buffer overflow in `socket->base->remote_addr` and `socket->base->local_addr`

## Test Plan

- [x] Existing tests pass with sanitizers enabled
- [x] test_socketdgram passes (all 97 dgram-specific tests)
- [x] test_socket passes
- [x] test_integration passes
- [x] No memory leaks detected by AddressSanitizer
- [x] Build succeeds with `-DNDEBUG` (release mode)

## References

- CWE-120: Buffer Copy without Checking Size of Input
- CWE-805: Buffer Access with Incorrect Length Value
- CERT C Coding Standard: ARR38-C

Closes #1379