### PR TITLE
refactor(http1-serialize): inline single-use add_optional_host_header function

### DIFF
--- a/src/http/SocketHTTP1-serialize.c
+++ b/src/http/SocketHTTP1-serialize.c
@@ -280,35 +280,6 @@ serialize_response_line (const SocketHTTP_Response *response, char **buf,
 }
 
 static int
-add_optional_host_header (const SocketHTTP_Request *request, char **buf,
-                          size_t *remaining)
-{
-  size_t auth_len;
-
-  if (!request->authority || request->authority[0] == '\0')
-    return 0;
-
-  if (request->headers && SocketHTTP_Headers_has (request->headers, "Host"))
-    return 0;
-
-  if (safe_append (buf, remaining, HTTP_HOST_PREFIX, HTTP_HOST_PREFIX_LEN) < 0)
-    return -1;
-
-  auth_len = strlen (request->authority);
-  if (!SocketHTTP_header_value_valid (request->authority, auth_len))
-    {
-      SOCKET_RAISE_MSG (
-          SocketHTTP1, SocketHTTP1_SerializeError,
-          "Invalid authority contains forbidden characters (CR/LF/NUL)");
-    }
-
-  if (safe_append (buf, remaining, request->authority, auth_len) < 0)
-    return -1;
-
-  return safe_append_crlf (buf, remaining);
-}
-
-static int
 add_response_extras (const SocketHTTP_Response *response, char **buf,
                      size_t *remaining)
 {
@@ -344,8 +315,28 @@ SocketHTTP1_serialize_request (const SocketHTTP_Request *request, char *output,
     return -1;
 
   /* Add optional Host header if authority present and no Host header set */
-  if (add_optional_host_header (request, &p, &remaining) < 0)
-    return -1;
+  if (request->authority && request->authority[0] != '\0')
+    {
+      if (!request->headers || !SocketHTTP_Headers_has (request->headers, "Host"))
+        {
+          if (safe_append (&p, &remaining, HTTP_HOST_PREFIX, HTTP_HOST_PREFIX_LEN) < 0)
+            return -1;
+
+          size_t auth_len = strlen (request->authority);
+          if (!SocketHTTP_header_value_valid (request->authority, auth_len))
+            {
+              SOCKET_RAISE_MSG (
+                  SocketHTTP1, SocketHTTP1_SerializeError,
+                  "Invalid authority contains forbidden characters (CR/LF/NUL)");
+            }
+
+          if (safe_append (&p, &remaining, request->authority, auth_len) < 0)
+            return -1;
+
+          if (safe_append_crlf (&p, &remaining) < 0)
+            return -1;
+        }
+    }
 
   /* Add Content-Length header if needed */
   if (append_content_length_header (&p, &remaining, request->headers,


### PR DESCRIPTION
## Summary

Implements #1743 - Inlines the static function `add_optional_host_header` into its single call site in `SocketHTTP1_serialize_request`.

## Changes

- Removed the `add_optional_host_header` function (lines 282-309)
- Inlined the function logic directly into `SocketHTTP1_serialize_request` at the single call site
- Preserved exact behavior: checks for authority presence, verifies no existing Host header, validates authority string, and appends Host header

## Benefits

- **Improved code locality**: Related logic is now together in one place
- **Reduced function call overhead**: Eliminates one function call from the request serialization path
- **Simpler code flow**: Easier to understand the complete request serialization logic

## Test Plan

- [x] All HTTP-related tests pass with sanitizers enabled
- [x] test_http_core: Passed
- [x] test_http1_parser: Passed
- [x] test_http2: Passed
- [x] test_http_client: Passed
- [x] test_httpserver: Passed
- [x] test_http_integration: Passed
- [x] test_http2_integration: Passed
- [x] Build succeeds with ASan/UBSan

Closes #1743