### PR TITLE
feat(quic): Integrate handshake field into connection struct

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -84,6 +84,7 @@ struct SocketQUICConnection {
   uint64_t draining_deadline_ms;
   uint8_t stateless_reset_token[QUIC_STATELESS_RESET_TOKEN_LEN];
   int has_stateless_reset_token;
+  void *handshake;  /* SocketQUICHandshake_T (opaque to avoid circular dependency) */
 };
 
 extern SocketQUICConnTable_T SocketQUICConnTable_new(Arena_T arena, size_t bucket_count);


### PR DESCRIPTION
## Summary

Implements #1521 - Integrates the handshake field into the QUIC connection structure.

## Changes

- Added `handshake` field to `SocketQUICConnection` struct (as opaque void pointer to avoid circular dependency)
- Updated `SocketQUICHandshake_new()` to automatically link the handshake to its connection
- Updated `SocketQUICHandshake_free()` to properly unlink handshake from connection
- Updated `SocketQUICHandshake_process_crypto()` to retrieve handshake from `conn->handshake` instead of using hardcoded NULL
- Removed NOTE comment about integration needs

## Test Plan

- [x] All 28 existing QUIC handshake tests pass
- [x] Added 3 new integration tests:
  - `handshake_connection_integration` - Verifies linking/unlinking
  - `handshake_process_crypto_with_connection` - Verifies process_crypto retrieves handshake correctly
  - `handshake_process_crypto_without_handshake` - Verifies ERROR_STATE when no handshake linked
- [x] All 26 QUIC tests pass (100%)
- [x] Tests pass with AddressSanitizer and UndefinedBehaviorSanitizer enabled

## Additional Notes

The handshake field is declared as `void*` rather than `SocketQUICHandshake_T` to avoid circular header dependencies between SocketQUICConnection.h and SocketQUICHandshake.h.

Closes #1521