### PR TITLE
refactor(http2): replace magic number with named constant in priority field

### DIFF
--- a/include/http/SocketHTTP2.h
+++ b/include/http/SocketHTTP2.h
@@ -304,6 +304,13 @@ typedef struct
 #define SOCKETHTTP2_PRIORITY_UPDATE_MAX_PAYLOAD 16
 
 /**
+ * Maximum serialized priority field length.
+ * RFC 9218 Section 4: Priority field format is "u=N" (3 bytes) + ", i" (3 bytes).
+ * Maximum output: "u=7, i" (7 bytes) + null terminator (1 byte) = 8 bytes.
+ */
+#define SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN 8
+
+/**
  * RFC 9218 Extensible Priority parameters.
  *
  * Priority replaces the deprecated RFC 7540 priority scheme.


### PR DESCRIPTION
## Summary

Implements #1877

Replaces hardcoded buffer size 32 with `SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN` constant in `SocketHTTP2_send_priority_update` function.

## Changes

- Added `SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN` (8) to `include/http/SocketHTTP2.h` with documentation
- Replaced magic number 32 with constant in `src/http/SocketHTTP2-priority.c`
- Reduces stack usage from 32 bytes to 8 bytes per function call

## Rationale

Based on analysis of `SocketHTTP2_Priority_serialize` (lines 281-323):
- Maximum output: "u=7, i" (7 characters)
- With null terminator: 8 bytes
- Previous allocation: 32 bytes (4x larger than needed)

The new constant is properly sized and documented per RFC 9218 Section 4.

## Test Plan

- [x] All HTTP/2 tests pass with sanitizers (test_http2, test_http2_priority, test_http2_integration, etc.)
- [x] Build succeeds with -Wall -Wextra
- [x] No new warnings introduced
- [x] Priority serialization still works correctly with exact-size buffer

Closes #1877