### PR TITLE
refactor(hpack): document why socket_util_normalize_hostname is unsuitable

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -81,6 +81,16 @@ valid_prefix_bits (int prefix_bits)
  * Create lowercase copy of header name in arena.
  * RFC 9113 §8.2: "Field names MUST be converted to lowercase when
  * constructing an HTTP/2 message."
+ *
+ * NOTE: socket_util_normalize_hostname() from SocketUtil.h cannot be used here
+ * because it has different semantics:
+ * - It writes to a pre-allocated buffer (void return) instead of returning a pointer
+ * - It always copies data, whereas we optimize by returning the original string
+ *   if no conversion is needed (common case in HTTP/2)
+ * - Our implementation minimizes arena allocations for performance
+ *
+ * The optimization matters for HPACK encoding hot paths where most headers
+ * are already lowercase (:method, :path, content-type, etc.).
  */
 static const char *
 lowercase_header_name (Arena_T arena, const char *name, size_t len)


### PR DESCRIPTION
## Summary

Implements #1826 by checking if `socket_util_normalize_hostname()` from SocketUtil.h can replace the custom `lowercase_header_name()` implementation in SocketHPACK.c.

## Analysis

After reviewing both implementations:

**socket_util_normalize_hostname()** (SocketUtil.h:1047-1053):
- Writes to pre-allocated buffer (void return)
- Always copies data regardless of content
- Requires caller to allocate buffer upfront

**lowercase_header_name()** (SocketHPACK.c:86-117):
- Returns pointer (either original or new allocation)
- Optimizes by returning original string when already lowercase
- Allocates in arena only when conversion needed

## Decision

The utility function is **not suitable** for replacement due to different semantics. The custom implementation provides critical performance optimization for the HPACK encoding hot path where most HTTP/2 headers are already lowercase (`:method`, `:path`, `content-type`, etc.).

## Changes

- Added comprehensive comment explaining why `socket_util_normalize_hostname()` cannot be used
- Documented the performance rationale for the custom implementation
- No functional changes

## Test Plan

- [x] Tests pass with sanitizers (116/117 tests pass, 1 pre-existing flaky test)
- [x] HPACK-specific tests pass: `test_hpack` ✓
- [x] No functional changes, comment-only addition

Closes #1826