### PR TITLE
refactor(http-uri): flatten 5-level nesting in check_path_traversal mixed encoding

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -1181,15 +1181,18 @@ check_path_traversal (const char *path, size_t len)
   /* Check 4: Mixed encoding "%2e." or "%2E." */
   for (size_t i = 0; i + 3 < len; i++)
     {
-      if (path[i] == '%' && path[i + 1] == '2'
-          && (path[i + 2] == 'e' || path[i + 2] == 'E') && path[i + 3] == '.')
-        {
-          if (i == 0 || path[i - 1] == '/')
-            {
-              if (i + 4 >= len || path[i + 4] == '/' || path[i + 4] == '?')
-                return URI_PARSE_INVALID_PATH;
-            }
-        }
+      if (path[i] != '%' || path[i + 1] != '2')
+        continue;
+      if ((path[i + 2] != 'e' && path[i + 2] != 'E') || path[i + 3] != '.')
+        continue;
+
+      if (i != 0 && path[i - 1] != '/')
+        continue;
+
+      if (i + 4 < len && path[i + 4] != '/' && path[i + 4] != '?')
+        continue;
+
+      return URI_PARSE_INVALID_PATH;
     }
 
   return URI_PARSE_OK;


### PR DESCRIPTION
## Summary

Implements #1731

Refactored Check 4 in `check_path_traversal` function to use early continue statements, reducing nesting from 5 levels to 2 levels.

## Changes

- Flattened nested if statements in mixed encoding `%2e.` detection logic
- Converted positive conditions to negative with early `continue`
- Improved code readability while maintaining identical security logic
- No functional changes - path traversal detection behavior is preserved

## Location

**File**: `src/http/SocketHTTP-uri.c`  
**Function**: `check_path_traversal`  
**Lines**: 1181-1196 (Check 4)

## Test Plan

- [x] Tests pass with sanitizers enabled (116/117 - one pre-existing flaky test)
- [x] HTTP core tests pass (225/225)
- [x] HTTP/1 parser tests pass (34/34)
- [x] Security validation logic unchanged
- [x] Build completes without warnings

Closes #1731