### PR TITLE
refactor(http2-stream): inline single-use function http2_stream_rate_record

### DIFF
--- a/src/http/SocketHTTP2-stream.c
+++ b/src/http/SocketHTTP2-stream.c
@@ -226,16 +226,6 @@ http2_stream_rate_check (SocketHTTP2_Conn_T conn)
   return 0;
 }
 
-/**
- * Record stream creation in sliding windows.
- */
-static void
-http2_stream_rate_record (SocketHTTP2_Conn_T conn)
-{
-  int64_t now_ms = Socket_get_monotonic_ms ();
-  TimeWindow_record (&conn->stream_create_window, now_ms);
-  TimeWindow_record (&conn->stream_burst_window, now_ms);
-}
 
 /**
  * Record stream close for churn detection.
@@ -311,7 +301,9 @@ http2_stream_create (SocketHTTP2_Conn_T conn, uint32_t stream_id,
   (*get_initiated_count (conn, stream->is_local_initiated))++;
 
   /* Record stream creation in sliding windows for rate limiting */
-  http2_stream_rate_record (conn);
+  int64_t now_ms = Socket_get_monotonic_ms ();
+  TimeWindow_record (&conn->stream_create_window, now_ms);
+  TimeWindow_record (&conn->stream_burst_window, now_ms);
 
   return stream;
 }


### PR DESCRIPTION
## Summary

Implements #1729

Inlines the `http2_stream_rate_record` function at its single call site in `http2_stream_create`.

## Changes

- Removed `http2_stream_rate_record` function (lines 232-238)
- Inlined the function body at the call site in `http2_stream_create` (line 314)
- Maintained the existing comment explaining the rate limiting purpose

## Benefits

- Eliminates unnecessary function call overhead
- Reduces code indirection (one less function to maintain)
- Makes rate limiting logic more visible at call site
- Consistent with other single-use inlining refactorings in the codebase

## Test Plan

- [x] All HTTP/2 tests pass with sanitizers (test_http2, test_http2_rate_limit, test_http2_priority, test_http2_integration, test_http2_server_push, test_tls_http2)
- [x] Full test suite passes (116/117 tests - pre-existing DNS test failure unrelated to this change)
- [x] Built with ASAN/UBSAN enabled

Closes #1729