### PR TITLE
refactor(hpack): inline single-use decode_string_header function

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -343,18 +343,6 @@ hpack_encode_string (const char *str, size_t len, int use_huffman,
 }
 
 static SocketHPACK_Result
-decode_string_header (const unsigned char *input, size_t input_len,
-                      size_t *pos, int *huffman, uint64_t *str_len)
-{
-  if (input_len == 0)
-    return HPACK_INCOMPLETE;
-
-  *huffman = (input[0] & HPACK_STRING_HUFFMAN_FLAG) != 0;
-  return SocketHPACK_int_decode (input, input_len, HPACK_PREFIX_STRING,
-                                 str_len, pos);
-}
-
-static SocketHPACK_Result
 allocate_string_buffer (Arena_T arena, size_t buf_size, char **buf_out)
 {
   size_t alloc_size = buf_size + 1;
@@ -417,7 +405,13 @@ hpack_decode_string (const unsigned char *input, size_t input_len,
   uint64_t str_len;
   SocketHPACK_Result result;
 
-  result = decode_string_header (input, input_len, &pos, &huffman, &str_len);
+  /* Inline decode_string_header */
+  if (input_len == 0)
+    return HPACK_INCOMPLETE;
+
+  huffman = (input[0] & HPACK_STRING_HUFFMAN_FLAG) != 0;
+  result = SocketHPACK_int_decode (input, input_len, HPACK_PREFIX_STRING,
+                                   &str_len, &pos);
   if (result != HPACK_OK)
     return result;
 


### PR DESCRIPTION
## Summary

Implements #1703

## Changes

- Removed `decode_string_header` function (lines 346-355)
- Inlined its logic directly into `hpack_decode_string` at the single call site
- Reduces function call overhead while maintaining code clarity

## Test Plan

- [x] All HTTP/HPACK tests pass with sanitizers enabled
- [x] Full test suite passes (116/117 tests - 1 pre-existing DNS test failure unrelated to this change)
- [x] No functional changes, purely a refactoring

Closes #1703