### PR TITLE
refactor(quic): replace magic number 4 with QUIC_HP_SAMPLE_OFFSET

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -569,10 +569,10 @@ remove_header_protection (uint8_t *packet, size_t pn_offset,
   int result = -1;
 
   /* Sample location: 4 bytes after the start of PN field */
-  sample = packet + pn_offset + 4;
+  sample = packet + pn_offset + QUIC_HP_SAMPLE_OFFSET;
 
   /* Ensure we have enough bytes for the sample */
-  if (pn_offset + 4 + QUIC_HP_SAMPLE_LEN > packet_len)
+  if (pn_offset + QUIC_HP_SAMPLE_OFFSET + QUIC_HP_SAMPLE_LEN > packet_len)
     return -1;
 
   /* Generate mask using AES-ECB */
@@ -802,7 +802,7 @@ SocketQUICInitial_protect (uint8_t *packet, size_t *packet_len,
   *packet_len += QUIC_INITIAL_TAG_LEN;
 
   /* Get sample for header protection (4 bytes after PN) */
-  sample = payload + (4 - pn_length);
+  sample = payload + (QUIC_HP_SAMPLE_OFFSET - pn_length);
 
   /* Apply header protection */
   if (apply_header_protection (packet, header_len, sample, hp_key) < 0)


### PR DESCRIPTION
## Summary

Implements #1384 by replacing hardcoded magic number 4 with the named constant `QUIC_HP_SAMPLE_OFFSET` in header protection sample offset calculations.

## Changes

- **File**: `src/quic/SocketQUICPacket-initial.c`
- **Lines Modified**: 572, 575, 805
- Replaced literal `4` with `QUIC_HP_SAMPLE_OFFSET` constant (defined in `SocketQUICConstants.h` line 244)

## Benefits

- **Consistency**: Aligns with RFC 9001 Section 5.4 terminology for header protection
- **Maintainability**: Uses existing constant from `SocketQUICConstants.h` 
- **Clarity**: Self-documenting code - constant name clearly indicates purpose

## Test Plan

- [x] All 26 QUIC tests pass with sanitizers (including `test_quic_initial`)
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] No functional changes - pure refactoring to use named constant
- [x] Constant `QUIC_HP_SAMPLE_OFFSET` already defined and equals 4

Closes #1384