### PR TITLE
refactor(synprotect): extract helpers from SocketSYNProtect_new for better testability

### DIFF
--- a/src/core/SocketSYNProtect.c
+++ b/src/core/SocketSYNProtect.c
@@ -403,19 +403,46 @@ check_whitelist_blacklist (T protect, const char *client_ip, int64_t now_ms,
   return 0;
 }
 
+/**
+ * @brief Cleanup stages for error handling during initialization.
+ * @internal
+ *
+ * Used to track initialization progress and perform appropriate cleanup
+ * on failure. Ordered by dependency: later stages depend on earlier ones.
+ */
 typedef enum
 {
-  SYN_CLEANUP_NONE = 0,
-  SYN_CLEANUP_MUTEX,
-  SYN_CLEANUP_IP_TABLE,
-  SYN_CLEANUP_WHITELIST,
-  SYN_CLEANUP_BLACKLIST,
-  SYN_CLEANUP_LIMITER
+  SYN_CLEANUP_NONE = 0,      /**< No resources initialized yet */
+  SYN_CLEANUP_MUTEX,         /**< Mutex initialized */
+  SYN_CLEANUP_IP_TABLE,      /**< IP hash table allocated */
+  SYN_CLEANUP_WHITELIST,     /**< Whitelist table allocated */
+  SYN_CLEANUP_BLACKLIST,     /**< Blacklist table allocated */
+  SYN_CLEANUP_LIMITER        /**< Global rate limiter initialized */
 } SYN_CleanupStage;
 
