### PR TITLE
refactor(dtls-cookie): remove redundant verified assignment

### DIFF
--- a/src/tls/SocketDTLS-cookie.c
+++ b/src/tls/SocketDTLS-cookie.c
@@ -280,7 +280,6 @@ dtls_cookie_verify_cb (SSL *ssl, const unsigned char *cookie,
     num_secrets = COOKIE_SECRET_COUNT;
   }
 
-  verified = 0;
   for (int s = 0; s < num_secrets; s++) {
     for (int t = 0; t < COOKIE_TIMESTAMP_WINDOW; t++) {
       /* Prevent underflow: only subtract if t <= timestamp */


### PR DESCRIPTION
## Summary

Removes redundant zero-assignment to `verified` variable in `dtls_cookie_verify_cb()` function.

## Changes

- Removed redundant `verified = 0;` assignment at line 283 in `src/tls/SocketDTLS-cookie.c`
- The variable is already initialized to 0 at declaration (line 255) and is not modified between initialization and the removed assignment

## Test Plan

- [x] Code compiles without errors
- [x] No functional changes - purely cosmetic refactoring
- [x] Logic remains unchanged

Fixes #2341