### PR TITLE
refactor(http-server-connections): flatten 4-level nesting in request body handling

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -500,8 +500,14 @@ connection_parse_request (SocketHTTPServer_T server, ServerConnection *conn)
       return -1;
     }
 
-  /* Handle request body if present */
-  if (conn->request->has_body && !conn->body_streaming)
+  /* Handle request body if present - use early returns to reduce nesting */
+  if (!conn->request->has_body)
+    {
+      conn->state = CONN_STATE_HANDLING;
+      return 1;
+    }
+
+  if (!conn->body_streaming)
     {
       /* Normal buffered mode: allocate body buffer */
       if (connection_setup_body_buffer (server, conn) < 0)
@@ -513,15 +519,15 @@ connection_parse_request (SocketHTTPServer_T server, ServerConnection *conn)
           if (body_result <= 0)
             return body_result;
         }
-    }
-  else if (conn->request->has_body && conn->body_streaming)
-    {
-      /* Streaming mode enabled by validator - read initial body with callback */
 
-      int body_result = connection_read_initial_body (server, conn);
-      if (body_result <= 0)
-        return body_result;
+      conn->state = CONN_STATE_HANDLING;
+      return 1;
     }
+
+  /* Streaming mode enabled by validator - read initial body with callback */
+  int body_result = connection_read_initial_body (server, conn);
+  if (body_result <= 0)
+    return body_result;
 
   conn->state = CONN_STATE_HANDLING;
   return 1;


### PR DESCRIPTION
## Summary

Implements #1726

## Changes

- Reduced nesting depth from 4 to 3 levels in `connection_parse_request()` function
- Added early return for requests without body
- Separated buffered and streaming mode handling with dedicated returns
- Improved code readability while preserving identical control flow semantics

## Technical Details

**Before**: 4-level nesting with if-else chain
```c
if (conn->request->has_body && !conn->body_streaming) {
    if (connection_setup_body_buffer (server, conn) < 0)
        return -1;
    if (conn->body_capacity > 0) {
        int body_result = connection_read_initial_body (server, conn);
        if (body_result <= 0)
            return body_result;
    }
}
else if (conn->request->has_body && conn->body_streaming) {
    int body_result = connection_read_initial_body (server, conn);
    if (body_result <= 0)
        return body_result;
}
```

**After**: 3-level nesting with early returns
```c
if (!conn->request->has_body) {
    conn->state = CONN_STATE_HANDLING;
    return 1;
}

if (!conn->body_streaming) {
    /* buffered mode */
    if (connection_setup_body_buffer (server, conn) < 0)
        return -1;
    if (conn->body_capacity > 0) {
        int body_result = connection_read_initial_body (server, conn);
        if (body_result <= 0)
            return body_result;
    }
    conn->state = CONN_STATE_HANDLING;
    return 1;
}

/* streaming mode */
int body_result = connection_read_initial_body (server, conn);
if (body_result <= 0)
    return body_result;
```

## Test Plan

- [x] Tests pass with sanitizers (27/27 HTTP server tests passed)
- [x] No functional changes - only control flow refactoring
- [x] Built with ASAN/UBSAN enabled
- [x] Verified identical behavior for all three paths (no body, buffered, streaming)

Closes #1726