### PR TITLE
refactor(http): replace magic number 65536 with named constant

### DIFF
--- a/src/http/SocketHTTPClient-pool.c
+++ b/src/http/SocketHTTPClient-pool.c
@@ -47,6 +47,11 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPClient);
 #define POOL_MAX_HASH_CHAIN_LEN 1024
 #endif
 
+/* SECURITY: Limit maximum hash table size to prevent excessive memory use */
+#ifndef POOL_MAX_HASH_TABLE_SIZE
+#define POOL_MAX_HASH_TABLE_SIZE 65536
+#endif
+
 /* Forward declarations */
 static void pool_entry_remove_and_recycle (HTTPPool *pool, HTTPPoolEntry *entry);
 
@@ -253,10 +258,9 @@ httpclient_pool_new (Arena_T arena, const SocketHTTPClient_Config *config)
     {
       suggested_size = HTTPCLIENT_POOL_HASH_SIZE;
     }
-  const size_t max_hash_size = 65536; /* Prevent excessive memory use */
-  if (suggested_size > max_hash_size)
+  if (suggested_size > POOL_MAX_HASH_TABLE_SIZE)
     {
-      suggested_size = max_hash_size;
+      suggested_size = POOL_MAX_HASH_TABLE_SIZE;
     }
   size_t elem_size = sizeof (HTTPPoolEntry *);
   size_t table_bytes;


### PR DESCRIPTION
## Summary

Implements #1920 - Replaces magic number 65536 with named constant `POOL_MAX_HASH_TABLE_SIZE` in HTTP client pool hash table size calculation.

## Changes

- Added `POOL_MAX_HASH_TABLE_SIZE` constant definition (65536) with security comment
- Replaced inline magic number with the named constant
- Constant can be overridden at compile time via `-DPOOL_MAX_HASH_TABLE_SIZE=value`

## Impact

- **Maintainability**: Named constant is self-documenting and easier to understand
- **Configuration**: Can be overridden at compile time if needed
- **Security**: Clearer indication that this limit prevents excessive memory use

## Test Plan

- [x] All HTTP client pool tests pass (97/97)
- [x] All HTTP client tests pass (45/45)
- [x] Full test suite passes with sanitizers (116/117, 1 unrelated flaky DNS test)
- [x] No functional changes - purely refactoring

Closes #1920