### PR TITLE
refactor(dns-cookie): optimize HMAC input buffer size

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -31,6 +31,9 @@ const Except_T SocketDNSCookie_Failed
 /* Client secret size (256 bits for HMAC-SHA256) */
 #define SECRET_SIZE 32
 
+/* Maximum HMAC input buffer size: IPv6 server (16) + IPv6 client (16) = 32 bytes */
+#define HMAC_INPUT_MAX_SIZE (sizeof(struct in6_addr) * 2)
+
 /* Minimum TTL/lifetime for all time-based settings (1 minute) */
 #define DNS_COOKIE_MIN_TTL_SECONDS 60
 
@@ -748,7 +751,7 @@ generate_client_cookie_hmac (T cache, const struct sockaddr *server_addr,
                              const struct sockaddr *client_addr,
                              socklen_t client_len, uint8_t *cookie)
 {
-  unsigned char data[256];
+  unsigned char data[HMAC_INPUT_MAX_SIZE];
   size_t data_len = 0;
 
   /* Build input: server IP + client IP */


### PR DESCRIPTION
## Summary

Implements #1887 by optimizing the HMAC input buffer in `generate_client_cookie_hmac()` from 256 bytes to 32 bytes.

## Changes

- Added `HMAC_INPUT_MAX_SIZE` constant defined as `sizeof(struct in6_addr) * 2`
- Replaced magic number `256` with the documented constant
- Buffer now sized exactly for maximum use case: IPv6 server (16 bytes) + IPv6 client (16 bytes)

## Benefits

- **Stack usage**: Reduced by 224 bytes (87.5% reduction)
- **Code clarity**: Eliminates magic number anti-pattern
- **Documentation**: Clear rationale via constant name and comment
- **Security**: Smaller attack surface

## Technical Details

The `serialize_address()` function only copies IP addresses into the buffer:
- IPv4: `sizeof(struct in_addr)` = 4 bytes  
- IPv6: `sizeof(struct in6_addr)` = 16 bytes
- Maximum usage: server IPv6 (16) + client IPv6 (16) = 32 bytes

## Test Plan

- [x] All DNS cookie tests pass (23/23)
- [x] Build succeeds with sanitizers enabled
- [x] No new sanitizer warnings
- [x] IPv6 test specifically verifies the optimized code path

Closes #1887