### PR TITLE
fix(quic): check return value of SocketQUICConnectionID_set in decode_preferred_address

### DIFF
--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -656,7 +656,10 @@ decode_preferred_address (const uint8_t *data, size_t len,
     return QUIC_TP_ERROR_INCOMPLETE;
 
   /* Connection ID */
-  SocketQUICConnectionID_set (&paddr->connection_id, data + pos, cid_len);
+  SocketQUICConnectionID_Result res =
+      SocketQUICConnectionID_set (&paddr->connection_id, data + pos, cid_len);
+  if (res != QUIC_CONNID_OK)
+    return QUIC_TP_ERROR_INVALID_VALUE;
   pos += cid_len;
 
   /* Stateless reset token */


### PR DESCRIPTION
## Summary

Fixes #2010 - Add error checking for `SocketQUICConnectionID_set()` return value in `decode_preferred_address()` function.

## Changes

- Added proper error checking for `SocketQUICConnectionID_set()` call on line 659
- Return `QUIC_TP_ERROR_INVALID_VALUE` on failure, consistent with `decode_connid_value()` pattern
- This prevents silent failures when connection ID validation fails during preferred address decoding

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All QUIC transport params tests pass (36/36)
- [x] Full test suite passes (116/117 - one pre-existing DNS test failure unrelated to this change)
- [x] Code follows existing error handling patterns in the module

## Impact

This fix ensures that if `SocketQUICConnectionID_set` fails during preferred address decoding (e.g., due to validation errors), the error is properly propagated instead of being silently ignored. This prevents potential security issues and protocol violations from invalid connection IDs.

Closes #2010