### PR TITLE
refactor(simple-ws): extract magic buffer size constants

### DIFF
--- a/include/simple/SocketSimple-ws.h
+++ b/include/simple/SocketSimple-ws.h
@@ -254,6 +254,16 @@ extern int Socket_simple_ws_fd(SocketSimple_WS_T ws);
  *============================================================================*/
 
 /**
+ * @brief Default maximum frame size (16 MB).
+ */
+#define SOCKET_SIMPLE_WS_DEFAULT_MAX_FRAME_SIZE   (16 * 1024 * 1024)
+
+/**
+ * @brief Default maximum message size (64 MB).
+ */
+#define SOCKET_SIMPLE_WS_DEFAULT_MAX_MESSAGE_SIZE (64 * 1024 * 1024)
+
+/**
  * @brief WebSocket server configuration.
  */
 typedef struct {

--- a/src/simple/SocketSimple-ws.c
+++ b/src/simple/SocketSimple-ws.c
@@ -523,8 +523,8 @@ Socket_simple_ws_server_config_init (SocketSimple_WSServerConfig *config)
   if (!config)
     return;
   memset (config, 0, sizeof (*config));
-  config->max_frame_size = 16 * 1024 * 1024;   /* 16MB */
-  config->max_message_size = 64 * 1024 * 1024; /* 64MB */
+  config->max_frame_size = SOCKET_SIMPLE_WS_DEFAULT_MAX_FRAME_SIZE;
+  config->max_message_size = SOCKET_SIMPLE_WS_DEFAULT_MAX_MESSAGE_SIZE;
   config->validate_utf8 = 1;
   config->enable_compression = 0;
   config->ping_interval_ms = 0;


### PR DESCRIPTION
## Summary

Implements #1984 by extracting hardcoded buffer size constants in WebSocket server configuration.

## Changes

- Added `SOCKET_SIMPLE_WS_DEFAULT_MAX_FRAME_SIZE` constant (16 MB)
- Added `SOCKET_SIMPLE_WS_DEFAULT_MAX_MESSAGE_SIZE` constant (64 MB)
- Updated `Socket_simple_ws_server_config_init` to use named constants instead of magic numbers

## Test Plan

- [x] Build successful with no compilation errors
- [x] All WebSocket tests pass
- [x] No functional changes - behavior remains identical
- [x] Code follows project anti-pattern guidelines (eliminates magic numbers)

## Notes

One pre-existing test failure in `test_dns_queue_limit` (memory leak in DNS module, unrelated to WebSocket changes). This issue exists in the main branch and is not introduced by this PR.

Closes #1984