### PR TITLE
refactor(core): replace magic sentinel SOCKET_COUNTER_UNMAPPED with proper enum value

### DIFF
--- a/include/core/SocketMetrics.h
+++ b/include/core/SocketMetrics.h
@@ -394,7 +394,8 @@ typedef enum SocketCounterMetric
   SOCKET_CTR_SYNPROTECT_BLACKLISTED,
   SOCKET_CTR_SYNPROTECT_LRU_EVICTIONS,
 
-  SOCKET_COUNTER_METRIC_COUNT
+  SOCKET_COUNTER_METRIC_COUNT,
+  SOCKET_COUNTER_UNMAPPED = -1 /* Sentinel for legacy mapping */
 } SocketCounterMetric;
 
 /**

--- a/src/core/SocketUtil.c
+++ b/src/core/SocketUtil.c
@@ -117,9 +117,6 @@ Socket_get_monotonic_ms (void)
 
 /* NOTE: Legacy system for backward compatibility. Prefer SocketMetrics.h. */
 
-/* Sentinel value for unmapped legacy metrics */
-#define SOCKET_COUNTER_UNMAPPED ((SocketCounterMetric)-1)
-
 static const SocketCounterMetric legacy_to_counter[SOCKET_METRIC_COUNT] = {
   [SOCKET_METRIC_SOCKET_CONNECT_SUCCESS] = SOCKET_CTR_SOCKET_CONNECT_SUCCESS,
   [SOCKET_METRIC_SOCKET_CONNECT_FAILURE] = SOCKET_CTR_SOCKET_CONNECT_FAILED,


### PR DESCRIPTION
## Summary

Implements #2203

Refactors `SOCKET_COUNTER_UNMAPPED` from a type-cast magic value to a proper enum constant.

## Changes

- Added `SOCKET_COUNTER_UNMAPPED = -1` as the last entry in the `SocketCounterMetric` enum in `include/core/SocketMetrics.h`
- Removed the `#define SOCKET_COUNTER_UNMAPPED ((SocketCounterMetric)-1)` from `src/core/SocketUtil.c`
- The sentinel value is now properly defined where it belongs: in the enum type itself

## Rationale

**Before** (Anti-pattern):
```c
#define SOCKET_COUNTER_UNMAPPED ((SocketCounterMetric)-1)
```

**After** (Best practice):
```c
typedef enum SocketCounterMetric
{
  SOCKET_CTR_POOL_CONNECTIONS_CREATED = 0,
  // ... existing counters ..
  
  SOCKET_COUNTER_METRIC_COUNT,
  SOCKET_COUNTER_UNMAPPED = -1  /* Sentinel for legacy mapping */
} SocketCounterMetric;
```

## Impact

- **No functional change**: The sentinel value remains -1 and is used identically
- **Improved maintainability**: The sentinel is now explicit in the enum definition
- **Better code clarity**: Follows C best practices for enum sentinel values
- **Low risk**: Pure refactoring with no behavioral changes

## Test Plan

- [x] Changes compile without errors or warnings
- [x] Verified header and implementation compile independently
- [ ] Full test suite blocked by pre-existing merge conflicts in repository (src/http/SocketHTTP2-validate.c, src/http/SocketHTTPClient-auth.c, src/simple/SocketSimple-pool.c)

**Note**: The repository currently has merge conflicts in files unrelated to this PR that prevent full build/test. Our changes compile correctly in isolation and do not touch the conflicted files.

Closes #2203