### PR TITLE
refactor(proxy): use constant for duplicated 'Request too large' error message

### DIFF
--- a/include/socket/SocketProxy-private.h
+++ b/include/socket/SocketProxy-private.h
@@ -262,6 +262,14 @@
 #define SOCKS4_REPLY_NO_IDENTD 92
 #define SOCKS4_REPLY_IDENTD_MISMATCH 93
 
+/** @brief SOCKS4 error message for buffer overflow during request building.
+ * @ingroup proxy_private
+ * Used when request size exceeds SOCKET_PROXY_BUFFER_SIZE.
+ * @see proxy_socks4_send_connect(), proxy_socks4a_send_connect()
+ * @see SOCKET_PROXY_BUFFER_SIZE
+ */
+#define SOCKS4_ERROR_MSG_REQUEST_TOO_LARGE "Request too large"
+
 /** @brief SOCKS5 protocol version number.
  * @ingroup proxy_private
  * Value: 5

--- a/src/socket/SocketProxy-socks4.c
+++ b/src/socket/SocketProxy-socks4.c
@@ -235,7 +235,8 @@ proxy_socks4_send_connect (struct SocketProxy_Conn_T *conn)
                            conn->username, &userid_written)
       < 0)
     {
-      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL, "Request too large");
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             SOCKS4_ERROR_MSG_REQUEST_TOO_LARGE);
       return -1;
     }
   len += userid_written;
@@ -300,7 +301,8 @@ proxy_socks4a_send_connect (struct SocketProxy_Conn_T *conn)
                            conn->username, &userid_written)
       < 0)
     {
-      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL, "Request too large");
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             SOCKS4_ERROR_MSG_REQUEST_TOO_LARGE);
       return -1;
     }
   len += userid_written;
@@ -308,7 +310,8 @@ proxy_socks4a_send_connect (struct SocketProxy_Conn_T *conn)
   /* Validate buffer space for hostname + null terminator */
   if (len + host_len + 1 > sizeof (conn->send_buf))
     {
-      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL, "Request too large");
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             SOCKS4_ERROR_MSG_REQUEST_TOO_LARGE);
       return -1;
     }
 


### PR DESCRIPTION
## Summary

Implements #1918

Refactors the SOCKS4/4a proxy implementation to use a named constant for the "Request too large" error message, which was previously duplicated 3 times in the code.

## Changes

- **Added** `SOCKS4_ERROR_MSG_REQUEST_TOO_LARGE` constant in `include/socket/SocketProxy-private.h`
- **Updated** 3 occurrences of hardcoded "Request too large" string in `src/socket/SocketProxy-socks4.c`:
  - Line 238 in `proxy_socks4_send_connect()`
  - Line 303 in `proxy_socks4a_send_connect()`
  - Line 311 in `proxy_socks4a_send_connect()`

## Benefits

- **Single source of truth**: Error message can be updated in one place
- **Consistency**: Ensures all error messages are identical
- **DRY principle**: Eliminates code duplication
- **Maintainability**: Easier to grep/search for this specific error

## Test Plan

- [x] Tests pass with sanitizers (proxy tests: 84 passed, 0 failed)
- [x] `test_proxy`: All 84 unit tests pass
- [x] `test_proxy_integration`: All 5 integration tests pass
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] No new memory leaks or sanitizer errors introduced

Closes #1918