### PR TITLE
refactor(simple): use SocketError_is_retryable_errno for retry logic

### DIFF
--- a/src/simple/SocketSimple-internal.h
+++ b/src/simple/SocketSimple-internal.h
@@ -20,6 +20,7 @@
 #include <string.h>
 
 #include "core/Except.h"
+#include "core/SocketError.h"
 #include "core/SocketUtil.h"
 #include "dns/SocketDNS.h"
 #include "http/SocketHTTPClient.h"

--- a/src/simple/SocketSimple.c
+++ b/src/simple/SocketSimple.c
@@ -85,10 +85,7 @@ Socket_simple_code (void)
 int
 Socket_simple_is_retryable (void)
 {
-  int err = simple_error.errno_value;
-  return err == EAGAIN || err == EWOULDBLOCK || err == EINTR
-         || err == ECONNREFUSED || err == ETIMEDOUT || err == ENETUNREACH
-         || err == EHOSTUNREACH;
+  return SocketError_is_retryable_errno (simple_error.errno_value);
 }
 
 void


### PR DESCRIPTION
## Summary

Implements #1937 - Refactors `Socket_simple_is_retryable()` to use the existing `SocketError_is_retryable_errno()` helper instead of duplicating errno checking logic.

## Changes

- Added `#include "core/SocketError.h"` to `src/simple/SocketSimple-internal.h`
- Replaced manual errno checking in `Socket_simple_is_retryable()` with call to `SocketError_is_retryable_errno()`
- Reduced function from 7 lines to 3 lines

## Benefits

- **DRY Principle**: Eliminates code duplication
- **Consistency**: Uses the same retry logic across the codebase
- **Maintainability**: Single source of truth for retryable error classification  
- **Correctness**: The existing helper includes `ECONNRESET` which the Simple API version was missing
- **Improved Functionality**: Now supports all retryable errnos defined in `SocketError.c`

## Test Plan

- [x] Build succeeds with sanitizers (`cmake -B build -DENABLE_SANITIZERS=ON`)
- [x] All non-flaky tests pass (91/91 tests passed)
- [x] Code compiles without warnings
- [x] No functional changes to public API

Closes #1937