### PR TITLE
docs(hpack): clarify uint64_t to size_t overflow checks for 32-bit platforms

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -415,6 +415,9 @@ hpack_decode_string (const unsigned char *input, size_t input_len,
   if (result != HPACK_OK)
     return result;
 
+  /* Check for 32-bit platform overflow (always false on 64-bit platforms where
+   * sizeof(size_t) == sizeof(uint64_t), but necessary for 32-bit compatibility
+   * where uint64_t values can exceed SIZE_MAX) */
   if (str_len > SIZE_MAX || pos + str_len > input_len)
     return (str_len > SIZE_MAX) ? HPACK_ERROR_INTEGER : HPACK_INCOMPLETE;
 
@@ -1006,6 +1009,9 @@ hpack_decode_table_update (SocketHPACK_Decoder_T decoder,
     return result;
   *pos += consumed;
 
+  /* Check for 32-bit platform overflow (always false on 64-bit platforms where
+   * sizeof(size_t) == sizeof(uint64_t), but necessary for 32-bit compatibility
+   * where uint64_t values can exceed SIZE_MAX) */
   if (new_size > SIZE_MAX)
     return HPACK_ERROR_INTEGER;
   if (new_size > decoder->settings_max_table_size)


### PR DESCRIPTION
## Summary

Implements #1830

Added clarifying comments to SIZE_MAX overflow checks in HPACK decoder to explain their purpose for 32-bit platform compatibility.

## Changes

- Added explanatory comments to two SIZE_MAX overflow checks in `src/http/SocketHPACK.c`
- Line 418: String length check in `hpack_decode_string`
- Line 1009: Table size check in `hpack_decode_table_update`

## Rationale

On 64-bit platforms where `sizeof(size_t) == sizeof(uint64_t)`, the condition `value > SIZE_MAX` is always false and may trigger compiler warnings about tautological comparisons.

However, on 32-bit platforms, `uint64_t` values can exceed `SIZE_MAX`, making these checks necessary for cross-platform compatibility.

The added comments document this behavior to help future maintainers understand why seemingly redundant checks exist.

## Test Plan

- [x] Tests pass with sanitizers: `cmake -B build -DENABLE_SANITIZERS=ON && cmake --build build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest --output-on-failure`
- [x] HPACK tests pass: All HPACK unit tests pass successfully
- [x] No functional changes: This is documentation-only, no code behavior changed

Closes #1830