### PR TITLE
refactor(tls): remove unnecessary volatile qualifiers in load_chain_from_file

### DIFF
--- a/src/tls/SocketTLSContext-certs.c
+++ b/src/tls/SocketTLSContext-certs.c
@@ -296,15 +296,15 @@ static STACK_OF (X509) * load_chain_from_file (const char *cert_file)
       ctx_raise_openssl_error ("Failed to allocate certificate chain stack");
     }
 
-  X509 *volatile cert = NULL;
-  volatile int num_certs = 0;
+  X509 *cert = NULL;
+  int num_certs = 0;
 
   while ((cert = PEM_read_X509 (fp, NULL, NULL, NULL)) != NULL)
     {
       /* Security: Limit certificate chain depth to prevent DoS */
       if (num_certs >= SOCKET_TLS_MAX_CERT_CHAIN_DEPTH)
         {
-          X509_free ((X509 *)cert);
+          X509_free (cert);
           fclose (fp);
           sk_X509_pop_free (chain, X509_free);
           ctx_raise_error_fmt (
@@ -312,10 +312,10 @@ static STACK_OF (X509) * load_chain_from_file (const char *cert_file)
               SOCKET_TLS_MAX_CERT_CHAIN_DEPTH);
         }
 
-      if (sk_X509_push (chain, (X509 *)cert) > 0)
+      if (sk_X509_push (chain, cert) > 0)
         num_certs++;
       else
-        X509_free ((X509 *)cert);
+        X509_free (cert);
       cert = NULL;
     }
 


### PR DESCRIPTION
## Summary

Removes unnecessary `volatile` qualifiers from variables in `load_chain_from_file` function that were not needed for exception safety.

## Changes

- Removed `volatile` from `cert` and `num_certs` variable declarations
- Removed casts to `(X509 *)` that were only needed due to volatile qualifier
- Improves code clarity and aligns with exception safety guidelines in CLAUDE.md

## Rationale

According to CLAUDE.md, variables should only be `volatile` if:
1. They are modified inside a TRY block AND
2. They are read after an exception is caught

In `load_chain_from_file`:
- No TRY/EXCEPT blocks are used
- Exceptions propagate immediately via `ctx_raise_error_fmt`
- Variables are not accessed after exceptions are raised

## Test Plan

- [x] All TLS tests pass with sanitizers (24/24 tests passing)
- [x] No behavioral changes - only removes unnecessary qualifiers
- [x] Code compiles without warnings

## Notes

One pre-existing test failure (`test_dns_queue_limit`) exists on main branch and is unrelated to these TLS certificate loading changes.

Closes #1963