### PR TITLE
refactor(simple-happyeyeballs): replace magic number with constant for default timeout

### DIFF
--- a/src/simple/SocketSimple-happyeyeballs.c
+++ b/src/simple/SocketSimple-happyeyeballs.c
@@ -68,7 +68,7 @@ Socket_simple_happyeyeballs_connect_config (
 
   if (timeout_ms <= 0)
     {
-      timeout_ms = 30000; /* Default 30 seconds */
+      timeout_ms = SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS;
     }
 
   /* Build core config from simple config */


### PR DESCRIPTION
## Summary

Implements #2291 - Replace hardcoded magic number `30000` with the existing constant `SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS` in Happy Eyeballs connection timeout handling.

## Changes

- **File**: `src/simple/SocketSimple-happyeyeballs.c` (line 71)
- **Change**: Replace `timeout_ms = 30000;` with `timeout_ms = SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS;`

## Benefits

- **Maintainability**: Single source of truth for default timeout value (defined in `SocketSimple-internal.h:130`)
- **Consistency**: All Simple API modules now use the same constant
- **Documentation**: The constant name is self-documenting
- **Safety**: Timeout adjustment only requires changing one location

## Test Plan

- [x] Code compiles cleanly (verified with gcc -c)
- [ ] Full test suite blocked by pre-existing build issues (conflict markers in `SocketHTTP2-validate.c`)

**Note**: The repository currently has merge conflict markers in `src/http/SocketHTTP2-validate.c` that prevent the full build from completing. This is a pre-existing issue unrelated to this change. The modified file compiles successfully on its own.

Closes #2291