### PR TITLE
refactor(tls): replace magic SHA256 digest size with OpenSSL API call

### DIFF
--- a/src/tls/SocketTLS.c
+++ b/src/tls/SocketTLS.c
@@ -2004,8 +2004,10 @@ SocketTLS_get_peer_cert_info (Socket_T socket, SocketTLS_CertInfo *info)
   unsigned int md_len = 0;
   if (X509_digest (cert, EVP_sha256 (), md, &md_len))
     {
-      /* Limit to SHA256 size (32 bytes = 64 hex chars) */
-      size_t hash_len = (md_len > 32) ? 32 : md_len;
+      /* Limit to SHA256 digest size (32 bytes = 64 hex chars) */
+      int expected_size = EVP_MD_size (EVP_sha256 ());
+      size_t hash_len
+          = (md_len > (unsigned)expected_size) ? (size_t)expected_size : md_len;
       SocketCrypto_hex_encode (md, hash_len, info->fingerprint,
                                sizeof (info->fingerprint));
     }


### PR DESCRIPTION
## Summary

Implements #2355 - Replaces hardcoded magic number `32` for SHA256 digest size with `EVP_MD_size(EVP_sha256())` OpenSSL API call in `SocketTLS_get_peer_cert_info()`.

## Changes

- **src/tls/SocketTLS.c**: Replace magic number `32` with `EVP_MD_size(EVP_sha256())` for better maintainability
- **src/http/SocketHTTP2-validate.c**: Fixed merge conflicts that were blocking builds
- **src/simple/SocketSimple-pool.c**: Fixed duplicate function definitions from merge conflicts

## Benefits

- More maintainable code - digest size is obtained from OpenSSL API rather than hardcoded
- Self-documenting - clear that the size comes from the algorithm's specification
- Consistent with OpenSSL best practices

## Test Plan

- [x] Library builds successfully with sanitizers enabled
- [x] No compiler warnings or errors
- [x] Change follows project conventions (EVP_MD_size API usage)

Closes #2355