### PR TITLE
fix(test): prevent socketpool test timeout with FINALLY block

### DIFF
--- a/src/test/test_socketpool.c
+++ b/src/test/test_socketpool.c
@@ -3235,9 +3235,12 @@ thread_validation_getter (void *arg)
   {
     atomic_store_explicit (&ctx->thread_error, 1, memory_order_relaxed);
   }
+  FINALLY
+  {
+    atomic_store_explicit (&ctx->stop, 1, memory_order_release);
+  }
   END_TRY;
 
-  atomic_store_explicit (&ctx->stop, 1, memory_order_release);
   return NULL;
 }
 


### PR DESCRIPTION
## Summary
- Move `ctx->stop` signal into FINALLY block in `thread_validation_getter()` to ensure it's always set even when an exception occurs
- Previously, the signal was placed after END_TRY, causing `thread_validation_remove_add` to loop forever if `SocketPool_get` raised an exception

Fixes #1604

## Test plan
- [x] Test `socketpool_validation_callback_threaded` now passes (test #1)
- [ ] Full test suite with sanitizers (Note: test #18 `socketpool_connect_async_multiple_pending` has a separate issue - async connect blocks up to 30s per connection)