### PR TITLE
refactor(dns): replace manual big-endian encoding with socket_util_pack_be16()

### DIFF
--- a/src/dns/SocketDNSTransport.c
+++ b/src/dns/SocketDNSTransport.c
@@ -1089,8 +1089,7 @@ tcp_send_query (T transport, struct SocketDNSQuery *query)
   /* Build message with length prefix */
   total_len = 2 + query->query_len;
   conn->send_buf = Arena_alloc (transport->arena, total_len, __FILE__, __LINE__);
-  len_prefix[0] = (unsigned char)((query->query_len >> 8) & 0xFF);
-  len_prefix[1] = (unsigned char)(query->query_len & 0xFF);
+  socket_util_pack_be16 (len_prefix, (uint16_t)query->query_len);
   memcpy (conn->send_buf, len_prefix, 2);
   memcpy (conn->send_buf + 2, query->query, query->query_len);
   conn->send_len = total_len;


### PR DESCRIPTION
## Summary

Implements #1893

Replaces manual bit-shifting big-endian encoding with the existing `socket_util_pack_be16()` utility function in `SocketDNSTransport.c`.

## Changes

- **File**: `src/dns/SocketDNSTransport.c`
- **Function**: `tcp_send_query()`
- **Lines**: 1092-1093

### Before
```c
len_prefix[0] = (unsigned char)((query->query_len >> 8) & 0xFF);
len_prefix[1] = (unsigned char)(query->query_len & 0xFF);
```

### After
```c
socket_util_pack_be16(len_prefix, (uint16_t)query->query_len);
```

## Rationale

The manual encoding duplicated logic from `socket_util_pack_be16()` (defined in `include/core/SocketUtil.h` lines 1247-1251), violating DRY principles. Using the utility function:
- Reduces code duplication
- Improves maintainability
- Makes the intent clearer (packing to big-endian)
- Maintains identical behavior

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All DNS transport tests pass (22/22)
- [x] Overall test suite: 116/117 tests pass (1 pre-existing failure unrelated to this change)
- [x] No memory leaks or undefined behavior detected by ASan/UBSan

Closes #1893