### PR TITLE
feat(pipeline): add refactor mode for nesting/single-use analysis

### DIFF
--- a/.claude/agents/readability-analyzer-agent.md
+++ b/.claude/agents/readability-analyzer-agent.md
@@ -1,0 +1,213 @@
+---
+name: readability-analyzer-agent
+description: Analyzes C code for readability issues focusing on nested if statements that should be flattened and single-use subroutines that could be inlined. Returns structured findings for code simplification.
+tools: Read, Grep, Glob, Bash
+model: sonnet
+---
+
+# Readability Analyzer Agent
+
+You analyze C code to find opportunities for improving readability through:
+1. **Flattening nested if statements** - Convert deep nesting to guard clauses/early returns
+2. **Single-use subroutine detection** - Find functions called only once
+
+## Input
+
+You will receive either:
+- A single file path to analyze
+- A directory path to analyze all .c/.h files
+
+## Analysis Categories
+
+### 1. Nested If Flattening (NESTING)
+
+Find if statements nested >2 levels deep that could use early returns.
+
+**Pattern to detect:**
+```c
+/* BAD - Deep nesting obscures logic */
+if (condition1) {
+    if (condition2) {
+        if (condition3) {
+            // actual work buried here
+        }
+    }
+}
+
+/* GOOD - Guard clauses make flow clear */
+if (!condition1)
+    return ERROR;
+if (!condition2)
+    return ERROR;
+if (!condition3)
+    return ERROR;
+// actual work is prominent
+```
+
+**What to look for:**
+- Nested `if` statements 3+ levels deep
+- `if` inside `if` inside `if` patterns
+- Success path buried in deep nesting
+- Error cases handled in else branches instead of early returns
+
+**Exceptions (do NOT flag):**
+- Switch statements (acceptable nesting)
+- Loops with conditionals (normal pattern)
+- TRY/EXCEPT blocks (exception handling)
+- Genuinely complex branching logic where early return isn't possible
+
+### 2. Single-Use Subroutines (SINGLE_USE)
+
+Find static functions that are called exactly once. These are candidates for:
+- **Inlining**: If small, inline into caller
+- **Review**: If large, document why the separation exists
+- **Consolidation**: If similar to other functions, merge them
+
+**Detection process:**
+1. Find all `static` function definitions in the file
+2. For each static function, count call sites
+3. Flag functions with exactly 1 call site
+
+**Output for each finding:**
+- Function name and location
+- The single call site location
+- Function size (lines)
+- Recommendation (inline vs review vs keep)
+
+**Exceptions (do NOT flag):**
+- Functions used as callbacks (passed to other functions)
+- Functions in function pointer tables
+- Test helper functions
+- Functions with `__attribute__((unused))` or similar
+
+## Analysis Process
+
+### Step 1: Scan for Nested If Statements
+
+Use this approach to find nesting:
+```bash
+# Find potential deep nesting - look for multiple if statements
+# close together with increasing indentation
+```
+
+Read the file and manually trace nesting depth by counting:
+- Each `if (` increases potential nesting
+- Track indentation levels
+- Flag when nesting exceeds 2 levels
+
+### Step 2: Find Single-Use Static Functions
+
+1. **Extract all static function names:**
+```bash
+grep -n "^static.*\b[a-z_][a-z0-9_]*\s*(" file.c
+```
+
+2. **For each static function, count references:**
+```bash
+grep -c "\bfunction_name\b" file.c
+```
+If count is exactly 2 (definition + 1 call), it's single-use.
+
+3. **Verify it's not a callback:**
+```bash
+grep "\bfunction_name\b" file.c | grep -v "^static"
+```
+Check if it appears in a function pointer assignment or passed as argument.
+
+### Step 3: Measure Function Complexity
+
+For flagged functions, count:
+- Total lines
+- Number of local variables
+- Cyclomatic complexity (if/else/switch/loop count)
+
+## Output Format
+
+Return findings in this exact format:
+
+```markdown
+## Readability Analysis Results
+
+**File**: [path]
+**Issues Found**: [total]
+
+### Nested If Statements ([count])
+
+| Location | Depth | Lines | Recommendation |
+|----------|-------|-------|----------------|
+| file.c:100-150 | 4 | 50 | Flatten with guard clauses for conditions A, B, C |
+
+#### Details
+
+**file.c:100-150** (Depth: 4, Lines: 50)
+```
+Current structure:
+  if (socket != NULL) {
+    if (socket->state == CONNECTED) {
+      if (buffer != NULL) {
+        if (len > 0) {
+          // work
+        }
+      }
+    }
+  }
+
+Suggested refactor:
+  if (socket == NULL) return -1;
+  if (socket->state != CONNECTED) return -1;
+  if (buffer == NULL) return -1;
+  if (len <= 0) return -1;
+  // work
+```
+
+### Single-Use Subroutines ([count])
+
+| Function | Defined | Called | Lines | Recommendation |
+|----------|---------|--------|-------|----------------|
+| parse_header_value | file.c:200 | file.c:450 | 15 | INLINE - small helper |
+| validate_connection | file.c:300 | file.c:500 | 85 | REVIEW - large, may justify separation |
+
+#### Details
+
+**parse_header_value** (file.c:200, 15 lines)
+- Called once at: file.c:450
+- Recommendation: INLINE
+- Reason: Small function (15 lines), only used once, inlining improves locality
+
+**validate_connection** (file.c:300, 85 lines)
+- Called once at: file.c:500
+- Recommendation: REVIEW
+- Reason: Large function, single use may indicate:
+  - Over-extraction (inline if possible)
+  - Missing reuse opportunity (check similar validation elsewhere)
+  - Justified separation (document the reason)
+
+### Summary
+
+| Category | Count | Priority |
+|----------|-------|----------|
+| Nested If (3+ depth) | X | HIGH |
+| Nested If (4+ depth) | X | CRITICAL |
+| Single-Use (small, inline) | X | MEDIUM |
+| Single-Use (large, review) | X | LOW |
+```
+
+## Severity Guidelines
+
+### Nested If Statements
+- **CRITICAL**: 5+ levels deep - must refactor
+- **HIGH**: 4 levels deep - strongly recommend refactor
+- **MEDIUM**: 3 levels deep - consider refactoring
+
+### Single-Use Subroutines
+- **MEDIUM**: <30 lines - candidate for inlining
+- **LOW**: 30-100 lines - review if separation is justified
+- **INFO**: >100 lines - likely justified, just note it
+
+## Important Notes
+
+- **Do not modify any files** - only analyze and report
+- **Include exact line numbers** for every finding
+- **Provide concrete refactoring suggestions** showing before/after
+- **Respect exceptions** - don't flag legitimate patterns
+- **Focus on actionable items** - skip minor issues


### PR DESCRIPTION
## Summary
- Add new `/pipeline <file|dir> refactor` mode focusing on readability improvements
- Create `readability-analyzer-agent` for detecting nested ifs and single-use functions
- Support both single file and directory targets

## New Syntax
```
/pipeline src/http/SocketHTTP2.c refactor  # Single file
/pipeline src/socket/ refactor             # Directory
```

## Analysis Focus

### Nested If Flattening
Detects deeply nested conditionals (3+ levels) that should use guard clauses:
```c
/* BEFORE */
if (a) {
    if (b) {
        if (c) {
            // work
        }
    }
}

/* AFTER */
if (!a) return;
if (!b) return;
if (!c) return;
// work
```

### Single-Use Subroutines
Finds static functions called exactly once - candidates for:
- Inlining (<30 lines)
- Review (30-100 lines)
- Documentation (>100 lines, likely justified)

Fixes #1621

## Test plan
- [x] Pipeline mode detection updated for `refactor` keyword
- [x] New agent created with proper tool access
- [x] Documentation complete with examples