### PR TITLE
fix(http2): prevent integer overflow in priority urgency parsing

### DIFF
--- a/src/http/SocketHTTP2-priority.c
+++ b/src/http/SocketHTTP2-priority.c
@@ -177,6 +177,15 @@ SocketHTTP2_Priority_parse (const char *value, size_t len,
               urgency = urgency * 10 + (*p - '0');
               digits++;
               p++;
+
+              /* Early bounds check to prevent overflow */
+              if (urgency > SOCKETHTTP2_PRIORITY_MAX_URGENCY)
+                {
+                  SOCKET_LOG_DEBUG_MSG (
+                      "Priority parse error: u=%d out of range [0-7]", urgency);
+                  return -1;
+                }
+
               if (digits > 15)
                 {
                   SOCKET_LOG_DEBUG_MSG (


### PR DESCRIPTION
## Summary

Fixes #1872 - Integer overflow vulnerability in HTTP/2 priority parsing

## Changes

- **Security Fix**: Added early bounds checking in `SocketHTTP2_Priority_parse()` to prevent integer overflow
- Validates `urgency <= 7` after each digit during parsing, catching out-of-range values before overflow occurs
- Prevents undefined behavior from malicious inputs like `u=9999999999`

## Test Plan

- [x] Added comprehensive overflow protection tests covering:
  - Large values that would overflow (`u=9999999999`, `u=123456789`)
  - Boundary violations (`u=8`, `u=10`)
  - Valid boundary values (`u=0`, `u=7`)
- [x] All existing HTTP/2 priority tests pass
- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] No regressions in test suite

## Security Impact

This fix prevents a CWE-190 (Integer Overflow) vulnerability where an attacker controlling the Priority header could cause undefined behavior through integer overflow during urgency value parsing.

## Files Changed

- `src/http/SocketHTTP2-priority.c`: Added early bounds check in parsing loop
- `src/test/test_http2_priority.c`: Added `test_priority_parse_overflow_protection()` test

Closes #1872