### PR TITLE
feat(quic): implement SocketQUICStream_event_string()

### DIFF
--- a/src/quic/SocketQUICStream.c
+++ b/src/quic/SocketQUICStream.c
@@ -52,6 +52,21 @@ static const char *result_strings[] = {
   [QUIC_STREAM_ERROR_LIMIT] = "Stream limit exceeded"
 };
 
+static const char *event_strings[] = {
+  [QUIC_STREAM_EVENT_SEND_DATA] = "Send Data",
+  [QUIC_STREAM_EVENT_SEND_FIN] = "Send FIN",
+  [QUIC_STREAM_EVENT_ALL_DATA_ACKED] = "All Data Acked",
+  [QUIC_STREAM_EVENT_SEND_RESET] = "Send Reset",
+  [QUIC_STREAM_EVENT_RESET_ACKED] = "Reset Acked",
+  [QUIC_STREAM_EVENT_RECV_DATA] = "Receive Data",
+  [QUIC_STREAM_EVENT_RECV_FIN] = "Receive FIN",
+  [QUIC_STREAM_EVENT_ALL_DATA_RECVD] = "All Data Received",
+  [QUIC_STREAM_EVENT_APP_READ_DATA] = "App Read Data",
+  [QUIC_STREAM_EVENT_RECV_RESET] = "Receive Reset",
+  [QUIC_STREAM_EVENT_APP_READ_RESET] = "App Read Reset",
+  [QUIC_STREAM_EVENT_RECV_STOP_SENDING] = "Receive Stop Sending"
+};
+
 /* ============================================================================
  * Stream ID Functions (RFC 9000 Section 2.1)
  * ============================================================================
@@ -247,6 +262,14 @@ SocketQUICStream_state_string (SocketQUICStreamState state)
   if (state > QUIC_STREAM_STATE_RESET_READ)
     return "Unknown";
   return state_strings[state];
+}
+
+const char *
+SocketQUICStream_event_string (SocketQUICStreamEvent event)
+{
+  if (event < 0 || event > QUIC_STREAM_EVENT_MAX)
+    return "Unknown";
+  return event_strings[event];
 }
 
 DEFINE_RESULT_STRING_FUNC (SocketQUICStream, QUIC_STREAM_ERROR_LIMIT)


### PR DESCRIPTION
## Summary

Implements #1378

This PR adds the missing implementation for `SocketQUICStream_event_string()` which was declared in the header file but not implemented in the source.

## Changes

- Added `event_strings[]` static array with all 12 stream event names
- Implemented `SocketQUICStream_event_string()` function following the same pattern as existing `type_string` and `state_string` functions
- Proper bounds checking for invalid event values (returns "Unknown")

## Implementation Details

The function provides human-readable string representations for all `SocketQUICStreamEvent` enum values:
- Send-side events: Send Data, Send FIN, All Data Acked, Send Reset, Reset Acked
- Receive-side events: Receive Data, Receive FIN, All Data Received, App Read Data, Receive Reset, App Read Reset
- Bidirectional events: Receive Stop Sending

## Test Plan

- [x] Code compiles without errors (`gcc -c` verification)
- [x] Follows existing module patterns (same style as type_string/state_string)
- [x] All 12 enum values have corresponding string mappings
- [x] Bounds checking handles invalid values correctly

## Notes

The build system has a pre-existing issue with a missing file (`SocketHTTPClient-request-async.c`) that prevents full cmake configuration. This is unrelated to the changes in this PR and affects the main branch as well.

Closes #1378