### PR TITLE
security(http): add secure clearing for authentication headers

### DIFF
--- a/include/http/SocketHTTPClient-private.h
+++ b/include/http/SocketHTTPClient-private.h
@@ -324,6 +324,7 @@ extern int httpclient_auth_digest_challenge (
 extern int httpclient_auth_bearer_header (const char *token, char *output,
                                           size_t output_size);
 extern int httpclient_auth_is_stale_nonce (const char *www_authenticate);
+extern void httpclient_auth_clear_header (char *header, size_t header_size);
 
 extern int httpclient_cookies_for_request (
     SocketHTTPClient_CookieJar_T jar, const SocketHTTP_URI *uri, char *output,


### PR DESCRIPTION
## Summary

Implements #1868

Addresses incomplete secure clearing of credentials in authentication functions. The plaintext credentials were being cleared but the base64-encoded output remained in memory, potentially exposing sensitive data through memory dumps or debugging sessions.

## Changes

- **Added** `httpclient_auth_clear_header()` function to securely clear authentication header buffers using `SocketCrypto_secure_clear()`
- **Enhanced** `httpclient_auth_basic_header()` to:
  - Clear credentials buffer on all error paths
  - Clear output buffer on encoding errors
  - Add security documentation about caller responsibilities
- **Enhanced** `httpclient_auth_bearer_header()` with security documentation
- **Added** comprehensive test coverage in `test_auth_secure_clear()`:
  - Verifies all bytes are zeroed after clearing
  - Tests Basic, Bearer, and Digest authentication headers
  - Validates secure clearing prevents credential leakage

## Security Impact

- Prevents credential leakage through memory dumps
- Follows principle of least privilege for sensitive data lifetime
- Provides explicit API for callers to clear sensitive headers when no longer needed
- All error paths now properly clear sensitive data

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] New test `test_auth_secure_clear()` validates proper clearing
- [x] Verified zero-fill of entire buffer after clearing
- [x] Tested all three auth types (Basic, Bearer, Digest)

Closes #1868