### PR TITLE
refactor(simple): extract hardcoded backlog constant

### DIFF
--- a/src/simple/SocketSimple-internal.h
+++ b/src/simple/SocketSimple-internal.h
@@ -74,6 +74,19 @@ struct SocketSimple_WS
 };
 
 /* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/**
+ * @brief Default backlog for listen() calls when user doesn't specify one.
+ *
+ * Used by Socket_simple_listen() and Socket_simple_listen_unix() when
+ * backlog parameter is <= 0. Value of 128 is typical for most systems.
+ */
+#define SOCKET_SIMPLE_DEFAULT_BACKLOG 128
+
+/* ============================================================================
  * Thread-Local Error State
  * ============================================================================
  */

--- a/src/simple/SocketSimple-tcp.c
+++ b/src/simple/SocketSimple-tcp.c
@@ -97,7 +97,7 @@ Socket_simple_listen (const char *host, int port, int backlog)
     /* Use library convenience function - handles address family automatically
      */
     sock = Socket_listen_tcp (host ? host : "0.0.0.0", port,
-                              backlog > 0 ? backlog : 128);
+                              backlog > 0 ? backlog : SOCKET_SIMPLE_DEFAULT_BACKLOG);
   }
   EXCEPT (Socket_Failed)
   {
@@ -938,7 +938,7 @@ Socket_simple_listen_unix (const char *path, int backlog)
   {
     sock = Socket_new (AF_UNIX, SOCK_STREAM, 0);
     Socket_bind_unix (sock, path);
-    Socket_listen (sock, backlog > 0 ? backlog : 128);
+    Socket_listen (sock, backlog > 0 ? backlog : SOCKET_SIMPLE_DEFAULT_BACKLOG);
   }
   EXCEPT (Socket_Failed)
   {


### PR DESCRIPTION
## Summary

Implements #1954 by extracting the hardcoded backlog value of 128 into a named constant for improved maintainability and consistency.

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_BACKLOG` constant (value: 128) to `src/simple/SocketSimple-internal.h`
- Replaced hardcoded `128` at line 100 in `Socket_simple_listen()` with the constant
- Replaced hardcoded `128` at line 941 in `Socket_simple_listen_unix()` with the constant

## Test Plan

- [x] All tests pass with sanitizers (116/116 tests excluding pre-existing DNS test failure)
- [x] Build completes successfully with ASan/UBSan enabled
- [x] Code compiles without warnings

Closes #1954