### PR TITLE
refactor(SocketSimple-security): replace magic numbers with constants from SocketConfig.h

### DIFF
--- a/src/simple/SocketSimple-security.c
+++ b/src/simple/SocketSimple-security.c
@@ -15,6 +15,7 @@
 #include "SocketSimple-internal.h"
 #include "simple/SocketSimple-security.h"
 
+#include "core/SocketConfig.h"
 #include "core/SocketIPTracker.h"
 #include "core/SocketSYNProtect.h"
 
@@ -44,16 +45,16 @@ Socket_simple_syn_config_init (SocketSimple_SYNConfig *config)
   if (!config)
     return;
   memset (config, 0, sizeof (*config));
-  config->window_duration_ms = 10000;
-  config->max_attempts_per_window = 100;
-  config->max_global_per_second = 1000;
-  config->min_success_ratio = 0.1f;
-  config->throttle_delay_ms = 100;
-  config->block_duration_ms = 300000;
-  config->score_throttle = 0.7f;
-  config->score_challenge = 0.5f;
-  config->score_block = 0.3f;
-  config->max_tracked_ips = 10000;
+  config->window_duration_ms = SOCKET_SYN_DEFAULT_WINDOW_MS;
+  config->max_attempts_per_window = SOCKET_SYN_DEFAULT_MAX_PER_WINDOW;
+  config->max_global_per_second = SOCKET_SYN_DEFAULT_GLOBAL_PER_SEC;
+  config->min_success_ratio = SOCKET_SYN_DEFAULT_MIN_SUCCESS_RATIO;
+  config->throttle_delay_ms = SOCKET_SYN_DEFAULT_THROTTLE_DELAY_MS;
+  config->block_duration_ms = SOCKET_SYN_DEFAULT_BLOCK_DURATION_MS;
+  config->score_throttle = SOCKET_SYN_DEFAULT_SCORE_THROTTLE;
+  config->score_challenge = SOCKET_SYN_DEFAULT_SCORE_CHALLENGE;
+  config->score_block = SOCKET_SYN_DEFAULT_SCORE_BLOCK;
+  config->max_tracked_ips = SOCKET_SYN_DEFAULT_MAX_TRACKED_IPS;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #2026

Replaced hardcoded magic numbers in `Socket_simple_syn_config_init()` with named constants from `SocketConfig.h`. This eliminates code duplication, ensures consistency between Simple API and core API defaults, and follows the DRY principle.

## Changes

- Added `#include "core/SocketConfig.h"` to `src/simple/SocketSimple-security.c`
- Replaced all 10 hardcoded configuration values with their corresponding constants:

| Field | Old Value | New Constant | Canonical Value |
|-------|-----------|--------------|-----------------|
| `window_duration_ms` | `10000` | `SOCKET_SYN_DEFAULT_WINDOW_MS` | `10000` ✓ |
| `max_attempts_per_window` | `100` | `SOCKET_SYN_DEFAULT_MAX_PER_WINDOW` | `50` (fixed) |
| `max_global_per_second` | `1000` | `SOCKET_SYN_DEFAULT_GLOBAL_PER_SEC` | `1000` ✓ |
| `min_success_ratio` | `0.1f` | `SOCKET_SYN_DEFAULT_MIN_SUCCESS_RATIO` | `0.3f` (fixed) |
| `throttle_delay_ms` | `100` | `SOCKET_SYN_DEFAULT_THROTTLE_DELAY_MS` | `100` ✓ |
| `block_duration_ms` | `300000` | `SOCKET_SYN_DEFAULT_BLOCK_DURATION_MS` | `60000` (fixed) |
| `score_throttle` | `0.7f` | `SOCKET_SYN_DEFAULT_SCORE_THROTTLE` | `0.7f` ✓ |
| `score_challenge` | `0.5f` | `SOCKET_SYN_DEFAULT_SCORE_CHALLENGE` | `0.4f` (fixed) |
| `score_block` | `0.3f` | `SOCKET_SYN_DEFAULT_SCORE_BLOCK` | `0.2f` (fixed) |
| `max_tracked_ips` | `10000` | `SOCKET_SYN_DEFAULT_MAX_TRACKED_IPS` | `100000` (fixed) |

## Impact

- **Code maintainability**: Changes to default values now only need to be made in `SocketConfig.h`
- **Consistency**: Simple API now uses the same defaults as the core API
- **Bug fixes**: Corrected 6 mismatched values to align with canonical constants

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] SYN protection tests pass (`test_synprotect`)
- [x] Security tests pass (`test_security`)
- [x] All Simple API wrappers work correctly

## Note

Pre-existing test failures in `test_dns_queue_limit`, `test_tls_phase4`, `test_tls_crl`, and `test_tls_crl_integration` are unrelated to this change (TLS/DNS subsystems). These failures exist on main branch and are being tracked separately.

Closes #2026