### PR TITLE
refactor(dns): replace manual big-endian unpacking in SOA parser with dns_unpack_be32 helper

### DIFF
--- a/src/dns/SocketDNSWire.c
+++ b/src/dns/SocketDNSWire.c
@@ -930,38 +930,23 @@ SocketDNS_rdata_parse_soa (const unsigned char *msg, size_t msglen,
     return -1;
 
   /* Extract SERIAL (32-bit, network byte order) */
-  soa->serial = ((uint32_t)msg[offset] << 24) |
-                ((uint32_t)msg[offset + 1] << 16) |
-                ((uint32_t)msg[offset + 2] << 8) |
-                ((uint32_t)msg[offset + 3]);
+  soa->serial = dns_unpack_be32(msg + offset);
   offset += 4;
 
   /* Extract REFRESH (32-bit, network byte order) */
-  soa->refresh = ((uint32_t)msg[offset] << 24) |
-                 ((uint32_t)msg[offset + 1] << 16) |
-                 ((uint32_t)msg[offset + 2] << 8) |
-                 ((uint32_t)msg[offset + 3]);
+  soa->refresh = dns_unpack_be32(msg + offset);
   offset += 4;
 
   /* Extract RETRY (32-bit, network byte order) */
-  soa->retry = ((uint32_t)msg[offset] << 24) |
-               ((uint32_t)msg[offset + 1] << 16) |
-               ((uint32_t)msg[offset + 2] << 8) |
-               ((uint32_t)msg[offset + 3]);
+  soa->retry = dns_unpack_be32(msg + offset);
   offset += 4;
 
   /* Extract EXPIRE (32-bit, network byte order) */
-  soa->expire = ((uint32_t)msg[offset] << 24) |
-                ((uint32_t)msg[offset + 1] << 16) |
-                ((uint32_t)msg[offset + 2] << 8) |
-                ((uint32_t)msg[offset + 3]);
+  soa->expire = dns_unpack_be32(msg + offset);
   offset += 4;
 
   /* Extract MINIMUM (32-bit, network byte order) */
-  soa->minimum = ((uint32_t)msg[offset] << 24) |
-                 ((uint32_t)msg[offset + 1] << 16) |
-                 ((uint32_t)msg[offset + 2] << 8) |
-                 ((uint32_t)msg[offset + 3]);
+  soa->minimum = dns_unpack_be32(msg + offset);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Implements #1853

Refactored the SOA record parser to use the existing `dns_unpack_be32` helper function instead of manual bit-shifting operations for unpacking 32-bit big-endian fields.

## Changes

- Replaced five instances of manual bit-shifting in `SocketDNS_rdata_parse_soa` with `dns_unpack_be32` calls
- Reduced code from ~32 lines to ~10 lines for the five field extractions (serial, refresh, retry, expire, minimum)
- No functional changes - behavior remains identical

## Benefits

- Reduces code duplication
- Improves maintainability
- Aligns with existing patterns used throughout the DNS wire format module
- Reduces visual noise in the code

## Test Plan

- [x] All DNS wire format tests pass (172 tests)
- [x] Specific SOA parser tests verified:
  - `dns_rdata_parse_soa_verify_values`
  - `dns_rdata_parse_soa_integration`
  - `dns_rdata_parse_soa_valid`
  - All other SOA-related tests
- [x] Build succeeds with sanitizers enabled

**Note**: Three tests fail on both main and this branch (pre-existing issues):
- `test_dns_queue_limit` - Memory leak in DNS resolver (unrelated to SOA parsing)
- `test_multi_protocol_integration` - Thread safety issue (unrelated to DNS wire format)
- `test_tls_crl_integration` - TLS CRL refresh timing (unrelated to DNS)

Closes #1853