### PR TITLE
fix(simple): add error check for clock_gettime() in rate limiter

### DIFF
--- a/src/simple/SocketSimple-ratelimit.c
+++ b/src/simple/SocketSimple-ratelimit.c
@@ -44,7 +44,14 @@ static uint64_t
 get_monotonic_ns (void)
 {
   struct timespec ts;
-  clock_gettime (CLOCK_MONOTONIC, &ts);
+  if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0)
+    {
+      /* CLOCK_MONOTONIC should never fail on properly configured systems,
+         but handle it defensively to avoid using uninitialized values.
+         Returning 0 is safe for rate limiting - it will just cause
+         a single-time delay calculation issue which will self-correct. */
+      return 0;
+    }
   return (uint64_t)ts.tv_sec * 1000000000ULL + (uint64_t)ts.tv_nsec;
 }
 


### PR DESCRIPTION
## Summary

Fixes #1945

Adds defensive error checking for `clock_gettime()` in the `get_monotonic_ns()` helper function used by the Simple API rate limiter.

## Changes

- Added error check for `clock_gettime(CLOCK_MONOTONIC, &ts)` return value
- Returns 0 on failure to avoid using uninitialized `timespec` values
- Added explanatory comment about error handling strategy

## Security Impact

While `CLOCK_MONOTONIC` should not fail on properly configured systems, the missing error check could lead to:
- Use of uninitialized memory (undefined behavior)
- Incorrect rate limiting calculations
- Potential security issues if rate limiting is used for DoS protection

## Test Plan

- [x] Build passes with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All existing tests pass (116/117, 1 pre-existing failure unrelated to this change)
- [x] No new memory leaks or undefined behavior detected by ASan/UBSan

## Implementation Notes

The fix returns 0 on `clock_gettime()` failure, which is safe for rate limiting:
- Causes a single-time delay calculation issue
- Self-corrects on subsequent successful calls
- Prevents undefined behavior from uninitialized values

Closes #1945