### PR TITLE
fix(http): add defensive snprintf check in connection_send_response

### DIFF
--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -593,7 +593,14 @@ connection_send_response (SocketHTTPServer_T server, ServerConnection *conn)
   if (conn->response_body_len > 0 && !conn->response_streaming)
     {
       char cl[HTTPSERVER_CONTENT_LENGTH_BUF_SIZE];
-      snprintf (cl, sizeof (cl), "%zu", conn->response_body_len);
+      int ret = snprintf (cl, sizeof (cl), "%zu", conn->response_body_len);
+      if (ret < 0 || ret >= (int)sizeof (cl))
+        {
+          /* Defensive check: should never happen with 32-byte buffer for size_t,
+           * but handle gracefully if buffer size assumptions change. */
+          conn->state = CONN_STATE_CLOSED;
+          return;
+        }
       SocketHTTP_Headers_set (conn->response_headers, "Content-Length", cl);
     }
 


### PR DESCRIPTION
## Summary

Implements #1914 - adds defensive return value checking for snprintf when formatting Content-Length headers.

## Changes

- Added return value validation for `snprintf` in `connection_send_response` function
- Connection is closed gracefully if truncation is detected
- Added explanatory comment noting this is a defensive check

## Implementation Details

The check validates that:
1. `snprintf` returns >= 0 (no encoding error)
2. Return value < buffer size (no truncation)

If truncation is detected, the connection state is set to `CONN_STATE_CLOSED` and the function returns early, preventing a malformed Content-Length header from being sent.

## Risk Assessment

- **Risk**: Very low - the 32-byte buffer is sufficient for all valid size_t values (max 20 digits)
- **Impact**: Defensive programming that makes buffer size assumptions explicit
- **Testing**: All core httpserver tests pass (27/27)

## Test Plan

- [x] Built with sanitizers (`-DENABLE_SANITIZERS=ON`)
- [x] All core httpserver tests pass (test_httpserver: 27/27)
- [x] Code compiles without warnings
- [x] Change is minimal and focused on the specific issue

Closes #1914