### PR TITLE
refactor(dns): replace manual big-endian decode with socket_util_unpack_be16()

### DIFF
--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -1133,7 +1133,7 @@ tcp_recv_length_prefix (struct DNSTCPConnection *conn)
     }
 
   /* Decode length from network byte order */
-  conn->msg_len = ((size_t)conn->len_buf[0] << 8) | (size_t)conn->len_buf[1];
+  conn->msg_len = socket_util_unpack_be16 (conn->len_buf);
   if (conn->msg_len == 0 || conn->msg_len > DNS_TCP_MAX_SIZE)
     {
       tcp_conn_close (conn);


### PR DESCRIPTION
## Summary

Implements #1894

Replaced manual big-endian decoding at line 1136 in `tcp_recv_length_prefix()` with the existing `socket_util_unpack_be16()` utility function from SocketUtil.h.

## Changes

- **src/dns/SocketDNSTransport.c**: Replaced manual bit-shift operation `((size_t)conn->len_buf[0] << 8) | (size_t)conn->len_buf[1]` with `socket_util_unpack_be16(conn->len_buf)`

## Test Plan

- [x] All tests pass with sanitizers (116/117, 1 pre-existing failure in test_dns_queue_limit)
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] No functional changes - pure refactoring
- [x] Verified pre-existing test failure exists on main branch

Closes #1894