### PR TITLE
refactor(quic): extract CONNID_EMPTY_STR constant for duplicated magic string

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -21,6 +21,9 @@
 /* Use SocketCrypto_random_bytes() for platform-independent secure random */
 #define SECURE_RANDOM(buf, len) (SocketCrypto_random_bytes ((buf), (len)) == 0)
 
+/* Connection ID empty string representation */
+#define CONNID_EMPTY_STR "empty"
+
 /* ============================================================================
  * Result Strings
  * ============================================================================
@@ -307,13 +310,13 @@ SocketQUICConnectionID_to_hex (const SocketQUICConnectionID_T *cid, char *buf,
 
   if (cid == NULL || cid->len == 0)
     {
-      if (size < sizeof ("empty"))
+      if (size < sizeof (CONNID_EMPTY_STR))
         {
           buf[0] = '\0';
           return -1;
         }
-      memcpy (buf, "empty", sizeof ("empty"));
-      return sizeof ("empty") - 1;
+      memcpy (buf, CONNID_EMPTY_STR, sizeof (CONNID_EMPTY_STR));
+      return sizeof (CONNID_EMPTY_STR) - 1;
     }
 
   /* Format: "XX:XX:XX..." requires 3*len-1 chars + null terminator.


### PR DESCRIPTION
## Summary

Implements #2028

Extracts the duplicated "empty" string literal in `SocketQUICConnectionID_to_hex()` into a named constant `CONNID_EMPTY_STR`. This eliminates magic string duplication and provides a single point of change if the empty representation needs modification in the future.

## Changes

- Define `CONNID_EMPTY_STR` constant at file scope in `src/quic/SocketQUICConnectionID.c`
- Replace 3 instances of `"empty"` literal with `CONNID_EMPTY_STR` (lines 310, 315, 316)

## Test Plan

- [x] All QUIC tests pass (26/26) with sanitizers enabled
- [x] Build succeeds with sanitizers
- [x] No behavior change - purely refactoring

Closes #2028