### PR TITLE
refactor(quic): use named constant for frame type size

### DIFF
--- a/include/quic/SocketQUICFrame.h
+++ b/include/quic/SocketQUICFrame.h
@@ -22,6 +22,11 @@
 #define QUIC_PATH_DATA_SIZE 8
 #define QUIC_PATH_FRAME_SIZE (1 + QUIC_PATH_DATA_SIZE)
 
+/* QUIC frame type field size (RFC 9000).
+ * All QUIC frames start with a variable-length integer type field.
+ * For frame types 0x00-0x3f, this is always encoded as 1 byte. */
+#define QUIC_FRAME_TYPE_SIZE 1
+
 /* CONNECTION_CLOSE reason phrase maximum length (RFC 9000 §19.19).
  * While the RFC doesn't mandate a specific limit, we enforce a reasonable
  * maximum to prevent DoS via extremely long reason strings. */

--- a/src/quic/SocketQUICFrame-close.c
+++ b/src/quic/SocketQUICFrame-close.c
@@ -88,7 +88,7 @@ encode_connection_close_common (uint8_t frame_type_byte, uint64_t error_code,
     return 0;
 
   /* Calculate required size */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t error_code_len = SocketQUICVarInt_size (error_code);
   size_t frame_type_len = frame_type_ptr ? SocketQUICVarInt_size (*frame_type_ptr) : 0;
   size_t reason_len_size = SocketQUICVarInt_size (reason_len);

--- a/src/quic/SocketQUICFrame-crypto.c
+++ b/src/quic/SocketQUICFrame-crypto.c
@@ -69,7 +69,7 @@ SocketQUICFrame_encode_crypto (uint64_t offset, const uint8_t *data,
     return 0;
 
   /* Calculate required buffer size */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t offset_len = SocketQUICVarInt_size (offset);
   size_t length_len = SocketQUICVarInt_size (len);
 

--- a/src/quic/SocketQUICFrame-flow.c
+++ b/src/quic/SocketQUICFrame-flow.c
@@ -41,7 +41,7 @@ SocketQUICFrame_encode_max_data (uint64_t max_data, uint8_t *out,
     return 0;
 
   /* Calculate required size: type (1 byte) + max_data (varint) */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t max_data_len = SocketQUICVarInt_size (max_data);
 
   if (max_data_len == 0)
@@ -82,7 +82,7 @@ SocketQUICFrame_encode_max_stream_data (uint64_t stream_id, uint64_t max_data,
     return 0;
 
   /* Calculate required size: type + stream_id + max_data (all varints) */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t stream_id_len = SocketQUICVarInt_size (stream_id);
   size_t max_data_len = SocketQUICVarInt_size (max_data);
 
@@ -127,7 +127,7 @@ SocketQUICFrame_encode_max_streams (int bidirectional, uint64_t max_streams,
     return 0;
 
   /* Calculate required size: type (1 byte) + max_streams (varint) */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t max_streams_len = SocketQUICVarInt_size (max_streams);
 
   if (max_streams_len == 0)
@@ -180,7 +180,7 @@ SocketQUICFrame_encode_data_blocked (uint64_t max_data, uint8_t *out,
     return 0;
 
   /* Calculate required size: type (1 byte) + max_data (varint) */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t max_data_len = SocketQUICVarInt_size (max_data);
 
   if (max_data_len == 0)
@@ -236,7 +236,7 @@ SocketQUICFrame_encode_stream_data_blocked (uint64_t stream_id,
     return 0;
 
   /* Calculate required size: type + stream_id + max_data (all varints) */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t stream_id_len = SocketQUICVarInt_size (stream_id);
   size_t max_data_len = SocketQUICVarInt_size (max_data);
 
@@ -297,7 +297,7 @@ SocketQUICFrame_encode_streams_blocked (int bidirectional, uint64_t max_streams,
     return 0;
 
   /* Calculate required size: type (1 byte) + max_streams (varint) */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t max_streams_len = SocketQUICVarInt_size (max_streams);
 
   if (max_streams_len == 0)

--- a/src/quic/SocketQUICFrame-stream.c
+++ b/src/quic/SocketQUICFrame-stream.c
@@ -52,7 +52,7 @@ SocketQUICFrame_encode_reset_stream (uint64_t stream_id, uint64_t error_code,
     return 0;
 
   /* Calculate required size: type + stream_id + error_code + final_size */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t stream_id_len = SocketQUICVarInt_size (stream_id);
   size_t error_code_len = SocketQUICVarInt_size (error_code);
   size_t final_size_len = SocketQUICVarInt_size (final_size);
@@ -120,7 +120,7 @@ SocketQUICFrame_encode_stop_sending (uint64_t stream_id, uint64_t error_code,
     return 0;
 
   /* Calculate required size: type + stream_id + error_code */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t stream_id_len = SocketQUICVarInt_size (stream_id);
   size_t error_code_len = SocketQUICVarInt_size (error_code);
 
@@ -202,7 +202,7 @@ SocketQUICFrame_encode_stream (uint64_t stream_id, uint64_t offset,
     frame_type |= QUIC_FRAME_STREAM_OFF; /* Bit 2: OFF */
 
   /* Calculate required buffer size */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t stream_id_len = SocketQUICVarInt_size (stream_id);
   size_t offset_len = (offset > 0) ? SocketQUICVarInt_size (offset) : 0;
   size_t length_len = SocketQUICVarInt_size (len);

--- a/src/quic/SocketQUICFrame-token.c
+++ b/src/quic/SocketQUICFrame-token.c
@@ -89,7 +89,7 @@ SocketQUICFrame_encode_new_token (const uint8_t *token, size_t token_len,
     return 0;
 
   /* Calculate required size: type + token_length + token */
-  size_t type_len = 1;
+  size_t type_len = QUIC_FRAME_TYPE_SIZE;
   size_t token_len_varint = SocketQUICVarInt_size (token_len);
 
   if (token_len_varint == 0)


### PR DESCRIPTION
## Summary

Implements #2021 - Replaces hardcoded magic number `1` with named constant `QUIC_FRAME_TYPE_SIZE` across all QUIC frame encoding functions.

## Changes

### Header File
- Added `QUIC_FRAME_TYPE_SIZE` constant to `include/quic/SocketQUICFrame.h`
- Documents that QUIC frame types 0x00-0x3f are always 1 byte (per RFC 9000)

### Implementation Files
Updated 12 frame encoding functions across 5 files:
- `SocketQUICFrame-stream.c`: 3 functions (RESET_STREAM, STOP_SENDING, STREAM)
- `SocketQUICFrame-flow.c`: 6 functions (MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS, DATA_BLOCKED, STREAM_DATA_BLOCKED, STREAMS_BLOCKED)
- `SocketQUICFrame-close.c`: 1 function (CONNECTION_CLOSE common encoding)
- `SocketQUICFrame-crypto.c`: 1 function (CRYPTO)
- `SocketQUICFrame-token.c`: 1 function (NEW_TOKEN)

## Benefits

1. **Code Clarity**: Explicitly documents what the value represents
2. **Maintainability**: Single source of truth if frame type encoding changes
3. **Consistency**: Follows existing pattern (e.g., `QUIC_PATH_DATA_SIZE`)

## Test Plan

- [x] All QUIC tests pass (26/26, 100% success rate)
- [x] Build succeeds with sanitizers enabled
- [x] No changes to logic, only naming

Closes #2021