### PR TITLE
refactor(dtls): replace magic timeout with SOCKET_DTLS_INITIAL_TIMEOUT_MS

### DIFF
--- a/src/tls/SocketDTLS.c
+++ b/src/tls/SocketDTLS.c
@@ -691,8 +691,8 @@ calculate_handshake_poll_timeout (int timeout_ms, int infinite_timeout,
 
   if (infinite_timeout)
     {
-      /* Infinite wait: Use 1 second to periodically check DTLS timers */
-      return 1000;
+      /* Infinite wait: Use default DTLS timeout for timer handling */
+      return SOCKET_DTLS_INITIAL_TIMEOUT_MS;
     }
 
   /* Compute remaining time from deadline */


### PR DESCRIPTION
## Summary

Implements #1406 - Replaces magic constant `1000` with properly documented `SOCKET_DTLS_INITIAL_TIMEOUT_MS` in DTLS handshake loop.

## Changes

- **src/tls/SocketDTLS.c**: Updated `calculate_handshake_poll_timeout()` to use `SOCKET_DTLS_INITIAL_TIMEOUT_MS` instead of hardcoded `1000` value
- Improved code comment to reference "default DTLS timeout" instead of "1 second"

## Rationale

The constant `SOCKET_DTLS_INITIAL_TIMEOUT_MS` is already properly defined in `include/tls/SocketDTLSConfig.h` (lines 266-268) with comprehensive documentation:
- Documented as "Initial retransmission timeout for DTLS handshake packets (ms)"
- Value is 1000ms per RFC 6347 recommendation
- Part of DTLS timeout configuration constants

Using the named constant:
- Improves code maintainability
- Ensures consistency across the codebase
- Makes the timeout value configurable via the header
- Self-documents the purpose of the value

## Test Plan

- [x] DTLS tests pass with sanitizers:
  - `test_dtls_basic`: 13/13 tests passed
  - `test_dtls_cookie`: 10/10 tests passed
  - `test_dtls_mtu`: 13/13 tests passed
- [x] No functional changes - constant value remains 1000ms
- [x] Compiled successfully with ASan/UBSan enabled

Closes #1406