### PR TITLE
refactor(http-uri): flatten 4-level nesting in parse_quoted_value escape handling

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -1263,23 +1263,29 @@ parse_quoted_value (const char *p, const char *end, const char **value_start,
   *value_start = p;
   while (p < end && *p != '"')
     {
-      if (*p == '\\')
+      if (*p != '\\')
         {
-          if (p + 1 >= end)
-            {
-              *value_start = NULL;
-              *value_len = 0;
-              return end;
-            }
           p++;
-          unsigned char esc = (unsigned char)*p;
-          if (esc < 0x20 || esc == 0x7F)
-            {
-              *value_start = NULL;
-              *value_len = 0;
-              return end;
-            }
+          continue;
         }
+
+      /* Handle escape sequence */
+      if (p + 1 >= end)
+        {
+          *value_start = NULL;
+          *value_len = 0;
+          return end;
+        }
+
+      p++;
+      unsigned char esc = (unsigned char)*p;
+      if (esc < 0x20 || esc == 0x7F)
+        {
+          *value_start = NULL;
+          *value_len = 0;
+          return end;
+        }
+
       p++;
     }
   *value_len = (size_t)(p - *value_start);


### PR DESCRIPTION
## Summary

Implements #1735 - Reduces nesting complexity in HTTP URI parsing

## Changes

- Flattened 4-level nesting to 3 levels in `parse_quoted_value` function
- Inverted backslash check condition to use early continue
- Added comment to clarify escape sequence handling section
- Maintains identical behavior for HTTP quoted string validation

## Test Plan

- [x] All HTTP core tests pass (225/225)
- [x] Full test suite passes with sanitizers (116/117 - 1 pre-existing failure unrelated to changes)
- [x] Builds successfully with ASan/UBSan enabled

## Technical Details

**File**: `src/http/SocketHTTP-uri.c`  
**Function**: `parse_quoted_value`  
**Lines changed**: 1266-1289

The refactoring inverts the initial `if (*p == '\\')` check to `if (*p != '\\')` with an early `continue`, which reduces nesting depth while preserving the exact same validation logic for escape sequences in HTTP Content-Type header quoted strings.

Closes #1735