### PR TITLE
refactor(simple-dtls): extract options copying into helper function

### DIFF
--- a/src/simple/SocketSimple-dtls.c
+++ b/src/simple/SocketSimple-dtls.c
@@ -38,6 +38,37 @@ Socket_simple_dtls_options_defaults (SocketSimple_DTLSOptions *opts)
   opts->alpn_count = 0;
 }
 
+/**
+ * @brief Copy DTLS options from struct to local variables.
+ *
+ * This helper function extracts option values from the SocketSimple_DTLSOptions
+ * structure into local variables before entering a TRY block, avoiding longjmp
+ * clobbering issues.
+ *
+ * @param opts Source options structure
+ * @param ca_file Output: CA file path
+ * @param verify_cert Output: Certificate verification flag
+ * @param client_cert Output: Client certificate path
+ * @param client_key Output: Client key path
+ * @param mtu Output: Maximum transmission unit
+ * @param alpn Output: ALPN protocols array
+ * @param alpn_count Output: Number of ALPN protocols
+ */
+static void
+copy_dtls_options (const SocketSimple_DTLSOptions *opts, const char **ca_file,
+                   int *verify_cert, const char **client_cert,
+                   const char **client_key, size_t *mtu, const char ***alpn,
+                   size_t *alpn_count)
+{
+  *ca_file = opts->ca_file;
+  *verify_cert = opts->verify_cert;
+  *client_cert = opts->client_cert;
+  *client_key = opts->client_key;
+  *mtu = opts->mtu;
+  *alpn = opts->alpn;
+  *alpn_count = opts->alpn_count;
+}
+
 /*============================================================================
  * DTLS Client Functions
  *============================================================================*/
@@ -89,13 +120,8 @@ Socket_simple_dtls_connect_ex (const char *host, int port,
 
   /* Copy all values before TRY block */
   timeout_ms = opts_param->timeout_ms;
-  verify_cert = opts_param->verify_cert;
-  ca_file = opts_param->ca_file;
-  client_cert = opts_param->client_cert;
-  client_key = opts_param->client_key;
-  mtu = opts_param->mtu;
-  alpn = opts_param->alpn;
-  alpn_count = opts_param->alpn_count;
+  copy_dtls_options (opts_param, &ca_file, &verify_cert, &client_cert,
+                     &client_key, &mtu, &alpn, &alpn_count);
 
   TRY
   {
@@ -252,13 +278,8 @@ Socket_simple_dtls_enable (SocketSimple_Socket_T sock, const char *hostname,
     }
 
   /* Copy all values before TRY block */
-  ca_file = opts_param->ca_file;
-  verify_cert = opts_param->verify_cert;
-  client_cert = opts_param->client_cert;
-  client_key = opts_param->client_key;
-  mtu = opts_param->mtu;
-  alpn = opts_param->alpn;
-  alpn_count = opts_param->alpn_count;
+  copy_dtls_options (opts_param, &ca_file, &verify_cert, &client_cert,
+                     &client_key, &mtu, &alpn, &alpn_count);
 
   TRY
   {


### PR DESCRIPTION
## Summary

Implements #1940 by extracting duplicated DTLS options copying code into a static helper function.

## Changes

- Added `copy_dtls_options()` static helper function with full documentation
- Replaced 7 lines of duplicated assignments in `Socket_simple_dtls_connect_ex` (lines 91-98)
- Replaced 7 lines of duplicated assignments in `Socket_simple_dtls_enable` (lines 255-261)
- Maintains exception safety by copying options before TRY block to avoid longjmp clobbering

## Test Plan

- [x] All DTLS tests pass (test_dtls_basic, test_dtls_integration, test_dtls_cookie, test_dtls_mtu)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes, refactoring only

## Pattern Addressed

Eliminates `DUPLICATED_CODE_OPTIONS_COPY` anti-pattern identified in issue #1940.

Closes #1940