### PR TITLE
refactor(http-server-connections): inline single-use connection_set_client_addr function

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -22,7 +22,6 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPServer);
 
 static void record_request_latency (SocketHTTPServer_T server,
                                     int64_t request_start_ms);
-static void connection_set_client_addr (ServerConnection *conn);
 static SocketHTTP1_Parser_T connection_create_parser (Arena_T arena,
                                                       const SocketHTTPServer_Config *config);
 static int connection_init_resources (SocketHTTPServer_T server,
@@ -613,17 +612,6 @@ connection_send_error (SocketHTTPServer_T server, ServerConnection *conn,
   connection_send_response (server, conn);
 }
 
-/* Cache client IP address from socket peer address */
-static void
-connection_set_client_addr (ServerConnection *conn)
-{
-  const char *addr = Socket_getpeeraddr (conn->socket);
-  if (addr != NULL)
-    {
-      socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
-    }
-}
-
 /* Create HTTP/1.1 parser with server config limits */
 static SocketHTTP1_Parser_T
 connection_create_parser (Arena_T arena, const SocketHTTPServer_Config *config)
@@ -667,7 +655,13 @@ connection_init_resources (SocketHTTPServer_T server, ServerConnection *conn,
   conn->created_at_ms = Socket_get_monotonic_ms ();
   conn->last_activity_ms = conn->created_at_ms;
 
-  connection_set_client_addr (conn);
+  /* Cache client IP address from socket peer address */
+  const char *addr = Socket_getpeeraddr (conn->socket);
+  if (addr != NULL)
+    {
+      socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
+    }
+
   conn->parser = connection_create_parser (arena, &server->config);
   conn->inbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
   conn->outbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);


### PR DESCRIPTION
## Summary

Implements #1734 by inlining the `connection_set_client_addr` function at its single call site.

## Changes

- Removed `connection_set_client_addr` forward declaration (line 25)
- Removed `connection_set_client_addr` function definition (lines 616-625)
- Inlined 4-line implementation directly into `connection_init_resources` at line 670

## Rationale

The function was:
- Called only once
- 8 lines long (10 including braces)
- Simple enough to inline without harming readability
- Creating unnecessary indirection

## Test Plan

- [x] All HTTP tests pass with sanitizers (`ctest -R http`)
  - test_httpserver: PASSED
  - test_httpserver_load: PASSED  
  - test_http_integration: PASSED
  - test_http2_integration: PASSED
  - 13/13 HTTP tests passed
- [x] Build succeeds with sanitizers enabled
- [x] Code follows project conventions for refactoring

## Notes

One pre-existing test failure in `test_dns_queue_limit` (memory leak in DNS module) is unrelated to this HTTP server change. All HTTP-specific tests pass.

Closes #1734