### PR TITLE
refactor(http): extract duplicated buffer clearing logic in pool.c

### DIFF
--- a/src/http/SocketHTTPClient-pool.c
+++ b/src/http/SocketHTTPClient-pool.c
@@ -157,6 +157,23 @@ pool_list_remove (HTTPPool *pool, HTTPPoolEntry *entry)
 }
 
 static void
+clear_http1_buffers (HTTPPoolEntry *entry)
+{
+  if (entry->version != HTTP_VERSION_1_1 && entry->version != HTTP_VERSION_1_0)
+    return;
+
+  /* SECURITY: Clear buffers before reuse to prevent information leakage */
+  if (entry->proto.h1.inbuf)
+    SocketBuf_clear (entry->proto.h1.inbuf);
+  if (entry->proto.h1.outbuf)
+    SocketBuf_clear (entry->proto.h1.outbuf);
+
+  /* Reset parser state */
+  if (entry->proto.h1.parser)
+    SocketHTTP1_Parser_reset (entry->proto.h1.parser);
+}
+
+static void
 close_http1_resources (HTTPPoolEntry *entry)
 {
   if (entry->proto.h1.socket != NULL)
@@ -385,20 +402,7 @@ httpclient_pool_get (HTTPPool *pool, const char *host, int port, int is_secure)
             }
           }
 
-          /* SECURITY: Clear buffers before reuse to prevent information leakage */
-          if (entry->version == HTTP_VERSION_1_1 || entry->version == HTTP_VERSION_1_0) {
-            if (entry->proto.h1.inbuf) {
-              SocketBuf_clear(entry->proto.h1.inbuf);
-            }
-            if (entry->proto.h1.outbuf) {
-              SocketBuf_clear(entry->proto.h1.outbuf);
-            }
-            /* Reset parser state */
-            if (entry->proto.h1.parser) {
-              SocketHTTP1_Parser_reset(entry->proto.h1.parser);
-            }
-          }
-
+          clear_http1_buffers (entry);
           entry_mark_in_use (entry);
           pool->reused_connections++;
           pthread_mutex_unlock (&pool->mutex);
@@ -445,18 +449,7 @@ httpclient_pool_get_prepared (HTTPPool *pool, const char *host, size_t host_len,
                 }
             }
 
-          /* SECURITY: Clear buffers before reuse */
-          if (entry->version == HTTP_VERSION_1_1
-              || entry->version == HTTP_VERSION_1_0)
-            {
-              if (entry->proto.h1.inbuf)
-                SocketBuf_clear (entry->proto.h1.inbuf);
-              if (entry->proto.h1.outbuf)
-                SocketBuf_clear (entry->proto.h1.outbuf);
-              if (entry->proto.h1.parser)
-                SocketHTTP1_Parser_reset (entry->proto.h1.parser);
-            }
-
+          clear_http1_buffers (entry);
           entry_mark_in_use (entry);
           pool->reused_connections++;
           pthread_mutex_unlock (&pool->mutex);


### PR DESCRIPTION
## Summary

Implements #1909

Consolidates identical HTTP/1.1 buffer clearing logic from `httpclient_pool_get` and `httpclient_pool_get_prepared` into a single helper function `clear_http1_buffers`.

## Changes

- **New helper function**: `clear_http1_buffers()` extracts the duplicated buffer clearing logic
- **Security comment preserved**: Maintains the SECURITY comment documenting the purpose
- **DRY principle**: Eliminates 26 lines of duplicated code
- **Maintainability**: If buffer clearing needs to be updated (e.g., to use `explicit_bzero`), only one location needs to be changed

## Test Plan

- [x] All 97 pool tests pass
- [x] All 45 HTTP client tests pass
- [x] Tests pass with sanitizers (ASan/UBSan)
- [x] No functional changes - pure refactoring

Closes #1909