### PR TITLE
refactor(http1-serialize): inline single-use add_response_extras function

### DIFF
--- a/src/http/SocketHTTP1-serialize.c
+++ b/src/http/SocketHTTP1-serialize.c
@@ -308,19 +308,6 @@ add_optional_host_header (const SocketHTTP_Request *request, char **buf,
   return safe_append_crlf (buf, remaining);
 }
 
-static int
-add_response_extras (const SocketHTTP_Response *response, char **buf,
-                     size_t *remaining)
-{
-  if (append_content_length_header (buf, remaining, response->headers,
-                                    response->has_body,
-                                    response->content_length)
-      < 0)
-    return -1;
-
-  return safe_append_crlf (buf, remaining);
-}
-
 ssize_t
 SocketHTTP1_serialize_request (const SocketHTTP_Request *request, char *output,
                                size_t output_size)
@@ -383,7 +370,13 @@ SocketHTTP1_serialize_response (const SocketHTTP_Response *response,
   if (serialize_headers_section (response->headers, &p, &remaining) < 0)
     return -1;
 
-  if (add_response_extras (response, &p, &remaining) < 0)
+  if (append_content_length_header (&p, &remaining, response->headers,
+                                    response->has_body,
+                                    response->content_length)
+      < 0)
+    return -1;
+
+  if (safe_append_crlf (&p, &remaining) < 0)
     return -1;
 
   *p = '\0';


### PR DESCRIPTION
## Summary

Implements #1732 by inlining the `add_response_extras` function directly into its only call site in `SocketHTTP1_serialize_response`.

## Changes

- Removed the `add_response_extras` static function (lines 311-322)
- Inlined its two operations into `SocketHTTP1_serialize_response`:
  - Call to `append_content_length_header`
  - Call to `safe_append_crlf`

## Rationale

The function was only called once, making it an unnecessary abstraction layer. Inlining improves code locality and makes the response serialization flow more explicit.

## Test Plan

- [x] All tests pass with sanitizers (116/117 - 1 pre-existing DNS leak unrelated to this change)
- [x] HTTP serialization tests verify correct behavior
- [x] No functional changes - pure refactoring

Closes #1732