### PR TITLE
refactor(http): replace default port magic numbers with constants

### DIFF
--- a/include/http/SocketHTTP-private.h
+++ b/include/http/SocketHTTP-private.h
@@ -146,7 +146,8 @@ sockethttp_is_token_valid (const char *s, size_t len)
 static inline int
 is_default_http_port (int port, int is_https)
 {
-  return port == -1 || port == (is_https ? 443 : 80);
+  return port == -1
+         || port == (is_https ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT);
 }
 
 /* ============================================================================

--- a/include/http/SocketHTTP.h
+++ b/include/http/SocketHTTP.h
@@ -118,6 +118,20 @@
 #define SOCKETHTTP_DATE_BUFSIZE 30
 
 /**
+ * @brief Default HTTP port per RFC 9110 Section 4.2.3.
+ *
+ * Standard port for http:// scheme. Used when port is omitted in URI.
+ */
+#define HTTP_DEFAULT_PORT 80
+
+/**
+ * @brief Default HTTPS port per RFC 9110 Section 4.2.3.
+ *
+ * Standard port for https:// scheme. Used when port is omitted in URI.
+ */
+#define HTTPS_DEFAULT_PORT 443
+
+/**
  * @brief Generic HTTP module failure.
  *
  * Use for general errors in HTTP core utilities. Specific errors should use

--- a/src/http/SocketHTTPClient.c
+++ b/src/http/SocketHTTPClient.c
@@ -2564,7 +2564,8 @@ prepare_format_host_header (SocketHTTPClient_T client,
   size_t host_header_len;
 
   /* Pre-format Host header - eliminates 2.9% CPU overhead per request */
-  if (prep->effective_port == 80 || prep->effective_port == 443)
+  if (prep->effective_port == HTTP_DEFAULT_PORT
+      || prep->effective_port == HTTPS_DEFAULT_PORT)
     {
       host_header_len
           = (size_t)snprintf (host_buf, sizeof (host_buf), "%s", prep->uri.host);
@@ -2651,7 +2652,7 @@ SocketHTTPClient_prepare (SocketHTTPClient_T client, SocketHTTP_Method method,
   prep->is_secure = SocketHTTP_URI_is_secure (&prep->uri);
   prep->effective_port = prep->uri.port;
   if (prep->effective_port == -1)
-    prep->effective_port = prep->is_secure ? 443 : 80;
+    prep->effective_port = prep->is_secure ? HTTPS_DEFAULT_PORT : HTTP_DEFAULT_PORT;
 
 /* Format Host header */
   if (prepare_format_host_header (client, prep, arena) != 0)


### PR DESCRIPTION
## Summary

Implements #1666 by replacing HTTP/HTTPS port magic numbers with named constants.

## Changes

- **Add constants in SocketHTTP.h**:
  - `HTTP_DEFAULT_PORT` (80)
  - `HTTPS_DEFAULT_PORT` (443)
- **Update helper function**: Modified `is_default_http_port()` in SocketHTTP-private.h to use constants
- **Replace magic numbers in SocketHTTPClient.c**:
  - Line 2567: Port comparison in `prepare_format_host_header()`
  - Line 2654: Default port assignment in `SocketHTTPClient_prepare()`

## Test Plan

- [x] All HTTP client tests pass (45/45)
- [x] All HTTP core tests pass (225/225)
- [x] Tests pass with sanitizers enabled (116/117, 1 pre-existing failure)
- [x] Build completes without warnings

## Impact

- Improves code readability and maintainability
- No functional changes (pure refactoring)
- Follows RFC 9110 Section 4.2.3 for default port definitions

Closes #1666