### PR TITLE
fix(dgram): replace assert with runtime bounds check for address length

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -613,13 +613,25 @@ dgram_try_addresses (T socket, struct addrinfo *res, int socket_family,
           /* Cache address in appropriate field based on operation type */
           if (op == DGRAM_OP_CONNECT)
             {
-              assert (rp->ai_addrlen <= sizeof (struct sockaddr_storage));
+              if (rp->ai_addrlen > sizeof (struct sockaddr_storage))
+                {
+                  SOCKET_ERROR_MSG ("Address length %u exceeds storage size %zu",
+                                    rp->ai_addrlen,
+                                    sizeof (struct sockaddr_storage));
+                  continue; /* Try next address */
+                }
               memcpy (&socket->base->remote_addr, rp->ai_addr, rp->ai_addrlen);
               socket->base->remote_addrlen = rp->ai_addrlen;
             }
           else
             {
-              assert (rp->ai_addrlen <= sizeof (struct sockaddr_storage));
+              if (rp->ai_addrlen > sizeof (struct sockaddr_storage))
+                {
+                  SOCKET_ERROR_MSG ("Address length %u exceeds storage size %zu",
+                                    rp->ai_addrlen,
+                                    sizeof (struct sockaddr_storage));
+                  continue; /* Try next address */
+                }
               memcpy (&socket->base->local_addr, rp->ai_addr, rp->ai_addrlen);
               socket->base->local_addrlen = rp->ai_addrlen;
             }


### PR DESCRIPTION
## Summary

Implements #1379

Replaces assert-only bounds checks with runtime validation in `dgram_try_addresses()` to ensure production builds properly validate address lengths before memcpy operations.

## Changes

- **src/socket/SocketDgram.c** (lines 616-637):
  - Replace `assert()` with runtime `if()` check for `ai_addrlen` validation
  - Log error message via `SOCKET_ERROR_MSG` when bounds exceeded
  - Continue to next address instead of undefined behavior in release builds
  - Applies to both `DGRAM_OP_CONNECT` (remote_addr) and `DGRAM_OP_BIND` (local_addr)

## Security Impact

- **Prevents buffer overflow** in release builds where asserts are disabled (`-DNDEBUG`)
- **Protects against memory corruption** of socket base structure
- **Defense-in-depth**: Validates even if getaddrinfo returns unexpected values
- **CWE-120**: Buffer Copy without Checking Size of Input
- **CWE-805**: Buffer Access with Incorrect Length Value

## Test Plan

- [x] Tests pass with sanitizers (AddressSanitizer + UBSan)
- [x] All socket-related tests pass (test_socketdgram, test_socket, etc.)
- [x] No new memory leaks detected
- [x] Existing test coverage validates fix

Closes #1379