### PR TITLE
refactor(http): add HTTP status code classification macros

### DIFF
--- a/include/http/SocketHTTP.h
+++ b/include/http/SocketHTTP.h
@@ -375,6 +375,22 @@ typedef enum
 #define HTTP_STATUS_5XX_MAX 599
 
 /**
+ * @brief Status code classification macros for quick category checking.
+ *
+ * Provide readable checks for HTTP status code ranges per RFC 9110.
+ * Use these instead of magic number comparisons for improved readability
+ * and maintainability.
+ *
+ * @param c HTTP status code to check
+ * @return 1 if code is in the specified range, 0 otherwise
+ */
+#define HTTP_STATUS_IS_INFORMATIONAL(c) ((c) >= 100 && (c) < 200)
+#define HTTP_STATUS_IS_SUCCESS(c) ((c) >= 200 && (c) < 300)
+#define HTTP_STATUS_IS_REDIRECT(c) ((c) >= 300 && (c) < 400)
+#define HTTP_STATUS_IS_CLIENT_ERROR(c) ((c) >= 400 && (c) < 500)
+#define HTTP_STATUS_IS_SERVER_ERROR(c) ((c) >= 500 && (c) < 600)
+
+/**
  * @brief Categories of HTTP status codes for quick classification.
  *
  * Maps to first digit of status code (1-5). Used for error handling,

--- a/src/http/SocketHTTPClient.c
+++ b/src/http/SocketHTTPClient.c
@@ -1310,7 +1310,8 @@ parse_http2_response_headers (const SocketHPACK_Header *headers,
         {
           /* Parse status code */
           response->status_code = (int)strtol (headers[i].value, NULL, 10);
-          if (response->status_code < 100 || response->status_code > 599)
+          if (response->status_code < HTTP_STATUS_CODE_MIN
+              || response->status_code > HTTP_STATUS_CODE_MAX)
             return -1;
           status_found = 1;
           break;
@@ -1939,7 +1940,7 @@ static int
 should_retry_5xx (SocketHTTPClient_T client,
                   SocketHTTPClient_Response *response, int attempt)
 {
-  if (response->status_code < 500 || response->status_code >= 600)
+  if (!HTTP_STATUS_IS_SERVER_ERROR (response->status_code))
     return 0;
 
   if (!httpclient_should_retry_status (client, response->status_code))
@@ -2303,7 +2304,7 @@ SocketHTTPClient_download (SocketHTTPClient_T client, const char *url,
   if (SocketHTTPClient_get (client, url, &response) != 0)
     return -1;
 
-  if (response.status_code < 200 || response.status_code >= 300)
+  if (!HTTP_STATUS_IS_SUCCESS (response.status_code))
     {
       SocketHTTPClient_Response_free (&response);
       return -1;


### PR DESCRIPTION
## Summary

Implements #1668

Replaces magic HTTP status code numbers with descriptive classification macros for improved readability and maintainability.

## Changes

- **Added macros to `include/http/SocketHTTP.h`:**
  - `HTTP_STATUS_IS_INFORMATIONAL(c)` - checks for 1xx codes
  - `HTTP_STATUS_IS_SUCCESS(c)` - checks for 2xx codes
  - `HTTP_STATUS_IS_REDIRECT(c)` - checks for 3xx codes
  - `HTTP_STATUS_IS_CLIENT_ERROR(c)` - checks for 4xx codes
  - `HTTP_STATUS_IS_SERVER_ERROR(c)` - checks for 5xx codes

- **Updated `src/http/SocketHTTPClient.c`:**
  - Line 1313: Use `HTTP_STATUS_CODE_MIN/MAX` for status code validation
  - Line 1942: Use `HTTP_STATUS_IS_SERVER_ERROR()` for 5xx retry logic
  - Line 2306: Use `HTTP_STATUS_IS_SUCCESS()` for download success check

## Benefits

- Code like `if (status >= 200 && status < 300)` becomes `if (HTTP_STATUS_IS_SUCCESS(status))`
- Self-documenting intent
- Centralized status code range definitions
- Easier to maintain and less error-prone

## Test Plan

- [x] All HTTP tests pass with sanitizers enabled
- [x] Build successful with ASan + UBSan
- [x] No new warnings or errors
- [x] 116/117 tests pass (1 pre-existing DNS test failure unrelated to changes)

Closes #1668