### PR TITLE
refactor(http-server): inline single-use is_ipv4_address function

### DIFF
--- a/src/http/SocketHTTPServer.c
+++ b/src/http/SocketHTTPServer.c
@@ -252,13 +252,6 @@ SocketHTTPServer_free (SocketHTTPServer_T *server)
 }
 
 static int
-is_ipv4_address (const char *addr)
-{
-  struct in_addr dummy;
-  return inet_pton (AF_INET, addr, &dummy) == 1;
-}
-
-static int
 is_ipv6_address (const char *addr)
 {
   struct in6_addr dummy;
@@ -282,7 +275,7 @@ SocketHTTPServer_start (SocketHTTPServer_T server)
       bind_addr = "::";
       socket_family = AF_INET6;
     }
-  else if (is_ipv4_address (bind_addr))
+  else if (inet_pton (AF_INET, bind_addr, &(struct in_addr){ 0 }) == 1)
     {
       socket_family = AF_INET;
     }


### PR DESCRIPTION
## Summary

Implements #1674 by inlining the single-use `is_ipv4_address()` helper function at its call site in `SocketHTTPServer_start()`.

## Changes

- Removed the 5-line `is_ipv4_address()` static function
- Inlined the `inet_pton()` call directly at line 278 using compound literal for the destination address
- Reduced function call overhead and improved code locality

## Test Plan

- [x] Tests pass with sanitizers (116/117 tests pass - 1 pre-existing failure in `test_dns_queue_limit` unrelated to this change)
- [x] Build succeeds with ASan/UBSan enabled
- [x] HTTP server functionality unchanged (logic preserved exactly)

Closes #1674