### PR TITLE
refactor(dns): use dns_char_equal_ci helper in bailiwick check

### DIFF
--- a/src/dns/SocketDNSWire.c
+++ b/src/dns/SocketDNSWire.c
@@ -1733,12 +1733,8 @@ SocketDNS_name_in_bailiwick (const char *record_name, const char *query_name)
   const char *suffix = record_name + (rec_len - qry_len);
   for (size_t i = 0; i < qry_len; i++)
     {
-      char a = suffix[i], b = query_name[i];
-      if (a >= 'A' && a <= 'Z')
-        a = (char)(a + 32);
-      if (b >= 'A' && b <= 'Z')
-        b = (char)(b + 32);
-      if (a != b)
+      if (!dns_char_equal_ci ((unsigned char)suffix[i],
+                              (unsigned char)query_name[i]))
         return 0;
     }
 


### PR DESCRIPTION
## Summary

Implements #1856

Refactors the bailiwick checking function to use the existing `dns_char_equal_ci` helper instead of duplicating case conversion logic.

## Changes

- **Modified**: `src/dns/SocketDNSWire.c`
  - Replaced manual case conversion loop in `SocketDNS_name_in_bailiwick` (lines 1733-1742)
  - Now uses `dns_char_equal_ci` helper function for case-insensitive comparison
  - Reduces code by 5 lines while improving maintainability

## Benefits

- Eliminates code duplication (logic was identical to `dns_char_equal_ci` at line 194)
- Ensures consistent case-insensitive comparison across DNS module
- Improves maintainability by using a single implementation
- Makes intent clearer through use of named helper function

## Test Plan

- [x] All DNS wire tests pass (172/172)
- [x] Full test suite passes with sanitizers (excluding pre-existing failures)
- [x] No new memory leaks or undefined behavior
- [x] Verified bailiwick check logic remains unchanged

Closes #1856