### PR TITLE
chore(hpack): remove unused HPACK_UINT64_SHIFT_LIMIT constant

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -57,7 +57,6 @@
 /* Conservative 2x ratio for Huffman decode buffer (worst-case is 8/5 ≈ 1.6) */
 #define HPACK_HUFFMAN_RATIO 2
 
-#define HPACK_UINT64_SHIFT_LIMIT 63
 /* Max continuation bytes to encode uint64_t: 10 bytes * 7 bits = 70 bits (> 64 bits needed)
  * RFC 7541 §5.1: Each continuation byte carries 7 bits of value.
  * This limit prevents DoS via oversized integer encodings. */


### PR DESCRIPTION
## Summary

Removes unused `HPACK_UINT64_SHIFT_LIMIT` constant from `src/http/SocketHPACK.c` (line 55).

## Changes

- Removed `#define HPACK_UINT64_SHIFT_LIMIT 63` which was never referenced in the codebase
- The actual shift limit check at line 219 uses a hardcoded value of 56, which is the correct value for HPACK integer decoding (64 - 8 bits for the last byte)

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] All HPACK tests pass (test_hpack)
- [x] All HTTP/2 tests pass (test_http2)
- [x] Full test suite passes (97% - pre-existing failures in unrelated tests)

Closes #1829