### PR TITLE
refactor(simple-http): replace magic redirect constant with named definition

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -18,6 +18,13 @@
 #include <pthread.h>
 
 /* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+#define SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS 5
+
+/* ============================================================================
  * Shared Global HTTP Client (Lazy Initialization)
  * ============================================================================
  */
@@ -63,7 +70,7 @@ Socket_simple_http_options_init (SocketSimple_HTTPOptions *opts)
   memset (opts, 0, sizeof (*opts));
   opts->connect_timeout_ms = 30000;
   opts->request_timeout_ms = 60000;
-  opts->max_redirects = 5;
+  opts->max_redirects = SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS;
   opts->verify_ssl = 1;
 }
 


### PR DESCRIPTION
## Summary

Implements #1952

Replaces hardcoded magic number `5` for max redirects in `Socket_simple_http_options_init` with a named constant `SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS`.

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS` constant definition (value: 5)
- Updated `Socket_simple_http_options_init` to use the named constant instead of magic number
- Improves code maintainability per CLAUDE.md coding standards

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] All tests pass (116/117 - one pre-existing DNS test failure unrelated to this change)
- [x] No new warnings or errors

Closes #1952