### PR TITLE
refactor(http-server-static): flatten 4-level nesting in sendfile error handling

### DIFF
--- a/src/http/SocketHTTPServer-static.c
+++ b/src/http/SocketHTTPServer-static.c
@@ -567,19 +567,16 @@ server_serve_static_file (SocketHTTPServer_T server, ServerConnection *conn,
   while (remaining > 0)
     {
       sent = sendfile (Socket_fd (conn->socket), fd, &offset, remaining);
+
+      /* Handle errors */
       if (sent < 0)
         {
-          if (errno == EAGAIN || errno == EWOULDBLOCK)
-            {
-              /* Would block - need to poll for write readiness */
-              /* For simplicity, we'll continue trying */
-              continue;
-            }
-          if (errno == EINTR)
+          if (errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR)
             continue;
           close (fd);
           return -1;
         }
+
       if (sent == 0)
         break;
 


### PR DESCRIPTION
## Summary

Implements #1746

## Changes

- Consolidated retryable errors (EAGAIN, EWOULDBLOCK, EINTR) into a single condition in the sendfile loop
- Reduced nesting from 4 levels to 2 levels
- Improved readability and maintainability of error handling logic

## Test Plan

- [x] All HTTP server tests pass with sanitizers
- [x] Build succeeds with -Werror
- [x] No functional changes to error handling behavior

Closes #1746