### PR TITLE
docs(hpack): document HPACK_HUFFMAN_RATIO constant

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -50,6 +50,7 @@
 #define HPACK_INT_CONTINUATION_VALUE 128
 
 #define HPACK_INT_BUF_SIZE 16
+/* Conservative 2x ratio for Huffman decode buffer (worst-case is 8/5 ≈ 1.6) */
 #define HPACK_HUFFMAN_RATIO 2
 
 #define HPACK_UINT64_SHIFT_LIMIT 63


### PR DESCRIPTION
## Summary

Documents the HPACK_HUFFMAN_RATIO magic number with an explanatory comment.

## Changes

- Added comment explaining the 2x ratio provides a safety margin over the theoretical worst-case Huffman expansion of 8/5 ≈ 1.6 per RFC 7541 Section 5.2

## Test Plan

- [x] All HPACK tests pass
- [x] Tests pass with sanitizers (116/117 passing, 1 unrelated flaky test)
- [x] Build succeeds with no warnings

Closes #1822