### PR TITLE
refactor(http): replace magic number 8 with POOL_TARGET_LOAD_FACTOR constant

### DIFF
--- a/src/http/SocketHTTPClient-pool.c
+++ b/src/http/SocketHTTPClient-pool.c
@@ -47,6 +47,14 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPClient);
 #define POOL_MAX_HASH_CHAIN_LEN 1024
 #endif
 
+/* Hash table load factor for sizing the hash table based on max connections.
+ * A load factor of 8 means we size the hash table to ~1/8 the number of
+ * max connections, providing a good balance between memory usage and
+ * hash lookup performance. */
+#ifndef POOL_TARGET_LOAD_FACTOR
+#define POOL_TARGET_LOAD_FACTOR 8
+#endif
+
 /* Forward declarations */
 static void pool_entry_remove_and_recycle (HTTPPool *pool, HTTPPoolEntry *entry);
 
@@ -248,7 +256,7 @@ httpclient_pool_new (Arena_T arena, const SocketHTTPClient_Config *config)
   /* Calculate hash table size based on expected connections, with security
    * limits */
   size_t suggested_size
-      = config->max_total_connections / 8; /* Target load factor ~8 */
+      = config->max_total_connections / POOL_TARGET_LOAD_FACTOR;
   if (suggested_size < HTTPCLIENT_POOL_HASH_SIZE)
     {
       suggested_size = HTTPCLIENT_POOL_HASH_SIZE;


### PR DESCRIPTION
## Summary

Implements #1924 by replacing the magic number 8 used for hash table load factor calculation with a named constant `POOL_TARGET_LOAD_FACTOR`.

## Changes

- Added `POOL_TARGET_LOAD_FACTOR` constant (value: 8) with documentation explaining its purpose
- Replaced hardcoded `/ 8` with `/ POOL_TARGET_LOAD_FACTOR` in `httpclient_pool_new()`
- Constant is defined with `#ifndef` to allow build-time override if needed

## Benefits

- **Maintainability**: Named constant clearly indicates purpose (load factor for hash table sizing)
- **Tunability**: Value can be adjusted in one place or overridden at compile-time
- **Documentation**: Comment explains the tradeoff between memory usage and lookup performance

## Test Plan

- [x] Built successfully with sanitizers enabled
- [x] All tests pass (116/117, 1 pre-existing failure unrelated to changes)
- [x] No functional changes - purely a refactoring for code clarity

Closes #1924