### PR TITLE
refactor(http-server-connections): inline single-use connection_init_resources function

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -25,9 +25,6 @@ static void record_request_latency (SocketHTTPServer_T server,
 static void connection_set_client_addr (ServerConnection *conn);
 static SocketHTTP1_Parser_T connection_create_parser (Arena_T arena,
                                                       const SocketHTTPServer_Config *config);
-static int connection_init_resources (SocketHTTPServer_T server,
-                                      ServerConnection *conn,
-                                      Socket_T socket);
 static int connection_add_to_server (SocketHTTPServer_T server,
                                      ServerConnection *conn);
 static int connection_setup_body_buffer (SocketHTTPServer_T server,
@@ -654,44 +651,6 @@ record_request_latency (SocketHTTPServer_T server, int64_t request_start_ms)
     }
 }
 
-/* Initialize connection resources: arena, buffers, parser. Enables TLS if configured */
-static int
-connection_init_resources (SocketHTTPServer_T server, ServerConnection *conn,
-                           Socket_T socket)
-{
-  Arena_T arena = Arena_new ();
-  conn->arena = arena;
-  conn->socket = socket;
-
-  conn->state = CONN_STATE_READING_REQUEST;
-  conn->created_at_ms = Socket_get_monotonic_ms ();
-  conn->last_activity_ms = conn->created_at_ms;
-
-  connection_set_client_addr (conn);
-  conn->parser = connection_create_parser (arena, &server->config);
-  conn->inbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
-  conn->outbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
-  conn->response_headers = SocketHTTP_Headers_new (arena);
-
-  conn->memory_used = sizeof (*conn) + (2 * HTTPSERVER_IO_BUFFER_SIZE);
-
-  /* Optional TLS enable: handshake is driven by server event loop. */
-  if (server->config.tls_context != NULL)
-    {
-#if SOCKET_HAS_TLS
-      conn->tls_enabled = 1;
-      conn->tls_handshake_done = 0;
-      SocketTLS_enable (conn->socket, server->config.tls_context);
-      conn->state = CONN_STATE_TLS_HANDSHAKE;
-#else
-      HTTPSERVER_ERROR_MSG ("TLS requested but SOCKET_HAS_TLS=0");
-      RAISE_HTTPSERVER_ERROR (SocketHTTPServer_Failed);
-#endif
-    }
-
-  return 0;
-}
-
 /* Add connection to server list and track IP for per-IP limits. Returns -1 if IP limit exceeded */
 static int
 connection_add_to_server (SocketHTTPServer_T server, ServerConnection *conn)
@@ -749,11 +708,37 @@ connection_new (SocketHTTPServer_T server, Socket_T socket)
 
   TRY
   {
-    if (connection_init_resources (server, conn, socket) < 0)
+    /* Initialize connection resources: arena, buffers, parser */
+    Arena_T arena = Arena_new ();
+    conn->arena = arena;
+    conn->socket = socket;
+
+    conn->state = CONN_STATE_READING_REQUEST;
+    conn->created_at_ms = Socket_get_monotonic_ms ();
+    conn->last_activity_ms = conn->created_at_ms;
+
+    connection_set_client_addr (conn);
+    conn->parser = connection_create_parser (arena, &server->config);
+    conn->inbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
+    conn->outbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
+    conn->response_headers = SocketHTTP_Headers_new (arena);
+
+    conn->memory_used = sizeof (*conn) + (2 * HTTPSERVER_IO_BUFFER_SIZE);
+
+    /* Optional TLS enable: handshake is driven by server event loop. */
+    if (server->config.tls_context != NULL)
       {
-        connection_cleanup_partial (conn, 0);
-        RETURN NULL;
+#if SOCKET_HAS_TLS
+        conn->tls_enabled = 1;
+        conn->tls_handshake_done = 0;
+        SocketTLS_enable (conn->socket, server->config.tls_context);
+        conn->state = CONN_STATE_TLS_HANDSHAKE;
+#else
+        HTTPSERVER_ERROR_MSG ("TLS requested but SOCKET_HAS_TLS=0");
+        RAISE_HTTPSERVER_ERROR (SocketHTTPServer_Failed);
+#endif
       }
+
     resources_ok = 1;
 
     if (connection_add_to_server (server, conn) < 0)


### PR DESCRIPTION
## Summary

Implements #1738

Inlined the `connection_init_resources` function into its only call site in `connection_new`. This single-use function was 35 lines long and added unnecessary indirection.

## Changes

- Removed `connection_init_resources` function declaration
- Removed `connection_init_resources` function definition (lines 657-693)
- Inlined the initialization logic directly into `connection_new` (line 752)
- Preserved all existing behavior including TLS setup and exception handling

## Test Plan

- [x] All HTTP server tests pass (`test_httpserver`: 27/27)
- [x] Full test suite passes with sanitizers (116/117, 1 pre-existing DNS test failure)
- [x] No functional changes, purely a refactoring to reduce indirection

Closes #1738