### PR TITLE
refactor(socket-fd): add static assertions for SOCKET_MAX_FDS_PER_MSG

### DIFF
--- a/src/socket/Socket-fd.c
+++ b/src/socket/Socket-fd.c
@@ -23,6 +23,16 @@
 
 #define T Socket_T
 
+/* Compile-time validation of FD passing limits */
+_Static_assert (SOCKET_MAX_FDS_PER_MSG > 0,
+                "SOCKET_MAX_FDS_PER_MSG must be positive");
+
+_Static_assert (SOCKET_MAX_FDS_PER_MSG <= 253,
+                "SOCKET_MAX_FDS_PER_MSG exceeds SCM_MAX_FD (253)");
+
+_Static_assert (CMSG_SPACE (sizeof (int) * SOCKET_MAX_FDS_PER_MSG) < 8192,
+                "CMSG buffer size too large for stack allocation");
+
 /* SCM_RIGHTS requires at least 1 byte of data to be sent */
 #define FD_PASS_DUMMY_BYTE '\x00'
 


### PR DESCRIPTION
## Summary

Implements #1962

Adds compile-time validation for `SOCKET_MAX_FDS_PER_MSG` configuration constant to catch errors early.

## Changes

- Added three `_Static_assert` statements in `src/socket/Socket-fd.c`:
  - Validates `SOCKET_MAX_FDS_PER_MSG > 0` (no zero-sized arrays)
  - Validates `SOCKET_MAX_FDS_PER_MSG <= 253` (kernel SCM_MAX_FD limit)
  - Validates CMSG buffer size < 8192 bytes (safe stack allocation)

## Benefits

- Fail fast at compile time instead of runtime
- Documents assumptions about the constant
- Prevents accidental misconfiguration
- Zero runtime cost

## Test Plan

- [x] Tests pass with sanitizers (115/117 passing, 2 pre-existing flaky tests)
- [x] Build succeeds with default configuration (SOCKET_MAX_FDS_PER_MSG=253)
- [x] Static assertions compile correctly
- [x] No runtime behavior changes

Closes #1962