### PR TITLE
fix(pool): include SocketConfig.h for SOCKET_SYN_DEFAULT_* constants

### DIFF
--- a/src/pool/SocketPool-ops.c
+++ b/src/pool/SocketPool-ops.c
@@ -27,6 +27,7 @@
 #include <time.h>
 #include <unistd.h>
 
+#include "core/SocketConfig.h"   /* for SOCKET_SYN_DEFAULT_* constants */
 #include "core/SocketSecurity.h" /* for SocketSecurity_check_multiply */
 #include "dns/SocketDNS.h"
 #include "pool/SocketPool-private.h"


### PR DESCRIPTION
## Summary

Fixes #2240 by adding the missing `#include "core/SocketConfig.h"` to SocketPool-ops.c.

## Changes

- Added include directive for `core/SocketConfig.h` at line 30
- This provides definitions for:
  - `SOCKET_SYN_DEFAULT_THROTTLE_DELAY_MS` (used at line 1458)
  - `SOCKET_SYN_DEFAULT_DEFER_SEC` (used at line 1480)

## Issue Details

The constants were referenced in `apply_syn_throttle()` and `apply_syn_challenge()` functions but not defined, causing compilation failures.

Both constants are defined in `include/core/SocketConfig.h`:
- `SOCKET_SYN_DEFAULT_THROTTLE_DELAY_MS = 100` (line 869)
- `SOCKET_SYN_DEFAULT_DEFER_SEC = 5` (line 885)

## Test Plan

- [x] File compiles successfully with fix applied
- [x] No undefined constant errors

Closes #2240