### PR TITLE
refactor(hpack-huffman): inline single-use refill_bit_buffer

### DIFF
--- a/src/http/SocketHPACK-huffman.c
+++ b/src/http/SocketHPACK-huffman.c
@@ -521,18 +521,6 @@ try_decode_symbol (uint64_t bits, int *bits_avail, unsigned char *output,
   return 0;
 }
 
-static void
-refill_bit_buffer (uint64_t *bits, int *bits_avail, const unsigned char *input,
-                   size_t *in_pos, size_t input_len)
-{
-  while (*bits_avail < HUFFMAN_REFILL_THRESHOLD && *in_pos < input_len)
-    {
-      *bits = (*bits << HUFFMAN_BITS_PER_BYTE) | input[(*in_pos)++];
-      *bits_avail += HUFFMAN_BITS_PER_BYTE;
-    }
-}
-
-
 /* ============================================================================
  * Public API
  * ============================================================================
@@ -625,7 +613,12 @@ SocketHPACK_huffman_decode (const unsigned char *input, size_t input_len,
 
   while (in_pos < input_len || bits_avail >= HUFFMAN_MIN_CODE_BITS)
     {
-      refill_bit_buffer (&bits, &bits_avail, input, &in_pos, input_len);
+      /* Refill bit buffer when running low */
+      while (bits_avail < HUFFMAN_REFILL_THRESHOLD && in_pos < input_len)
+        {
+          bits = (bits << HUFFMAN_BITS_PER_BYTE) | input[in_pos++];
+          bits_avail += HUFFMAN_BITS_PER_BYTE;
+        }
 
       if (bits_avail < HUFFMAN_MIN_CODE_BITS)
         break;


### PR DESCRIPTION
## Summary

Implements #1707

The `refill_bit_buffer` function was called exactly once in the codebase, making it a candidate for inlining. This refactoring reduces indirection and simplifies the decode loop.

## Changes

- Removed `refill_bit_buffer` static function (lines 524-533)
- Inlined the bit buffer refill logic directly in `SocketHPACK_huffman_decode` at line 616
- Added a comment explaining the refill operation
- Net reduction: 7 lines (13 removed, 6 added)

## Impact

- Reduces function call overhead in the HPACK Huffman decode hot path
- Maintains code clarity with inline comment
- No functional changes - all HPACK tests pass

## Test Plan

- [x] Tests pass with sanitizers enabled (`ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest`)
- [x] All HPACK tests pass
- [x] Huffman encode/decode round-trip tests pass
- [x] RFC 7541 test vectors pass

Closes #1707