### PR TITLE
refactor(happy-eyeballs): replace magic number 255 with SOCKET_MAX_HOSTNAME_LEN

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -498,6 +498,17 @@ extern const char *Socket_safe_strerror (int errnum);
 #endif
 
 /**
+ * @brief Maximum hostname length per RFC 1035.
+ *
+ * DNS hostnames are limited to 255 octets per RFC 1035 §2.3.4.
+ * This constant is used for hostname length validation across the library.
+ *
+ */
+#ifndef SOCKET_MAX_HOSTNAME_LEN
+#define SOCKET_MAX_HOSTNAME_LEN 255 /* RFC 1035 §2.3.4 */
+#endif
+
+/**
  * @brief DNS request hash table size.
  *
  * Prime number for optimal hash distribution.

--- a/src/socket/SocketHappyEyeballs.c
+++ b/src/socket/SocketHappyEyeballs.c
@@ -106,7 +106,7 @@ static int
 he_copy_hostname (T he, const char *host)
 {
   size_t len = strlen (host);
-  if (len == 0 || len > 255)
+  if (len == 0 || len > SOCKET_MAX_HOSTNAME_LEN)
     {
       RAISE_MODULE_ERROR (SocketHE_Failed);
     }


### PR DESCRIPTION
## Summary

Implements #1912

Replaces hardcoded magic number `255` in `src/socket/SocketHappyEyeballs.c` with a named constant `SOCKET_MAX_HOSTNAME_LEN` for improved code maintainability and self-documentation.

## Changes

- Added `SOCKET_MAX_HOSTNAME_LEN` constant (255) to `include/core/SocketConfig.h` with proper RFC 1035 §2.3.4 documentation
- Updated `src/socket/SocketHappyEyeballs.c` line 109 to use `SOCKET_MAX_HOSTNAME_LEN` instead of magic number `255`

## Test Plan

- [x] Tests pass with sanitizers (excluding pre-existing `test_dns_queue_limit` failure)
- [x] Happy Eyeballs specific tests pass (`test_happy_eyeballs`)
- [x] All 116/117 tests pass (1 pre-existing failure unrelated to changes)
- [x] Build completes successfully with `-DENABLE_SANITIZERS=ON`

## Rationale

Per RFC 1035 §2.3.4, DNS hostnames are limited to 255 octets. Using a named constant instead of a magic number:
- Improves code readability and maintainability
- Self-documents the RFC limit
- Follows the anti-pattern guidance in CLAUDE.md

Closes #1912