### PR TITLE
refactor(http-server-connections): inline single-use connection_add_to_server function

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -28,8 +28,6 @@ static SocketHTTP1_Parser_T connection_create_parser (Arena_T arena,
 static int connection_init_resources (SocketHTTPServer_T server,
                                       ServerConnection *conn,
                                       Socket_T socket);
-static int connection_add_to_server (SocketHTTPServer_T server,
-                                     ServerConnection *conn);
 static int connection_setup_body_buffer (SocketHTTPServer_T server,
                                          ServerConnection *conn);
 static int connection_read_initial_body (SocketHTTPServer_T server,
@@ -692,36 +690,6 @@ connection_init_resources (SocketHTTPServer_T server, ServerConnection *conn,
   return 0;
 }
 
-/* Add connection to server list and track IP for per-IP limits. Returns -1 if IP limit exceeded */
-static int
-connection_add_to_server (SocketHTTPServer_T server, ServerConnection *conn)
-{
-  /* Track per-IP connections */
-  if (server->ip_tracker != NULL && conn->client_addr[0] != '\0')
-    {
-      if (!SocketIPTracker_track (server->ip_tracker, conn->client_addr))
-        {
-          SERVER_METRICS_INC (server, SOCKET_CTR_LIMIT_CONNECTIONS_EXCEEDED,
-                              connections_rejected);
-          return -1;
-        }
-    }
-
-  /* Add to server's connection list */
-  conn->next = server->connections;
-  if (server->connections != NULL)
-    server->connections->prev = conn;
-  server->connections = conn;
-
-  /* Update global + per-server metrics */
-  SERVER_GAUGE_INC (server, SOCKET_GAU_HTTP_SERVER_ACTIVE_CONNECTIONS,
-                    active_connections);
-  SERVER_METRICS_INC (server, SOCKET_CTR_HTTP_SERVER_CONNECTIONS_TOTAL,
-                      connections_total);
-
-  return 0;
-}
-
 /* Clean up partially initialized connection */
 static void
 connection_cleanup_partial (ServerConnection *conn, int resources_initialized)
@@ -756,11 +724,30 @@ connection_new (SocketHTTPServer_T server, Socket_T socket)
       }
     resources_ok = 1;
 
-    if (connection_add_to_server (server, conn) < 0)
+    /* Track per-IP connections */
+    if (server->ip_tracker != NULL && conn->client_addr[0] != '\0')
       {
-        connection_cleanup_partial (conn, 1);
-        RETURN NULL;
+        if (!SocketIPTracker_track (server->ip_tracker, conn->client_addr))
+          {
+            SERVER_METRICS_INC (server, SOCKET_CTR_LIMIT_CONNECTIONS_EXCEEDED,
+                                connections_rejected);
+            connection_cleanup_partial (conn, 1);
+            RETURN NULL;
+          }
       }
+
+    /* Add to server's connection list */
+    conn->next = server->connections;
+    if (server->connections != NULL)
+      server->connections->prev = conn;
+    server->connections = conn;
+
+    /* Update global + per-server metrics */
+    SERVER_GAUGE_INC (server, SOCKET_GAU_HTTP_SERVER_ACTIVE_CONNECTIONS,
+                      active_connections);
+    SERVER_METRICS_INC (server, SOCKET_CTR_HTTP_SERVER_CONNECTIONS_TOTAL,
+                        connections_total);
+
     added_to_server = 1;
 
     RETURN conn;


### PR DESCRIPTION
## Summary

Implements #1740

Inlined the static helper function `connection_add_to_server()` directly into its single call site in `connection_new()`. The function was only used once and was 29 lines long.

## Changes

- Removed the 29-line helper function (lines 695-723)
- Removed the forward declaration (lines 31-32)
- Inlined the IP tracking and connection list management logic directly at the call site
- Maintains identical behavior for IP limits and metrics tracking
- Improves code locality for connection initialization logic

## Test Plan

- [x] Tests pass with sanitizers (116/117 passed - 1 pre-existing DNS leak unrelated to this change)
- [x] Build successful with ENABLE_SANITIZERS=ON
- [x] No new warnings or errors introduced
- [x] Verified test failure exists on main branch (pre-existing issue)

Closes #1740