### PR TITLE
refactor(http-client-async): flatten 3-level nesting in SocketHTTPClient_post_async

### DIFF
--- a/src/http/SocketHTTPClient-async.c
+++ b/src/http/SocketHTTPClient-async.c
@@ -434,17 +434,17 @@ SocketHTTPClient_post_async (SocketHTTPClient_T client, const char *url,
           SocketHTTPClient_Request_free (&req);
           return NULL;
         }
+    }
 
-      /* Set Content-Type header */
-      if (content_type != NULL)
+  /* Set Content-Type header if provided with body */
+  if (body != NULL && body_len > 0 && content_type != NULL)
+    {
+      if (SocketHTTPClient_Request_header (req, "Content-Type",
+                                           content_type)
+          != 0)
         {
-          if (SocketHTTPClient_Request_header (req, "Content-Type",
-                                               content_type)
-              != 0)
-            {
-              SocketHTTPClient_Request_free (&req);
-              return NULL;
-            }
+          SocketHTTPClient_Request_free (&req);
+          return NULL;
         }
     }
 


### PR DESCRIPTION
## Summary

Implements #1727 by reducing nesting depth from 3 to 2 levels in `SocketHTTPClient_post_async()`.

## Changes

- Separated body setting and Content-Type header logic into two independent top-level blocks
- Both blocks now explicitly check preconditions (`body != NULL && body_len > 0`)
- Improved code readability while preserving identical functional behavior

## Test Plan

- [x] All HTTP tests pass with sanitizers enabled
- [x] No functional changes introduced - same logic, clearer structure
- [x] Verified test_http_client, test_http_integration, and all other HTTP-related tests pass

Closes #1727