### PR TITLE
refactor(quic): move QUIC_STATELESS_RESET_TOKEN_SIZE to header file

### DIFF
--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -22,6 +22,9 @@
 #define QUIC_PATH_DATA_SIZE 8
 #define QUIC_PATH_FRAME_SIZE (1 + QUIC_PATH_DATA_SIZE)
 
+/* Stateless Reset Token size (RFC 9000 §10.3) */
+#define QUIC_STATELESS_RESET_TOKEN_SIZE 16
+
 /* CONNECTION_CLOSE reason phrase maximum length (RFC 9000 §19.19).
  * While the RFC doesn't mandate a specific limit, we enforce a reasonable
  * maximum to prevent DoS via extremely long reason strings. */
@@ -127,7 +130,7 @@ typedef struct SocketQUICFrameStreamsBlocked {
 
 typedef struct SocketQUICFrameNewConnectionID {
   uint64_t sequence; uint64_t retire_prior_to; uint8_t cid_length;
-  uint8_t cid[20]; uint8_t stateless_reset_token[16];
+  uint8_t cid[20]; uint8_t stateless_reset_token[QUIC_STATELESS_RESET_TOKEN_SIZE];
 } SocketQUICFrameNewConnectionID_T;
 
 typedef struct SocketQUICFrameRetireConnectionID {

--- a/src/quic/SocketQUICFrame.c
+++ b/src/quic/SocketQUICFrame.c
@@ -34,9 +34,6 @@
 /* 1-RTT only */
 #define PKT_1 (QUIC_PKT_1RTT)
 
-/* RFC 9000 Section 10.3: Stateless Reset Token size */
-#define QUIC_STATELESS_RESET_TOKEN_SIZE 16
-
 /**
  * @brief Frame type to allowed packet types mapping.
  */


### PR DESCRIPTION
## Summary

Implements #1993

Move protocol constant `QUIC_STATELESS_RESET_TOKEN_SIZE` from SocketQUICFrame.c to SocketQUICFrame.h and replace magic number in struct definition with named constant.

## Changes

- Add `QUIC_STATELESS_RESET_TOKEN_SIZE` constant to header file (RFC 9000 §10.3)
- Update `SocketQUICFrameNewConnectionID_T` struct to use constant instead of magic number `16`
- Remove duplicate definition from implementation file

## Test Plan

- [x] All QUIC frame tests pass (87/87)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - pure refactoring

Closes #1993