### PR TITLE
refactor(http-uri): flatten 5-level nesting in check_path_traversal mixed encoding .%2e check

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -1167,15 +1167,18 @@ check_path_traversal (const char *path, size_t len)
   /* Check 3: Mixed encoding ".%2e" or ".%2E" */
   for (size_t i = 0; i + 3 < len; i++)
     {
-      if (path[i] == '.' && path[i + 1] == '%' && path[i + 2] == '2'
-          && (path[i + 3] == 'e' || path[i + 3] == 'E'))
-        {
-          if (i == 0 || path[i - 1] == '/')
-            {
-              if (i + 4 >= len || path[i + 4] == '/' || path[i + 4] == '?')
-                return URI_PARSE_INVALID_PATH;
-            }
-        }
+      if (path[i] != '.' || path[i + 1] != '%' || path[i + 2] != '2')
+        continue;
+      if (path[i + 3] != 'e' && path[i + 3] != 'E')
+        continue;
+
+      if (i != 0 && path[i - 1] != '/')
+        continue;
+
+      if (i + 4 < len && path[i + 4] != '/' && path[i + 4] != '?')
+        continue;
+
+      return URI_PARSE_INVALID_PATH;
     }
 
   /* Check 4: Mixed encoding "%2e." or "%2E." */


### PR DESCRIPTION
## Summary

Implements #1730

Reduces nesting from 5 levels to 2 levels in Check 3 of the `check_path_traversal` function (mixed encoding `.%2e` or `.%2E` detection).

## Changes

- Refactored Check 3 in `src/http/SocketHTTP-uri.c` (lines 1167-1182)
- Used early `continue` statements to avoid deep nesting
- Maintained identical security logic and behavior
- No functional changes, purely readability improvement

## Test Plan

- [x] All HTTP tests pass with sanitizers (`ctest -R http`)
- [x] Full test suite passes (116/117 tests - 1 pre-existing DNS leak unrelated to this change)
- [x] Build succeeds with sanitizers enabled
- [x] Security logic unchanged - path traversal detection still catches mixed encoding attacks

Closes #1730