### PR TITLE
refactor(http): extract duplicate hostname validation functions

### DIFF
--- a/src/http/SocketHTTPClient.c
+++ b/src/http/SocketHTTPClient.c
@@ -2503,22 +2503,6 @@ SocketHTTPClient_json_post (SocketHTTPClient_T client, const char *url,
 
 /* ===== Prepared Request API (Issue #185) ===== */
 
-/**
- * @brief Validate hostname for security (no control characters).
- *
- * SECURITY: Prevents CRLF injection in Host header.
- */
-static int
-prepared_hostname_safe (const char *host, size_t len)
-{
-  for (size_t i = 0; i < len; i++)
-    {
-      unsigned char c = (unsigned char)host[i];
-      if (c == '\r' || c == '\n' || c == '\0' || c < 0x20)
-        return 0;
-    }
-  return 1;
-}
 
 /**
  * @brief Parse URI and validate hostname safety.
@@ -2541,7 +2525,7 @@ prepare_parse_and_validate_uri (SocketHTTPClient_T client, const char *url,
     }
 
   /* SECURITY: Validate hostname for control characters */
-  if (!prepared_hostname_safe (uri->host, uri->host_len))
+  if (!hostname_safe (uri->host, uri->host_len))
     {
       client->last_error = HTTPCLIENT_ERROR_PROTOCOL;
       HTTPCLIENT_ERROR_MSG ("Invalid characters in hostname");


### PR DESCRIPTION
## Summary

Implements #1662 - Consolidates two identical hostname validation functions into a single implementation.

## Changes

- Removed duplicate `prepared_hostname_safe()` function (lines 2512-2521)
- Updated caller in `prepare_parse_and_validate_uri()` to use existing `hostname_safe()` function
- Eliminates 15 lines of redundant code
- Maintains security-critical CRLF injection prevention logic

## Test Plan

- [x] All HTTP client tests pass (45/45 tests)
- [x] Prepared request tests validate hostname security (CRLF injection tests)
- [x] Tests pass with sanitizers enabled (116/117 tests - 1 pre-existing DNS test failure)
- [x] No changes to validation logic - functionally identical

## Files Changed

- `src/http/SocketHTTPClient.c` - Removed duplicate function, updated caller

Closes #1662