### PR TITLE
refactor(simple-dtls): extract magic timeout constant DTLS_DEFAULT_TIMEOUT_MS

### DIFF
--- a/src/simple/SocketSimple-dtls.c
+++ b/src/simple/SocketSimple-dtls.c
@@ -18,6 +18,15 @@
 #include "tls/SocketDTLSContext.h"
 
 /*============================================================================
+ * Constants
+ *============================================================================*/
+
+/**
+ * @brief Default timeout for DTLS handshakes (30 seconds).
+ */
+#define SOCKET_SIMPLE_DTLS_DEFAULT_TIMEOUT_MS 30000
+
+/*============================================================================
  * Options Helpers
  *============================================================================*/
 
@@ -27,7 +36,7 @@ Socket_simple_dtls_options_defaults (SocketSimple_DTLSOptions *opts)
   if (!opts)
     return;
 
-  opts->timeout_ms = 30000;
+  opts->timeout_ms = SOCKET_SIMPLE_DTLS_DEFAULT_TIMEOUT_MS;
   opts->verify_cert = 1;
   opts->ca_file = NULL;
   opts->ca_path = NULL;
@@ -429,7 +438,7 @@ Socket_simple_dtls_accept (SocketSimple_Socket_T server_sock, int timeout_ms)
 
     /* Complete handshake */
     state = SocketDTLS_handshake_loop (server_sock->dgram,
-                                       timeout_ms > 0 ? timeout_ms : 30000);
+                                       timeout_ms > 0 ? timeout_ms : SOCKET_SIMPLE_DTLS_DEFAULT_TIMEOUT_MS);
 
     if (state != DTLS_HANDSHAKE_COMPLETE)
       {
@@ -641,7 +650,7 @@ Socket_simple_dtls_handshake (SocketSimple_Socket_T sock, int timeout_ms)
   {
     DTLSHandshakeState state
         = SocketDTLS_handshake_loop (sock->dgram,
-                                     timeout_ms > 0 ? timeout_ms : 30000);
+                                     timeout_ms > 0 ? timeout_ms : SOCKET_SIMPLE_DTLS_DEFAULT_TIMEOUT_MS);
 
     if (state != DTLS_HANDSHAKE_COMPLETE)
       {


### PR DESCRIPTION
## Summary

Implements #1922 - Extracts hardcoded DTLS timeout value into a named constant for better maintainability.

## Changes

- Added `SOCKET_SIMPLE_DTLS_DEFAULT_TIMEOUT_MS` constant definition (30000 ms)
- Replaced magic number `30000` at 3 locations:
  - Line 30: `Socket_simple_dtls_options_defaults()` 
  - Line 432: `Socket_simple_dtls_accept()`
  - Line 644: `Socket_simple_dtls_handshake()`

## Test Plan

- [x] All DTLS tests pass with sanitizers (4/4)
- [x] Build succeeds with ASAN/UBSAN enabled
- [x] No functional changes - purely refactoring

Closes #1922