### PR TITLE
refactor(metrics): move extern declaration to file scope

### DIFF
--- a/src/core/SocketMetrics.c
+++ b/src/core/SocketMetrics.c
@@ -17,6 +17,9 @@
 #include "core/SocketMetrics.h"
 #include "core/SocketUtil.h"
 
+/* Forward declaration for Socket module live count tracking */
+extern int Socket_debug_live_count (void);
+
 #define PERCENTILE_P50 50.0
 #define PERCENTILE_P75 75.0
 #define PERCENTILE_P90 90.0
@@ -1099,7 +1102,6 @@ SocketMetrics_category_name (SocketMetricCategory category)
 int
 SocketMetrics_get_socket_count (void)
 {
-  extern int Socket_debug_live_count (void);
   return Socket_debug_live_count ();
 }
 


### PR DESCRIPTION
## Summary

Implements #1638 - Moves `Socket_debug_live_count()` extern declaration from inside function body to file scope.

## Changes

- Moved `extern int Socket_debug_live_count(void);` declaration from inside `SocketMetrics_get_socket_count()` to file scope
- Added comment explaining the forward declaration for Socket module

## Rationale

While technically valid C, declaring `extern` functions inside function bodies is:
- Unconventional and discouraged by most coding standards
- Harder to track for dependency analysis
- Potentially problematic for static analysis tools
- Inconsistent with the rest of the codebase

## Test Plan

- [x] Tests pass with sanitizers enabled (116/117 passing, 1 pre-existing failure)
- [x] Metrics tests pass completely (35/35)
- [x] No compilation warnings with `-Wall -Wextra`
- [x] Behavioral verification: function still correctly returns socket count

Closes #1638