### PR TITLE
docs(hpack): add comment explaining HUFFMAN_REFILL_THRESHOLD value

### DIFF
--- a/src/http/SocketHPACK-huffman.c
+++ b/src/http/SocketHPACK-huffman.c
@@ -23,6 +23,11 @@
 
 #define HUFFMAN_MIN_CODE_BITS 5 /* Shortest code (common chars) */
 #define HUFFMAN_MAX_PAD_BITS 7  /* Max EOS padding (RFC 7541 §5.2) */
+/*
+ * Refill bit buffer when fewer than this many bits remain.
+ * Set to 32 to ensure at least 30 bits available (longest HPACK Huffman code).
+ * Uses ~50% of 64-bit accumulator, balancing refill overhead vs. buffer size.
+ */
 #define HUFFMAN_REFILL_THRESHOLD 32
 #define HUFFMAN_BITS_PER_BYTE 8
 


### PR DESCRIPTION
## Summary

Implements #2269 - Adds documentation comment explaining the HUFFMAN_REFILL_THRESHOLD value in HPACK Huffman decoder.

## Changes

- Added multi-line comment above `HUFFMAN_REFILL_THRESHOLD` constant
- Explains the value 32 ensures at least 30 bits available for longest HPACK Huffman code
- Documents the efficiency trade-off: uses ~50% of 64-bit accumulator, balancing refill overhead vs buffer size

## Rationale

The constant was previously undocumented, making it appear arbitrary. The new comment clarifies:
1. Longest HPACK Huffman code is 30 bits (RFC 7541 Appendix B)
2. 32-bit threshold provides safety margin for any single decode operation
3. Uses approximately half the 64-bit accumulator for optimal performance

## Test Plan

- [x] File compiles successfully (SocketHPACK-huffman.c.o built without errors)
- [x] Documentation-only change, no functional impact
- [x] Follows project comment style conventions

## Note

The build currently fails on main branch due to pre-existing conflict markers in `src/http/SocketHTTP2-validate.c`. This is unrelated to the current PR. The specific file modified in this PR (`src/http/SocketHPACK-huffman.c`) compiles successfully.

Closes #2269