### PR TITLE
security(quic): use constant-time comparison for Connection ID equality

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -131,7 +131,7 @@ SocketQUICConnectionID_equal (const SocketQUICConnectionID_T *a,
   if (a->len == 0)
     return 1; /* Both zero-length CIDs are equal */
 
-  return (memcmp (a->data, b->data, a->len) == 0);
+  return (SocketCrypto_secure_compare (a->data, b->data, a->len) == 0);
 }
 
 int
@@ -150,7 +150,7 @@ SocketQUICConnectionID_equal_raw (const SocketQUICConnectionID_T *cid,
   if (data == NULL)
     return 0;
 
-  return (memcmp (cid->data, data, len) == 0);
+  return (SocketCrypto_secure_compare (cid->data, data, len) == 0);
 }
 
 SocketQUICConnectionID_Result


### PR DESCRIPTION
## Summary

Implements #2027 - Replaces timing-vulnerable `memcmp()` with constant-time comparison in QUIC Connection ID equality functions.

## Security Context

QUIC Connection IDs are security-sensitive identifiers that:
- Route packets to the correct connection
- Identify and authenticate connections  
- Are used in packet protection mechanisms

Using `memcmp()` in comparison functions creates a timing side-channel that could allow attackers to:
- Probe for valid Connection IDs through timing analysis
- Track connections by observing timing differences
- Perform connection correlation attacks

## Changes

**Modified Functions:**
- `SocketQUICConnectionID_equal()` - Replaced `memcmp()` with `SocketCrypto_secure_compare()`
- `SocketQUICConnectionID_equal_raw()` - Replaced `memcmp()` with `SocketCrypto_secure_compare()`

**Implementation:**
- Uses `CRYPTO_memcmp()` when OpenSSL is available (TLS builds)
- Falls back to constant-time XOR loop when OpenSSL is not available
- Comparison time is independent of data values, preventing timing attacks

## Test Plan

- [x] All 57 QUIC Connection ID tests pass (`test_quic_connid`)
- [x] Full test suite passes with ASan/UBSan (115/117 tests - 2 unrelated flaky tests)
- [x] No functional changes - only security improvement
- [x] Both comparison functions maintain exact same behavior

## Performance Impact

Minimal - constant-time comparison has negligible overhead compared to security benefit. Connection ID comparisons are infrequent (packet routing, connection lookup) and not in hot paths.

Closes #2027