### PR TITLE
fix(simple-http): add zero-length validation for header names

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -265,7 +265,7 @@ Socket_simple_http_get_ex (const char *url, const char **headers,
             if (colon)
               {
                 size_t name_len = (size_t)(colon - *h);
-                if (name_len < 256)
+                if (name_len > 0 && name_len < 256)
                   {
                     char name[256];
                     memcpy (name, *h, name_len);
@@ -707,7 +707,7 @@ add_custom_headers (SocketHTTPClient_Request_T req, const char **headers)
       if (colon)
         {
           size_t name_len = (size_t)(colon - *h);
-          if (name_len < 256)
+          if (name_len > 0 && name_len < 256)
             {
               char name[256];
               memcpy (name, *h, name_len);


### PR DESCRIPTION
## Summary

Implements #1996

## Changes

- Added zero-length validation for header names in `Socket_simple_http_get_ex` (line 268)
- Added zero-length validation for header names in `add_custom_headers` (line 710)

Both functions now check `name_len > 0 && name_len < 256` instead of just `name_len < 256`, preventing empty header names from being passed to the HTTP client layer when headers start with ':' (e.g., ":value").

## Test Plan

- [x] Tests pass with sanitizers (89/89 excluding known pre-existing failures)
- [x] Build succeeds with sanitizers enabled
- [x] No new memory leaks or undefined behavior detected

Closes #1996