### PR TITLE
fix(tls): add errno validation to dtls_parse_port_string strtol call

### DIFF
--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -1024,8 +1024,11 @@ dtls_parse_port_string (const char *port_str)
     return 0;
 
   char *endptr;
+  errno = 0; /* Clear errno before call (CERT C: ERR07-C) */
   long p = strtol (port_str, &endptr, 10);
-  if (endptr > port_str && *endptr == '\0' && p >= 1 && p <= 65535)
+  if (errno == ERANGE || endptr == port_str || *endptr != '\0')
+    return 0;
+  if (p >= 1 && p <= 65535)
     return (int)p;
   return 0;
 }


### PR DESCRIPTION
## Summary

Implements #1397 - Adds proper errno checking for strtol() overflow detection in the dtls_parse_port_string function.

## Changes

- Added `errno = 0` before strtol() call to clear any previous errors
- Added `errno == ERANGE` check to detect integer overflow/underflow  
- Reorganized validation logic to check error conditions first
- Added CERT C ERR07-C comment documenting the security pattern

## Security Impact

This fix addresses CWE-190 (Integer Overflow or Wraparound) by ensuring that extremely large port number strings (e.g., "999999999999999999999") that cause strtol() to return LONG_MAX/LONG_MIN with errno=ERANGE are properly rejected instead of potentially being accepted.

## Test Plan

- [x] Library compiles successfully with sanitizers enabled
- [x] DTLS module (SocketDTLS.c) compiles without errors
- [x] No changes to public API - internal static function only

Closes #1397