### PR TITLE
refactor(simple-http): replace magic timeout constants with named definitions

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -55,14 +55,17 @@ get_global_http_client (void)
  * ============================================================================
  */
 
+#define SOCKET_SIMPLE_DEFAULT_CONNECT_TIMEOUT_MS 30000
+#define SOCKET_SIMPLE_DEFAULT_REQUEST_TIMEOUT_MS 60000
+
 void
 Socket_simple_http_options_init (SocketSimple_HTTPOptions *opts)
 {
   if (!opts)
     return;
   memset (opts, 0, sizeof (*opts));
-  opts->connect_timeout_ms = 30000;
-  opts->request_timeout_ms = 60000;
+  opts->connect_timeout_ms = SOCKET_SIMPLE_DEFAULT_CONNECT_TIMEOUT_MS;
+  opts->request_timeout_ms = SOCKET_SIMPLE_DEFAULT_REQUEST_TIMEOUT_MS;
   opts->max_redirects = 5;
   opts->verify_ssl = 1;
 }


### PR DESCRIPTION
## Summary

Implements #1949

Replaces hardcoded magic numbers (30000 and 60000) in `Socket_simple_http_options_init` with named constants for better maintainability and code clarity.

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_CONNECT_TIMEOUT_MS` (30000)
- Added `SOCKET_SIMPLE_DEFAULT_REQUEST_TIMEOUT_MS` (60000)
- Updated `Socket_simple_http_options_init` to use these constants

## Test Plan

- [x] All tests pass with sanitizers (91/91 excluding known pre-existing failures)
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] No functional changes - constants have same values as before
- [x] Constants properly defined and used in source file

Closes #1949