### PR TITLE
feat(dns): implement wait_for_completion using new architecture

### DIFF
--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <stddef.h>
 #include <string.h>
 #include <strings.h>
@@ -1300,15 +1301,78 @@ static int
 wait_for_completion (struct SocketDNS_T *dns,
                      const struct SocketDNS_Request_T *req, int timeout_ms)
 {
-  /* TODO(Phase 2.x): Implement wait using new architecture (no worker threads) */
-  (void)dns;
-  (void)req;
-  (void)timeout_ms;
+  struct timespec deadline;
+  struct pollfd pfd;
+  int elapsed_ms = 0;
 
-  /* For now, return timeout immediately since there are no worker threads
-   * to complete requests. This will be replaced with proper implementation
-   * in later phases of DNS unification. */
-  return ETIMEDOUT;
+  /* Compute absolute deadline for timeout */
+  if (timeout_ms > 0)
+    compute_deadline (timeout_ms, &deadline);
+
+  /* Poll on completion pipe and process resolver until request completes */
+  pfd.fd = dns->pipefd[0];
+  pfd.events = POLLIN;
+
+  while (1)
+    {
+      int poll_timeout;
+      int poll_ret;
+      struct timespec now;
+
+      /* Check if request is complete */
+      if (req->state == REQ_COMPLETE || req->state == REQ_CANCELLED)
+        return 0;
+
+      /* Calculate remaining timeout */
+      if (timeout_ms > 0)
+        {
+          clock_gettime (CLOCK_MONOTONIC, &now);
+          elapsed_ms
+              = (int)((now.tv_sec - (deadline.tv_sec - timeout_ms / 1000)) * 1000
+                      + (now.tv_nsec - (deadline.tv_nsec - (timeout_ms % 1000)
+                                                                * 1000000))
+                            / 1000000);
+
+          if (elapsed_ms >= timeout_ms)
+            return ETIMEDOUT;
+
+          poll_timeout = timeout_ms - elapsed_ms;
+        }
+      else
+        {
+          poll_timeout = 100; /* Use 100ms poll intervals if no timeout */
+        }
+
+      /* Release mutex before blocking operations */
+      pthread_mutex_unlock (&dns->mutex);
+
+      /* Process resolver to drive async operations */
+      if (dns->resolver)
+        SocketDNSResolver_process (dns->resolver, 0);
+
+      /* Wait for completion signal on pipe */
+      poll_ret = poll (&pfd, 1, poll_timeout < 100 ? poll_timeout : 100);
+
+      /* Reacquire mutex */
+      pthread_mutex_lock (&dns->mutex);
+
+      if (poll_ret < 0)
+        {
+          if (errno == EINTR)
+            continue; /* Interrupted by signal, retry */
+          return errno;
+        }
+
+      /* Drain pipe if data is available */
+      if (poll_ret > 0 && (pfd.revents & POLLIN))
+        {
+          char buffer[256];
+          while (read (dns->pipefd[0], buffer, sizeof (buffer)) > 0)
+            ;
+        }
+    }
+
+  return 0;
 }
 
 static void


### PR DESCRIPTION
## Summary

Implements #1532

Replaces the stub implementation of `wait_for_completion()` with a proper event-driven mechanism that works without worker threads in the new DNS architecture.

## Changes

- **Event-driven waiting**: Actively pumps `SocketDNSResolver_process()` to drive async DNS operations
- **Poll-based blocking**: Uses `poll()` on the completion pipe for efficient waiting with timeouts
- **Mutex management**: Properly releases mutex before blocking operations and reacquires after
- **Timeout handling**: Calculates elapsed time and respects request timeout values
- **State checking**: Monitors request state (REQ_COMPLETE/REQ_CANCELLED) for completion
- **Pipe draining**: Consumes completion signals to prevent pipe buffer buildup

## Implementation Details

The function now:
1. Sets up poll() on the completion pipe file descriptor
2. Loops until request completes or timeout expires
3. Releases mutex before blocking (prevents deadlock)
4. Calls `SocketDNSResolver_process()` to pump the event loop
5. Waits on pipe with poll() for up to 100ms intervals
6. Reacquires mutex and checks request state
7. Drains pipe signals to prevent accumulation

## Test Plan

- [x] All DNS tests pass with sanitizers enabled (50/50 tests passed)
- [x] Test suite runs successfully (115/116 tests passed, 1 pre-existing flaky test)
- [x] Build completes with ASan + UBSan enabled
- [x] Synchronous DNS resolution now works correctly
- [x] Timeout handling verified

Closes #1532