### PR TITLE
fix(http): replace weak RNG fallback with hard failure in cnonce generation

### DIFF
--- a/src/http/SocketHTTPClient-auth.c
+++ b/src/http/SocketHTTPClient-auth.c
@@ -505,10 +505,8 @@ generate_cnonce (char *cnonce, size_t size)
 
   if (SocketCrypto_random_bytes (random_bytes, sizeof (random_bytes)) != 0)
     {
-      uint64_t t = (uint64_t)time (NULL);
-      memcpy (random_bytes, &t, sizeof (t));
-      memset (random_bytes + sizeof (t), 0,
-              sizeof (random_bytes) - sizeof (t));
+      SOCKET_LOG_ERROR_MSG ("Failed to generate secure random bytes for cnonce");
+      RAISE (SocketHTTPClient_Failed);
     }
 
   SocketCrypto_hex_encode (random_bytes, sizeof (random_bytes), cnonce, 1);


### PR DESCRIPTION
## Summary

Fixes #1899

Removes the weak `time(NULL)` fallback in `generate_cnonce()` and replaces it with hard failure when secure RNG is unavailable.

## Security Impact

The previous fallback to `time(NULL)` when `SocketCrypto_random_bytes()` failed provided only ~32 bits of entropy for digest authentication nonce generation, enabling:

- **Replay attacks**: Attacker can predict/brute-force cnonce values
- **Pre-computation attacks**: Limited entropy allows precomputed rainbow tables  
- **Session hijacking**: Predictable nonces enable session token guessing

## Changes

- Remove weak `time(NULL)` + zero-padding fallback in `generate_cnonce()`
- Log error with `SOCKET_LOG_ERROR_MSG()` when RNG fails
- Raise `SocketHTTPClient_Failed` exception to fail explicitly
- No changes to test suite (auth functions currently untested)

## Rationale

**Failing hard is appropriate** because:

1. `SocketCrypto_random_bytes()` should rarely fail on modern systems (uses OpenSSL RAND_bytes or /dev/urandom)
2. Weak auth is worse than no auth (false sense of security)
3. If RNG fails, indicates serious system issue requiring immediate attention
4. RFC 7616 requires sufficient randomness for cnonce

## Test Plan

- [x] Builds successfully with `-DENABLE_SANITIZERS=ON`
- [x] All tests pass except pre-existing failure in `test_dns_queue_limit`
- [x] No new compiler warnings

## References

- RFC 7616 §3.9.1: cnonce security requirements
- RFC 7616 §5.3: Security Considerations for client nonce generation