### PR TITLE
fix(simple): add error checking for getsockopt in Socket_simple_get_keepalive

### DIFF
--- a/src/simple/SocketSimple-tcp.c
+++ b/src/simple/SocketSimple-tcp.c
@@ -1110,21 +1110,36 @@ Socket_simple_get_keepalive (SocketSimple_Socket_T sock, int *enabled,
   if (idle_secs)
     {
       len = sizeof (*idle_secs);
-      getsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, idle_secs, &len);
+      if (getsockopt (fd, IPPROTO_TCP, TCP_KEEPIDLE, idle_secs, &len) < 0)
+        {
+          simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                                  "Failed to get TCP_KEEPIDLE");
+          return -1;
+        }
     }
 #endif
 #ifdef TCP_KEEPINTVL
   if (interval_secs)
     {
       len = sizeof (*interval_secs);
-      getsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, interval_secs, &len);
+      if (getsockopt (fd, IPPROTO_TCP, TCP_KEEPINTVL, interval_secs, &len) < 0)
+        {
+          simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                                  "Failed to get TCP_KEEPINTVL");
+          return -1;
+        }
     }
 #endif
 #ifdef TCP_KEEPCNT
   if (count)
     {
       len = sizeof (*count);
-      getsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, count, &len);
+      if (getsockopt (fd, IPPROTO_TCP, TCP_KEEPCNT, count, &len) < 0)
+        {
+          simple_set_error_errno (SOCKET_SIMPLE_ERR_SOCKET,
+                                  "Failed to get TCP_KEEPCNT");
+          return -1;
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

Implements #1966 - Adds error checking for three getsockopt calls in Socket_simple_get_keepalive that were previously ignoring return values.

## Changes

- Added error checking for `getsockopt(TCP_KEEPIDLE)` at line 1113
- Added error checking for `getsockopt(TCP_KEEPINTVL)` at line 1125
- Added error checking for `getsockopt(TCP_KEEPCNT)` at line 1137
- Each failure now properly sets error state and returns -1

## Test Plan

- [x] Built with sanitizers enabled
- [x] All existing tests pass (115/117 passing - 2 pre-existing failures unrelated to this change)
- [x] No new memory leaks or sanitizer errors introduced

Closes #1966