### PR TITLE
refactor(http-core): inline single-use sockethttp_header_value_is_safe function

### DIFF
--- a/src/http/SocketHTTP-core.c
+++ b/src/http/SocketHTTP-core.c
@@ -141,18 +141,6 @@ sockethttp_parse_enum(const char *str, size_t len, const struct ParseEntry *tabl
   return default_val;
 }
 
-/* SECURITY: Check for NUL/CR/LF to prevent header injection (CWE-113) */
-static int
-sockethttp_header_value_is_safe (const char *s, size_t len)
-{
-  for (size_t i = 0; i < len; i++)
-    {
-      unsigned char c = (unsigned char)s[i];
-      if (c == 0 || c == '\r' || c == '\n')
-        return 0;
-    }
-  return 1;
-}
 
 /* ============================================================================
  * HTTP Version
@@ -436,7 +424,15 @@ SocketHTTP_header_value_valid (const char *value, size_t len)
   len = sockethttp_effective_length (value, len);
   if (len > SOCKETHTTP_MAX_HEADER_VALUE)
     return 0;
-  return sockethttp_header_value_is_safe (value, len);
+
+  /* SECURITY: Check for NUL/CR/LF to prevent header injection (CWE-113) */
+  for (size_t i = 0; i < len; i++)
+    {
+      unsigned char c = (unsigned char)value[i];
+      if (c == 0 || c == '\r' || c == '\n')
+        return 0;
+    }
+  return 1;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #1714 - Inlines the single-use static function `sockethttp_header_value_is_safe` into its only call site in `SocketHTTP_header_value_valid`.

## Changes

- **Removed**: `sockethttp_header_value_is_safe` static function (lines 145-155)
- **Inlined**: Function body directly into `SocketHTTP_header_value_valid` at line 439
- **Preserved**: Security comment (CWE-113 header injection prevention) at the inlined location

## Rationale

1. The function was called exactly once in the entire codebase
2. Inlining improves code locality and readability
3. Eliminates unnecessary indirection (11-line function for a simple loop)
4. Follows recent refactoring patterns (#1695, #1692) that inline similar single-use functions
5. The security comment is preserved at the call site for documentation

## Test Plan

- [x] All HTTP tests pass (`test_http_core`, `test_http1_parser`, `test_http2`, etc.)
- [x] Tests pass with AddressSanitizer and UndefinedBehaviorSanitizer
- [x] Existing test coverage validates header value security checks (CR/LF/NUL injection prevention)

Closes #1714