### PR TITLE
refactor(socket-fd): flatten CMSG iteration nesting with early continue

### DIFF
--- a/src/socket/Socket-fd.c
+++ b/src/socket/Socket-fd.c
@@ -259,16 +259,15 @@ extract_rights_fds (const struct msghdr *msg, int *fds, size_t max_count)
 
         memset (temp_fds, -1, sizeof (temp_fds));
 
-        cmsg = CMSG_FIRSTHDR ((struct msghdr *)msg);
-        while (cmsg != NULL)
+        for (cmsg = CMSG_FIRSTHDR ((struct msghdr *)msg);
+             cmsg != NULL;
+             cmsg = CMSG_NXTHDR ((struct msghdr *)msg, cmsg))
         {
-                if (cmsg->cmsg_level == SOL_SOCKET
-                    && cmsg->cmsg_type == SCM_RIGHTS)
-                {
-                        process_single_cmsg (cmsg, temp_fds, &total_fds,
-                                             SOCKET_MAX_FDS_PER_MSG);
-                }
-                cmsg = CMSG_NXTHDR ((struct msghdr *)msg, cmsg);
+                if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS)
+                        continue;
+
+                process_single_cmsg (cmsg, temp_fds, &total_fds,
+                                     SOCKET_MAX_FDS_PER_MSG);
         }
 
         if (total_fds > max_count)


### PR DESCRIPTION
## Summary

Implements #1959 - Refactors CMSG iteration loop in `extract_rights_fds` to flatten deep nesting.

## Changes

- Converted `while` loop with nested `if` to `for` loop with guard clause
- Inverted condition to use early `continue` for non-matching CMSGs
- Reduced indentation from 3 levels to 2 levels
- Follows "Deep Nesting (Arrow Code)" anti-pattern fix from CLAUDE.md

## Before

```c
cmsg = CMSG_FIRSTHDR ((struct msghdr *)msg);
while (cmsg != NULL)
{
    if (cmsg->cmsg_level == SOL_SOCKET
        && cmsg->cmsg_type == SCM_RIGHTS)
    {
        process_single_cmsg (cmsg, temp_fds, &total_fds,
                             SOCKET_MAX_FDS_PER_MSG);
    }
    cmsg = CMSG_NXTHDR ((struct msghdr *)msg, cmsg);
}
```

## After

```c
for (cmsg = CMSG_FIRSTHDR ((struct msghdr *)msg);
     cmsg != NULL;
     cmsg = CMSG_NXTHDR ((struct msghdr *)msg, cmsg))
{
    if (cmsg->cmsg_level != SOL_SOCKET || cmsg->cmsg_type != SCM_RIGHTS)
        continue;

    process_single_cmsg (cmsg, temp_fds, &total_fds,
                         SOCKET_MAX_FDS_PER_MSG);
}
```

## Test Plan

- [x] Code compiles without warnings
- [x] 114/117 tests pass (3 pre-existing failures in integration tests)
- [x] No tests exist for FD passing functionality, so refactoring cannot break tests
- [x] Logic is functionally equivalent (early continue on inverted condition)

Closes #1959