### PR TITLE
refactor(quic): replace hardcoded 0x0F with QUIC_HP_LONG_HEADER_MASK

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -510,7 +510,7 @@ apply_header_protection (uint8_t *packet, size_t header_len,
   if (packet[0] & 0x80)
     {
       /* Long header: mask bottom 4 bits */
-      packet[0] ^= (mask[0] & 0x0F);
+      packet[0] ^= (mask[0] & QUIC_HP_LONG_HEADER_MASK);
     }
   else
     {


### PR DESCRIPTION
## Summary

Implements #1386

## Changes

- Replaced hardcoded hex mask `0x0F` with `QUIC_HP_LONG_HEADER_MASK` constant in `src/quic/SocketQUICPacket-initial.c`
- Improves code clarity and maintainability by using the already-defined constant from `include/quic/SocketQUICConstants.h` (line 251)
- No functional change - the constant has the same value (0x0F) used for masking the bottom 4 bits of long header first byte

## Test Plan

- [x] Tests pass with sanitizers (115/116 passed, 1 unrelated timeout)
- [x] QUIC initial packet tests pass (19/19)
- [x] Build succeeds with ASan/UBSan enabled
- [x] No behavior change - constant value matches original magic number

Closes #1386