### PR TITLE
fix(ratelimit): replace usleep() with nanosleep() to prevent overflow

### DIFF
--- a/src/simple/SocketSimple-ratelimit.c
+++ b/src/simple/SocketSimple-ratelimit.c
@@ -196,7 +196,10 @@ Socket_simple_ratelimit_acquire (SocketSimple_RateLimit_T limit, int tokens)
       int wait_ms = Socket_simple_ratelimit_wait_ms (limit, tokens);
       if (wait_ms > 0)
         {
-          usleep ((useconds_t)wait_ms * 1000);
+          struct timespec ts;
+          ts.tv_sec = wait_ms / 1000;
+          ts.tv_nsec = (wait_ms % 1000) * 1000000;
+          nanosleep (&ts, NULL);
           pthread_mutex_lock (&limit->mutex);
           limit->total_waited_ms += wait_ms;
           pthread_mutex_unlock (&limit->mutex);
@@ -239,7 +242,10 @@ Socket_simple_ratelimit_acquire_timeout (SocketSimple_RateLimit_T limit,
 
       if (wait_ms > 0)
         {
-          usleep ((useconds_t)wait_ms * 1000);
+          struct timespec ts;
+          ts.tv_sec = wait_ms / 1000;
+          ts.tv_nsec = (wait_ms % 1000) * 1000000;
+          nanosleep (&ts, NULL);
           pthread_mutex_lock (&limit->mutex);
           limit->total_waited_ms += wait_ms;
           pthread_mutex_unlock (&limit->mutex);


### PR DESCRIPTION
## Summary

Implements #1960 - Fixes potential overflow in usleep() cast in SocketSimple-ratelimit.c

## Changes

- Replaced `usleep((useconds_t)wait_ms * 1000)` with `nanosleep()` in two locations:
  - `Socket_simple_ratelimit_acquire()` (line 199)
  - `Socket_simple_ratelimit_acquire_timeout()` (line 242)
- Uses `timespec` to properly split milliseconds into seconds and nanoseconds

## Problem Fixed

The original code had two issues:
1. **Overflow risk**: Casting `wait_ms` to `useconds_t` and multiplying by 1000 could overflow if `wait_ms` is large (e.g., when requesting many tokens with low tokens_per_sec)
2. **POSIX limit**: `usleep()` only guarantees correct behavior for values < 1,000,000 microseconds (1 second), but `wait_ms` could be much larger

## Solution

Using `nanosleep()` which:
- Takes a `timespec` structure (no unsafe cast + multiplication)
- Has no practical upper limit on wait time
- Is POSIX-compliant and portable

## Test Plan

- [x] Tests pass with sanitizers (116/117 tests, 1 pre-existing failure in test_dns_queue_limit)
- [x] All 28 ratelimit tests pass
- [x] Build successful with ASAN/UBSAN enabled
- [x] No new warnings or errors

Closes #1960