### PR TITLE
refactor(dns): remove redundant zero initialization in SocketDNSoverHTTPS_new

### DIFF
--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -221,11 +221,7 @@ SocketDNSoverHTTPS_new (Arena_T arena)
   memset (transport, 0, sizeof (*transport));
 
   transport->arena = arena;
-  transport->server_count = 0;
-  transport->current_server = 0;
-  transport->pending_head = NULL;
-  transport->pending_tail = NULL;
-  transport->pending_count = 0;
+  /* All other fields already zeroed by memset */
 
   /* Create HTTP client with HTTP/2 support */
   SocketHTTPClient_Config config;


### PR DESCRIPTION
## Summary

Implements #1855

Removed redundant zero/NULL assignments after `memset(transport, 0, sizeof(*transport))` in `SocketDNSoverHTTPS_new()`.

## Changes

- Removed 5 redundant field initializations (server_count, current_server, pending_head, pending_tail, pending_count)
- Added clarifying comment that memset handles zero initialization
- Kept only the necessary `arena` field assignment

## Test Plan

- [x] All DNS-over-HTTPS tests pass with sanitizers (15/15 tests passing)
- [x] Build completes successfully with ASan/UBSan enabled
- [x] No functional changes - purely refactoring redundant code

Closes #1855