### PR TITLE
fix(simple): round up millisecond-to-second conversion in pool cleanup

### DIFF
--- a/include/simple/SocketSimple-pool.h
+++ b/include/simple/SocketSimple-pool.h
@@ -85,7 +85,7 @@ typedef enum {
 typedef struct SocketSimple_PoolOptions {
     int max_connections;      /**< Maximum connections (default: 1024) */
     int buffer_size;          /**< Per-connection buffer size (default: 4096) */
-    int idle_timeout_ms;      /**< Idle connection timeout, 0=none (default: 0) */
+    int idle_timeout_ms;      /**< Idle timeout in ms, rounded up to seconds, 0=none (default: 0) */
     int conn_rate_limit;      /**< Max connections/sec, 0=unlimited (default: 0) */
     int max_per_ip;           /**< Max connections per IP, 0=unlimited (default: 0) */
 } SocketSimple_PoolOptions;
@@ -178,6 +178,10 @@ extern int Socket_simple_pool_remove(SocketSimple_Pool_T pool,
 
 /**
  * @brief Remove idle connections older than timeout.
+ *
+ * Note: Milliseconds are rounded up to the nearest second internally
+ * (e.g., 1999ms becomes 2s). This ensures connections are not prematurely
+ * removed due to truncation.
  *
  * @param pool Pool handle.
  * @param max_idle_ms Maximum idle time in milliseconds.

--- a/src/simple/SocketSimple-pool.c
+++ b/src/simple/SocketSimple-pool.c
@@ -136,7 +136,9 @@ Socket_simple_pool_new_ex (const SocketSimple_PoolOptions *opts)
     }
   if (opts->idle_timeout_ms > 0)
     {
-      SocketPool_set_idle_timeout (pool, opts->idle_timeout_ms / 1000);
+      /* Round up to nearest second to avoid truncation */
+      time_t timeout_sec = (opts->idle_timeout_ms + 999) / 1000;
+      SocketPool_set_idle_timeout (pool, timeout_sec);
     }
 
   return handle;
@@ -297,7 +299,9 @@ Socket_simple_pool_cleanup (SocketSimple_Pool_T pool, int max_idle_ms)
       return -1;
     }
 
-  time_t idle_timeout = max_idle_ms / 1000;
+  /* Round up to nearest second to avoid truncation.
+   * Example: 1999ms becomes 2s, not 1s (safer for idle timeout). */
+  time_t idle_timeout = (max_idle_ms + 999) / 1000;
   SocketPool_cleanup (pool->pool, idle_timeout);
 
   return 0;


### PR DESCRIPTION
## Summary

Fixes #1931 - Resolves millisecond truncation in pool cleanup operations

## Changes

- **Socket_simple_pool_cleanup**: Round up `max_idle_ms` to prevent premature connection cleanup
- **Socket_simple_pool_new_ex**: Round up `idle_timeout_ms` during pool initialization  
- **Documentation**: Clarified rounding behavior in header file comments

## Problem

The Simple API pool functions were truncating milliseconds when converting to seconds:
- `1999ms` became `1s` instead of `2s`
- `500ms` became `0s` instead of `1s`

This caused connections to be prematurely removed, not matching user expectations.

## Solution

Changed from floor division to ceiling division: `(ms + 999) / 1000`

This ensures:
- `1999ms` → `2s` (safer, prevents premature cleanup)
- `500ms` → `1s` (safer, avoids zero timeout)
- `1000ms` → `1s` (exact second values unchanged)

## Test Plan

- [x] Built with sanitizers (`-DENABLE_SANITIZERS=ON`)
- [x] All 97 pool tests pass (`test_socketpool`)
- [x] 114/117 total tests pass (3 pre-existing failures unrelated to pool changes)

Closes #1931