### PR TITLE
fix(simple-http): check strdup return values in convert_response

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -105,6 +105,13 @@ convert_response (SocketHTTPClient_Response *src,
   if (ct)
     {
       dst->content_type = strdup (ct);
+      if (!dst->content_type)
+        {
+          free (dst->body);
+          simple_set_error (SOCKET_SIMPLE_ERR_MEMORY,
+                            "Failed to copy Content-Type header");
+          return -1;
+        }
     }
 
   /* Extract Location header */
@@ -112,6 +119,14 @@ convert_response (SocketHTTPClient_Response *src,
   if (loc)
     {
       dst->location = strdup (loc);
+      if (!dst->location)
+        {
+          free (dst->body);
+          free (dst->content_type);
+          simple_set_error (SOCKET_SIMPLE_ERR_MEMORY,
+                            "Failed to copy Location header");
+          return -1;
+        }
     }
 
   return 0;


### PR DESCRIPTION
## Summary

Fixes #1995 - Adds NULL checks for `strdup()` return values in `convert_response()` function

## Changes

- Add NULL check after `strdup(ct)` for Content-Type header
- Add NULL check after `strdup(loc)` for Location header  
- Properly clean up previously allocated memory on failure
- Set descriptive error message using `simple_set_error()`

## Security Impact

Prevents NULL pointer dereferences when `strdup()` fails due to memory exhaustion. Without these checks, the code would continue with NULL pointers that could be dereferenced by callers.

## Test Plan

- [x] Code builds successfully with sanitizers enabled
- [x] Existing tests pass (3 pre-existing OpenSSL-related failures unrelated to this change)
- [x] Verified proper cleanup chain: if Location strdup fails, both body and content_type are freed

## Pattern

Follows the existing error handling pattern in this file:
- Check for NULL return from allocation
- Free any previously allocated resources  
- Call `simple_set_error()` with appropriate error code
- Return -1 to indicate failure

Closes #1995