### PR TITLE
refactor(quic): replace magic number 2 with QUIC_STREAM_TYPE_BITS constant

### DIFF
--- a/include/quic/SocketQUICStream.h
+++ b/include/quic/SocketQUICStream.h
@@ -70,6 +70,17 @@
  */
 #define QUIC_STREAM_TYPE_MASK 0x03
 
+/**
+ * @brief Number of bits used for stream type encoding (RFC 9000 Section 2.1).
+ *
+ * The lower 2 bits of stream ID encode:
+ *   Bit 0: Initiator (0=client, 1=server)
+ *   Bit 1: Directionality (0=bidirectional, 1=unidirectional)
+ *
+ * Sequence number = stream_id >> QUIC_STREAM_TYPE_BITS
+ */
+#define QUIC_STREAM_TYPE_BITS 2
+
 /* ============================================================================
  * Data Structures
  * ============================================================================

--- a/src/quic/SocketQUICStream.c
+++ b/src/quic/SocketQUICStream.c
@@ -129,7 +129,7 @@ SocketQUICStream_first_id (SocketQUICStreamType type)
 uint64_t
 SocketQUICStream_sequence (uint64_t stream_id)
 {
-  return stream_id >> 2;
+  return stream_id >> QUIC_STREAM_TYPE_BITS;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #2002

Replaces hardcoded magic number `2` with named constant `QUIC_STREAM_TYPE_BITS` in `SocketQUICStream_sequence()` to improve code clarity and maintainability.

## Changes

- Added `QUIC_STREAM_TYPE_BITS` constant to `include/quic/SocketQUICStream.h` with full documentation explaining the RFC 9000 Section 2.1 bit layout
- Updated `SocketQUICStream_sequence()` in `src/quic/SocketQUICStream.c` to use the new constant instead of the magic number `2`

## RFC 9000 Context

Per RFC 9000 Section 2.1, stream IDs use the lower 2 bits to encode:
- Bit 0: Initiator (0=client, 1=server)
- Bit 1: Directionality (0=bidirectional, 1=unidirectional)

The sequence number is therefore `stream_id >> QUIC_STREAM_TYPE_BITS`.

## Test Plan

- [x] Tests pass with sanitizers (116/117 passing, 1 pre-existing flaky test)
- [x] Build completes without warnings
- [x] No functional changes - purely refactoring for clarity

Closes #2002