### PR TITLE
feat(quic): store close error code in SocketQUICConnection for diagnostics

### DIFF
--- a/include/quic/SocketQUICConnection.h
+++ b/include/quic/SocketQUICConnection.h
@@ -84,8 +84,10 @@ struct SocketQUICConnection {
   uint64_t last_packet_received_ms;
   uint64_t closing_deadline_ms;
   uint64_t draining_deadline_ms;
+  uint64_t close_error_code;
   uint8_t stateless_reset_token[QUIC_STATELESS_RESET_TOKEN_LEN];
   int has_stateless_reset_token;
+  int has_close_error;
 };
 
 extern SocketQUICConnTable_T SocketQUICConnTable_new(Arena_T arena, size_t bucket_count);
@@ -123,5 +125,6 @@ extern int SocketQUICConnection_is_closing_or_draining(SocketQUICConnection_T co
 extern int SocketQUICConnection_check_termination_deadline(SocketQUICConnection_T conn, uint64_t now_ms);
 extern void SocketQUICConnection_set_stateless_reset_token(SocketQUICConnection_T conn, const uint8_t token[QUIC_STATELESS_RESET_TOKEN_LEN]);
 extern int SocketQUICConnection_verify_stateless_reset(const uint8_t *packet, size_t packet_len, const uint8_t *expected_token);
+extern int SocketQUICConnection_get_close_error(SocketQUICConnection_T conn, uint64_t *error_code);
 
 #endif /* SOCKETQUICCONNECTION_INCLUDED */


### PR DESCRIPTION
## Summary

Implements issue #2016 to store CONNECTION_CLOSE error codes in the SocketQUICConnection structure for improved diagnostics and debugging capabilities.

## Changes

### Core Implementation
- **Added fields to `SocketQUICConnection` struct**:
  - `close_error_code` (uint64_t): Stores the error code from CONNECTION_CLOSE
  - `has_close_error` (int): Flag indicating if error code is set

- **Updated `SocketQUICConnection_initiate_close`**:
  - Removed unused `(void)error_code;` cast
  - Now stores error code and sets `has_close_error` flag
  - Updated documentation to reflect new behavior

- **Added new API `SocketQUICConnection_get_close_error`**:
  - Retrieves stored error code if available
  - Returns 1 on success, 0 if no error code is set
  - NULL-safe with proper parameter validation

### Testing
Added 5 comprehensive test cases:
- `test_close_error_code_storage`: Basic storage and retrieval
- `test_close_error_code_various_values`: Tests transport errors (0x00-0x10), crypto errors (0x0100+), and large values (UINT64_MAX)
- `test_close_error_code_null_checks`: NULL pointer safety
- `test_close_error_code_before_close`: Verifies no error code before close
- `test_close_error_code_draining_no_error`: Verifies draining state doesn't set error code

## Benefits

1. **Post-mortem debugging**: Applications can inspect why a connection closed after the fact
2. **Metrics and monitoring**: Track distribution of close reasons for operational insights
3. **Client feedback**: Return meaningful error messages to end users
4. **RFC compliance**: Aligns with RFC 9000 Section 10.2 which specifies error codes should be available

## Use Cases

```c
/* Example: Logging connection closure reasons */
if (conn->state == QUIC_CONN_STATE_CLOSED) {
    uint64_t error_code;
    if (SocketQUICConnection_get_close_error(conn, &error_code)) {
        log_connection_close(conn_id, error_code);
    }
}

/* Example: Metrics collection */
uint64_t error_code;
if (SocketQUICConnection_get_close_error(conn, &error_code)) {
    metrics_record_close_reason(error_code);
}
```

## Test Plan

- [x] All existing tests pass with sanitizers enabled
- [x] New tests pass with AddressSanitizer (ASan)
- [x] New tests pass with UndefinedBehaviorSanitizer (UBSan)
- [x] No memory leaks detected
- [x] NULL pointer handling verified
- [x] Edge cases tested (UINT64_MAX, various error code ranges)

## Implementation Notes

- Fields are initialized to 0 by existing `memset` in `SocketQUICConnection_init`
- No changes required to initialization code
- Backward compatible: doesn't affect existing connection state machine
- Minimal overhead: only 2 additional fields (9 bytes with padding)

Closes #2016