### PR TITLE
refactor(simple): define SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE constant

### DIFF
--- a/src/simple/SocketSimple-pool.c
+++ b/src/simple/SocketSimple-pool.c
@@ -16,6 +16,13 @@
 #include "pool/SocketPool.h"
 
 /* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+#define SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE 4096
+
+/* ============================================================================
  * Internal Structures
  * ============================================================================
  */
@@ -66,7 +73,7 @@ Socket_simple_pool_options_init (SocketSimple_PoolOptions *opts)
     return;
 
   opts->max_connections = 1024;
-  opts->buffer_size = 4096;
+  opts->buffer_size = SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE;
   opts->idle_timeout_ms = 0;
   opts->conn_rate_limit = 0;
   opts->max_per_ip = 0;


### PR DESCRIPTION
## Summary

Implements #1927 - Replaces magic number 4096 with named constant

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE` constant (4096) in `src/simple/SocketSimple-pool.c`
- Updated `Socket_simple_pool_options_init()` to use the named constant instead of hardcoded value
- Follows anti-pattern guidance from CLAUDE.md regarding magic numbers

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] Socketpool tests pass
- [x] No functional changes - pure refactoring
- [x] Code compiles cleanly with -Werror

Closes #1927