### PR TITLE
docs(tls): add explanatory comment for sessions_per_shard default calculation

### DIFF
--- a/src/tls/SocketTLS-performance.c
+++ b/src/tls/SocketTLS-performance.c
@@ -796,6 +796,9 @@ SocketTLSContext_create_sharded_cache (SocketTLSContext_T ctx,
                                                        sizeof (TLSSessionShard_T),
                                                        __FILE__, __LINE__);
 
+    /* Default: evenly distribute total cache capacity across shards.
+     * If sessions_per_shard is 0, calculate it by dividing the global
+     * SOCKET_TLS_SESSION_CACHE_SIZE (1000 sessions) by the number of shards. */
     size_t sessions_per_shard_final = sessions_per_shard ? sessions_per_shard : (SOCKET_TLS_SESSION_CACHE_SIZE / actual_shards);
 
     for (size_t i = 0; i < actual_shards; i++)


### PR DESCRIPTION
## Summary

Implements #2346 - Adds explanatory comment for the `sessions_per_shard` default calculation in `SocketTLSContext_create_sharded_cache()`.

## Changes

- Added multi-line comment explaining that when `sessions_per_shard` is 0, the function evenly distributes the global `SOCKET_TLS_SESSION_CACHE_SIZE` (1000 sessions) across all shards
- Improves code readability and maintainability by clarifying non-obvious calculation logic

## File Modified

- `src/tls/SocketTLS-performance.c` (line 799-801)

## Test Plan

- [x] Documentation-only change (no functional changes)
- [x] Core library builds successfully
- [x] Comment accurately describes the code behavior

## Notes

This is a documentation improvement with zero functional impact. The calculation logic remains unchanged, only adding clarity for future maintainers.

Closes #2346