### PR TITLE
refactor(simple): extract hardcoded timeout constant in Socket_simple_connect

### DIFF
--- a/src/simple/SocketSimple-internal.h
+++ b/src/simple/SocketSimple-internal.h
@@ -105,4 +105,14 @@ SocketSimple_Socket_T simple_create_handle (Socket_T sock, int is_server,
 
 SocketSimple_Socket_T simple_create_udp_handle (SocketDgram_T dgram);
 
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/**
+ * @brief Default timeout for Socket_simple_connect (milliseconds).
+ */
+#define SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS 30000
+
 #endif /* SOCKETSIMPLE_INTERNAL_H */

--- a/src/simple/SocketSimple-tcp.c
+++ b/src/simple/SocketSimple-tcp.c
@@ -25,7 +25,7 @@ SocketSimple_Socket_T
 Socket_simple_connect (const char *host, int port)
 {
   /* Use timeout version with default timeout */
-  return Socket_simple_connect_timeout (host, port, 30000);
+  return Socket_simple_connect_timeout (host, port, SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS);
 }
 
 SocketSimple_Socket_T


### PR DESCRIPTION
## Summary

Implements #1946

- Extracts magic number `30000` (30 seconds) to named constant `SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS`
- Improves code maintainability by making the default timeout explicit
- No functional changes

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS` constant to `src/simple/SocketSimple-internal.h`
- Updated `Socket_simple_connect()` in `src/simple/SocketSimple-tcp.c` to use the constant

## Test Plan

- [x] Tests pass with sanitizers (116/117 - pre-existing DNS test failure on main)
- [x] `test_new_features` passes (simple API tests)
- [x] No functional changes - constant value unchanged

Closes #1946