### PR TITLE
refactor(http-server-connections): inline single-use connection_create_parser function

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -23,8 +23,6 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPServer);
 static void record_request_latency (SocketHTTPServer_T server,
                                     int64_t request_start_ms);
 static void connection_set_client_addr (ServerConnection *conn);
-static SocketHTTP1_Parser_T connection_create_parser (Arena_T arena,
-                                                      const SocketHTTPServer_Config *config);
 static int connection_init_resources (SocketHTTPServer_T server,
                                       ServerConnection *conn,
                                       Socket_T socket);
@@ -624,22 +622,6 @@ connection_set_client_addr (ServerConnection *conn)
     }
 }
 
-/* Create HTTP/1.1 parser with server config limits */
-static SocketHTTP1_Parser_T
-connection_create_parser (Arena_T arena, const SocketHTTPServer_Config *config)
-{
-  SocketHTTP1_Config pcfg;
-  SocketHTTP1_config_defaults (&pcfg);
-  pcfg.max_header_size = config->max_header_size;
-
-  SocketHTTP1_Parser_T p
-      = SocketHTTP1_Parser_new (HTTP1_PARSE_REQUEST, &pcfg, arena);
-  if (p == NULL)
-    RAISE_HTTPSERVER_ERROR (SocketHTTPServer_Failed);
-
-  return p;
-}
-
 /* Record request latency to histogram */
 static void
 record_request_latency (SocketHTTPServer_T server, int64_t request_start_ms)
@@ -668,7 +650,15 @@ connection_init_resources (SocketHTTPServer_T server, ServerConnection *conn,
   conn->last_activity_ms = conn->created_at_ms;
 
   connection_set_client_addr (conn);
-  conn->parser = connection_create_parser (arena, &server->config);
+
+  /* Create HTTP/1.1 parser with server config limits */
+  SocketHTTP1_Config pcfg;
+  SocketHTTP1_config_defaults (&pcfg);
+  pcfg.max_header_size = server->config.max_header_size;
+  conn->parser = SocketHTTP1_Parser_new (HTTP1_PARSE_REQUEST, &pcfg, arena);
+  if (conn->parser == NULL)
+    RAISE_HTTPSERVER_ERROR (SocketHTTPServer_Failed);
+
   conn->inbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
   conn->outbuf = SocketBuf_new (arena, HTTPSERVER_IO_BUFFER_SIZE);
   conn->response_headers = SocketHTTP_Headers_new (arena);


### PR DESCRIPTION
## Summary

Implements #1736

## Changes

- Removed `connection_create_parser()` function declaration and definition
- Inlined parser initialization code directly into `connection_init_resources()` at the single call site
- Preserved error handling with `RAISE_HTTPSERVER_ERROR` on allocation failure

## Test Plan

- [x] All tests pass with sanitizers enabled (116/117 tests, 1 unrelated DNS test failure)
- [x] HTTP server tests pass (27/27)
- [x] HTTP integration tests pass (8/8)
- [x] No functional changes, pure refactoring

Closes #1736