### PR TITLE
refactor(simple-poll): replace magic number 64 with named constant

### DIFF
--- a/include/simple/SocketSimple-poll.h
+++ b/include/simple/SocketSimple-poll.h
@@ -58,6 +58,18 @@ extern "C" {
 typedef struct SocketSimple_Poll *SocketSimple_Poll_T;
 
 /*============================================================================
+ * Constants
+ *============================================================================*/
+
+/**
+ * @brief Default maximum events for poll instance when not specified.
+ *
+ * Used when max_events <= 0 is passed to Socket_simple_poll_new().
+ * Balances memory usage with event handling capacity for typical use cases.
+ */
+#define SOCKET_SIMPLE_POLL_DEFAULT_MAX_EVENTS 64
+
+/*============================================================================
  * Event Flags
  *============================================================================*/
 

--- a/src/simple/SocketSimple-poll.c
+++ b/src/simple/SocketSimple-poll.c
@@ -76,7 +76,7 @@ Socket_simple_poll_new (int max_events_arg)
 
   if (max_events <= 0)
     {
-      max_events = 64; /* Default */
+      max_events = SOCKET_SIMPLE_POLL_DEFAULT_MAX_EVENTS;
     }
 
   TRY { poll = SocketPoll_new (max_events); }


### PR DESCRIPTION
## Summary

Implements #2006

Replaces the hardcoded magic number `64` in `src/simple/SocketSimple-poll.c` with a named constant `SOCKET_SIMPLE_POLL_DEFAULT_MAX_EVENTS` defined in the public header.

## Changes

- **include/simple/SocketSimple-poll.h**: Added `SOCKET_SIMPLE_POLL_DEFAULT_MAX_EVENTS` constant with documentation
- **src/simple/SocketSimple-poll.c**: Replaced magic number `64` with the constant in `Socket_simple_poll_new()`

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All poll tests pass (32/32)
- [x] Full test suite passes (115/117, 2 pre-existing failures unrelated to this change)
- [x] No functional changes - purely refactoring

## Benefits

- **Maintainability**: Single point of change for default max_events
- **Documentation**: Constant name is self-documenting
- **Consistency**: Follows C anti-patterns guide in CLAUDE.md
- **Discoverability**: Public constant can be referenced by API users

Closes #2006