### PR TITLE
refactor(quic): replace ECN magic numbers with named constants in SocketQUICAck

### DIFF
--- a/include/quic/SocketQUICAck.h
+++ b/include/quic/SocketQUICAck.h
@@ -42,6 +42,24 @@
  */
 
 /**
+ * @brief ECN codepoint types (RFC 3168).
+ *
+ * Explicit Congestion Notification codepoints used in IP headers
+ * to signal network congestion. QUIC tracks these to implement
+ * congestion control.
+ *
+ * @see RFC 3168 (The Addition of Explicit Congestion Notification to IP)
+ * @see RFC 9000 Section 13.4 (ECN Validation)
+ */
+typedef enum
+{
+  QUIC_ECN_NOT_ECT = 0, /**< Not ECN-Capable Transport */
+  QUIC_ECN_ECT0    = 1, /**< ECN Capable Transport (0) */
+  QUIC_ECN_ECT1    = 2, /**< ECN Capable Transport (1) */
+  QUIC_ECN_CE      = 3  /**< Congestion Experienced */
+} SocketQUICECN_Type;
+
+/**
  * @brief Maximum number of ACK ranges to track.
  *
  * RFC 9000 doesn't specify a limit but practical implementations
@@ -208,7 +226,7 @@ SocketQUICAck_record_packet (SocketQUICAckState_T state, uint64_t packet_number,
  * @brief Record ECN information from received packet.
  *
  * @param state    ACK state to update.
- * @param ecn_type ECN codepoint (0=not-ECT, 1=ECT0, 2=ECT1, 3=CE).
+ * @param ecn_type ECN codepoint (SocketQUICECN_Type).
  */
 extern void SocketQUICAck_record_ecn (SocketQUICAckState_T state, int ecn_type);
 

--- a/src/quic/SocketQUICAck.c
+++ b/src/quic/SocketQUICAck.c
@@ -292,13 +292,13 @@ SocketQUICAck_record_ecn (SocketQUICAckState_T state, int ecn_type)
 
   switch (ecn_type)
     {
-    case 1: /* ECT(0) */
+    case QUIC_ECN_ECT0:
       state->ecn_counts.ect0_count++;
       break;
-    case 2: /* ECT(1) */
+    case QUIC_ECN_ECT1:
       state->ecn_counts.ect1_count++;
       break;
-    case 3: /* CE */
+    case QUIC_ECN_CE:
       state->ecn_counts.ce_count++;
       break;
     default:

--- a/src/test/test_quic_ack.c
+++ b/src/test/test_quic_ack.c
@@ -231,12 +231,12 @@ TEST (ack_record_ecn)
   arena = Arena_new ();
   state = SocketQUICAck_new (arena, 0, 0);
 
-  SocketQUICAck_record_ecn (state, 1); /* ECT(0) */
-  SocketQUICAck_record_ecn (state, 1);
-  SocketQUICAck_record_ecn (state, 2); /* ECT(1) */
-  SocketQUICAck_record_ecn (state, 3); /* CE */
-  SocketQUICAck_record_ecn (state, 3);
-  SocketQUICAck_record_ecn (state, 3);
+  SocketQUICAck_record_ecn (state, QUIC_ECN_ECT0);
+  SocketQUICAck_record_ecn (state, QUIC_ECN_ECT0);
+  SocketQUICAck_record_ecn (state, QUIC_ECN_ECT1);
+  SocketQUICAck_record_ecn (state, QUIC_ECN_CE);
+  SocketQUICAck_record_ecn (state, QUIC_ECN_CE);
+  SocketQUICAck_record_ecn (state, QUIC_ECN_CE);
 
   ASSERT_EQ (2, state->ecn_counts.ect0_count);
   ASSERT_EQ (1, state->ecn_counts.ect1_count);
@@ -248,7 +248,7 @@ TEST (ack_record_ecn)
 TEST (ack_record_ecn_null)
 {
   /* Should not crash */
-  SocketQUICAck_record_ecn (NULL, 1);
+  SocketQUICAck_record_ecn (NULL, QUIC_ECN_ECT0);
 }
 
 /* ============================================================================
@@ -412,7 +412,7 @@ TEST (ack_encode_with_ecn)
   state = SocketQUICAck_new (arena, 0, 0);
 
   SocketQUICAck_record_packet (state, 5, 1000000, 1);
-  SocketQUICAck_record_ecn (state, 1); /* ECT(0) */
+  SocketQUICAck_record_ecn (state, QUIC_ECN_ECT0);
   state->ecn_validated = 1;
 
   res = SocketQUICAck_encode (state, 1000000, buf, sizeof (buf), &len);


### PR DESCRIPTION
## Summary

Implements #2017

Replaces hardcoded magic numbers (1, 2, 3) in `SocketQUICAck_record_ecn()` with named constants defined in a new `SocketQUICECN_Type` enum.

## Changes

### Added
- `SocketQUICECN_Type` enum in `include/quic/SocketQUICAck.h` defining ECN codepoints per RFC 3168:
  - `QUIC_ECN_NOT_ECT = 0` - Not ECN-Capable Transport
  - `QUIC_ECN_ECT0 = 1` - ECN Capable Transport (0)
  - `QUIC_ECN_ECT1 = 2` - ECN Capable Transport (1)
  - `QUIC_ECN_CE = 3` - Congestion Experienced

### Modified
- `src/quic/SocketQUICAck.c`: Replaced magic numbers in switch statement with named constants
- `src/test/test_quic_ack.c`: Updated test cases to use named constants
- Updated function documentation to reference `SocketQUICECN_Type`

## Test Plan

- [x] All 32 tests in `test_quic_ack` pass with sanitizers enabled
- [x] 116 of 117 tests in full test suite pass (1 pre-existing DNS test failure unrelated to changes)
- [x] Code follows existing project patterns (see `QUIC_ACK_*` constants)
- [x] No functional changes - purely refactoring for code quality

## Impact

**Severity:** Code Quality / Maintainability  
**Category:** Refactoring

- No security vulnerabilities introduced
- No functional bugs
- Improves code readability and self-documentation
- Makes ECN types type-safe and easier to maintain
- Follows RFC 3168 terminology

Closes #2017