### PR TITLE
refactor(http2): add error handling convenience macros

### DIFF
--- a/include/http/SocketHTTP2-private.h
+++ b/include/http/SocketHTTP2-private.h
@@ -276,6 +276,37 @@ extern void http2_emit_stream_event (SocketHTTP2_Conn_T conn,
                                      SocketHTTP2_Stream_T stream, int event);
 
 extern void http2_emit_conn_event (SocketHTTP2_Conn_T conn, int event);
+
+/* --- Error handling convenience macros --- */
+
+/**
+ * @brief Send connection error and return failure
+ *
+ * Combines http2_send_connection_error() with return -1 for cleaner
+ * error handling in frame processing functions.
+ */
+#define HTTP2_SEND_CONN_ERROR_AND_FAIL(conn, code)                            \
+  do                                                                          \
+    {                                                                         \
+      http2_send_connection_error ((conn), (code));                           \
+      return -1;                                                              \
+    }                                                                         \
+  while (0)
+
+/**
+ * @brief Send stream error and return success (continue processing)
+ *
+ * Combines http2_send_stream_error() with return 0 for stream-level
+ * errors that don't terminate the connection.
+ */
+#define HTTP2_SEND_STREAM_ERROR_AND_CONTINUE(conn, id, code)                  \
+  do                                                                          \
+    {                                                                         \
+      http2_send_stream_error ((conn), (id), (code));                         \
+      return 0;                                                               \
+    }                                                                         \
+  while (0)
+
 static inline void
 write_u16_be (unsigned char *buf, uint16_t value)
 {


### PR DESCRIPTION
## Summary

Add `HTTP2_SEND_CONN_ERROR_AND_FAIL` and `HTTP2_SEND_STREAM_ERROR_AND_CONTINUE` macros to `SocketHTTP2-private.h` for cleaner error handling patterns.

These macros combine `http2_send_*_error()` with the appropriate return statement, reducing boilerplate in frame processing functions.

### Note

The STRLEN_LIT changes that were originally planned for this PR were already merged in commit `a579e540` ("perf(http2): eliminate redundant strlen() calls in request header building").

Fixes #1661

## Test plan
- [x] All HTTP tests pass with sanitizers enabled
- [x] Build completes successfully