### PR TITLE
refactor(tls): fix brace placement in SocketTLSContext-ct.c

### DIFF
--- a/src/tls/SocketTLSContext-ct.c
+++ b/src/tls/SocketTLSContext-ct.c
@@ -107,7 +107,8 @@ SocketTLSContext_set_ctlog_list_file (T ctx, const char *log_file)
 #else /* !SOCKET_HAS_CT_SUPPORT */
 
 static void
-raise_ct_not_supported(T ctx, const char *feature) {
+raise_ct_not_supported(T ctx, const char *feature)
+{
   assert(ctx);
   RAISE_CTX_ERROR_MSG(SocketTLS_Failed, "%s not supported (requires OpenSSL 1.1.0+ with CT)", feature);
 }


### PR DESCRIPTION
## Summary

Implements #1979

## Changes

- Move opening brace to separate line in `raise_ct_not_supported()` function in `src/tls/SocketTLSContext-ct.c`
- Matches GNU style conventions used throughout the codebase

## Test Plan

- [x] Build succeeded with sanitizers enabled
- [x] Tests pass (116/117, 1 pre-existing failure in test_dns_queue_limit unrelated to this change)
- [x] Style fix only - no functional changes

Closes #1979