### PR TITLE
fix(dns): correct prefer_http2 ternary operator in DoH config

### DIFF
--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -302,7 +302,7 @@ SocketDNSoverHTTPS_configure (T transport,
 
   memcpy (s->url, config->url, url_len + 1); /* Include null terminator */
   s->method = config->method;
-  s->prefer_http2 = config->prefer_http2 ? 1 : 1; /* Default to HTTP/2 */
+  s->prefer_http2 = config->prefer_http2 ? 1 : 0; /* Respect HTTP/2 preference */
   s->timeout_ms
       = config->timeout_ms > 0 ? config->timeout_ms : DOH_QUERY_TIMEOUT_MS;
 


### PR DESCRIPTION
## Summary

Fixes #1851

Fixed logic bug in `SocketDNSoverHTTPS.c` line 305 where the ternary operator always returned 1, preventing users from disabling HTTP/2 preference for DNS-over-HTTPS.

## Changes

- Changed `config->prefer_http2 ? 1 : 1` to `config->prefer_http2 ? 1 : 0`
- Updated comment to clarify the fix

## Impact

- Users can now properly configure HTTP/1.1 preference by setting `prefer_http2 = 0` in DoH configuration
- Configuration parameter is now properly respected

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] All tests pass (excluding pre-existing `test_dns_queue_limit` failure on main)
- [x] DoH configuration logic now correctly honors the `prefer_http2` parameter

Closes #1851