### PR TITLE
refactor(dns-cookie): use SOCKET_CRYPTO_SHA256_SIZE for SECRET_SIZE

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -12,6 +12,7 @@
 #include "dns/SocketDNSCookie.h"
 #include "dns/SocketDNSWire.h"
 #include "core/Arena.h"
+#include "core/SocketCrypto.h"
 #include <arpa/inet.h>
 #include <string.h>
 #include <sys/random.h>
@@ -28,8 +29,8 @@
 const Except_T SocketDNSCookie_Failed
     = {&SocketDNSCookie_Failed, "DNS Cookie operation failed"};
 
-/* Client secret size (256 bits for HMAC-SHA256) */
-#define SECRET_SIZE 32
+/* Client secret size (HMAC-SHA256 key size) */
+#define SECRET_SIZE SOCKET_CRYPTO_SHA256_SIZE
 
 /* Minimum TTL/lifetime for all time-based settings (1 minute) */
 #define DNS_COOKIE_MIN_TTL_SECONDS 60


### PR DESCRIPTION
## Summary

Implements #1916 - Replaces hardcoded magic number 32 with `SOCKET_CRYPTO_SHA256_SIZE` constant in DNS Cookie implementation.

## Changes

- Include `core/SocketCrypto.h` for crypto size constants
- Define `SECRET_SIZE` as `SOCKET_CRYPTO_SHA256_SIZE` instead of hardcoded `32`
- Update comment to reference HMAC-SHA256 key size

## Benefits

- Eliminates magic number redundancy
- Creates explicit link between secret size and HMAC-SHA256 algorithm
- Prevents inconsistency if crypto constants change in the future
- Self-documenting code

## Test Plan

- [x] DNS cookie tests pass (test_dnscookie: 23/23 passed)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - purely refactoring

Closes #1916