### PR TITLE
fix: disable automatic WIP label removal in issue-processor

### DIFF
--- a/.claude/skills/issue-processor/scripts/claim_issue.py
+++ b/.claude/skills/issue-processor/scripts/claim_issue.py
@@ -244,9 +244,10 @@ def main():
         sys.exit(0 if success else 1)
 
     elif args.action == "release":
-        success, message = release_issue(owner, repo, args.issue)
-        print(message)
-        sys.exit(0 if success else 2)
+        log_error("RELEASE ACTION DISABLED: WIP labels must NEVER be removed automatically.")
+        log_error("WIP labels indicate work in progress by another agent/session.")
+        log_error("If you need to manually release a stuck claim, do it via GitHub UI.")
+        sys.exit(2)
 
     elif args.action == "check":
         available, message = check_issue(owner, repo, args.issue)

--- a/.claude/skills/issue-processor/scripts/finish_batch.py
+++ b/.claude/skills/issue-processor/scripts/finish_batch.py
@@ -20,19 +20,12 @@ import sys
 from pathlib import Path
 
 from utils import (
-    run_gh,
     load_json,
     save_json,
     validate_repo_format,
     log_info,
     log_warning,
 )
-
-
-def release_claim(owner: str, repo: str, issue_num: int, wip_label: str) -> None:
-    """Remove the wip label from an issue to release the claim."""
-    run_gh(["issue", "edit", str(issue_num), "--repo", f"{owner}/{repo}",
-            "--remove-label", wip_label], check=False)
 
 
 def main():


### PR DESCRIPTION
## Summary
- Disables `--action release` in claim_issue.py - now exits with error
- Removes dead `release_claim` function from finish_batch.py
- Updates SKILL.md to document that WIP labels are sacred and never removed automatically

## Rationale
WIP labels indicate work in progress by other agents/sessions running in parallel. Removing them programmatically can interrupt active work. Only users should remove labels via GitHub UI after confirming work is truly abandoned.

## Test plan
- [x] Verified `--action release` now exits with error code 2
- [x] Verified documentation updated consistently