### PR TITLE
refactor(dns-cookie): use socket_util_pack_be64 for big-endian serialization

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -12,6 +12,7 @@
 #include "dns/SocketDNSCookie.h"
 #include "dns/SocketDNSWire.h"
 #include "core/Arena.h"
+#include "core/SocketUtil.h"
 #include <arpa/inet.h>
 #include <string.h>
 #include <sys/random.h>
@@ -818,14 +819,7 @@ generate_client_cookie_fnv (T cache, const struct sockaddr *server_addr,
     }
 
   /* Store as big-endian */
-  cookie[0] = (hash >> 56) & 0xFF;
-  cookie[1] = (hash >> 48) & 0xFF;
-  cookie[2] = (hash >> 40) & 0xFF;
-  cookie[3] = (hash >> 32) & 0xFF;
-  cookie[4] = (hash >> 24) & 0xFF;
-  cookie[5] = (hash >> 16) & 0xFF;
-  cookie[6] = (hash >> 8) & 0xFF;
-  cookie[7] = hash & 0xFF;
+  socket_util_pack_be64 (cookie, hash);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Implements #1882

Replaces manual 8-operation big-endian serialization in `generate_client_cookie_fnv()` with the existing `socket_util_pack_be64()` helper from `SocketUtil.h`.

## Changes

- Added `#include "core/SocketUtil.h"` to `src/dns/SocketDNSCookie.c`
- Replaced 8 manual shift operations with single call to `socket_util_pack_be64()`
- Reduced code from 8 lines to 1 line

## Benefits

- Eliminates code duplication - uses standard endianness helper
- Reduces maintenance burden (magic shift values centralized)
- Follows existing codebase patterns for big-endian serialization
- More maintainable and less error-prone

## Test Plan

- [x] DNS cookie tests pass (`test_dnscookie`)
- [x] All non-flaky tests pass with sanitizers (89/89)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - same byte output

Closes #1882