### PR TITLE
refactor(dns): replace magic number 0x7F with named constant

### DIFF
--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -46,6 +46,12 @@
 /** Maximum query size for GET method (to prevent base64 explosion). */
 #define DOH_MAX_GET_QUERY_SIZE 512
 
+/** ASCII control character boundary (space character). */
+#define ASCII_SPACE 0x20
+
+/** ASCII DEL control character. */
+#define ASCII_DEL 0x7F
+
 /* Well-known DoH servers */
 static const struct
 {
@@ -296,7 +302,7 @@ SocketDNSoverHTTPS_configure (T transport,
   for (size_t i = 0; i < url_len; i++)
     {
       unsigned char c = (unsigned char)config->url[i];
-      if (c < 0x20 || c == 0x7F)
+      if (c < ASCII_SPACE || c == ASCII_DEL)
         return -1;
     }
 


### PR DESCRIPTION
## Summary

Implements #1852

Replaces hardcoded magic numbers `0x20` and `0x7F` with named constants `ASCII_SPACE` and `ASCII_DEL` in URL validation code.

## Changes

- Added `ASCII_SPACE` constant for 0x20
- Added `ASCII_DEL` constant for 0x7F  
- Updated control character validation in `SocketDNSoverHTTPS_configure()` to use named constants

## Test Plan

- [x] All DNS-over-HTTPS tests pass (15/15)
- [x] Build succeeds with sanitizers enabled
- [x] Code readability improved - constants now self-documenting

Closes #1852