### PR TITLE
fix(pool,dns): resolve mutex deadlock and exception timing issues

### DIFF
--- a/src/core/Arena.c
+++ b/src/core/Arena.c
@@ -405,7 +405,7 @@ arena_release_all_chunks (T arena)
 }
 
 static void
-arena_reset (Arena *arena, int locked)
+arena_reset (T arena, int locked)
 {
   arena->prev = NULL;
   arena->avail = NULL;

--- a/src/test/test_socketdns.c
+++ b/src/test/test_socketdns.c
@@ -1694,15 +1694,12 @@ TEST (socketdns_queue_full_raises_exception)
 
   TRY
   {
-    /* Set a very low max_pending */
-    SocketDNS_setmaxpending (dns, 2);
+    /* Set max_pending to 0 - any hostname request should fail immediately
+     * Note: IP literals (like 127.0.0.1) complete synchronously and don't
+     * count as pending, so we use a hostname that requires actual DNS lookup */
+    SocketDNS_setmaxpending (dns, 0);
 
-    /* Fill the queue */
-    SocketDNS_resolve (dns, "localhost", 80, NULL, NULL);
-    SocketDNS_resolve (dns, "127.0.0.1", 80, NULL, NULL);
-    ASSERT_EQ (SocketDNS_getpendingcount (dns), 2);
-
-    /* Try to exceed the limit - should raise exception */
+    /* Try to resolve a hostname - should raise exception since max_pending=0 */
     SocketDNS_resolve (dns, "example.com", 80, NULL, NULL);
 
     /* Should not reach here */


### PR DESCRIPTION
## Summary
- Fix mutex deadlock in `SocketPool_connect_async()` by releasing pool lock before calling `SocketDNS_resolve()`. The callback may fire synchronously for IP literals or cache hits, causing deadlock when it tries to acquire the same lock.
- Move `check_queue_capacity()` before `prepare_resolve_request()` in `SocketDNS_resolve()` to prevent memory leak when queue is full.
- Fix `test_socketdns` queue test to use `max_pending=0` with hostname instead of IP literals (which complete synchronously and don't count as pending).
- Fix `arena_reset` parameter type from `Arena*` to `T` for consistency.

Fixes #1619

## Test plan
- [x] `test_socketpool` passes (was timing out due to deadlock)
- [x] `test_dns_queue_limit` passes (exception now raised before allocation)
- [x] `test_socketdns` passes (57/57 tests)
- [x] All tests pass with AddressSanitizer enabled