### PR TITLE
fix(hpack): add NULL assertions before memcpy operations

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -365,6 +365,7 @@ decode_string_data_literal (const unsigned char *input, size_t str_len,
   if (result != HPACK_OK)
     return result;
 
+  assert (input != NULL);
   memcpy (*str_out, input + pos, str_len);
   (*str_out)[str_len] = '\0';
   *str_len_out = str_len;
@@ -872,6 +873,7 @@ hpack_copy_indexed_name (SocketHPACK_Decoder_T decoder, size_t index,
   if (alloc_result != HPACK_OK)
     return alloc_result;
 
+  assert (name_hdr.name != NULL);
   memcpy (name_copy, name_hdr.name, name_hdr.name_len);
   name_copy[name_hdr.name_len] = '\0';
 


### PR DESCRIPTION
## Summary

Implements #1825 - Add defensive NULL pointer assertions before memcpy operations in HPACK code.

## Changes

- Added `assert(input != NULL)` before memcpy in `decode_string_data_literal` (line 368)
- Added `assert(name_hdr.name != NULL)` before memcpy in `hpack_copy_indexed_name` (line 875)

## Rationale

While callers currently perform validation, these assertions:
- Document function preconditions explicitly
- Prevent future bugs if caller validation changes
- Provide clear failure points during development
- Compile to nothing in release builds (with NDEBUG)

## Test Plan

- [x] All HPACK tests pass (test_hpack: 42/42)
- [x] All HTTP/2 tests pass (test_http2: 29/29)
- [x] Full test suite runs with sanitizers (116/117 pass, 1 pre-existing DNS test failure unrelated to changes)
- [x] No new memory leaks or undefined behavior detected

Closes #1825