### PR TITLE
refactor(SocketBuf): replace manual min with MIN macro

### DIFF
--- a/src/socket/SocketBuf.c
+++ b/src/socket/SocketBuf.c
@@ -161,7 +161,7 @@ static size_t
 circular_calc_chunk (size_t capacity, size_t pos, size_t remaining)
 {
   size_t chunk = capacity - pos;
-  return chunk > remaining ? remaining : chunk;
+  return MIN (chunk, remaining);
 }
 
 
@@ -473,8 +473,7 @@ SocketBuf_readptr (T buf, size_t *len)
     }
 
   size_t contiguous = buf->capacity - buf->head;
-  if (contiguous > buf->size)
-    contiguous = buf->size;
+  contiguous = MIN (contiguous, buf->size);
 
   assert (contiguous > 0);
   assert (contiguous <= buf->capacity);
@@ -508,8 +507,7 @@ SocketBuf_writeptr (T buf, size_t *len)
     }
 
   size_t contiguous = buf->capacity - buf->tail;
-  if (contiguous > space)
-    contiguous = space;
+  contiguous = MIN (contiguous, space);
 
   assert (contiguous > 0);
   assert (contiguous <= buf->capacity);


### PR DESCRIPTION
## Summary

Implements #1896

Replaces manual minimum calculations in SocketBuf.c with the MIN macro from SocketUtil.h for improved code clarity and consistency.

## Changes

- **circular_calc_chunk** (line 164): Replaced `chunk > remaining ? remaining : chunk` with `MIN(chunk, remaining)`
- **SocketBuf_readptr** (lines 476-477): Replaced if-statement with `MIN(contiguous, buf->size)`
- **SocketBuf_writeptr** (lines 511-512): Replaced if-statement with `MIN(contiguous, space)`

## Benefits

- **Code clarity**: MIN macro is more readable than ternary operators and if-statements
- **Consistency**: Aligns with codebase utilities pattern
- **Safety**: MIN macro uses GCC statement expressions to evaluate arguments exactly once, preventing side-effect bugs

## Test Plan

- [x] All socketbuf tests pass (19/19)
- [x] Full test suite passes with ASan/UBSan (116/117, one pre-existing failure)
- [x] No functional changes, pure refactoring

Closes #1896