### PR TITLE
refactor(http-client-cookie): inline single-use cookie_entry_init_full function

### DIFF
--- a/src/http/SocketHTTPClient-cookie.c
+++ b/src/http/SocketHTTPClient-cookie.c
@@ -326,32 +326,6 @@ evict_oldest_cookie (SocketHTTPClient_CookieJar_T jar)
     }
 }
 
-static void
-cookie_entry_init_full (CookieEntry *entry,
-                        const SocketHTTPClient_Cookie *cookie,
-                        const char *effective_path, Arena_T arena)
-{
-  entry->cookie.name = socket_util_arena_strdup (arena, cookie->name);
-  if (entry->cookie.name == NULL)
-    RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
-
-  entry->cookie.value = socket_util_arena_strdup (arena, cookie->value);
-  if (entry->cookie.value == NULL)
-    RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
-
-  entry->cookie.domain = socket_util_arena_strdup (arena, cookie->domain);
-  if (entry->cookie.domain == NULL)
-    RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
-
-  entry->cookie.path = socket_util_arena_strdup (arena, effective_path);
-  if (entry->cookie.path == NULL)
-    RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
-
-  entry->cookie.expires = cookie->expires;
-  entry->cookie.secure = cookie->secure;
-  entry->cookie.http_only = cookie->http_only;
-  entry->cookie.same_site = cookie->same_site;
-}
 
 static CookieEntry *
 cookie_jar_find_entry (SocketHTTPClient_CookieJar_T jar, const char *domain,
@@ -584,7 +558,27 @@ SocketHTTPClient_CookieJar_set (SocketHTTPClient_CookieJar_T jar,
         if (entry == NULL)
           RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
 
-        cookie_entry_init_full (entry, cookie, effective_path, jar->arena);
+        entry->cookie.name = socket_util_arena_strdup (jar->arena, cookie->name);
+        if (entry->cookie.name == NULL)
+          RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
+
+        entry->cookie.value = socket_util_arena_strdup (jar->arena, cookie->value);
+        if (entry->cookie.value == NULL)
+          RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
+
+        entry->cookie.domain = socket_util_arena_strdup (jar->arena, cookie->domain);
+        if (entry->cookie.domain == NULL)
+          RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
+
+        entry->cookie.path = socket_util_arena_strdup (jar->arena, effective_path);
+        if (entry->cookie.path == NULL)
+          RAISE_HTTPCLIENT_ERROR (SocketHTTPClient_Failed);
+
+        entry->cookie.expires = cookie->expires;
+        entry->cookie.secure = cookie->secure;
+        entry->cookie.http_only = cookie->http_only;
+        entry->cookie.same_site = cookie->same_site;
+
         entry->created = time (NULL);
 
         entry->next = jar->hash_table[hash];


### PR DESCRIPTION
## Summary

Implements #1711 by inlining the single-use static function `cookie_entry_init_full` directly at its call site in `SocketHTTPClient_CookieJar_set`.

## Changes

- Removed `cookie_entry_init_full` function definition (lines 330-354)
- Inlined the 26-line initialization sequence at line 587 (now line 561-582)
- Improved code locality by making cookie entry initialization visible at its single use point

## Benefits

- Eliminates unnecessary function call overhead
- Reduces code indirection for initialization logic
- Makes the full cookie entry setup visible at the call site
- Improves code locality for a single-use operation

## Test Plan

- [x] All tests pass with sanitizers enabled (116/117 tests pass)
- [x] HTTP client cookie tests pass
- [x] Pre-existing test failure in `test_dns_queue_limit` confirmed on main branch (unrelated to changes)

Closes #1711