### PR TITLE
refactor(http): remove redundant header validation function

### DIFF
--- a/src/http/SocketHTTP1-serialize.c
+++ b/src/http/SocketHTTP1-serialize.c
@@ -77,18 +77,6 @@ safe_append_int64 (char **buf, size_t *remaining, int64_t value)
   return safe_append (buf, remaining, num, (size_t)len);
 }
 
-static int
-header_value_valid_for_serialize (const char *value, size_t len)
-{
-  for (size_t i = 0; i < len; i++)
-    {
-      unsigned char c = (unsigned char)value[i];
-      if (c == '\r' || c == '\n' || c == '\0')
-        return 0;
-    }
-  return 1;
-}
-
 /**
  * serialize_ctx - Context for header serialization callback
  */
@@ -115,7 +103,7 @@ serialize_header_cb (const char *name, size_t name_len, const char *value,
         name_valid = 0;
     }
 
-  if (!name_valid || !header_value_valid_for_serialize (value, value_len))
+  if (!name_valid || !SocketHTTP_header_value_valid (value, value_len))
     {
       return -1; /* Reject headers with control characters */
     }


### PR DESCRIPTION
## Summary

Implements #1971

Removes duplicate `header_value_valid_for_serialize` function and replaces it with the standard `SocketHTTP_header_value_valid` which provides stronger validation.

## Changes

- **Removed**: `header_value_valid_for_serialize()` function (lines 81-90 in SocketHTTP1-serialize.c)
- **Replaced**: Call at line 118 now uses `SocketHTTP_header_value_valid()`

## Security Improvements

The standard validation function provides:
1. ✅ NULL pointer checks (prevents crashes)
2. ✅ Maximum length enforcement (prevents DoS via oversized headers)
3. ✅ Consistent effective length calculation
4. ✅ Same CR/LF/NUL character rejection

The custom function only performed CR/LF/NUL checks, missing critical security validations.

## Test Plan

- [x] All HTTP tests pass with sanitizers
- [x] No regression in header injection protection
- [x] Build succeeds with no warnings
- [x] All serialization tests pass (test_http1_parser, test_http_core, test_http_client, etc.)

## Note

One pre-existing test failure exists in `test_dns_queue_limit` (unrelated DNS memory leak), which was already failing on main branch.

Closes #1971