### PR TITLE
security(dns): check snprintf truncation in SocketDNSTransport_add_nameserver

### DIFF
--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -605,7 +605,9 @@ SocketDNSTransport_add_nameserver (T transport, const char *address, int port)
     return -1;
 
   ns = &transport->nameservers[transport->nameserver_count];
-  snprintf (ns->address, sizeof (ns->address), "%s", address);
+  int ret = snprintf (ns->address, sizeof (ns->address), "%s", address);
+  if (SOCKET_SNPRINTF_CHECK (ret, sizeof (ns->address)) < 0)
+    return -1; /* Address string truncated */
   ns->port = port > 0 ? port : DNS_PORT;
   ns->family = family;
 


### PR DESCRIPTION
## Summary

Implements #1881

## Changes

- Added truncation check for `snprintf()` call in `SocketDNSTransport_add_nameserver()`
- Uses `SOCKET_SNPRINTF_CHECK` macro from `SocketUtil.h` for consistent error handling
- Function now returns -1 if address string truncation would occur

## Security Impact

Previously, if a nameserver address string exceeded DNS_ADDR_STR_MAX (64 bytes), it would be silently truncated. This could lead to:
- Invalid/corrupted IP addresses being stored
- Unexpected DNS resolution failures
- Potential security issues with truncated addresses

Now the function properly validates the return value and rejects oversized addresses.

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] DNS transport tests pass
- [x] Verified SOCKET_SNPRINTF_CHECK macro is available in SocketUtil.h
- [x] Confirmed DNS_ADDR_STR_MAX is defined (64 bytes in SocketDNSDeadServer.h)

Closes #1881