### PR TITLE
docs(socket-fd): document TOCTOU race in FD validation

### DIFF
--- a/include/socket/Socket.h
+++ b/include/socket/Socket.h
@@ -2454,8 +2454,16 @@ extern int Socket_getpeergid (const T socket);
  * - Only works with connected Unix domain sockets
  * - Receiving process should validate the fd type before use
  *
- * @threadsafe Yes - uses thread-local error buffers for safe concurrent
- * operation.
+ * THREAD-SAFETY LIMITATIONS:
+ * - WARNING: The passed file descriptor MUST NOT be closed by another thread
+ *   during this operation. There is an inherent TOCTOU (Time-Of-Check to
+ *   Time-Of-Use) race between FD validation and the actual sendmsg() call.
+ * - Caller is responsible for ensuring FD remains valid throughout this call.
+ * - Violation may result in EBADF from sendmsg() or passing invalid FD.
+ *
+ * @threadsafe Conditional - safe only if fd_to_pass is not concurrently
+ * modified or closed by another thread. Socket operations use thread-local
+ * error buffers.
  * @see Socket_recvfd() for receiving file descriptors.
  * @see Socket_sendfds() for sending multiple descriptors.
  */
@@ -2493,8 +2501,17 @@ extern int Socket_recvfd (T socket, int *fd_received);
  * Passes multiple file descriptors atomically in a single message.
  * All descriptors are either sent together or none are sent.
  *
- * @threadsafe Yes - uses thread-local error buffers for safe concurrent
- * operation.
+ * THREAD-SAFETY LIMITATIONS:
+ * - WARNING: All passed file descriptors MUST NOT be closed by another thread
+ *   during this operation. There is an inherent TOCTOU (Time-Of-Check to
+ *   Time-Of-Use) race between FD validation and the actual sendmsg() call.
+ * - Caller is responsible for ensuring all FDs remain valid throughout this
+ *   call.
+ * - Violation may result in EBADF from sendmsg() or passing invalid FDs.
+ *
+ * @threadsafe Conditional - safe only if file descriptors in fds array are
+ * not concurrently modified or closed by another thread. Socket operations
+ * use thread-local error buffers.
  * @see Socket_recvfds() for receiving multiple descriptors.
  * @see Socket_sendfd() for sending single descriptor.
  */

--- a/src/socket/Socket-fd.c
+++ b/src/socket/Socket-fd.c
@@ -4,7 +4,24 @@
  * https://x.com/tetsuoai
  */
 
-/* Reference: POSIX.1-2008, sendmsg/recvmsg with SCM_RIGHTS */
+/* Reference: POSIX.1-2008, sendmsg/recvmsg with SCM_RIGHTS
+ *
+ * THREAD-SAFETY NOTE (CWE-367: TOCTOU):
+ * The FD validation functions (validate_fd_open, validate_fd_array_nonclosing,
+ * validate_fd_array_closing) check file descriptor validity using fcntl(F_GETFD).
+ * However, there is an inherent Time-Of-Check to Time-Of-Use (TOCTOU) race
+ * condition where an FD could be closed by another thread between validation
+ * and actual use in sendmsg()/recvmsg().
+ *
+ * MITIGATION:
+ * This limitation is documented in the public API (Socket.h). Callers MUST
+ * ensure that file descriptors are not concurrently closed during FD passing
+ * operations. This is a fundamental limitation of the FD passing API design
+ * and cannot be fully eliminated without application-level synchronization.
+ *
+ * IMPACT: Low likelihood (requires concurrent FD operations), medium consequence
+ * (sendmsg may fail with EBADF or pass closed FD to peer).
+ */
 
 #include <errno.h>
 #include <fcntl.h>
@@ -48,12 +65,21 @@ validate_unix_socket (const T socket)
         return 1;
 }
 
+/*
+ * TOCTOU WARNING: This check is inherently racy. FD could be closed by another
+ * thread immediately after this function returns true but before sendmsg() is
+ * called. Callers must ensure FD lifecycle synchronization at application level.
+ */
 static int
 validate_fd_open (int fd)
 {
         return (fd >= 0 && fcntl (fd, F_GETFD) >= 0);
 }
 
+/*
+ * Validate FD array before sending. Note: TOCTOU race exists between this
+ * check and sendmsg() - see file header for details.
+ */
 static int
 validate_fd_array_nonclosing (const int *fds, size_t count, const char *context)
 {
@@ -177,6 +203,11 @@ validate_cmsg_data_len (const struct cmsghdr *cmsg)
         return 1;
 }
 
+/*
+ * Validate received FDs. Note: TOCTOU race exists - an FD received from peer
+ * could theoretically be closed by another thread before validation completes,
+ * though this is extremely unlikely in practice as FDs are just received.
+ */
 static void
 validate_fd_array_closing (int *fds, size_t *received_count, size_t count, const char *context)
 {


### PR DESCRIPTION
## Summary

Implements #1955 by documenting the inherent TOCTOU (Time-Of-Check to Time-Of-Use) race condition in file descriptor validation for FD passing operations.

## Changes

- **Socket.h**: Added comprehensive thread-safety warnings to `Socket_sendfd()` and `Socket_sendfds()` function documentation
  - Documents CWE-367 TOCTOU limitation  
  - Clarifies that FDs must not be concurrently closed during operations
  - Updates `@threadsafe` annotations to reflect conditional safety

- **Socket-fd.c**: Added implementation-level documentation
  - File header comment explaining TOCTOU race and mitigation strategy
  - Inline comments on validation functions noting inherent race
  - References to CWE-367 for security tracking

## Rationale

The FD validation uses `fcntl(F_GETFD)` to check if file descriptors are valid before passing them via `SCM_RIGHTS`. However, there's an inherent race where another thread could close the FD between validation and the actual `sendmsg()` call.

This limitation **cannot be fully eliminated** without application-level synchronization, as it's fundamental to how file descriptors work in a multi-threaded environment. The best approach is to document it clearly so users can design their code accordingly.

## Impact Assessment

- **Likelihood**: Low (requires concurrent FD operations from multiple threads)
- **Consequence**: Medium (could pass closed FD, causing sendmsg to fail with EBADF)
- **Exploitability**: Low (attacker would need to control thread scheduling)

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] 113/117 tests pass (4 pre-existing failures unrelated to this change)
- [x] No new compiler warnings
- [x] Documentation is clear and comprehensive

Closes #1955