### PR TITLE
fix(simple): use Socket_safe_strerror instead of unsafe strerror

### DIFF
--- a/src/simple/SocketSimple.c
+++ b/src/simple/SocketSimple.c
@@ -52,7 +52,7 @@ simple_set_error_errno (SocketSimple_ErrorCode code, const char *prefix)
   simple_error.code = code;
   simple_error.errno_value = errno;
   snprintf (simple_error.message, sizeof (simple_error.message), "%s: %s",
-            prefix, strerror (errno));
+            prefix, Socket_safe_strerror (errno));
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #1968

## Changes

- Replace unsafe `strerror()` with thread-safe `Socket_safe_strerror()` in `simple_set_error_errno()` function

## Details

The `strerror()` function is NOT thread-safe. From the man page:

> The string returned by strerror() may be overwritten by a subsequent call to strerror().

Since the Simple API uses thread-local error storage (`__thread SimpleError simple_error`), it's clearly designed for multi-threaded use. Using `strerror()` creates a race condition where concurrent threads calling `simple_set_error_errno()` can corrupt each other's error messages.

## Fix

The codebase already provides `Socket_safe_strerror()` (declared in `include/core/SocketError.h` and implemented in `src/core/SocketError.c`), which uses thread-safe `strerror_r()` internally. This change replaces the single unsafe call with the safe alternative.

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] Tests pass (3 pre-existing failures unrelated to this change)
- [x] No new warnings or errors

Closes #1968