### PR TITLE
refactor(http-server): flatten nesting in parse_range_header

### DIFF
--- a/src/http/SocketHTTPServer.c
+++ b/src/http/SocketHTTPServer.c
@@ -2903,25 +2903,21 @@ parse_range_header (const char *range_str, off_t file_size, off_t *start,
         return 0;
       *start = (off_t)val;
 
-      if (*endptr == '-')
+      if (*endptr != '-')
+        return 0;
+
+      p = endptr + 1;
+      if (*p == '\0' || *p == ',')
         {
-          p = endptr + 1;
-          if (*p == '\0' || *p == ',')
-            {
-              /* Open-ended: "500-" means 500 to end */
-              *end = file_size - 1;
-            }
-          else
-            {
-              val = strtoll (p, &endptr, 10);
-              if (endptr == p)
-                return 0;
-              *end = (off_t)val;
-            }
+          /* Open-ended: "500-" means 500 to end */
+          *end = file_size - 1;
         }
       else
         {
-          return 0;
+          val = strtoll (p, &endptr, 10);
+          if (endptr == p)
+            return 0;
+          *end = (off_t)val;
         }
     }
 


### PR DESCRIPTION
## Summary

Implements #1673 - Reduces deep nesting in `parse_range_header()` function.

## Changes

- Flattened nesting depth from 7 to 6 in the normal range parsing path (lines 2906-2922)
- Replaced nested if-else block with early return pattern for invalid '-' check
- Maintains identical behavior while improving code readability

## Test Plan

- [x] All HTTP-related tests pass with sanitizers (13/13)
- [x] `test_httpserver` validates range header parsing
- [x] Build succeeds with ASan/UBSan enabled
- [x] No behavioral changes, pure refactoring

## Note

One pre-existing DNS test failure (`test_dns_queue_limit`) exists in the codebase unrelated to this change - verified by running HTTP-specific tests which all pass.

Closes #1673