### PR TITLE
refactor(quic): eliminate code duplication in flow control frame encoding

### DIFF
--- a/src/quic/SocketQUICFrame-flow.c
+++ b/src/quic/SocketQUICFrame-flow.c
@@ -25,6 +25,88 @@
 #include <string.h>
 
 /* ============================================================================
+ * Common Helper Function
+ * ============================================================================
+ *
+ * This helper eliminates 90%+ code duplication across the 6 flow control
+ * frame encoding functions. Each function follows the identical pattern:
+ * 1. Validate output buffer
+ * 2. Calculate varint sizes for all fields
+ * 3. Validate field sizes (detect overflow)
+ * 4. Check output buffer capacity
+ * 5. Encode frame type byte
+ * 6. Encode variable number of varint fields
+ */
+
+/**
+ * @brief Generic flow control frame encoder.
+ *
+ * Encodes a flow control frame with 1-2 varint fields following the frame type.
+ * All 6 flow control frames (MAX_DATA, MAX_STREAM_DATA, MAX_STREAMS,
+ * DATA_BLOCKED, STREAM_DATA_BLOCKED, STREAMS_BLOCKED) share this structure.
+ *
+ * @param frame_type QUIC frame type (0x10-0x17).
+ * @param field1     First varint field value.
+ * @param field2     Second varint field value (ignored if field_count == 1).
+ * @param field_count Number of fields to encode (1 or 2).
+ * @param out        Output buffer for encoded frame.
+ * @param out_size   Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, 0 on error.
+ *
+ * @note This function performs all validation checks that were previously
+ *       duplicated across the 6 individual encoding functions.
+ */
+static size_t
+encode_flow_control_frame (uint8_t frame_type, uint64_t field1,
+                           uint64_t field2, size_t field_count, uint8_t *out,
+                           size_t out_size)
+{
+  if (!out)
+    return 0;
+
+  /* Calculate required size: type (1 byte) + field(s) (varint) */
+  size_t type_len = 1;
+  size_t field1_len = SocketQUICVarInt_size (field1);
+
+  if (field1_len == 0)
+    return 0; /* field1 exceeds varint maximum */
+
+  size_t total_len = type_len + field1_len;
+
+  /* Handle second field if present */
+  size_t field2_len = 0;
+  if (field_count == 2)
+    {
+      field2_len = SocketQUICVarInt_size (field2);
+      if (field2_len == 0)
+        return 0; /* field2 exceeds varint maximum */
+      total_len += field2_len;
+    }
+
+  if (out_size < total_len)
+    return 0; /* Buffer too small */
+
+  size_t pos = 0;
+
+  /* Encode frame type */
+  out[pos++] = frame_type;
+
+  /* Encode first field */
+  if (!encode_varint_field (field1, out, &pos, out_size))
+    return 0;
+
+  /* Encode second field if present */
+  if (field_count == 2)
+    {
+      if (!encode_varint_field (field2, out, &pos, out_size))
+        return 0;
+    }
+
+  return pos;
+}
+
+/* ============================================================================
  * MAX_DATA Frame Encoding (RFC 9000 Section 19.9)
  * ============================================================================
  *
@@ -37,31 +119,8 @@ size_t
 SocketQUICFrame_encode_max_data (uint64_t max_data, uint8_t *out,
                                   size_t out_size)
 {
-  if (!out)
-    return 0;
-
-  /* Calculate required size: type (1 byte) + max_data (varint) */
-  size_t type_len = 1;
-  size_t max_data_len = SocketQUICVarInt_size (max_data);
-
-  if (max_data_len == 0)
-    return 0; /* max_data exceeds varint maximum */
-
-  size_t total_len = type_len + max_data_len;
-
-  if (out_size < total_len)
-    return 0; /* Buffer too small */
-
-  size_t pos = 0;
-
-  /* Type: 0x10 */
-  out[pos++] = QUIC_FRAME_MAX_DATA;
-
-  /* Maximum Data */
-  if (!encode_varint_field (max_data, out, &pos, out_size))
-    return 0;
-
-  return pos;
+  return encode_flow_control_frame (QUIC_FRAME_MAX_DATA, max_data, 0, 1, out,
+                                    out_size);
 }
 
 /* ============================================================================
@@ -78,36 +137,8 @@ size_t
 SocketQUICFrame_encode_max_stream_data (uint64_t stream_id, uint64_t max_data,
                                          uint8_t *out, size_t out_size)
 {
-  if (!out)
-    return 0;
-
-  /* Calculate required size: type + stream_id + max_data (all varints) */
-  size_t type_len = 1;
-  size_t stream_id_len = SocketQUICVarInt_size (stream_id);
-  size_t max_data_len = SocketQUICVarInt_size (max_data);
-
-  if (stream_id_len == 0 || max_data_len == 0)
-    return 0; /* Value exceeds varint maximum */
-
-  size_t total_len = type_len + stream_id_len + max_data_len;
-
-  if (out_size < total_len)
-    return 0; /* Buffer too small */
-
-  size_t pos = 0;
-
-  /* Type: 0x11 */
-  out[pos++] = QUIC_FRAME_MAX_STREAM_DATA;
-
-  /* Stream ID */
-  if (!encode_varint_field (stream_id, out, &pos, out_size))
-    return 0;
-
-  /* Maximum Stream Data */
-  if (!encode_varint_field (max_data, out, &pos, out_size))
-    return 0;
-
-  return pos;
+  return encode_flow_control_frame (QUIC_FRAME_MAX_STREAM_DATA, stream_id,
+                                    max_data, 2, out, out_size);
 }
 
 /* ============================================================================
@@ -123,32 +154,10 @@ size_t
 SocketQUICFrame_encode_max_streams (int bidirectional, uint64_t max_streams,
                                      uint8_t *out, size_t out_size)
 {
-  if (!out)
-    return 0;
-
-  /* Calculate required size: type (1 byte) + max_streams (varint) */
-  size_t type_len = 1;
-  size_t max_streams_len = SocketQUICVarInt_size (max_streams);
-
-  if (max_streams_len == 0)
-    return 0; /* max_streams exceeds varint maximum */
-
-  size_t total_len = type_len + max_streams_len;
-
-  if (out_size < total_len)
-    return 0; /* Buffer too small */
-
-  size_t pos = 0;
-
-  /* Type: 0x12 (bidi) or 0x13 (uni) */
-  out[pos++] = bidirectional ? QUIC_FRAME_MAX_STREAMS_BIDI
-                              : QUIC_FRAME_MAX_STREAMS_UNI;
-
-  /* Maximum Streams */
-  if (!encode_varint_field (max_streams, out, &pos, out_size))
-    return 0;
-
-  return pos;
+  uint8_t frame_type = bidirectional ? QUIC_FRAME_MAX_STREAMS_BIDI
+                                     : QUIC_FRAME_MAX_STREAMS_UNI;
+  return encode_flow_control_frame (frame_type, max_streams, 0, 1, out,
+                                    out_size);
 }
 
 /* ============================================================================
@@ -176,31 +185,8 @@ size_t
 SocketQUICFrame_encode_data_blocked (uint64_t max_data, uint8_t *out,
                                       size_t out_size)
 {
-  if (!out)
-    return 0;
-
-  /* Calculate required size: type (1 byte) + max_data (varint) */
-  size_t type_len = 1;
-  size_t max_data_len = SocketQUICVarInt_size (max_data);
-
-  if (max_data_len == 0)
-    return 0; /* max_data exceeds varint maximum */
-
-  size_t total_len = type_len + max_data_len;
-
-  if (out_size < total_len)
-    return 0; /* Buffer too small */
-
-  size_t pos = 0;
-
-  /* Encode frame type */
-  out[pos++] = QUIC_FRAME_DATA_BLOCKED;
-
-  /* Encode max_data */
-  if (!encode_varint_field (max_data, out, &pos, out_size))
-    return 0;
-
-  return pos;
+  return encode_flow_control_frame (QUIC_FRAME_DATA_BLOCKED, max_data, 0, 1,
+                                    out, out_size);
 }
 
 /* ============================================================================
@@ -232,36 +218,8 @@ SocketQUICFrame_encode_stream_data_blocked (uint64_t stream_id,
                                              uint64_t max_data, uint8_t *out,
                                              size_t out_size)
 {
-  if (!out)
-    return 0;
-
-  /* Calculate required size: type + stream_id + max_data (all varints) */
-  size_t type_len = 1;
-  size_t stream_id_len = SocketQUICVarInt_size (stream_id);
-  size_t max_data_len = SocketQUICVarInt_size (max_data);
-
-  if (stream_id_len == 0 || max_data_len == 0)
-    return 0; /* Value exceeds varint maximum */
-
-  size_t total_len = type_len + stream_id_len + max_data_len;
-
-  if (out_size < total_len)
-    return 0; /* Buffer too small */
-
-  size_t pos = 0;
-
-  /* Encode frame type */
-  out[pos++] = QUIC_FRAME_STREAM_DATA_BLOCKED;
-
-  /* Encode stream ID */
-  if (!encode_varint_field (stream_id, out, &pos, out_size))
-    return 0;
-
-  /* Encode max_data */
-  if (!encode_varint_field (max_data, out, &pos, out_size))
-    return 0;
-
-  return pos;
+  return encode_flow_control_frame (QUIC_FRAME_STREAM_DATA_BLOCKED, stream_id,
+                                    max_data, 2, out, out_size);
 }
 
 /* ============================================================================
@@ -293,30 +251,8 @@ size_t
 SocketQUICFrame_encode_streams_blocked (int bidirectional, uint64_t max_streams,
                                         uint8_t *out, size_t out_size)
 {
-  if (!out)
-    return 0;
-
-  /* Calculate required size: type (1 byte) + max_streams (varint) */
-  size_t type_len = 1;
-  size_t max_streams_len = SocketQUICVarInt_size (max_streams);
-
-  if (max_streams_len == 0)
-    return 0; /* max_streams exceeds varint maximum */
-
-  size_t total_len = type_len + max_streams_len;
-
-  if (out_size < total_len)
-    return 0; /* Buffer too small */
-
-  size_t pos = 0;
-
-  /* Encode frame type based on direction */
-  out[pos++] = bidirectional ? QUIC_FRAME_STREAMS_BLOCKED_BIDI
-                              : QUIC_FRAME_STREAMS_BLOCKED_UNI;
-
-  /* Encode max_streams */
-  if (!encode_varint_field (max_streams, out, &pos, out_size))
-    return 0;
-
-  return pos;
+  uint8_t frame_type = bidirectional ? QUIC_FRAME_STREAMS_BLOCKED_BIDI
+                                     : QUIC_FRAME_STREAMS_BLOCKED_UNI;
+  return encode_flow_control_frame (frame_type, max_streams, 0, 1, out,
+                                    out_size);
 }


