### PR TITLE
refactor(tls): remove unused helper function sni_realloc_array

### DIFF
--- a/src/tls/SocketTLSContext-certs.c
+++ b/src/tls/SocketTLSContext-certs.c
@@ -162,16 +162,6 @@ sni_callback (SSL *ssl, int *ad, void *arg)
                          ctx->sni_certs.pkeys[idx]);
 }
 
-static int
-sni_realloc_array (void **ptr, size_t new_size)
-{
-  void *new_ptr = realloc (*ptr, new_size);
-  if (!new_ptr)
-    return 0;
-  *ptr = new_ptr;
-  return 1;
-}
-
 static void
 expand_sni_capacity (T ctx)
 {


### PR DESCRIPTION
## Summary

Implements #1943

Removes the unused `sni_realloc_array` helper function from `src/tls/SocketTLSContext-certs.c`.

## Changes

- Removed dead code: `sni_realloc_array` function (lines 165-173)
- This function was defined but never called anywhere in the codebase
- The `expand_sni_capacity` function performs inline reallocation with atomic allocation and proper rollback instead

## Test Plan

- [x] Tests pass with sanitizers (90/90 tests excluding pre-existing failures)
- [x] All TLS-specific tests pass (test_tls_integration, test_tls_context, test_tls_handshake)
- [x] Build succeeds with no warnings
- [x] Verified function has no callers via grep

Closes #1943