### PR TITLE
refactor(proxy-socks5): define constant for SOCKS5 domain length byte size

### DIFF
--- a/include/socket/SocketProxy-private.h
+++ b/include/socket/SocketProxy-private.h
@@ -345,6 +345,7 @@
 #define SOCKS5_IPV4_ADDR_SIZE 4  /**< IPv4 address bytes */
 #define SOCKS5_IPV6_ADDR_SIZE 16 /**< IPv6 address bytes */
 #define SOCKS5_PORT_SIZE 2       /**< Port bytes (network order) */
+#define SOCKS5_DOMAIN_LENGTH_SIZE 1 /**< Domain name length byte (ATYP_DOMAIN) */
 
 /** @brief SOCKS5 response message size constants.
  * @ingroup proxy_private

--- a/src/socket/SocketProxy-socks5.c
+++ b/src/socket/SocketProxy-socks5.c
@@ -113,14 +113,15 @@ calculate_socks5_connect_response_length (struct SocketProxy_Conn_T *conn,
     case SOCKS5_ATYP_DOMAIN:
       /* Need header + length byte to read domain length */
       {
-        SocketProxy_Result res
-            = proxy_socks5_ensure_data (conn, SOCKS5_CONNECT_HEADER_SIZE + 1);
+        SocketProxy_Result res = proxy_socks5_ensure_data (
+            conn, SOCKS5_CONNECT_HEADER_SIZE + SOCKS5_DOMAIN_LENGTH_SIZE);
         if (res != PROXY_OK)
           return res;
       }
       addr_len = buf[4];
       /* header + len byte + domain + port */
-      needed = SOCKS5_CONNECT_HEADER_SIZE + 1 + addr_len + SOCKS5_PORT_SIZE;
+      needed = SOCKS5_CONNECT_HEADER_SIZE + SOCKS5_DOMAIN_LENGTH_SIZE
+               + addr_len + SOCKS5_PORT_SIZE;
       break;
 
     case SOCKS5_ATYP_IPV6:


### PR DESCRIPTION
## Summary

Implements #2343

Replaces magic number `1` with named constant `SOCKS5_DOMAIN_LENGTH_SIZE` in SOCKS5 protocol code to improve code clarity.

## Changes

- Added `SOCKS5_DOMAIN_LENGTH_SIZE` constant in `include/socket/SocketProxy-private.h`
- Replaced magic number `1` with constant in `calculate_socks5_connect_response_length()`
- Improved code readability per CLAUDE.md anti-patterns guidelines

## Technical Details

The literal `1` represents the size of the domain length byte in the SOCKS5 ATYP_DOMAIN address format (RFC 1928 Section 4). Domain addresses are encoded as: `[ATYP][LEN][domain...]` where LEN is a single byte.

## Test Plan

- [x] Code compiles successfully (verified with gcc -c)
- [x] No functional changes - purely refactoring
- [x] Follows existing naming conventions in the codebase

Closes #2343