### PR TITLE
refactor(http-client-arena): flatten 3-level nesting in httpclient_get_arena_cache

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -95,18 +95,18 @@ httpclient_get_arena_cache (void)
   pthread_once (&arena_cache_once, arena_cache_init_key);
 
   cache = pthread_getspecific (arena_cache_key);
-  if (cache == NULL)
+  if (cache != NULL)
+    return cache;
+
+  cache = calloc (1, sizeof (*cache));
+  if (!cache)
+    return NULL;
+
+  if (pthread_setspecific (arena_cache_key, cache) != 0)
     {
-      cache = calloc (1, sizeof (*cache));
-      if (cache)
-        {
-          if (pthread_setspecific (arena_cache_key, cache) != 0)
-            {
-              /* Failed to store in TLS - free and continue without cache */
-              free (cache);
-              cache = NULL;
-            }
-        }
+      /* Failed to store in TLS - free and continue without cache */
+      free (cache);
+      return NULL;
     }
 
   return cache;


### PR DESCRIPTION
## Summary

Implements #1712

Refactored `httpclient_get_arena_cache` function to flatten 3-level nested if statements using early returns, improving code readability and reducing cognitive load.

## Changes

- **Before**: 3 levels of nested if statements (lines 98-110)
  - `if (cache == NULL)` wrapping calloc
  - `if (cache)` wrapping pthread_setspecific  
  - `if (pthread_setspecific != 0)` for error handling
  
- **After**: Linear flow with early returns
  - Early return if cache already exists
  - Early return if calloc fails
  - Early return if pthread_setspecific fails
  - Final return of cache on success

## Benefits

- Easier to follow control flow
- Reduced cognitive load from eliminating nested blocks
- Consistent with project's readability standards
- Matches refactoring pattern from #1696, #1697, #1700

## Test Plan

- [x] Built with sanitizers enabled (`ENABLE_SANITIZERS=ON`)
- [x] All HTTP client tests pass (45/45)
- [x] HTTP integration tests pass (8/8)
- [x] No behavioral changes - purely structural refactoring

Closes #1712