### PR TITLE
refactor(http): extract algorithm string selection into helper function

### DIFF
--- a/src/http/SocketHTTPClient-auth.c
+++ b/src/http/SocketHTTPClient-auth.c
@@ -341,6 +341,12 @@ httpclient_auth_bearer_header (const char *token, char *output,
   return 0;
 }
 
+static inline const char *
+get_digest_algorithm_name (int use_sha256)
+{
+  return use_sha256 ? "SHA-256" : "MD5";
+}
+
 static int
 format_digest_header_with_qop (const char *username, const char *realm,
                                const char *nonce, const char *uri,
@@ -353,7 +359,7 @@ format_digest_header_with_qop (const char *username, const char *realm,
                   "Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", "
                   "uri=\"%s\", algorithm=%s, qop=%s, nc=%s, "
                   "cnonce=\"%s\", response=\"%s\"",
-                  username, realm, nonce, uri, use_sha256 ? "SHA-256" : "MD5",
+                  username, realm, nonce, uri, get_digest_algorithm_name (use_sha256),
                   qop, nc, cnonce, response_hex);
 
   return (written < 0 || (size_t)written >= output_size) ? -1 : 0;
@@ -369,7 +375,7 @@ format_digest_header_no_qop (const char *username, const char *realm,
       = snprintf (output, output_size,
                   "Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", "
                   "uri=\"%s\", algorithm=%s, response=\"%s\"",
-                  username, realm, nonce, uri, use_sha256 ? "SHA-256" : "MD5",
+                  username, realm, nonce, uri, get_digest_algorithm_name (use_sha256),
                   response_hex);
 
   return (written < 0 || (size_t)written >= output_size) ? -1 : 0;


### PR DESCRIPTION
## Summary

Implements #1888

## Changes

- Added `get_digest_algorithm_name()` static inline helper function
- Eliminated duplicate ternary expression `use_sha256 ? "SHA-256" : "MD5"` from:
  - `format_digest_header_with_qop()` (line 356)
  - `format_digest_header_no_qop()` (line 372)

## Impact

- **Improves maintainability**: Algorithm name mapping is now centralized in a single location
- **DRY compliance**: Eliminates code duplication
- **Future-proof**: Changes to algorithm names only require one edit

## Test Plan

- [x] All HTTP client tests pass (45/45)
- [x] Digest authentication tests pass with MD5 and SHA-256
- [x] Build succeeds with sanitizers enabled
- [x] No behavioral changes - pure refactoring

## Note

Two unrelated tests (`test_dns_queue_limit`, `test_platform_integration`) have pre-existing failures in main branch (DNS memory leak, platform flakiness). These are not related to HTTP authentication changes.

Closes #1888