### PR TITLE
refactor(http1-compress): inline single-use get_effective_max_encoded_size function

### DIFF
--- a/src/http/SocketHTTP1-compress.c
+++ b/src/http/SocketHTTP1-compress.c
@@ -204,13 +204,6 @@ get_effective_max_decompressed_size (const SocketHTTP1_Config *cfg)
   return cfg->max_decompressed_size;
 }
 
-static size_t
-get_effective_max_encoded_size (const SocketHTTP1_Config *cfg)
-{
-  (void)cfg; /* Currently unused, reserved for future configuration */
-  return SIZE_MAX;
-}
-
 #ifdef SOCKETHTTP1_HAS_ZLIB
 
 static int
@@ -864,6 +857,7 @@ SocketHTTP1_Encoder_new (SocketHTTP_Coding coding,
 {
   SocketHTTP1_Encoder_T encoder;
 
+  (void)cfg; /* Currently unused, reserved for future configuration */
   assert (arena);
 
   if (!is_supported_coding (coding))
@@ -876,7 +870,7 @@ SocketHTTP1_Encoder_new (SocketHTTP_Coding coding,
   encoder->coding = coding;
   encoder->arena = arena;
   encoder->level = level;
-  encoder->max_encoded_size = get_effective_max_encoded_size (cfg);
+  encoder->max_encoded_size = SIZE_MAX;  /* No current limit on encoded size */
 
   if (!init_encoder_backend (encoder))
     return NULL;


### PR DESCRIPTION
## Summary

Implements #1698

Removes the `get_effective_max_encoded_size` function which was an unnecessary abstraction:
- Called exactly once in `SocketHTTP1_Encoder_new` (line 879)
- Trivial implementation returning `SIZE_MAX` constant
- Unused `cfg` parameter cast to `(void)` indicating it's completely ignored
- Premature abstraction for "future configuration" that hasn't materialized

## Changes

- Removed `get_effective_max_encoded_size` function (lines 207-212)
- Inlined function call with direct assignment: `encoder->max_encoded_size = SIZE_MAX;`
- Added explanatory comment: `/* No current limit on encoded size */`
- Moved unused parameter suppression to the calling function

## Test Plan

- [x] Built successfully with HTTP compression enabled (`-DENABLE_HTTP_COMPRESSION=ON`)
- [x] All HTTP tests pass (13/13 tests passed)
- [x] Tests pass with sanitizers enabled
- [x] No impact on other modules (HTTP-only change)

## Rationale

Inlining improves code readability by eliminating unnecessary indirection. When developers see `SIZE_MAX`, they immediately understand there's no limit. The previous implementation required jumping to the function definition to understand it returns a constant.

If future configuration support is needed, the abstraction can be reintroduced at that time with actual implementation.

Closes #1698