### PR TITLE
refactor(simple-dns): replace magic timeout constant with named definition

### DIFF
--- a/src/simple/SocketSimple-dns.c
+++ b/src/simple/SocketSimple-dns.c
@@ -21,6 +21,8 @@
  * ============================================================================
  */
 
+#define SOCKET_SIMPLE_DNS_DEFAULT_TIMEOUT_MS 5000
+
 int
 Socket_simple_dns_resolve_timeout (const char *hostname,
                                    SocketSimple_DNSResult *result,
@@ -136,7 +138,7 @@ Socket_simple_dns_resolve_timeout (const char *hostname,
 int
 Socket_simple_dns_resolve (const char *hostname, SocketSimple_DNSResult *result)
 {
-  return Socket_simple_dns_resolve_timeout (hostname, result, 5000);
+  return Socket_simple_dns_resolve_timeout (hostname, result, SOCKET_SIMPLE_DNS_DEFAULT_TIMEOUT_MS);
 }
 
 int
@@ -184,7 +186,7 @@ Socket_simple_dns_lookup4 (const char *hostname, char *buf, size_t len)
   SocketCommon_setup_hints (&hints, SOCK_STREAM, 0);
   hints.ai_family = AF_INET; /* Override for IPv4 only */
 
-  TRY { res = SocketDNS_resolve_sync (dns, hostname, 0, &hints, 5000); }
+  TRY { res = SocketDNS_resolve_sync (dns, hostname, 0, &hints, SOCKET_SIMPLE_DNS_DEFAULT_TIMEOUT_MS); }
   EXCEPT (SocketDNS_Failed)
   {
     simple_set_error (SOCKET_SIMPLE_ERR_DNS, "DNS resolution failed");
@@ -254,7 +256,7 @@ Socket_simple_dns_lookup6 (const char *hostname, char *buf, size_t len)
   SocketCommon_setup_hints (&hints, SOCK_STREAM, 0);
   hints.ai_family = AF_INET6; /* Override for IPv6 only */
 
-  TRY { res = SocketDNS_resolve_sync (dns, hostname, 0, &hints, 5000); }
+  TRY { res = SocketDNS_resolve_sync (dns, hostname, 0, &hints, SOCKET_SIMPLE_DNS_DEFAULT_TIMEOUT_MS); }
   EXCEPT (SocketDNS_Failed)
   {
     simple_set_error (SOCKET_SIMPLE_ERR_DNS, "DNS resolution failed");


### PR DESCRIPTION
## Summary

Implements #1904

Replaces hardcoded `5000` millisecond timeout value in `src/simple/SocketSimple-dns.c` with the named constant `SOCKET_SIMPLE_DNS_DEFAULT_TIMEOUT_MS`, eliminating the magic number anti-pattern documented in CLAUDE.md.

## Changes

- Added `#define SOCKET_SIMPLE_DNS_DEFAULT_TIMEOUT_MS 5000` at the top of the DNS resolution section
- Replaced all 3 instances of hardcoded `5000` with the new constant:
  - `Socket_simple_dns_resolve()` (line 141)
  - `Socket_simple_dns_lookup4()` (line 189)
  - `Socket_simple_dns_lookup6()` (line 259)

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] 116/117 tests pass with ASan/UBSan (1 pre-existing failure in `test_dns_queue_limit`)
- [x] DNS resolution tests pass successfully
- [x] No new memory leaks or undefined behavior introduced
- [x] Code compiles without warnings

## Notes

The `test_dns_queue_limit` failure is pre-existing and unrelated to this change. It exists on main branch as well (verified by testing clean main).

Closes #1904