### PR TITLE
refactor(hpack-huffman): inline single-use hpack_find_symbol

### DIFF
--- a/src/http/SocketHPACK-huffman.c
+++ b/src/http/SocketHPACK-huffman.c
@@ -445,24 +445,6 @@ try_decode_nbit (const HuffmanDecodeConfig *cfg, uint64_t bits, int bits_avail,
   return 0;
 }
 
-/* Linear search for longer codes (9-30 bits). O(257) worst case. */
-static int
-hpack_find_symbol (uint64_t code, int cl)
-{
-  size_t s;
-
-  if (cl < HUFFMAN_MIN_CODE_BITS || cl > HPACK_HUFFMAN_MAX_BITS)
-    return -1;
-
-  for (s = 0; s < HPACK_HUFFMAN_SYMBOLS; s++)
-    {
-      const HPACK_HuffmanSymbol *sym = &hpack_huffman_encode[s];
-      if (sym->bits == (unsigned) cl && sym->code == code)
-        return (int) s;
-    }
-  return -1;
-}
-
 /* Decode long codes (9-30 bits) and EOS. Returns 1=symbol, 2=EOS, 0=no match. */
 static int
 try_full_decode (uint64_t bits, int *bits_avail, unsigned char *output,
@@ -478,7 +460,21 @@ try_full_decode (uint64_t bits, int *bits_avail, unsigned char *output,
     {
       uint64_t mask = (1ULL << cl) - 1ULL;
       uint64_t thiscode = (bits >> (*bits_avail - cl)) & mask;
-      int sym = hpack_find_symbol (thiscode, cl);
+
+      /* Linear search for longer codes (9-30 bits). O(257) worst case. */
+      int sym = -1;
+      if (cl >= HUFFMAN_MIN_CODE_BITS && cl <= HPACK_HUFFMAN_MAX_BITS)
+        {
+          for (size_t s = 0; s < HPACK_HUFFMAN_SYMBOLS; s++)
+            {
+              const HPACK_HuffmanSymbol *sym_entry = &hpack_huffman_encode[s];
+              if (sym_entry->bits == (unsigned) cl && sym_entry->code == thiscode)
+                {
+                  sym = (int) s;
+                  break;
+                }
+            }
+        }
 
       if (sym >= 0)
         {


### PR DESCRIPTION
## Summary

Implements #1706 - inlines `hpack_find_symbol` static function at its single call site.

## Changes

- **Removed** `hpack_find_symbol` static function (was 16 lines at lines 449-464)
- **Inlined** linear search logic directly into `try_full_decode` at line 481
- **Preserved** O(257) worst-case complexity comment at the usage site
- **Renamed** loop variable `s` to `sym_entry` to avoid name collision with outer scope variable `sym`

## Rationale

The function was called exactly once, making it an ideal candidate for inlining per the SINGLE_USE_INLINE pattern. This:
- Reduces indirection (one fewer function call)
- Keeps the linear search logic co-located with its single use case
- Maintains readability with preserved comments

## Test Plan

- [x] All HPACK tests pass (test_hpack - all 40+ tests passed)
- [x] Tests run with sanitizers enabled (116/117 tests pass)
- [x] Pre-existing test failure in test_dns_queue_limit (unrelated DNS memory leak)
- [x] No change to algorithm or behavior - pure refactoring

Closes #1706