### PR TITLE
refactor(http): replace manual delimiter checks with sockethttp_is_token_boundary() helper

### DIFF
--- a/src/http/SocketHTTP-headers.c
+++ b/src/http/SocketHTTP-headers.c
@@ -236,7 +236,7 @@ static size_t
 extract_token_bounds (const char *start, const char **end)
 {
   const char *p = start;
-  while (*p && *p != ',' && *p != ' ' && *p != '\t')
+  while (!sockethttp_is_token_boundary (*p))
     p++;
   *end = p;
   return (size_t)(p - start);


### PR DESCRIPTION
## Summary

Implements #2231

Refactors `extract_token_bounds()` in `src/http/SocketHTTP-headers.c` to use the existing `sockethttp_is_token_boundary()` helper function instead of manual character checking.

## Changes

- **File**: `src/http/SocketHTTP-headers.c` (line 239)
- **Function**: `extract_token_bounds()`
- **Before**: `while (*p && *p != ',' && *p != ' ' && *p != '\t')`
- **After**: `while (!sockethttp_is_token_boundary(*p))`

## Benefits

- Eliminates code duplication
- Centralizes delimiter definition in one place (`SocketHTTP-private.h`)
- Improves maintainability

## Verification

- Compiled successfully with `-Wall -Wextra`
- Helper function checks exact same delimiters: `'\0'`, `','`, `' '`, `'\t'`
- Functional equivalence verified with test harness

## Notes

The repository's main branch currently has pre-existing build issues (merge conflict markers in `SocketHTTP2-validate.c` and duplicate function definitions in `SocketSimple-pool.c`) that prevent a full test suite run. This PR only modifies `SocketHTTP-headers.c` and compiles cleanly in isolation.

Closes #2231