### PR TITLE
refactor(dns): remove redundant get_monotonic_ms macro

### DIFF
--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -120,9 +120,6 @@ struct T
 const Except_T SocketDNSoverHTTPS_Failed
     = { &SocketDNSoverHTTPS_Failed, "DNS-over-HTTPS operation failed" };
 
-/* Use centralized monotonic time utility from SocketUtil.h */
-#define get_monotonic_ms() Socket_get_monotonic_ms()
-
 /**
  * Convert standard Base64 to Base64URL (RFC 4648 Section 5).
  * Replaces + with -, / with _, and removes padding.
@@ -603,7 +600,7 @@ allocate_query_structure (T transport, const unsigned char *query, size_t len,
   q->id = extract_query_id (query, len);
   q->callback = callback;
   q->userdata = userdata;
-  q->sent_time_ms = get_monotonic_ms ();
+  q->sent_time_ms = Socket_get_monotonic_ms ();
   q->cancelled = 0;
   q->completed = 0;
   q->error = DOH_ERROR_SUCCESS;


### PR DESCRIPTION
## Summary

Implements #2220

Removes the redundant `get_monotonic_ms()` macro in `SocketDNSoverHTTPS.c` that simply wraps `Socket_get_monotonic_ms()` from `SocketUtil.h`. This eliminates unnecessary indirection and aligns with usage patterns in other DNS modules.

## Changes

- **Removed macro definition** (lines 123-124):
  ```c
  /* Use centralized monotonic time utility from SocketUtil.h */
  #define get_monotonic_ms() Socket_get_monotonic_ms()
  ```

- **Updated usage site** (line 603):
  ```c
  /* Before */
  q->sent_time_ms = get_monotonic_ms ();
  
  /* After */
  q->sent_time_ms = Socket_get_monotonic_ms ();
  ```

## Test Plan

- [x] Modified file compiles successfully (`gcc -c` verification)
- [ ] Full test suite with sanitizers (blocked by pre-existing merge conflicts in `src/http/SocketHTTP2-validate.c` on main branch)

## Notes

The repository currently has committed merge conflict markers in `src/http/SocketHTTP2-validate.c` on the main branch, which prevents running the full test suite. This issue should be resolved separately. The changes in this PR are isolated to `SocketDNSoverHTTPS.c` and compile successfully.

Closes #2220