### PR TITLE
docs(hpack): document HPACK_MAX_INT_CONTINUATION_BYTES constant

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -53,6 +53,9 @@
 #define HPACK_HUFFMAN_RATIO 2
 
 #define HPACK_UINT64_SHIFT_LIMIT 63
+/* Max continuation bytes to encode uint64_t: 10 bytes * 7 bits = 70 bits (> 64 bits needed)
+ * RFC 7541 §5.1: Each continuation byte carries 7 bits of value.
+ * This limit prevents DoS via oversized integer encodings. */
 #define HPACK_MAX_INT_CONTINUATION_BYTES 10
 
 #define HPACK_LITERAL_WITH_INDEXING 0x40


### PR DESCRIPTION
## Summary

Implements #1823

Adds comprehensive documentation for the `HPACK_MAX_INT_CONTINUATION_BYTES` constant that was previously undocumented.

## Changes

- Added multi-line comment above the constant definition explaining:
  - The mathematical rationale: 10 bytes × 7 bits = 70 bits (exceeds 64-bit uint64_t)
  - RFC 7541 §5.1 reference for integer representation specification
  - Security context: prevents DoS attacks via oversized integer encodings

## Test Plan

- [x] All HPACK tests pass
- [x] Build succeeds with sanitizers enabled
- [x] No functionality changes, documentation only

Closes #1823