### PR TITLE
refactor(dns): eliminate code redundancy in SocketDNS.c

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -573,6 +573,25 @@ extern const char *Socket_safe_strerror (int errnum);
 #define SOCKET_DNS_CACHE_HASH_SIZE 1021
 #endif
 
+/**
+ * @brief Poll interval for synchronous DNS wait operations.
+ *
+ * Used in wait_for_completion() to periodically check for completion
+ * and process the resolver backend.
+ */
+#ifndef SOCKET_DNS_POLL_INTERVAL_MS
+#define SOCKET_DNS_POLL_INTERVAL_MS 100
+#endif
+
+/**
+ * @brief Maximum DNS hostname length per RFC 1035.
+ *
+ * DNS hostnames are limited to 255 characters total.
+ */
+#ifndef SOCKET_DNS_MAX_HOSTNAME_LEN
+#define SOCKET_DNS_MAX_HOSTNAME_LEN 255
+#endif
+
 /* ============================================================================
  * Poll Backend Configuration
  * ============================================================================

--- a/include/dns/SocketDNS-private.h
+++ b/include/dns/SocketDNS-private.h
@@ -31,6 +31,18 @@
 #include "socket/SocketCommon.h"
 
 /**
+ * @brief DNS cancellation error code.
+ * @ingroup dns
+ *
+ * Returns EAI_CANCELLED if available, otherwise EAI_AGAIN as fallback.
+ */
+#ifdef EAI_CANCELLED
+#define DNS_CANCELLATION_ERROR EAI_CANCELLED
+#else
+#define DNS_CANCELLATION_ERROR EAI_AGAIN
+#endif
+
+/**
  * @brief Opaque handle for a single DNS resolution request.
  * @ingroup dns
  *


### PR DESCRIPTION
## Summary
- Remove `dns_cancellation_error()` function and replace with `DNS_CANCELLATION_ERROR` macro
- Add DNS configuration constants to SocketConfig.h (`SOCKET_DNS_POLL_INTERVAL_MS`, `SOCKET_DNS_MAX_HOSTNAME_LEN`)
- Replace magic numbers with named constants throughout SocketDNS.c

Fixes #1660

## Test plan
- [x] All 117 tests pass with sanitizers enabled
- [x] DNS-specific tests (15 tests) all pass