### PR TITLE
refactor(dns-tls): replace magic numbers with named constants in ServerConfig

### DIFF
--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -76,6 +76,40 @@
  */
 #define DOT_MAX_TOTAL_QUERY_BYTES (10 * 1024 * 1024)
 
+/**
+ * Server address buffer size.
+ *
+ * Sized to hold IPv6 addresses with zone identifiers:
+ * - IPv6 max: 39 chars (8 groups of 4 hex + 7 colons)
+ * - Zone ID: "%" + zone name (up to 20 chars typical)
+ * - Null terminator: 1 char
+ * - Total: 39 + 1 + 20 + 1 = 61, rounded to 64 for alignment
+ *
+ * Example: "fe80::1234:5678:90ab:cdef%eth0"
+ */
+#define DOT_SERVER_ADDRESS_SIZE 64
+
+/**
+ * DNS server name buffer size.
+ *
+ * RFC 1035 §2.3.4 specifies maximum domain name length of 255 octets.
+ * Add 1 byte for null terminator.
+ */
+#define DOT_SERVER_NAME_SIZE 256
+
+/**
+ * SPKI pin buffer size.
+ *
+ * Base64-encoded SHA256 hash:
+ * - SHA256 hash: 32 bytes
+ * - Base64 encoding: ceil(32 * 4/3) = 44 chars
+ * - Null terminator: 1 char
+ * - Padding/alignment: rounded to 64 bytes
+ *
+ * Used for RFC 7469 Public Key Pinning (HPKP) in DNS-over-TLS.
+ */
+#define DOT_SPKI_PIN_SIZE 64
+
 /* Well-known DoT servers */
 static const struct
 {
@@ -96,13 +130,13 @@ static const struct
 /* Server configuration entry */
 struct ServerConfig
 {
-  char address[64];
+  char address[DOT_SERVER_ADDRESS_SIZE];
   int port;
-  char server_name[256];
+  char server_name[DOT_SERVER_NAME_SIZE];
   SocketDNSoverTLS_Mode mode;
-  char spki_pin[64];        /* Base64-encoded SHA256 */
-  char spki_pin_backup[64]; /* Backup pin */
-  int family;               /* AF_INET or AF_INET6 */
+  char spki_pin[DOT_SPKI_PIN_SIZE];        /* Base64-encoded SHA256 */
+  char spki_pin_backup[DOT_SPKI_PIN_SIZE]; /* Backup pin */
+  int family;                              /* AF_INET or AF_INET6 */
 };
 
 /* TLS connection state */


### PR DESCRIPTION
## Summary

Implements #2226

Refactors `struct ServerConfig` in `src/dns/SocketDNSoverTLS.c` to replace magic numbers (64, 256, 64) with descriptive named constants.

## Changes

### Named Constants Added
- `DOT_SERVER_ADDRESS_SIZE` (64): For IPv6 addresses with zone IDs
- `DOT_SERVER_NAME_SIZE` (256): Per RFC 1035 §2.3.4 domain name limit
- `DOT_SPKI_PIN_SIZE` (64): For Base64-encoded SHA256 SPKI pins

### Benefits
- **Maintainability**: Sizes can be adjusted in one location
- **Documentation**: Constants explain intent and sizing rationale
- **Consistency**: Follows project patterns for magic number elimination

## Technical Details

Buffer size justifications documented inline:
- Address: IPv6 (39) + zone separator (1) + zone name (20) + null (1) = 61, rounded to 64
- Server name: RFC 1035 max (255) + null (1) = 256
- SPKI pin: Base64-encoded SHA256 (44) + null (1) + padding = 64

## Test Plan

- [x] Syntax check passes for modified file
- [ ] Full test suite (blocked by unrelated merge conflicts in base branch)

## Notes

**Base branch issue**: The current HEAD (4f2392e5) contains merge conflict markers in `src/http/SocketHTTP2-validate.c` and `src/simple/SocketSimple-pool.c`, preventing full build. This PR's changes to `src/dns/SocketDNSoverTLS.c` are independent and verified via syntax check.

Closes #2226