### PR TITLE
refactor(http-server): inline single-use is_ipv6_address function

### DIFF
--- a/src/http/SocketHTTPServer.c
+++ b/src/http/SocketHTTPServer.c
@@ -258,13 +258,6 @@ is_ipv4_address (const char *addr)
   return inet_pton (AF_INET, addr, &dummy) == 1;
 }
 
-static int
-is_ipv6_address (const char *addr)
-{
-  struct in6_addr dummy;
-  return inet_pton (AF_INET6, addr, &dummy) == 1;
-}
-
 int
 SocketHTTPServer_start (SocketHTTPServer_T server)
 {
@@ -286,13 +279,17 @@ SocketHTTPServer_start (SocketHTTPServer_T server)
     {
       socket_family = AF_INET;
     }
-  else if (is_ipv6_address (bind_addr))
-    {
-      socket_family = AF_INET6;
-    }
   else
     {
-      socket_family = AF_INET6;
+      struct in6_addr dummy;
+      if (inet_pton (AF_INET6, bind_addr, &dummy) == 1)
+        {
+          socket_family = AF_INET6;
+        }
+      else
+        {
+          socket_family = AF_INET6;
+        }
     }
 
   server->listen_socket = Socket_new (socket_family, SOCK_STREAM, 0);


### PR DESCRIPTION
## Summary

Implements #1675

## Changes

- Removed the static `is_ipv6_address()` function (lines 261-266)
- Inlined the IPv6 address validation logic at its single call site in `SocketHTTPServer_start()`
- Preserved the original semantics: checks if bind address is a valid IPv6 address

## Test Plan

- [x] Tests pass with sanitizers (116 of 117 tests - 1 pre-existing DNS test failure unrelated to this change)
- [x] HTTP server functionality unaffected
- [x] No regressions in address family detection logic

Closes #1675