### PR TITLE
refactor(http-uri): flatten 5-level nesting in check_path_traversal

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -1142,14 +1142,16 @@ check_path_traversal (const char *path, size_t len)
   /* Check 1: Literal ".." */
   for (size_t i = 0; i + 1 < len; i++)
     {
-      if (path[i] == '.' && path[i + 1] == '.')
-        {
-          if (i == 0 || path[i - 1] == '/')
-            {
-              if (i + 2 >= len || path[i + 2] == '/' || path[i + 2] == '?')
-                return URI_PARSE_INVALID_PATH;
-            }
-        }
+      if (path[i] != '.' || path[i + 1] != '.')
+        continue;
+
+      if (i != 0 && path[i - 1] != '/')
+        continue;
+
+      if (i + 2 < len && path[i + 2] != '/' && path[i + 2] != '?')
+        continue;
+
+      return URI_PARSE_INVALID_PATH;
     }
 
   /* Check 2: Fully encoded "%2e%2e" or "%2E%2E" */


### PR DESCRIPTION
## Summary

Implements #1716

Refactors the literal `..` path traversal detection logic in `check_path_traversal()` to reduce nesting depth from 5 levels to 2 levels, improving code readability while preserving the exact same security checks.

## Changes

- **File**: `src/http/SocketHTTP-uri.c`
- **Function**: `check_path_traversal()` (Check 1: Literal "..")
- **Lines**: 1142-1155 (previously 1143-1153)

### Before (5 levels of nesting):
```c
for (size_t i = 0; i + 1 < len; i++)
  {
    if (path[i] == '.' && path[i + 1] == '.')
      {
        if (i == 0 || path[i - 1] == '/')
          {
            if (i + 2 >= len || path[i + 2] == '/' || path[i + 2] == '?')
              return URI_PARSE_INVALID_PATH;
          }
      }
  }
```

### After (2 levels of nesting):
```c
for (size_t i = 0; i + 1 < len; i++)
  {
    if (path[i] != '.' || path[i + 1] != '.')
      continue;

    if (i != 0 && path[i - 1] != '/')
      continue;

    if (i + 2 < len && path[i + 2] != '/' && path[i + 2] != '?')
      continue;

    return URI_PARSE_INVALID_PATH;
  }
```

## Logic Equivalence

The refactored code uses inverted conditions with early `continue` statements:
- Skip iterations where we don't have `..` pattern
- Skip iterations where `..` is not at start or after `/`
- Skip iterations where `..` is not followed by end/`/`/`?`
- Return error for valid path traversal attempts

This is logically equivalent to the original nested conditions but more readable.

## Test Plan

- [x] All HTTP-related tests pass (15/15 tests)
- [x] Security tests pass (`test_security`, `test_tls_security`)
- [x] Build passes with sanitizers enabled
- [x] No changes to security logic or behavior

## Context

This is a readability refactoring of security-critical path traversal detection code (RFC 3986). The function detects various forms of `..` path segments:
- Literal `..` (this refactoring)
- URL-encoded `%2e%2e` (Check 2)
- Mixed encoding `.%2e` (Check 3)
- Mixed encoding `%2e.` (Check 4)

Closes #1716