### PR TITLE
refactor(hpack): flatten 3-level nesting in Encoder_set_table_size

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -506,12 +506,17 @@ SocketHPACK_Encoder_set_table_size (SocketHPACK_Encoder_T encoder,
   assert (encoder != NULL);
 
   /* RFC 7541 §4.2: Multiple size changes - emit smallest first, then final */
+
+  /* No pending sizes - just set the first one */
   if (encoder->pending_table_size_count == 0)
     {
       encoder->pending_table_sizes[0] = max_size;
       encoder->pending_table_size_count = 1;
+      return;
     }
-  else if (encoder->pending_table_size_count == 1)
+
+  /* One pending size - need to add a second one */
+  if (encoder->pending_table_size_count == 1)
     {
       if (max_size < encoder->pending_table_sizes[0])
         {
@@ -523,19 +528,19 @@ SocketHPACK_Encoder_set_table_size (SocketHPACK_Encoder_T encoder,
           encoder->pending_table_sizes[1] = max_size;
         }
       encoder->pending_table_size_count = 2;
+      return;
+    }
+
+  /* Two or more pending sizes - update the second one or reset to one */
+  if (max_size < encoder->pending_table_sizes[0])
+    {
+      encoder->pending_table_sizes[0] = max_size;
+      encoder->pending_table_sizes[1] = 0;
+      encoder->pending_table_size_count = 1;
     }
   else
     {
-      if (max_size < encoder->pending_table_sizes[0])
-        {
-          encoder->pending_table_sizes[0] = max_size;
-          encoder->pending_table_sizes[1] = 0;
-          encoder->pending_table_size_count = 1;
-        }
-      else
-        {
-          encoder->pending_table_sizes[1] = max_size;
-        }
+      encoder->pending_table_sizes[1] = max_size;
     }
 }
 


### PR DESCRIPTION
## Summary

Implements #1696 - Refactors `SocketHPACK_Encoder_set_table_size` to reduce nesting depth from 3 to 2 levels by using early returns.

## Changes

- Replaced nested if-else-if-else structure with sequential if statements using early returns
- Maintained identical logic for handling three states (count==0, count==1, count>=2)
- Added clarifying comments for each state transition
- No functional changes - pure readability improvement

## Test Plan

- [x] All tests pass with sanitizers enabled (ASAN + UBSan)
- [x] HPACK tests specifically verified
- [x] Build succeeds with no warnings

The refactoring maintains the exact same behavior per RFC 7541 §4.2 for managing pending table size updates.

Closes #1696