### PR TITLE
refactor(http2-stream): inline single-use clear_pending_header_block function

### DIFF
--- a/src/http/SocketHTTP2-stream.c
+++ b/src/http/SocketHTTP2-stream.c
@@ -1283,13 +1283,6 @@ init_pending_header_block (SocketHTTP2_Conn_T conn,
   return 0;
 }
 
-static void
-clear_pending_header_block (SocketHTTP2_Stream_T stream)
-{
-  stream->header_block = NULL;
-  stream->header_block_len = 0;
-  stream->header_block_capacity = 0;
-}
 
 static int
 send_single_headers_frame (SocketHTTP2_Conn_T conn,
@@ -2398,7 +2391,10 @@ http2_process_continuation (SocketHTTP2_Conn_T conn,
       int result = process_complete_header_block (conn, stream,
                                                   stream->header_block,
                                                   stream->header_block_len);
-      clear_pending_header_block (stream);
+      /* Clear pending header block */
+      stream->header_block = NULL;
+      stream->header_block_len = 0;
+      stream->header_block_capacity = 0;
       return result;
     }
 


### PR DESCRIPTION
## Summary

Implements #1737

Inlines the single-use `clear_pending_header_block` helper function directly into its only call site in `http2_process_continuation`.

## Changes

- Removed `clear_pending_header_block` static function (lines 1286-1292)
- Inlined the three cleanup statements at line 2401 with explanatory comment
- No functional changes - pure refactoring

## Benefits

- Eliminates unnecessary function call overhead
- Reduces code indirection (one less function to maintain)
- Makes cleanup logic more visible at call site
- Consistent with project pattern of avoiding single-use helpers

## Test Plan

- [x] All HTTP/2 tests pass with sanitizers:
  - `test_http2` - 29/29 passed
  - `test_http2_integration` - 4/4 passed  
  - `test_http2_priority` - 13/13 passed
  - `test_http2_rate_limit` - 9/9 passed
  - `test_http2_server_push` - 11/11 passed
- [x] Full test suite: 116/117 tests passed (1 unrelated DNS test has pre-existing memory leak)
- [x] Build completes with `-DENABLE_SANITIZERS=ON`

Closes #1737