### PR TITLE
refactor(http-server): flatten 5-level nesting in find_rate_limiter

### DIFF
--- a/src/http/SocketHTTPServer.c
+++ b/src/http/SocketHTTPServer.c
@@ -63,13 +63,10 @@ find_rate_limiter (SocketHTTPServer_T server, const char *path)
   for (RateLimitEntry *e = server->rate_limiters; e != NULL; e = e->next)
     {
       size_t len = strlen (e->path_prefix);
-      if (strncmp (path, e->path_prefix, len) == 0)
+      if (strncmp (path, e->path_prefix, len) == 0 && len > best_len)
         {
-          if (len > best_len)
-            {
-              best = e;
-              best_len = len;
-            }
+          best = e;
+          best_len = len;
         }
     }
 


### PR DESCRIPTION
## Summary

Implements #1677

Reduced nesting depth in `find_rate_limiter()` function by combining two consecutive if conditions into a single logical AND expression.

## Changes

- Flattened 5-level nesting to 4-level in `src/http/SocketHTTPServer.c` (lines 66-70)
- Combined `strncmp` prefix check and length comparison into single condition
- Improved code readability while maintaining identical behavior

## Test Plan

- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] All HTTP server tests pass (`test_httpserver`, `test_httpserver_load`)
- [x] All HTTP-related tests pass (14 tests including HTTP/2, rate limiting, etc.)
- [x] No behavior changes - purely refactoring

Closes #1677