### PR TITLE
refactor(simple): extract helper for policy field mapping in reconnect

### DIFF
--- a/src/simple/SocketSimple-reconnect.c
+++ b/src/simple/SocketSimple-reconnect.c
@@ -49,6 +49,30 @@ state_callback_wrapper (SocketReconnect_T core __attribute__ ((unused)),
  * Policy Helpers
  *============================================================================*/
 
+/**
+ * @brief Map Simple API policy to Core API policy.
+ *
+ * Translates field names from the simpler Simple API to the more verbose
+ * Core API names. This centralizes the API translation logic.
+ *
+ * @param core Core policy structure to populate.
+ * @param simple Simple policy to translate.
+ */
+static void
+map_policy_to_core (SocketReconnect_Policy_T *core,
+                    const SocketSimple_Reconnect_Policy *simple)
+{
+  core->initial_delay_ms = simple->initial_delay_ms;
+  core->max_delay_ms = simple->max_delay_ms;
+  core->multiplier = simple->multiplier;
+  core->jitter = simple->jitter;
+  core->max_attempts = simple->max_attempts;
+  core->circuit_failure_threshold = simple->circuit_threshold;
+  core->circuit_reset_timeout_ms = simple->circuit_reset_ms;
+  core->health_check_interval_ms = simple->health_interval_ms;
+  core->health_check_timeout_ms = simple->health_timeout_ms;
+}
+
 void
 Socket_simple_reconnect_policy_defaults (SocketSimple_Reconnect_Policy *policy)
 {
@@ -103,15 +127,7 @@ Socket_simple_reconnect_new (const char *host, int port,
 
   if (policy)
     {
-      core_policy.initial_delay_ms = policy->initial_delay_ms;
-      core_policy.max_delay_ms = policy->max_delay_ms;
-      core_policy.multiplier = policy->multiplier;
-      core_policy.jitter = policy->jitter;
-      core_policy.max_attempts = policy->max_attempts;
-      core_policy.circuit_failure_threshold = policy->circuit_threshold;
-      core_policy.circuit_reset_timeout_ms = policy->circuit_reset_ms;
-      core_policy.health_check_interval_ms = policy->health_interval_ms;
-      core_policy.health_check_timeout_ms = policy->health_timeout_ms;
+      map_policy_to_core (&core_policy, policy);
     }
 
   TRY


### PR DESCRIPTION
## Summary

Implements #2302

Refactors policy field mapping in `Socket_simple_reconnect_new()` by extracting the repetitive field-by-field copying into a dedicated `map_policy_to_core()` static helper function.

## Changes

- Added `map_policy_to_core()` helper to centralize Simple API → Core API policy translation
- Reduced 9-line repetitive field copying in `Socket_simple_reconnect_new()` to single function call
- Improved maintainability while preserving intentional API differences

## API Translation

The Simple API uses shorter field names for simplicity:
- `circuit_threshold` → `circuit_failure_threshold`
- `circuit_reset_ms` → `circuit_reset_timeout_ms`  
- `health_interval_ms` → `health_check_interval_ms`
- `health_timeout_ms` → `health_check_timeout_ms`

This helper makes the mapping explicit and reusable.

## Test Plan

- [x] All 67 reconnect tests pass with sanitizers (ASan + UBSan)
- [x] No functional changes - pure refactoring
- [x] Helper function properly documents the API translation

Closes #2302