### PR TITLE
feat(quic): determine encryption level from packet context

### DIFF
--- a/include/quic/SocketQUICHandshake.h
+++ b/include/quic/SocketQUICHandshake.h
@@ -252,12 +252,14 @@ SocketQUICHandshake_send_initial(SocketQUICConnection_T conn);
  *
  * @param conn  QUIC connection.
  * @param frame CRYPTO frame to process.
+ * @param level Encryption level from packet context.
  *
  * @return QUIC_HANDSHAKE_OK on success, error code otherwise.
  */
 extern SocketQUICHandshake_Result
 SocketQUICHandshake_process_crypto(SocketQUICConnection_T conn,
-                                   const SocketQUICFrameCrypto_T *frame);
+                                   const SocketQUICFrameCrypto_T *frame,
+                                   SocketQUICCryptoLevel level);
 
 /**
  * @brief Derive packet protection keys for encryption level.


### PR DESCRIPTION
## Summary

Implements #1519

Adds proper encryption level handling to `SocketQUICHandshake_process_crypto` by:
- Accepting encryption level as a parameter derived from packet context
- Validating encryption level is within valid range (0 to QUIC_CRYPTO_LEVEL_COUNT)
- Routing CRYPTO frame data to the correct encryption level stream
- Providing a helper function to map packet types to encryption levels per RFC 9000

This enables proper handling of CRYPTO frames received at different encryption levels during the QUIC handshake (Initial, 0-RTT, Handshake, and Application).

## Changes

### API Changes
- **Modified**: `SocketQUICHandshake_process_crypto` now accepts `SocketQUICCryptoLevel level` parameter
- **Added**: `packet_type_to_crypto_level` internal helper function

### Implementation Details
- Added encryption level validation to reject invalid levels (>= QUIC_CRYPTO_LEVEL_COUNT)
- Updated function to use provided encryption level instead of hardcoding to INITIAL
- Added packet type to encryption level mapping per RFC 9000 Section 4.1.4:
  - Initial packets → Initial encryption level
  - 0-RTT packets → 0-RTT encryption level  
  - Handshake packets → Handshake encryption level
  - 1-RTT packets → Application encryption level

### Test Coverage
- Added test for invalid encryption level (returns QUIC_HANDSHAKE_ERROR_CRYPTO)
- Added test for processing CRYPTO frames at different encryption levels
- Updated all existing test calls to include encryption level parameter
- All 26 QUIC tests pass with sanitizers enabled

## Test Plan

- [x] All QUIC tests pass (26/26)
- [x] Tests run with AddressSanitizer enabled
- [x] Tests run with UndefinedBehaviorSanitizer enabled
- [x] New tests verify encryption level validation
- [x] New tests verify correct routing to encryption level streams

Closes #1519