### PR TITLE
refactor(quic): Mark unused 'role' parameter with __attribute__((unused))

### DIFF
--- a/src/quic/SocketQUICHandshake.c
+++ b/src/quic/SocketQUICHandshake.c
@@ -261,13 +261,11 @@ SocketQUICHandshake_free(SocketQUICHandshake_T *handshake)
 
 SocketQUICHandshake_Result
 SocketQUICHandshake_init(SocketQUICConnection_T conn,
-                         SocketQUICConnection_Role role)
+                         SocketQUICConnection_Role role __attribute__((unused)))
 {
   if (!conn) {
     return QUIC_HANDSHAKE_ERROR_NULL;
   }
-
-  (void)role; /* Unused for now - will be used for TLS context setup */
 
   /* TODO: Initialize TLS context */
   /* This requires:


### PR DESCRIPTION
## Summary

Implements #1413

## Changes

- Removed `(void)role;` cast in `SocketQUICHandshake_init()` (line 270)
- Added `__attribute__((unused))` to the `role` parameter in function signature
- Parameter retained for future TLS context setup implementation

## Test Plan

- [x] Tests pass with sanitizers (115/116 tests passed, 1 timeout unrelated to changes)
- [x] Code compiles without warnings
- [x] No functional changes - parameter preserved for future use

Closes #1413