### PR TITLE
refactor(simple): extract magic timeout constant in happyeyeballs

### DIFF
--- a/include/simple/SocketSimple-happyeyeballs.h
+++ b/include/simple/SocketSimple-happyeyeballs.h
@@ -53,6 +53,14 @@ extern "C" {
  *============================================================================*/
 
 /**
+ * @brief Default timeout for Happy Eyeballs connections (milliseconds).
+ *
+ * When timeout_ms parameter is 0 or negative, this default of 30 seconds
+ * is used for the overall connection timeout.
+ */
+#define SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS 30000
+
+/**
  * @brief Happy Eyeballs connection configuration.
  */
 typedef struct SocketSimple_HappyEyeballs_Config {

--- a/src/simple/SocketSimple-happyeyeballs.c
+++ b/src/simple/SocketSimple-happyeyeballs.c
@@ -67,7 +67,7 @@ Socket_simple_happyeyeballs_connect_config (
 
   if (timeout_ms <= 0)
     {
-      timeout_ms = 30000; /* Default 30 seconds */
+      timeout_ms = SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS;
     }
 
   /* Build core config from simple config */


### PR DESCRIPTION
## Summary

Implements #1928 - Extracts hardcoded 30-second timeout magic number into a named constant for better maintainability.

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS` constant to `SocketSimple-happyeyeballs.h`
- Updated implementation to use the constant instead of magic number `30000`
- Added documentation explaining when the default timeout is used

## Test Plan

- [x] All non-excluded tests pass with sanitizers (91/91 passed)
- [x] Code compiles without warnings
- [x] Constant is properly defined in header and used in implementation
- [x] No behavioral changes - only refactoring

## Notes

The constant follows project naming conventions for Simple API modules (`SOCKET_SIMPLE_*`). The default value of 30 seconds remains unchanged, ensuring backward compatibility.

Closes #1928