### PR TITLE
security: use compiler built-ins for overflow checking in parse_chunk_size

### DIFF
--- a/src/http/SocketHTTP1-chunked.c
+++ b/src/http/SocketHTTP1-chunked.c
@@ -325,12 +325,13 @@ parse_chunk_size (const char *const input, size_t len, size_t *line_len,
   while (p < end && http1_is_hex (*p))
     {
       uint64_t digit = (uint64_t)http1_hex_value (*p);
+      uint64_t new_size;
 
-      /* Check overflow before multiplication */
-      if (size > (UINT64_MAX - digit) / HTTP1_HEX_RADIX)
+      /* Check overflow using compiler built-ins */
+      if (__builtin_mul_overflow (size, HTTP1_HEX_RADIX, &new_size)
+          || __builtin_add_overflow (new_size, digit, &size))
         return -1;
 
-      size = size * HTTP1_HEX_RADIX + digit;
       has_digit = 1;
       p++;
     }


### PR DESCRIPTION
## Summary

Implements #1869

Replaces manual overflow check in `parse_chunk_size` with GCC/Clang compiler built-ins (`__builtin_mul_overflow` and `__builtin_add_overflow`) for better clarity, portability, and potential performance.

## Changes

- **File**: `src/http/SocketHTTP1-chunked.c`
- **Function**: `parse_chunk_size` (line 330)
- Replaced manual arithmetic overflow check with compiler built-ins
- Added intermediate `new_size` variable for clearer semantics

## Security Benefits

- Uses well-tested compiler intrinsics instead of manual arithmetic
- Clearer intent - immediately obvious this is overflow checking
- More portable across different architectures
- Potential for better code generation on some platforms
- Reduces risk of subtle errors in manual overflow calculations

## Test Plan

- [x] All HTTP tests pass with sanitizers enabled
- [x] test_http1_parser - validates chunked encoding parsing
- [x] test_http_core - core HTTP functionality
- [x] test_http_integration - integration tests
- [x] test_httpserver - server-side chunked encoding
- [x] Build successful with ASan + UBSan
- [x] No new compiler warnings

Closes #1869