### PR TITLE
refactor(simple): extract RFC 8305 delay constants in happyeyeballs

### DIFF
--- a/include/simple/SocketSimple-happyeyeballs.h
+++ b/include/simple/SocketSimple-happyeyeballs.h
@@ -53,6 +53,20 @@ extern "C" {
  *============================================================================*/
 
 /**
+ * @brief Default resolution delay in milliseconds (RFC 8305 § 5).
+ *
+ * Delay before starting parallel DNS resolution for both address families.
+ */
+#define SOCKET_HE_DEFAULT_RESOLUTION_DELAY_MS 50
+
+/**
+ * @brief Default connection attempt delay in milliseconds (RFC 8305 § 5).
+ *
+ * Delay before starting IPv4 connection attempt after IPv6 has started.
+ */
+#define SOCKET_HE_DEFAULT_CONNECTION_DELAY_MS 250
+
+/**
  * @brief Happy Eyeballs connection configuration.
  */
 typedef struct SocketSimple_HappyEyeballs_Config {

--- a/src/simple/SocketSimple-happyeyeballs.c
+++ b/src/simple/SocketSimple-happyeyeballs.c
@@ -27,8 +27,8 @@ Socket_simple_happyeyeballs_config_defaults (
   if (!config)
     return;
 
-  config->resolution_delay_ms = 50;
-  config->connection_delay_ms = 250;
+  config->resolution_delay_ms = SOCKET_HE_DEFAULT_RESOLUTION_DELAY_MS;
+  config->connection_delay_ms = SOCKET_HE_DEFAULT_CONNECTION_DELAY_MS;
   config->prefer_ipv6 = 1;
   config->max_attempts = 0;
 }


### PR DESCRIPTION
## Summary

Implements #1933

Extracts hardcoded RFC 8305 timing constants (50ms and 250ms) to named constants for improved code clarity and maintainability.

## Changes

- Added `SOCKET_HE_DEFAULT_RESOLUTION_DELAY_MS` constant (50ms) to `include/simple/SocketSimple-happyeyeballs.h`
- Added `SOCKET_HE_DEFAULT_CONNECTION_DELAY_MS` constant (250ms) to `include/simple/SocketSimple-happyeyeballs.h`
- Updated `Socket_simple_happyeyeballs_config_defaults()` to use the new constants instead of magic numbers

## Test Plan

- [x] Build passes with sanitizers enabled
- [x] No behavior changes - purely refactoring (same values, now named)
- [x] Follows project pattern for extracting magic numbers (CLAUDE.md § C Anti-Patterns)

Closes #1933