### PR TITLE
feat(security): add SocketSecurity_size_to_int helper for OpenSSL I/O

### DIFF
--- a/include/core/SocketSecurity.h
+++ b/include/core/SocketSecurity.h
@@ -25,6 +25,7 @@
 #define SOCKETSECURITY_INCLUDED
 
 #include <assert.h>
+#include <limits.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -281,6 +282,33 @@ SocketSecurity_safe_add (size_t a, size_t b)
   if (a > SIZE_MAX - b)
     return SIZE_MAX; /* Would overflow */
   return a + b;
+}
+
+/**
+ * @brief Convert size_t to int with INT_MAX capping for OpenSSL I/O.
+ *
+ * OpenSSL I/O functions (SSL_read, SSL_write) take int length parameters,
+ * but modern APIs use size_t. This helper safely converts size_t to int,
+ * capping at INT_MAX to prevent overflow.
+ *
+ * @param len  Size to convert (typically buffer length)
+ *
+ * Returns: len capped to INT_MAX if len > INT_MAX, otherwise (int)len
+ *
+ * @threadsafe Yes (pure function)
+ * @complexity O(1)
+ *
+ * Example usage:
+ * @code{.c}
+ * size_t buf_len = 4096;
+ * int ssl_len = SocketSecurity_size_to_int(buf_len);
+ * int result = SSL_write(ssl, buf, ssl_len);
+ * @endcode
+ */
+static inline int
+SocketSecurity_size_to_int (size_t len)
+{
+  return (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
 }
 
 /**

--- a/src/test/test_security.c
+++ b/src/test/test_security.c
@@ -1245,6 +1245,55 @@ TEST (security_control_chars_high_ascii)
 }
 
 /* ============================================================================
+ * Size to Int Conversion Tests
+ * ============================================================================
+ */
+
+TEST (security_size_to_int_normal)
+{
+  /* Normal sizes should be converted correctly */
+  ASSERT_EQ (0, SocketSecurity_size_to_int (0));
+  ASSERT_EQ (1, SocketSecurity_size_to_int (1));
+  ASSERT_EQ (1024, SocketSecurity_size_to_int (1024));
+  ASSERT_EQ (65535, SocketSecurity_size_to_int (65535));
+}
+
+TEST (security_size_to_int_max_valid)
+{
+  /* INT_MAX should be returned unchanged */
+  ASSERT_EQ (INT_MAX, SocketSecurity_size_to_int ((size_t)INT_MAX));
+
+  /* Just below INT_MAX should be returned unchanged */
+  ASSERT_EQ (INT_MAX - 1, SocketSecurity_size_to_int ((size_t)INT_MAX - 1));
+}
+
+TEST (security_size_to_int_capping)
+{
+  /* Sizes exceeding INT_MAX should be capped */
+  ASSERT_EQ (INT_MAX,
+             SocketSecurity_size_to_int ((size_t)INT_MAX + 1));
+  ASSERT_EQ (INT_MAX,
+             SocketSecurity_size_to_int ((size_t)INT_MAX + 1000));
+
+  /* Very large sizes should be capped to INT_MAX */
+  ASSERT_EQ (INT_MAX, SocketSecurity_size_to_int (SIZE_MAX));
+  ASSERT_EQ (INT_MAX, SocketSecurity_size_to_int (SIZE_MAX / 2));
+}
+
+TEST (security_size_to_int_openssl_pattern)
+{
+  /* Test the typical OpenSSL I/O pattern */
+  size_t buf_len = 4096;
+  int ssl_len = SocketSecurity_size_to_int (buf_len);
+  ASSERT_EQ (4096, ssl_len);
+
+  /* Simulate large buffer that would exceed INT_MAX */
+  size_t huge_buf = (size_t)INT_MAX + 1000;
+  int capped_len = SocketSecurity_size_to_int (huge_buf);
+  ASSERT_EQ (INT_MAX, capped_len);
+}
+
+/* ============================================================================
  * TLS Utility Macro Tests
  * ============================================================================
  */

--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -890,8 +890,8 @@ SocketDTLS_send (SocketDgram_T socket, const void *buf, size_t len)
 
   SSL *ssl = VALIDATE_DTLS_IO_READY (socket, SocketDTLS_Failed);
 
-  /* Cap length to INT_MAX */
-  int write_len = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
+  /* Cap length to INT_MAX for OpenSSL API */
+  int write_len = SocketSecurity_size_to_int (len);
   int result = SSL_write (ssl, buf, write_len);
 
   if (result > 0)
@@ -922,8 +922,8 @@ SocketDTLS_recv (SocketDgram_T socket, void *buf, size_t len)
   /* Handle any pending timeout retransmissions */
   DTLSv1_handle_timeout (ssl);
 
-  /* Cap length to INT_MAX */
-  int read_len = (len > (size_t)INT_MAX) ? INT_MAX : (int)len;
+  /* Cap length to INT_MAX for OpenSSL API */
+  int read_len = SocketSecurity_size_to_int (len);
   int result = SSL_read (ssl, buf, read_len);
 
   if (result > 0)


### PR DESCRIPTION
## Summary

Implements #1411 by adding a centralized helper function for size_t to int conversion with INT_MAX capping.

## Changes

- **SocketSecurity.h**: Added `SocketSecurity_size_to_int()` inline function
  - Converts size_t to int with INT_MAX capping for OpenSSL API compatibility
  - Fully documented with examples
- **SocketDTLS.c**: Replaced manual INT_MAX capping in:
  - `SocketDTLS_send()` (line 894)
  - `SocketDTLS_recv()` (line 926)
- **test_security.c**: Added comprehensive test coverage
  - Normal size conversions
  - INT_MAX boundary conditions
  - Capping behavior for oversized values
  - OpenSSL usage pattern verification

## Test Plan

- [x] All DTLS tests pass with sanitizers
- [x] Security test suite passes (4 new tests added)
- [x] Manual verification of INT_MAX capping logic
- [x] Verified no regressions in TLS/DTLS functionality

## Benefits

- Improves code consistency across the codebase
- Centralizes size conversion logic in SocketSecurity module
- Makes future OpenSSL I/O code easier to write correctly
- Provides reusable pattern for similar conversions

Closes #1411