### PR TITLE
style(tls): replace strncpy with socket_util_safe_strncpy

### DIFF
--- a/src/tls/SocketTLS.c
+++ b/src/tls/SocketTLS.c
@@ -1409,8 +1409,7 @@ SocketTLS_get_verify_error_string (Socket_T socket, char *buf, size_t size)
   const char *code_str = X509_verify_cert_error_string (code);
   if (code_str)
     {
-      strncpy (buf, code_str, size - 1);
-      buf[size - 1] = '\0';
+      socket_util_safe_strncpy (buf, code_str, size);
       return buf;
     }
 
@@ -1422,8 +1421,7 @@ SocketTLS_get_verify_error_string (Socket_T socket, char *buf, size_t size)
       return buf;
     }
 
-  strncpy (buf, "TLS verification failed (unknown error)", size - 1);
-  buf[size - 1] = '\0';
+  socket_util_safe_strncpy (buf, "TLS verification failed (unknown error)", size);
   return buf;
 }
 
@@ -1877,8 +1875,7 @@ SocketTLS_get_peer_cert_info (Socket_T socket, SocketTLS_CertInfo *info)
           char *hex = BN_bn2hex (bn);
           if (hex)
             {
-              strncpy (info->serial, hex, sizeof (info->serial) - 1);
-              info->serial[sizeof (info->serial) - 1] = '\0';
+              socket_util_safe_strncpy (info->serial, hex, sizeof (info->serial));
               OPENSSL_free (hex);
             }
           BN_free (bn);


### PR DESCRIPTION
## Summary

Implements #1407 - Replaces verbose strncpy + manual null termination patterns with the existing `socket_util_safe_strncpy()` utility function.

## Changes

- **SocketTLS_get_verify_error_string()**: Replaced 2 instances of manual string copying
- **SocketTLS_get_peer_cert_info()**: Replaced 1 instance of manual string copying

All three locations previously used the pattern:
```c
strncpy(buf, src, size - 1);
buf[size - 1] = '\0';
```

Now replaced with:
```c
socket_util_safe_strncpy(buf, src, size);
```

## Benefits

- Single line instead of two - cleaner and more concise
- Intent is clearer (safe copy with guaranteed null termination)
- Consistent pattern across codebase using established utility
- Easier to audit for string safety

## Test Plan

- [x] Tests pass with sanitizers (99% pass rate, 1 unrelated timeout)
- [x] TLS tests specifically pass (16/17 pass, 1 pre-existing failure in test_tls_crl)
- [x] No new compiler warnings
- [x] Verified string handling is identical in behavior

## Note

This is a style improvement for code quality. The previous pattern was functionally safe but verbose. Using the utility function improves readability and maintainability.

Closes #1407