### PR TITLE
refactor(quic): replace magic number 4 with QUIC_STREAM_ID_INCREMENT constant

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -73,6 +73,26 @@
 #define QUIC_HKDF_LABEL_MAX_SIZE 520
 
 /* ============================================================================
+ * Stream ID Constants (RFC 9000 Section 2.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Stream ID increment value (RFC 9000 Section 2.1).
+ *
+ * Stream IDs increment by 4 to preserve the 2-bit type encoding
+ * in bits 0-1. Same-type streams use IDs: 0, 4, 8, 12, ...
+ *
+ * The lower 2 bits of a stream ID encode:
+ *   - Bit 0: Initiator (0=client, 1=server)
+ *   - Bit 1: Directionality (0=bidirectional, 1=unidirectional)
+ *
+ * Incrementing by 4 preserves these bits, ensuring consecutive
+ * stream IDs are of the same type.
+ */
+#define QUIC_STREAM_ID_INCREMENT 4
+
+/* ============================================================================
  * Congestion Control Constants (RFC 9002)
  * ============================================================================
  */

--- a/src/quic/SocketQUICStream.c
+++ b/src/quic/SocketQUICStream.c
@@ -111,7 +111,7 @@ SocketQUICStream_is_valid_id (uint64_t stream_id)
 uint64_t
 SocketQUICStream_next_id (uint64_t stream_id)
 {
-  uint64_t next = stream_id + 4;
+  uint64_t next = stream_id + QUIC_STREAM_ID_INCREMENT;
 
   /* Check for overflow */
   if (next > QUIC_STREAM_ID_MAX || next < stream_id)


### PR DESCRIPTION
## Summary

Implements #1994 - replaces hardcoded magic number `4` in `SocketQUICStream_next_id()` with a named constant `QUIC_STREAM_ID_INCREMENT` to improve code documentation and maintainability.

## Changes

- **Added** `QUIC_STREAM_ID_INCREMENT` constant to `include/quic/SocketQUICConstants.h`
- **Updated** `src/quic/SocketQUICStream.c` to use the constant instead of magic number
- **Documented** RFC 9000 Section 2.1 requirement in comprehensive Doxygen comments

## Why This Matters

Per RFC 9000 Section 2.1, stream IDs increment by 4 to preserve the 2-bit type encoding in bits 0-1:
- Bit 0: Initiator (0=client, 1=server)
- Bit 1: Directionality (0=bidirectional, 1=unidirectional)

This ensures consecutive stream IDs maintain the same type (e.g., 0, 4, 8, 12... are all client-initiated bidirectional streams).

## Test Plan

- [x] All QUIC stream tests pass (38/38)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - pure refactoring
- [x] Code compiles without warnings

## Notes

Pre-existing test failure (`test_dns_queue_limit`) is unrelated to these changes and also fails on main branch. This is a memory leak in the DNS module that should be fixed separately.

Closes #1994