### PR TITLE
refactor(http): replace magic 0/1 with boolean constants in arena cache

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -30,13 +30,19 @@
 #include <stdlib.h>
 
 /**
+ * Arena cache flags.
+ */
+#define ARENA_AVAILABLE  0
+#define ARENA_IN_USE     1
+
+/**
  * Thread-local arena cache structure.
  */
 typedef struct
 {
   Arena_T request_arena;      /**< Cached arena for request allocations */
   Arena_T response_arena;     /**< Cached arena for response allocations */
-  int response_arena_in_use;  /**< Non-zero if response arena is leased */
+  int response_arena_in_use;  /**< ARENA_IN_USE if response arena is leased */
 } HTTPClientArenaCache;
 
 static pthread_key_t arena_cache_key;
@@ -192,7 +198,7 @@ httpclient_acquire_response_arena (void)
   if (cache->response_arena && !cache->response_arena_in_use)
     {
       Arena_reset (cache->response_arena);
-      cache->response_arena_in_use = 1;
+      cache->response_arena_in_use = ARENA_IN_USE;
       return cache->response_arena;
     }
 
@@ -200,7 +206,7 @@ httpclient_acquire_response_arena (void)
   if (!cache->response_arena)
     {
       cache->response_arena = Arena_new_unlocked ();
-      cache->response_arena_in_use = 1;
+      cache->response_arena_in_use = ARENA_IN_USE;
       return cache->response_arena;
     }
 
@@ -232,7 +238,7 @@ httpclient_release_response_arena (Arena_T *arena_ptr)
     {
       /* Arena is from our cache - reset and mark available */
       Arena_reset (*arena_ptr);
-      cache->response_arena_in_use = 0;
+      cache->response_arena_in_use = ARENA_AVAILABLE;
       *arena_ptr = NULL;
       return;
     }


### PR DESCRIPTION
## Summary

Implements #1879

Replaces hardcoded magic numbers `0` and `1` with named constants `ARENA_AVAILABLE` and `ARENA_IN_USE` for the `response_arena_in_use` flag in the HTTP client arena cache.

## Changes

- Added `ARENA_AVAILABLE` (0) and `ARENA_IN_USE` (1) constants
- Replaced magic `1` with `ARENA_IN_USE` at lines 195, 203
- Replaced magic `0` with `ARENA_AVAILABLE` at line 235
- Updated struct documentation to reference constant name

## Test Plan

- [x] All HTTP client tests pass (45/45)
- [x] Code builds successfully with sanitizers enabled
- [x] No new memory leaks or undefined behavior introduced
- [x] Follows CLAUDE.md anti-pattern guidelines for boolean blindness

## Notes

This is a low-risk refactoring that improves code clarity without changing functionality. The pre-existing test failures in `test_dns_queue_limit`, `test_multi_protocol_integration`, and `test_tls_phase4` are unrelated to this change (they exist on main branch and are in different modules).

Closes #1879