### PR TITLE
refactor(hpack): define HPACK_MAX_SAFE_SHIFT constant for shift limit

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -55,6 +55,10 @@
 #define HPACK_UINT64_SHIFT_LIMIT 63
 #define HPACK_MAX_INT_CONTINUATION_BYTES 10
 
+/* Max safe shift: 64 bits - 8 bits for last continuation byte payload.
+ * Prevents left shift overflow in integer decoding (RFC 7541 §5.1). */
+#define HPACK_MAX_SAFE_SHIFT 56
+
 #define HPACK_LITERAL_WITH_INDEXING 0x40
 #define HPACK_LITERAL_WITHOUT_INDEX 0x00
 #define HPACK_LITERAL_NEVER_INDEX 0x10
@@ -216,7 +220,7 @@ decode_int_continuation (const unsigned char *input, size_t input_len,
 
       byte_val = input[(*pos)++];
 
-      if (*shift > 56)
+      if (*shift > HPACK_MAX_SAFE_SHIFT)
         return HPACK_ERROR_INTEGER;
 
       uint64_t add_val = (byte_val & HPACK_INT_PAYLOAD_MASK) << *shift;


### PR DESCRIPTION
## Summary

Implements #1824

Replaces hardcoded magic number `56` with named constant `HPACK_MAX_SAFE_SHIFT` in HPACK integer decoding.

## Changes

- Added `HPACK_MAX_SAFE_SHIFT` constant definition with documentation
- Replaced `if (*shift > 56)` with `if (*shift > HPACK_MAX_SAFE_SHIFT)`
- Added comment explaining the security-critical overflow prevention logic

## Rationale

The value 56 represents `64 bits (uint64_t) - 8 bits (final continuation byte)` and is a critical security boundary for preventing left shift overflow in HPACK integer decoding per RFC 7541 Section 5.1.

Without documentation, maintainers may not understand why this specific value is used. This change makes the security invariant explicit.

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All HPACK tests pass (test_hpack)
- [x] 116 out of 117 tests pass (1 pre-existing DNS test failure unrelated to this change)
- [x] No functional changes - purely refactoring for code clarity

Closes #1824