### PR TITLE
fix(simple-dtls): eliminate unsafe volatile pointer casts in exception cleanup

### DIFF
--- a/src/simple/SocketSimple-dtls.c
+++ b/src/simple/SocketSimple-dtls.c
@@ -181,9 +181,15 @@ Socket_simple_dtls_connect_ex (const char *host, int port,
     if (exception_occurred)
       {
         if (ctx)
-          SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
+          {
+            SocketDTLSContext_T temp_ctx = (SocketDTLSContext_T)ctx;
+            SocketDTLSContext_free (&temp_ctx);
+          }
         if (dgram)
-          SocketDgram_free ((SocketDgram_T *)&dgram);
+          {
+            SocketDgram_T temp_dgram = (SocketDgram_T)dgram;
+            SocketDgram_free (&temp_dgram);
+          }
       }
   }
   END_TRY;
@@ -195,7 +201,8 @@ Socket_simple_dtls_connect_ex (const char *host, int port,
   SocketSimple_Socket_T handle = simple_create_udp_handle (dgram);
   if (!handle)
     {
-      SocketDgram_free ((SocketDgram_T *)&dgram);
+      SocketDgram_T temp_dgram = (SocketDgram_T)dgram;
+      SocketDgram_free (&temp_dgram);
       simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Failed to create handle");
       return NULL;
     }
@@ -305,7 +312,10 @@ Socket_simple_dtls_enable (SocketSimple_Socket_T sock, const char *hostname,
   FINALLY
   {
     if (exception_occurred && ctx)
-      SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
+      {
+        SocketDTLSContext_T temp_ctx = (SocketDTLSContext_T)ctx;
+        SocketDTLSContext_free (&temp_ctx);
+      }
   }
   END_TRY;
 
@@ -361,18 +371,30 @@ Socket_simple_dtls_listen (const char *host, int port, const char *cert_file,
     simple_set_error (SOCKET_SIMPLE_ERR_TLS,
                       "Failed to create DTLS server context");
     if (ctx)
-      SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
+      {
+        SocketDTLSContext_T temp_ctx = (SocketDTLSContext_T)ctx;
+        SocketDTLSContext_free (&temp_ctx);
+      }
     if (dgram)
-      SocketDgram_free ((SocketDgram_T *)&dgram);
+      {
+        SocketDgram_T temp_dgram = (SocketDgram_T)dgram;
+        SocketDgram_free (&temp_dgram);
+      }
     return NULL;
   }
   EXCEPT (SocketDgram_Failed)
   {
     simple_set_error_errno (SOCKET_SIMPLE_ERR_BIND, "Failed to bind UDP socket");
     if (ctx)
-      SocketDTLSContext_free ((SocketDTLSContext_T *)&ctx);
+      {
+        SocketDTLSContext_T temp_ctx = (SocketDTLSContext_T)ctx;
+        SocketDTLSContext_free (&temp_ctx);
+      }
     if (dgram)
-      SocketDgram_free ((SocketDgram_T *)&dgram);
+      {
+        SocketDgram_T temp_dgram = (SocketDgram_T)dgram;
+        SocketDgram_free (&temp_dgram);
+      }
     return NULL;
   }
   END_TRY;
@@ -380,7 +402,8 @@ Socket_simple_dtls_listen (const char *host, int port, const char *cert_file,
   SocketSimple_Socket_T handle = simple_create_udp_handle (dgram);
   if (!handle)
     {
-      SocketDgram_free ((SocketDgram_T *)&dgram);
+      SocketDgram_T temp_dgram = (SocketDgram_T)dgram;
+      SocketDgram_free (&temp_dgram);
       simple_set_error (SOCKET_SIMPLE_ERR_MEMORY, "Failed to create handle");
       return NULL;
     }


### PR DESCRIPTION
## Summary

Fixes #1977 by eliminating unsafe casts of volatile pointers in exception cleanup paths.

## Problem

The code used the pattern `(Type_T *)&volatile_var` when calling free functions, which discards the volatile qualifier. This can lead to undefined behavior if the compiler optimizes based on non-volatile assumptions.

## Solution

Introduced temporary non-volatile variables to hold the volatile value before passing to free functions:
- `SocketDTLSContext_free(&temp_ctx)` instead of `SocketDTLSContext_free((SocketDTLSContext_T *)&ctx)`
- `SocketDgram_free(&temp_dgram)` instead of `SocketDgram_free((SocketDgram_T *)&dgram)`

## Changes

Modified `src/simple/SocketSimple-dtls.c`:
- `Socket_simple_dtls_connect_ex`: Updated FINALLY block (lines 179-194)
- `Socket_simple_dtls_enable`: Updated FINALLY block (lines 311-318)
- `Socket_simple_dtls_listen`: Updated EXCEPT blocks (lines 368-398)
- Error handling after successful TRY blocks (lines 200-208, 402-409)

## Test Plan

- [x] All DTLS tests pass with sanitizers
- [x] Tests run: `test_dtls_basic`, `test_dtls_cookie`, `test_dtls_integration`, `test_dtls_mtu`
- [x] Full test suite passes with excluded pre-existing failures
- [x] No new compiler warnings
- [x] Code follows project exception safety guidelines from CLAUDE.md

Closes #1977