### PR TITLE
refactor(dns-cookie): define FNV-1a hash constants

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -40,6 +40,10 @@ const Except_T SocketDNSCookie_Failed
 /* Previous secret validity during rollover (RFC 7873 §5.3) */
 #define DNS_COOKIE_ROLLOVER_PERIOD 150
 
+/* FNV-1a 64-bit constants (RFC 7873 Appendix A.1) */
+#define FNV1A_64_OFFSET_BASIS 14695981039346656037ULL
+#define FNV1A_64_PRIME        1099511628211ULL
+
 /* Internal cache entry with LRU tracking */
 typedef struct CacheNode
 {
@@ -788,8 +792,8 @@ generate_client_cookie_fnv (T cache, const struct sockaddr *server_addr,
                             socklen_t client_len, uint8_t *cookie)
 {
   /* Fallback: FNV-1a 64-bit (RFC 7873 Appendix A.1) */
-  uint64_t hash = 14695981039346656037ULL; /* FNV offset basis */
-  const uint64_t prime = 1099511628211ULL; /* FNV prime */
+  uint64_t hash = FNV1A_64_OFFSET_BASIS;
+  const uint64_t prime = FNV1A_64_PRIME;
 
   /* Hash server address */
   const uint8_t *p = (const uint8_t *)server_addr;


### PR DESCRIPTION
## Summary

Implements #1873

Replace magic numbers with named constants for the FNV-1a 64-bit hash algorithm used in DNS cookie generation fallback.

## Changes

- Add `FNV1A_64_OFFSET_BASIS` constant (14695981039346656037ULL)
- Add `FNV1A_64_PRIME` constant (1099511628211ULL)
- Replace inline magic numbers in `generate_client_cookie_fnv()` function

## Benefits

- Improves code readability and searchability
- Makes RFC 7873 Appendix A.1 reference more explicit
- Follows C anti-pattern guidelines from CLAUDE.md

## Test Plan

- [x] All tests pass (116/117 tests pass - 1 pre-existing flaky test unrelated to changes)
- [x] Code compiles cleanly with sanitizers enabled
- [x] No functional changes - constants have identical values to original magic numbers
- [x] Verified on main branch that `test_dns_queue_limit` failure is pre-existing

Closes #1873