### PR TITLE
refactor(simple-dtls): extract magic MTU constant DTLS_DEFAULT_MTU

### DIFF
--- a/include/simple/SocketSimple-dtls.h
+++ b/include/simple/SocketSimple-dtls.h
@@ -44,6 +44,19 @@ extern "C" {
 #endif
 
 /*============================================================================
+ * DTLS Constants
+ *============================================================================*/
+
+/**
+ * @brief Default MTU for DTLS connections.
+ *
+ * The default Maximum Transmission Unit for DTLS is 1400 bytes,
+ * which accounts for typical IPv6 overhead and ensures the DTLS
+ * record plus UDP/IP headers fit within the path MTU.
+ */
+#define SOCKET_SIMPLE_DTLS_DEFAULT_MTU 1400
+
+/*============================================================================
  * DTLS Options
  *============================================================================*/
 
@@ -57,7 +70,7 @@ typedef struct SocketSimple_DTLSOptions {
     const char *ca_path;      /**< CA certificate directory */
     const char *client_cert;  /**< Client certificate file (for mTLS) */
     const char *client_key;   /**< Client private key file (for mTLS) */
-    size_t mtu;               /**< MTU size, 0 for default (1400) */
+    size_t mtu;               /**< MTU size, 0 for default (SOCKET_SIMPLE_DTLS_DEFAULT_MTU) */
     const char **alpn;        /**< ALPN protocol list (NULL-terminated) */
     size_t alpn_count;        /**< Number of ALPN protocols */
 } SocketSimple_DTLSOptions;

--- a/src/simple/SocketSimple-dtls.c
+++ b/src/simple/SocketSimple-dtls.c
@@ -33,7 +33,7 @@ Socket_simple_dtls_options_defaults (SocketSimple_DTLSOptions *opts)
   opts->ca_path = NULL;
   opts->client_cert = NULL;
   opts->client_key = NULL;
-  opts->mtu = 0; /* Use default 1400 */
+  opts->mtu = 0; /* 0 = use DTLS default (SOCKET_SIMPLE_DTLS_DEFAULT_MTU) */
   opts->alpn = NULL;
   opts->alpn_count = 0;
 }


### PR DESCRIPTION
## Summary

Implements #1925 - Extract hardcoded MTU value `1400` from comments into a named constant.

## Changes

- Added `SOCKET_SIMPLE_DTLS_DEFAULT_MTU` constant definition (1400) in `include/simple/SocketSimple-dtls.h`
- Updated struct field comment to reference the constant instead of magic number `1400`
- Updated implementation comment to reference the constant for clarity

## Rationale

The magic number `1400` appeared in:
1. Comment on line 36: `/* Use default 1400 */`
2. Header struct field comment: `/**< MTU size, 0 for default (1400) */`

This violates the C Anti-Patterns guideline against magic numbers (CLAUDE.md). By extracting to a named constant with documentation, the code is more maintainable and the default value is clearly defined.

## Test Plan

- [x] All DTLS tests pass with sanitizers (4/4 tests)
- [x] Build completes without warnings
- [x] No behavior changes - constant is for documentation only

Closes #1925