### PR TITLE
feat(http): add error logging for pthread_setspecific failure

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -102,9 +102,14 @@ httpclient_get_arena_cache (void)
   if (!cache)
     return NULL;
 
-  if (pthread_setspecific (arena_cache_key, cache) != 0)
+  int rc = pthread_setspecific (arena_cache_key, cache);
+  if (rc != 0)
     {
       /* Failed to store in TLS - free and continue without cache */
+      fprintf (stderr,
+               "WARNING: pthread_setspecific failed: %d (falling back to "
+               "non-cached arenas)\n",
+               rc);
       free (cache);
       return NULL;
     }


### PR DESCRIPTION
## Summary

Implements #1876

Adds error logging when `pthread_setspecific` fails in the HTTP client arena cache, improving debuggability in production environments.

## Changes

- Added `fprintf` warning message when `pthread_setspecific` fails in `httpclient_get_arena_cache()`
- Captures error code in `rc` variable for logging (matching pattern used for `pthread_key_create`)
- Message explains the failure and fallback behavior (non-cached arenas)

## Behavior

Before: Silent failure when TLS allocation fails
After: Warning logged to stderr with error code

```
WARNING: pthread_setspecific failed: <errno> (falling back to non-cached arenas)
```

The function already handles the failure safely by freeing the cache and returning NULL, which triggers fallback to non-cached arena allocation. Operators now get visibility into TLS issues like:
- TLS slot exhaustion (PTHREAD_KEYS_MAX reached)
- Memory corruption affecting pthread internals
- Platform-specific threading issues

## Test Plan

- [x] All HTTP-related tests pass with sanitizers
- [x] test_http_core - PASS
- [x] test_http1_parser - PASS  
- [x] test_http2 - PASS
- [x] test_http2_priority - PASS
- [x] test_http2_rate_limit - PASS
- [x] test_http_client - PASS
- [x] test_http_integration - PASS
- [x] test_http2_integration - PASS
- [x] test_httpserver_load - PASS
- [x] test_httpserver - PASS
- [x] test_tls_http2 - PASS
- [x] test_http2_server_push - PASS
- [x] test_dns_over_https - PASS

Closes #1876