### PR DESCRIPTION
## Summary

Refactors the QUIC flow control frame encoding functions in `src/quic/SocketQUICFrame-flow.c` to eliminate 90%+ code duplication across 6 nearly-identical functions.

Implements #2022

## Changes

### Before
- 6 functions with 200+ lines of duplicated validation logic
- Each function repeated the same pattern:
  1. Validate output buffer
  2. Calculate varint sizes for all fields
  3. Validate field sizes (detect overflow)
  4. Check output buffer capacity
  5. Encode frame type byte
  6. Encode variable number of varint fields

### After
- Introduced `encode_flow_control_frame()` static helper
- Handles 1-2 field frames generically
- Each public function now delegates to this helper (3-5 lines each)
- File reduced from 323 to 259 lines (~20% reduction)

### Affected Functions
1. `SocketQUICFrame_encode_max_data` (1 field)
2. `SocketQUICFrame_encode_max_stream_data` (2 fields)
3. `SocketQUICFrame_encode_max_streams` (1 field, dynamic type)
4. `SocketQUICFrame_encode_data_blocked` (1 field)
5. `SocketQUICFrame_encode_stream_data_blocked` (2 fields)
6. `SocketQUICFrame_encode_streams_blocked` (1 field, dynamic type)

## Benefits

- **Maintainability**: Bug fixes apply to all 6 functions automatically
- **Readability**: Each function's purpose is now immediately clear
- **Code Size**: ~64 lines removed (~20% reduction)
- **DRY Principle**: Eliminates validation pattern repetition

## Test Plan

- [x] All tests pass with sanitizers (116/117, 1 pre-existing failure)
- [x] `test_quic_flow` passes (exercises all 6 functions)
- [x] Build succeeds with ASan/UBSan enabled
- [x] No changes to public API signatures
- [x] Identical behavior verified (all encoding logic preserved)

## Files Changed

- `src/quic/SocketQUICFrame-flow.c` - Refactored implementation

Closes #2022