### PR TITLE
fix(quic): use constant-time comparison for Connection ID equality

### DIFF
--- a/src/quic/SocketQUICConnectionID.c
+++ b/src/quic/SocketQUICConnectionID.c
@@ -131,7 +131,7 @@ SocketQUICConnectionID_equal (const SocketQUICConnectionID_T *a,
   if (a->len == 0)
     return 1; /* Both zero-length CIDs are equal */
 
-  return (memcmp (a->data, b->data, a->len) == 0);
+  return (SocketCrypto_secure_compare (a->data, b->data, a->len) == 0);
 }
 
 int
@@ -150,7 +150,7 @@ SocketQUICConnectionID_equal_raw (const SocketQUICConnectionID_T *cid,
   if (data == NULL)
     return 0;
 
-  return (memcmp (cid->data, data, len) == 0);
+  return (SocketCrypto_secure_compare (cid->data, data, len) == 0);
 }
 
 SocketQUICConnectionID_Result


### PR DESCRIPTION
## Summary

Implements #2024 - Replaces timing-vulnerable `memcmp()` with constant-time comparison in QUIC Connection ID equality checks to prevent timing attacks.

## Changes

- **SocketQUICConnectionID_equal()**: Use `SocketCrypto_secure_compare()` instead of `memcmp()`
- **SocketQUICConnectionID_equal_raw()**: Use `SocketCrypto_secure_compare()` instead of `memcmp()`

## Security Impact

QUIC Connection IDs are security-sensitive as they:
- Route packets to the correct connection
- Identify connections across network changes
- Enable connection migration (RFC 9000 §9)

Using `memcmp()` could leak timing information through early-exit behavior, potentially allowing attackers to:
- Probe for valid Connection IDs
- Track connections across migrations
- Gain information about active connections

The constant-time comparison prevents these timing side-channels.

## Test Plan

- [x] All 57 QUIC Connection ID tests pass with sanitizers
- [x] Builds successfully with ASan/UBSan
- [x] No new test failures introduced
- [x] Existing `SocketCrypto_secure_compare()` function used (already in codebase)

Closes #2024