### PR TITLE
refactor(http-uri): flatten 3-level nesting in alloc_and_validate

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -138,16 +138,18 @@ alloc_and_validate (Arena_T arena, const char *start, const char *end,
   *out_str = NULL;
   *out_len = 0;
 
+  /* Handle empty input */
   if (!start || end <= start)
     {
-      if (alloc_empty)
-        {
-          char *empty = arena_strndup (arena, "", 0);
-          if (!empty)
-            return URI_PARSE_ERROR;
-          *out_str = empty;
-          *out_len = 0;
-        }
+      if (!alloc_empty)
+        return URI_PARSE_OK;
+
+      char *empty = arena_strndup (arena, "", 0);
+      if (!empty)
+        return URI_PARSE_ERROR;
+
+      *out_str = empty;
+      *out_len = 0;
       return URI_PARSE_OK;
     }
 


### PR DESCRIPTION
## Summary

Implements #1739

## Changes

- Refactored `alloc_and_validate` function in `SocketHTTP-uri.c` to reduce nesting from 3 levels to 2
- Used early return guard clause for the `!alloc_empty` case
- Added clarifying comment for empty input handling
- Maintained identical functionality with improved readability

## Test Plan

- [x] All HTTP core tests pass (225/225)
- [x] URI parsing tests pass
- [x] Build completes successfully with sanitizers
- [x] No functional changes, pure refactoring

Closes #1739