### PR TITLE
refactor(tls): use SOCKET_BUFFER_GROWTH_FACTOR in pin capacity growth

### DIFF
--- a/src/tls/SocketTLSContext-pinning.c
+++ b/src/tls/SocketTLSContext-pinning.c
@@ -95,7 +95,7 @@ calculate_pin_capacity (size_t current_cap, size_t max_pins)
   if (current_cap == 0)
     return SOCKET_TLS_PIN_INITIAL_CAPACITY;
 
-  size_t new_cap = current_cap * 2;
+  size_t new_cap = current_cap * SOCKET_BUFFER_GROWTH_FACTOR;
   return (new_cap > max_pins) ? max_pins : new_cap;
 }
 


### PR DESCRIPTION
## Summary

Implements #2373

- Replaces hardcoded `2` multiplier with `SOCKET_BUFFER_GROWTH_FACTOR` constant in `calculate_pin_capacity()` function
- Improves code consistency by using existing well-documented constant from `SocketUtil.h`

## Changes

- Modified `src/tls/SocketTLSContext-pinning.c` line 98
- Changed `current_cap * 2` to `current_cap * SOCKET_BUFFER_GROWTH_FACTOR`

## Test Plan

- [x] Code compiles successfully (verified with independent gcc test)
- [x] No functional changes - constant has same value (2)
- [x] Improves maintainability and consistency

## Note

The change is isolated to the TLS pinning module and maintains identical behavior while improving code quality.

Closes #2373