### PR TITLE
refactor(tls): replace magic 1000LL with SOCKET_MS_PER_SECOND in CRL

### DIFF
--- a/src/tls/SocketTLSContext-crl.c
+++ b/src/tls/SocketTLSContext-crl.c
@@ -105,7 +105,7 @@ schedule_crl_refresh (T ctx, long interval_seconds)
   if (interval_seconds > 0)
     {
       int64_t now_ms = Socket_get_monotonic_ms ();
-      int64_t interval_ms = interval_seconds * 1000LL;
+      int64_t interval_ms = interval_seconds * SOCKET_MS_PER_SECOND;
       ctx->crl_next_refresh_ms = now_ms + interval_ms;
     }
   else
@@ -193,7 +193,7 @@ SocketTLSContext_crl_check_refresh (T ctx)
           {
             int success = try_load_crl (ctx, ctx->crl_refresh_path);
             ctx->crl_next_refresh_ms
-                = now_ms + (ctx->crl_refresh_interval * 1000LL);
+                = now_ms + (ctx->crl_refresh_interval * SOCKET_MS_PER_SECOND);
             notify_crl_callback (ctx, ctx->crl_refresh_path, success);
             result = 1;
           }


### PR DESCRIPTION
## Summary

Replaces hardcoded `1000LL` magic numbers with `SOCKET_MS_PER_SECOND` constant in CRL auto-refresh functionality.

## Changes

- **Line 108** (`schedule_crl_refresh`): Replace `interval_seconds * 1000LL` with `interval_seconds * SOCKET_MS_PER_SECOND`
- **Line 196** (`SocketTLSContext_crl_check_refresh`): Replace `ctx->crl_refresh_interval * 1000LL` with `ctx->crl_refresh_interval * SOCKET_MS_PER_SECOND`

## Benefits

- **Consistency**: Aligns with codebase pattern of using named constants for time conversions
- **Maintainability**: Single source of truth for millisecond conversion factor in `SocketConfig.h`
- **Readability**: Self-documenting code that clearly indicates milliseconds per second

## Test Plan

- [x] Tests pass with sanitizers enabled (ASan/UBSan)
- [x] All TLS/CRL tests pass (`test_tls_crl`, `test_tls_crl_integration`)
- [x] No functional changes - pure refactoring

Closes #1414