### PR TITLE
refactor(simple-pool): extract MS_TO_SEC_ROUND_UP macro

### DIFF
--- a/src/simple/SocketSimple-pool.c
+++ b/src/simple/SocketSimple-pool.c
@@ -22,6 +22,12 @@
 
 #define SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE 4096
 
+/**
+ * @brief Convert milliseconds to seconds, rounding up.
+ * Examples: 0ms→0s, 1ms→1s, 999ms→1s, 1000ms→1s, 1001ms→2s
+ */
+#define MS_TO_SEC_ROUND_UP(ms) (((ms) + 999) / 1000)
+
 /* ============================================================================
  * Internal Structures
  * ============================================================================
@@ -143,8 +149,7 @@ Socket_simple_pool_new_ex (const SocketSimple_PoolOptions *opts)
     }
   if (opts->idle_timeout_ms > 0)
     {
-      /* Round up to nearest second to avoid truncation */
-      time_t timeout_sec = (opts->idle_timeout_ms + 999) / 1000;
+      time_t timeout_sec = MS_TO_SEC_ROUND_UP (opts->idle_timeout_ms);
       SocketPool_set_idle_timeout (pool, timeout_sec);
     }
 
@@ -306,9 +311,7 @@ Socket_simple_pool_cleanup (SocketSimple_Pool_T pool, int max_idle_ms)
       return -1;
     }
 
-  /* Round up to nearest second to avoid truncation.
-   * Example: 1999ms becomes 2s, not 1s (safer for idle timeout). */
-  time_t idle_timeout = (max_idle_ms + 999) / 1000;
+  time_t idle_timeout = MS_TO_SEC_ROUND_UP (max_idle_ms);
   SocketPool_cleanup (pool->pool, idle_timeout);
 
   return 0;


### PR DESCRIPTION
## Summary

Implements #2371

Extracts duplicated millisecond-to-second conversion pattern into a reusable macro.

## Changes

- Added `MS_TO_SEC_ROUND_UP` macro with documentation and examples
- Replaced inline calculations in `Socket_simple_pool_new_ex()` (line 147)
- Replaced inline calculations in `Socket_simple_pool_cleanup()` (line 311)
- Removed redundant explanatory comments

## Benefits

- **DRY principle**: Single definition of conversion logic
- **Self-documenting**: Macro name makes intent clear without comments  
- **Maintainability**: Changes only need to be made once
- **Consistency**: Eliminates risk of diverging implementations

## Test Plan

- [x] Macro compiles successfully (tested independently)
- [x] Changes are syntactically correct
- [ ] Full test suite (blocked by pre-existing repository conflicts in src/http/SocketHTTP2-validate.c)

**Note**: The repository currently contains merge conflict markers in `src/http/SocketHTTP2-validate.c` that prevent full build. This is unrelated to these changes.

Closes #2371