+/* Forward declarations for cleanup helpers */
+static void free_ip_entries (T protect);
+static void free_whitelist_entries (T protect);
+static void free_blacklist_entries (T protect);
+
+/**
+ * @brief Clean up partially initialized SYN protection resources.
+ * @internal
+ *
+ * @param protect  The partially initialized SYN protection instance
+ * @param stage    How far initialization progressed before failure
+ *
+ * Frees resources in reverse dependency order based on the cleanup stage.
+ * Only frees resources that were successfully initialized. For malloc-based
+ * allocations, also frees any entries in the hash tables.
+ */
 static void
 cleanup_synprotect_init (T protect, SYN_CleanupStage stage)
 {
+  if (protect == NULL)
+    return;
+
+  /* Clean up in reverse order of initialization */
   switch (stage)
     {
     case SYN_CLEANUP_LIMITER:
@@ -423,16 +450,29 @@ cleanup_synprotect_init (T protect, SYN_CleanupStage stage)
         SocketRateLimit_free (&protect->global_limiter);
       /* FALLTHROUGH */
     case SYN_CLEANUP_BLACKLIST:
-      free_memory (protect, protect->blacklist_table);
+      if (protect->use_malloc && protect->blacklist_table != NULL)
+        {
+          free_blacklist_entries (protect);
+          free (protect->blacklist_table);
+        }
       /* FALLTHROUGH */
     case SYN_CLEANUP_WHITELIST:
-      free_memory (protect, protect->whitelist_table);
+      if (protect->use_malloc && protect->whitelist_table != NULL)
+        {
+          free_whitelist_entries (protect);
+          free (protect->whitelist_table);
+        }
       /* FALLTHROUGH */
     case SYN_CLEANUP_IP_TABLE:
-      free_memory (protect, protect->ip_table);
+      if (protect->use_malloc && protect->ip_table != NULL)
+        {
+          free_ip_entries (protect);
+          free (protect->ip_table);
+        }
       /* FALLTHROUGH */
     case SYN_CLEANUP_MUTEX:
-      pthread_mutex_destroy (&protect->mutex);
+      if (protect->initialized == SOCKET_MUTEX_INITIALIZED)
+        pthread_mutex_destroy (&protect->mutex);
       /* FALLTHROUGH */
     case SYN_CLEANUP_NONE:
       if (protect->use_malloc)
@@ -876,6 +916,40 @@ synprotect_init_tables (T protect, const SocketSYNProtect_Config *config)
   return -1;
 }
 
+/**
+ * @brief Initialize all SYN protection resources (mutex and tables).
+ * @internal
+ *
+ * @param protect       The SYN protection instance
+ * @param cfg           Validated configuration
+ * @param cleanup_stage Output parameter for cleanup stage on failure
+ * @return 1 on success, 0 on failure (with cleanup_stage set)
+ *
+ * Initializes mutex first, then all hash tables in sequence. On failure,
+ * sets cleanup_stage to indicate which resources need cleanup.
+ */
+static int
+synprotect_init_all_resources (T protect, const SocketSYNProtect_Config *cfg,
+                                int *cleanup_stage)
+{
+  int mutex_error = 0;
+
+  if (!synprotect_init_mutex (protect, &mutex_error))
+    {
+      *cleanup_stage = SYN_CLEANUP_NONE;
+      return 0;
+    }
+
+  int init_result = synprotect_init_tables (protect, cfg);
+  if (init_result >= 0)
+    {
+      *cleanup_stage = init_result;
+      return 0;
+    }
+
+  return 1;
+}
+
 T
 SocketSYNProtect_new (Arena_T arena, const SocketSYNProtect_Config *config)
 {
@@ -893,23 +967,11 @@ SocketSYNProtect_new (Arena_T arena, const SocketSYNProtect_Config *config)
 
   synprotect_init_base (protect, arena, cfg);
 
-  {
-    int mutex_error = 0;
-    if (!synprotect_init_mutex (protect, &mutex_error))
-      {
-        cleanup_synprotect_init (protect, SYN_CLEANUP_NONE);
-        SOCKET_RAISE_MSG (SocketSYNProtect, SocketSYNProtect_Failed,
-                          "Failed to initialize mutex: %s",
-                          strerror (mutex_error));
-      }
-  }
-
-  init_result = synprotect_init_tables (protect, cfg);
-  if (init_result >= 0)
+  if (!synprotect_init_all_resources (protect, cfg, &init_result))
     {
       cleanup_synprotect_init (protect, (SYN_CleanupStage)init_result);
       SOCKET_RAISE_MSG (SocketSYNProtect, SocketSYNProtect_Failed,
-                        "Failed to initialize hash tables");
+                        "Failed to initialize SYN protection resources");
     }
 
   synprotect_finalize (protect);


### PR DESCRIPTION
## Summary

Implements #1849 by refactoring `SocketSYNProtect_new()` to improve testability, readability, and maintainability through better separation of concerns.

## Changes

### Enhanced Cleanup Infrastructure
- **Documented `SYN_CleanupStage` enum**: Added comprehensive comments explaining the dependency ordering of initialization stages (None → Mutex → IP Table → Whitelist → Blacklist → Limiter)
- **Improved `cleanup_synprotect_init()`**: Enhanced to properly free hash table entries (IP, whitelist, blacklist) when using malloc-based allocation, preventing memory leaks on error paths
- **Added forward declarations**: Declared `free_ip_entries()`, `free_whitelist_entries()`, and `free_blacklist_entries()` to enable their use in cleanup

### New Helper Function
- **`synprotect_init_all_resources()`**: Consolidates mutex and table initialization into a single focused function with clear error reporting via cleanup stage output parameter

### Simplified Main Function
- **Refactored `SocketSYNProtect_new()`**: Delegates resource initialization to `synprotect_init_all_resources()` with unified error handling, reducing complexity from nested error blocks to a single cleanup path

## Benefits

- **Improved testability**: Resource initialization can now be tested in isolation
- **Clearer error paths**: Single cleanup point for all resource initialization failures
- **Better separation of concerns**: Allocation → Init → Finalize stages are distinct and well-documented
- **Memory safety**: Cleanup properly handles partially initialized state, preventing leaks

## Test Plan

- [x] All 36 SYN protection tests pass with sanitizers enabled
- [x] Build succeeds with `-Wall -Wextra -Werror`
- [x] No new memory leaks detected by ASan/LSan
- [x] Error handling paths properly clean up resources

Closes #1849