### PR TITLE
refactor(http2): replace magic numbers with named constants in priority update

### DIFF
--- a/include/http/SocketHTTP2.h
+++ b/include/http/SocketHTTP2.h
@@ -297,6 +297,12 @@ typedef struct
 /** Maximum valid urgency value */
 #define SOCKETHTTP2_PRIORITY_MAX_URGENCY 7
 
+/** Maximum serialized priority field length: "u=7, i" = 7 bytes */
+#define SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN 8
+
+/** PRIORITY_UPDATE frame payload size: 4 bytes stream ID + priority field */
+#define SOCKETHTTP2_PRIORITY_UPDATE_MAX_PAYLOAD 16
+
 /**
  * RFC 9218 Extensible Priority parameters.
  *

--- a/src/http/SocketHTTP2-priority.c
+++ b/src/http/SocketHTTP2-priority.c
@@ -352,8 +352,8 @@ SocketHTTP2_send_priority_update (SocketHTTP2_Conn_T conn, uint32_t stream_id,
                                   const SocketHTTP2_Priority *priority)
 {
   SocketHTTP2_FrameHeader header;
-  unsigned char payload[64]; /* 4 bytes stream ID + priority field value */
-  char priority_field[32];
+  unsigned char payload[SOCKETHTTP2_PRIORITY_UPDATE_MAX_PAYLOAD];
+  char priority_field[SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN];
   ssize_t priority_len;
   size_t payload_len;
 


### PR DESCRIPTION
## Summary

Implements #1874

Replaced hardcoded buffer sizes in `SocketHTTP2_send_priority_update` with named constants for improved maintainability and clarity.

## Changes

- Added `SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN` (8 bytes) constant for maximum serialized priority field length
- Added `SOCKETHTTP2_PRIORITY_UPDATE_MAX_PAYLOAD` (16 bytes) constant for PRIORITY_UPDATE frame payload size  
- Replaced `payload[64]` with `payload[SOCKETHTTP2_PRIORITY_UPDATE_MAX_PAYLOAD]`
- Replaced `priority_field[32]` with `priority_field[SOCKETHTTP2_PRIORITY_FIELD_MAX_LEN]`

## Benefits

- **Maintainability**: Named constants document the sizing rationale
- **Memory efficiency**: Reduced stack allocation by 75% (payload: 64→16 bytes, priority_field: 32→8 bytes)
- **Consistency**: Follows project convention of using named constants over magic numbers
- **Safety**: Maintains adequate margins per RFC 9218 requirements

## Test Plan

- [x] All HTTP2 tests pass with sanitizers enabled (`test_http2`, `test_http2_priority`, `test_http2_rate_limit`, `test_http2_integration`, `test_http2_server_push`, `test_tls_http2`)
- [x] All HPACK tests pass
- [x] Build completes without warnings with `-Wall -Wextra -Werror`
- [x] No regressions in priority update functionality

Closes #1874