### PR TITLE
feat(tls): add defensive assertions to configure_ticket_keys

### DIFF
--- a/src/tls/SocketTLSContext-session.c
+++ b/src/tls/SocketTLSContext-session.c
@@ -201,6 +201,10 @@ SocketTLSContext_get_cache_stats (T ctx, size_t *hits, size_t *misses,
 static int
 configure_ticket_keys (T ctx, const unsigned char *key, size_t key_len)
 {
+  assert (ctx != NULL);
+  assert (key != NULL);
+  assert (key_len == SOCKET_TLS_TICKET_KEY_LEN);
+
   memcpy (ctx->ticket_key, key, key_len);
 
   if (SSL_CTX_ctrl (ctx->ssl_ctx, SSL_CTRL_SET_TLSEXT_TICKET_KEYS,


### PR DESCRIPTION
## Summary

Implements #2336 - adds defense-in-depth parameter validation to `configure_ticket_keys` function.

## Changes

Added three defensive assertions to the `configure_ticket_keys` static function in `src/tls/SocketTLSContext-session.c`:

- `assert(ctx != NULL)` - prevents null context pointer
- `assert(key != NULL)` - prevents null key pointer  
- `assert(key_len == SOCKET_TLS_TICKET_KEY_LEN)` - ensures exactly 80 bytes

## Rationale

While both public callers (`SocketTLSContext_enable_session_tickets` at line 238 and `SocketTLSContext_rotate_session_ticket_key` at line 277) currently validate the `key_len` parameter, the internal `configure_ticket_keys` function should enforce its own preconditions.

This provides:
- **Buffer overflow protection** - prevents memcpy from copying incorrect number of bytes into `ctx->ticket_key[80]` buffer
- **Clear documentation** - makes the exact 80-byte requirement explicit in the function
- **Early error detection** - fails fast during development/testing if preconditions violated
- **Defense-in-depth** - protects against future modifications to callers

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] Library target (`socket_objects`) builds without errors or warnings
- [x] Change is minimal and localized to security-critical function
- [x] Assertions follow existing project pattern (assert.h already included)

## Security Impact

This is a **defense-in-depth** improvement. No current security vulnerability exists because callers validate parameters, but this change prevents potential future buffer overflow if callers are modified incorrectly.

Closes #2336