### PR TITLE
docs(http-client-arena): fix Arena_clear/Arena_reset comment inconsistency

### DIFF
--- a/src/http/SocketHTTPClient-arena.c
+++ b/src/http/SocketHTTPClient-arena.c
@@ -127,7 +127,7 @@ httpclient_get_arena_cache (void)
  * Acquire a request arena from thread-local cache.
  *
  * First call per thread creates the arena. Subsequent calls reuse it
- * after clearing (Arena_clear preserves mutex, avoiding init overhead).
+ * after resetting (Arena_reset avoids global mutex, improving throughput).
  *
  * @return Arena for request allocations (never NULL, may raise on OOM)
  */


### PR DESCRIPTION
## Summary

Fixes #2223

Corrects documentation comment in `src/http/SocketHTTPClient-arena.c` that incorrectly referenced `Arena_clear()` when the code actually uses `Arena_reset()`.

## Changes

- Updated line 130 comment to correctly state "Arena_reset avoids global mutex, improving throughput" instead of "Arena_clear preserves mutex, avoiding init overhead"

## Details

The implementation on line 144 correctly uses `Arena_reset()`, which:
- Keeps one chunk allocated
- Resets pointer to beginning
- Avoids global mutex contention

The comment incorrectly mentioned `Arena_clear()`, which:
- Returns chunks to global pool
- Requires global mutex

## Test Plan

- [x] Documentation-only change, no functional impact
- [ ] Build currently blocked by merge conflict markers in origin/main (unrelated to this change)

Closes #2223