### PR TITLE
refactor(simple-ws): replace magic timeout 30000 with constant

### DIFF
--- a/src/simple/SocketSimple-ws.c
+++ b/src/simple/SocketSimple-ws.c
@@ -28,7 +28,7 @@ Socket_simple_ws_options_init (SocketSimple_WSOptions *opts)
   if (!opts)
     return;
   memset (opts, 0, sizeof (*opts));
-  opts->connect_timeout_ms = 30000;
+  opts->connect_timeout_ms = SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #2310

Replace hardcoded timeout value `30000` in `Socket_simple_ws_options_init()` with the `SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS` constant defined in `src/simple/SocketSimple-internal.h:130`.

## Changes

- `src/simple/SocketSimple-ws.c:31`: Replace `30000` with `SOCKET_SIMPLE_DEFAULT_TIMEOUT_MS`

## Benefits

- Eliminates magic number
- Ensures consistency across Simple API
- Single source of truth for default timeout
- Easier to maintain if default changes

## Test Plan

- [x] Code compiles successfully (SocketSimple-ws.c.o built without errors)
- [x] Change follows project conventions
- [ ] Full test suite blocked by pre-existing build issues in main branch (conflict markers in SocketHTTP2-validate.c, missing function in test_http_client.c)

## Notes

The main branch currently has pre-existing build issues unrelated to this change:
1. Conflict markers in `src/http/SocketHTTP2-validate.c`
2. Duplicate functions in `src/simple/SocketSimple-pool.c`
3. Missing `httpclient_auth_clear_header` function causing linker errors

This PR's changes compile successfully - verified by successful build of `CMakeFiles/socket_objects.dir/src/simple/SocketSimple-ws.c.o`.

Closes #2310