### PR TITLE
refactor(http-server-static): inline single-use get_mime_type function

### DIFF
--- a/src/http/SocketHTTPServer-static.c
+++ b/src/http/SocketHTTPServer-static.c
@@ -102,42 +102,6 @@ static const struct
   { NULL, NULL }
 };
 
-/**
- * get_mime_type - Determine MIME type from file extension
- * @path: File path to check
- *
- * Returns: MIME type string or "application/octet-stream" for unknown
- */
-static const char *
-get_mime_type (const char *path)
-{
-  const char *ext;
-  size_t path_len, ext_len;
-
-  if (path == NULL)
-    return "application/octet-stream";
-
-  path_len = strlen (path);
-
-  /* Find the last dot in the path */
-  ext = strrchr (path, '.');
-  if (ext == NULL)
-    return "application/octet-stream";
-
-  ext_len = path_len - (size_t)(ext - path);
-
-  /* Check against known extensions (case-insensitive) */
-  for (int i = 0; mime_types[i].extension != NULL; i++)
-    {
-      if (strlen (mime_types[i].extension) == ext_len
-          && strcasecmp (ext, mime_types[i].extension) == 0)
-        {
-          return mime_types[i].mime_type;
-        }
-    }
-
-  return "application/octet-stream";
-}
 
 /**
  * validate_static_path - Validate path for security (no traversal attacks)
@@ -447,8 +411,27 @@ server_serve_static_file (SocketHTTPServer_T server, ServerConnection *conn,
       return 0;
     }
 
-  /* Get MIME type */
-  mime_type = get_mime_type (resolved_path);
+  /* Determine MIME type from file extension */
+  mime_type = "application/octet-stream"; /* Default for unknown types */
+  {
+    const char *ext = strrchr (resolved_path, '.');
+    if (ext != NULL)
+      {
+        size_t path_len = strlen (resolved_path);
+        size_t ext_len = path_len - (size_t)(ext - resolved_path);
+
+        /* Check against known extensions (case-insensitive) */
+        for (int i = 0; mime_types[i].extension != NULL; i++)
+          {
+            if (strlen (mime_types[i].extension) == ext_len
+                && strcasecmp (ext, mime_types[i].extension) == 0)
+              {
+                mime_type = mime_types[i].mime_type;
+                break;
+              }
+          }
+      }
+  }
 
   /* Check If-Modified-Since header */
   if_modified_since = SocketHTTP_Headers_get (conn->request->headers,


### PR DESCRIPTION
## Summary

Implements #1747

Inlines the `get_mime_type` function which was called only once in `server_serve_static_file`. This 29-line helper function added indirection without clear benefit.

## Changes

- Removed `get_mime_type` function (lines 112-140)
- Inlined MIME type determination logic directly into `server_serve_static_file`
- Maintained identical behavior with clearer scope management
- Added `break` statement to exit loop early when match found (minor optimization)

## Test Plan

- [x] Tests pass with sanitizers (116/117 - one pre-existing DNS test failure unrelated to these changes)
- [x] Build succeeds with `-Wall -Wextra -Werror`
- [x] No functional changes to MIME type detection logic
- [x] Code remains readable and follows project conventions

Closes #1747