### PR TITLE
refactor(dns-cookie): use SOCKET_CRYPTO_SHA256_SIZE for hmac_out buffer

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -12,6 +12,7 @@
 #include "dns/SocketDNSCookie.h"
 #include "dns/SocketDNSWire.h"
 #include "core/Arena.h"
+#include "core/SocketCrypto.h"
 #include <arpa/inet.h>
 #include <string.h>
 #include <sys/random.h>
@@ -762,7 +763,7 @@ generate_client_cookie_hmac (T cache, const struct sockaddr *server_addr,
     }
 
   /* HMAC-SHA256 and truncate to 64 bits */
-  unsigned char hmac_out[32];
+  unsigned char hmac_out[SOCKET_CRYPTO_SHA256_SIZE];
   unsigned int hmac_len = 0;
 
   HMAC (EVP_sha256 (), cache->secret, SECRET_SIZE, data, data_len, hmac_out,


### PR DESCRIPTION
## Summary

Implements #1921

Replaces hardcoded magic number 32 with `SOCKET_CRYPTO_SHA256_SIZE` constant for HMAC-SHA256 output buffer in DNS cookie generation.

## Changes

- Added `#include "core/SocketCrypto.h"` to access the constant
- Replaced `unsigned char hmac_out[32]` with `unsigned char hmac_out[SOCKET_CRYPTO_SHA256_SIZE]` at line 766

## Benefits

- Eliminates magic number, improving code readability
- Self-documenting: buffer size clearly matches SHA-256 output size (32 bytes)
- Prevents buffer sizing errors if hash algorithm changes in future
- Consistent with other crypto code in the codebase

## Test Plan

- [x] All DNS cookie tests pass (23/23)
- [x] Build succeeds with sanitizers enabled
- [x] Tests pass with ASan/UBSan (100% of 91 non-excluded tests)

Closes #1921