### PR TITLE
refactor(dgram): extract duplicate exception handling in bind_udp* functions

### DIFF
--- a/src/socket/SocketDgram.c
+++ b/src/socket/SocketDgram.c
@@ -894,58 +894,6 @@ SocketDgram_recvvall (T socket, struct iovec *iov, int iovcnt)
   return (ssize_t)total_received;
 }
 
-T
-SocketDgram_bind_udp4 (const char *host, int port)
-{
-  T server = NULL;
-
-  assert (port >= 0 && port <= SOCKET_MAX_PORT);
-
-  TRY
-  {
-    /* Create IPv4 UDP socket */
-    server = SocketDgram_new (AF_INET, 0);
-
-    /* Bind to address/port */
-    SocketDgram_bind (server, host, port);
-  }
-  EXCEPT (SocketDgram_Failed)
-  {
-    if (server)
-      SocketDgram_free (&server);
-    RERAISE;
-  }
-  END_TRY;
-
-  return server;
-}
-
-T
-SocketDgram_bind_udp6 (const char *host, int port)
-{
-  T server = NULL;
-
-  assert (port >= 0 && port <= SOCKET_MAX_PORT);
-
-  TRY
-  {
-    /* Create IPv6 UDP socket */
-    server = SocketDgram_new (AF_INET6, 0);
-
-    /* Bind to address/port */
-    SocketDgram_bind (server, host, port);
-  }
-  EXCEPT (SocketDgram_Failed)
-  {
-    if (server)
-      SocketDgram_free (&server);
-    RERAISE;
-  }
-  END_TRY;
-
-  return server;
-}
-
 static int
 detect_address_family (const char *host)
 {
@@ -961,23 +909,16 @@ detect_address_family (const char *host)
   return AF_INET;
 }
 
-T
-SocketDgram_bind_udp (const char *host, int port)
+static T
+dgram_bind_with_family (int family, const char *host, int port)
 {
   T server = NULL;
-  int family;
 
   assert (port >= 0 && port <= SOCKET_MAX_PORT);
 
-  /* Auto-detect address family from host string */
-  family = detect_address_family (host);
-
   TRY
   {
-    /* Create UDP socket with detected family */
     server = SocketDgram_new (family, 0);
-
-    /* Bind to address/port */
     SocketDgram_bind (server, host, port);
   }
   EXCEPT (SocketDgram_Failed)
@@ -989,6 +930,25 @@ SocketDgram_bind_udp (const char *host, int port)
   END_TRY;
 
   return server;
+}
+
+T
+SocketDgram_bind_udp4 (const char *host, int port)
+{
+  return dgram_bind_with_family (AF_INET, host, port);
+}
+
+T
+SocketDgram_bind_udp6 (const char *host, int port)
+{
+  return dgram_bind_with_family (AF_INET6, host, port);
+}
+
+T
+SocketDgram_bind_udp (const char *host, int port)
+{
+  int family = detect_address_family (host);
+  return dgram_bind_with_family (family, host, port);
 }
 
 #undef T


### PR DESCRIPTION
## Summary

Implements #1978

Extracts the common exception handling pattern from `SocketDgram_bind_udp4()`, `SocketDgram_bind_udp6()`, and `SocketDgram_bind_udp()` into a static helper function `dgram_bind_with_family()`.

## Changes

- Added static helper function `dgram_bind_with_family(int family, const char *host, int port)`
- Refactored `SocketDgram_bind_udp4()` to call helper with `AF_INET`
- Refactored `SocketDgram_bind_udp6()` to call helper with `AF_INET6`
- Refactored `SocketDgram_bind_udp()` to call helper with auto-detected family
- Moved `detect_address_family()` before the helper function for clarity

## Benefits

- Reduces code duplication from ~80 lines to ~30 lines
- Single source of truth for exception handling logic
- Easier maintenance and testing
- Consistent behavior across all three convenience functions

## Test Plan

- [x] All 77 socketdgram tests pass with sanitizers
- [x] No changes to public API or behavior
- [x] Exception handling preserved exactly as before

Closes #1978