### PR TITLE
refactor(tls): add static assertion for ALPN length cast safety

### DIFF
--- a/src/tls/SocketTLSContext-alpn.c
+++ b/src/tls/SocketTLSContext-alpn.c
@@ -22,6 +22,7 @@
 
 #include "tls/SocketTLS-private.h"
 #include <assert.h>
+#include <limits.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <string.h>
@@ -29,6 +30,15 @@
 #include "core/SocketSecurity.h"
 
 #define T SocketTLSContext_T
+
+/**
+ * RFC 7301 Section 3.1: Protocol name length is encoded as a single byte
+ * in wire format (opaque ProtocolName<1..2^8-1>), limiting maximum length
+ * to 255 bytes. This assertion ensures SOCKET_TLS_MAX_ALPN_LEN can be
+ * safely cast to unsigned char in alpn_select_cb() and build_wire_format().
+ */
+_Static_assert(SOCKET_TLS_MAX_ALPN_LEN <= UCHAR_MAX,
+               "ALPN protocol length must fit in unsigned char (RFC 7301 wire format)");
 
 /** Initial capacity for dynamically-grown protocol arrays */
 #define ALPN_INITIAL_CAPACITY 4


### PR DESCRIPTION
## Summary

Implements #1990 - Adds compile-time static assertion to ensure `SOCKET_TLS_MAX_ALPN_LEN` can be safely cast to `unsigned char`.

## Changes

- Added `_Static_assert` after includes in `src/tls/SocketTLSContext-alpn.c`
- Included `<limits.h>` for `UCHAR_MAX` constant
- Added comprehensive documentation explaining RFC 7301 wire format requirement

## Technical Details

RFC 7301 Section 3.1 defines ALPN wire format as:
```
opaque ProtocolName<1..2^8-1>;
```

This means protocol length is encoded as a single byte, limiting maximum to 255. The static assertion prevents future configuration errors where someone might increase `SOCKET_TLS_MAX_ALPN_LEN` beyond 255, which would cause silent truncation in:

1. **Line 404** (`alpn_select_cb`): `*outlen = (unsigned char)validated_len;`
2. **Line 455** (`build_wire_format`): `buf[offset++] = (unsigned char)lengths[i];`

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] All ALPN tests pass (test_tls_context, test_tls_phase4 ALPN tests)
- [x] Static assertion is verified at compile time (zero runtime cost)
- [x] No behavior change - purely defensive programming

## Impact

- **Runtime**: Zero overhead (compile-time check only)
- **Safety**: Prevents future bugs from configuration changes
- **Maintainability**: Documents the RFC 7301 constraint explicitly

Closes #1990