### PR TITLE
refactor(simple): extract helpers to reduce pool accept function length

### DIFF
--- a/src/simple/SocketSimple-pool.c
+++ b/src/simple/SocketSimple-pool.c
@@ -308,6 +308,49 @@ Socket_simple_pool_cleanup (SocketSimple_Pool_T pool, int max_idle_ms)
  * ============================================================================
  */
 
+/* Helper: Validate listener socket for accept operations */
+static int
+validate_listener_for_accept (SocketSimple_Pool_T pool,
+                               SocketSimple_Socket_T listener)
+{
+  if (!pool || !listener)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Invalid pool or listener");
+      return -1;
+    }
+
+  if (!listener->socket || !listener->is_server)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Invalid listener socket");
+      return -1;
+    }
+
+  return 0;
+}
+
+/* Helper: Create simple wrapper and add to pool */
+static SocketSimple_Conn_T
+wrap_and_add_to_pool (SocketSimple_Pool_T pool, Socket_T client)
+{
+  SocketSimple_Socket_T simple_sock = simple_create_handle (client, 0, 0);
+  if (!simple_sock)
+    {
+      Socket_free ((Socket_T *)&client);
+      return NULL;
+    }
+
+  SocketSimple_Conn_T conn = Socket_simple_pool_add (pool, simple_sock);
+  if (!conn)
+    {
+      Socket_simple_close (&simple_sock);
+      return NULL;
+    }
+
+  return conn;
+}
+
 SocketSimple_Conn_T
 Socket_simple_pool_accept (SocketSimple_Pool_T pool,
                            SocketSimple_Socket_T listener)
@@ -316,19 +359,8 @@ Socket_simple_pool_accept (SocketSimple_Pool_T pool,
 
   Socket_simple_clear_error ();
 
-  if (!pool || !listener)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid pool or listener");
-      return NULL;
-    }
-
-  if (!listener->socket || !listener->is_server)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid listener socket");
-      return NULL;
-    }
+  if (validate_listener_for_accept (pool, listener) != 0)
+    return NULL;
 
   TRY { client = Socket_accept (listener->socket); }
   EXCEPT (Socket_Failed)
@@ -344,23 +376,7 @@ Socket_simple_pool_accept (SocketSimple_Pool_T pool,
       return NULL;
     }
 
-  /* Create simple socket wrapper for the accepted connection */
-  SocketSimple_Socket_T simple_sock = simple_create_handle (client, 0, 0);
-  if (!simple_sock)
-    {
-      Socket_free ((Socket_T *)&client);
-      return NULL;
-    }
-
-  /* Add to pool */
-  SocketSimple_Conn_T conn = Socket_simple_pool_add (pool, simple_sock);
-  if (!conn)
-    {
-      Socket_simple_close (&simple_sock);
-      return NULL;
-    }
-
-  return conn;
+  return wrap_and_add_to_pool (pool, client);
 }
 
 SocketSimple_Conn_T
@@ -371,19 +387,8 @@ Socket_simple_pool_accept_limited (SocketSimple_Pool_T pool,
 
   Socket_simple_clear_error ();
 
-  if (!pool || !listener)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid pool or listener");
-      return NULL;
-    }
-
-  if (!listener->socket || !listener->is_server)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid listener socket");
-      return NULL;
-    }
+  if (validate_listener_for_accept (pool, listener) != 0)
+    return NULL;
 
   /* Check pool state */
   if (SocketPool_is_draining (pool->pool))
@@ -412,23 +417,7 @@ Socket_simple_pool_accept_limited (SocketSimple_Pool_T pool,
       return NULL;
     }
 
-  /* Create simple socket wrapper */
-  SocketSimple_Socket_T simple_sock = simple_create_handle (client, 0, 0);
-  if (!simple_sock)
-    {
-      Socket_free ((Socket_T *)&client);
-      return NULL;
-    }
-
-  /* Add to pool */
-  SocketSimple_Conn_T conn = Socket_simple_pool_add (pool, simple_sock);
-  if (!conn)
-    {
-      Socket_simple_close (&simple_sock);
-      return NULL;
-    }
-
-  return conn;
+  return wrap_and_add_to_pool (pool, client);
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #1967

Extracted common validation and socket handling logic from `Socket_simple_pool_accept_limited` and `Socket_simple_pool_accept` into reusable helper functions to improve maintainability and reduce code duplication.

## Changes

- Added `validate_listener_for_accept()` - validates pool and listener parameters (18 lines)
- Added `wrap_and_add_to_pool()` - creates socket wrapper and adds to pool (17 lines)
- Refactored `Socket_simple_pool_accept()` - reduced from 54 to 27 lines using helpers
- Refactored `Socket_simple_pool_accept_limited()` - reduced from 66 to 40 lines using helpers

Both functions are now well under the 50-line maintainability guideline from CLAUDE.md.

## Test Plan

- [x] All socketpool tests pass (97/97)
- [x] All pool_health tests pass (23/23)
- [x] All pool-related integration tests pass (test_socketpool_tls, test_quic_connid_pool)
- [x] Build passes with sanitizers enabled
- [x] No functional changes, pure refactoring

Closes #1967