### PR TITLE
refactor(quic): extract MurmurHash3 magic number to named constant

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -45,6 +45,27 @@
 #define QUIC_HASH_FNV1A_PRIME 16777619u
 
 /* ============================================================================
+ * Hash Constants (MurmurHash3)
+ * ============================================================================
+ *
+ * MurmurHash3 is used for sequence number hashing in the connection ID pool.
+ * Provides excellent avalanche characteristics for integer hashing.
+ *
+ * @see https://github.com/aappleby/smhasher
+ */
+
+/**
+ * @brief MurmurHash3 64-bit finalizer mixing constant.
+ *
+ * Used in multiplicative hashing for avalanche effect in sequence number
+ * hashing. This constant is part of the MurmurHash3 finalizer step and
+ * ensures that similar input values produce well-distributed hash outputs.
+ *
+ * From MurmurHash3 by Austin Appleby (public domain).
+ */
+#define QUIC_HASH_MURMUR3_MIX 0xff51afd7ed558ccdULL
+
+/* ============================================================================
  * HKDF Label Constants (RFC 8446)
  * ============================================================================
  */

--- a/src/quic/SocketQUICConnectionID-pool.c
+++ b/src/quic/SocketQUICConnectionID-pool.c
@@ -67,7 +67,9 @@ hash_cid_bytes (const uint8_t *id, size_t len, uint32_t seed)
 /**
  * @brief Hash a sequence number for O(1) lookup.
  *
- * Uses multiplicative hash with Knuth's constant mixed with seed.
+ * Uses MurmurHash3-inspired mixing for excellent avalanche characteristics.
+ * The hash combines Knuth's multiplicative constant with the MurmurHash3
+ * finalizer to ensure uniform distribution even for sequential inputs.
  *
  * @param sequence Sequence number to hash.
  * @param seed Random seed for collision resistance.
@@ -80,7 +82,7 @@ hash_sequence (uint64_t sequence, uint32_t seed)
   uint64_t hash = sequence * 2654435761ULL;
   hash ^= seed;
   hash ^= (hash >> 33);
-  hash *= 0xff51afd7ed558ccdULL;
+  hash *= QUIC_HASH_MURMUR3_MIX;
   hash ^= (hash >> 33);
 
   return (unsigned)(hash & (QUIC_CONNID_POOL_HASH_SIZE - 1));


### PR DESCRIPTION
## Summary

Implements #2264

Extracts undocumented magic number `0xff51afd7ed558ccdULL` to named constant `QUIC_HASH_MURMUR3_MIX` in the QUIC connection ID pool's hash_sequence() function.

## Changes

- Added `QUIC_HASH_MURMUR3_MIX` constant to `include/quic/SocketQUICConstants.h` with comprehensive documentation
- Updated `hash_sequence()` in `src/quic/SocketQUICConnectionID-pool.c` to use the named constant
- Improved function documentation to clarify MurmurHash3 algorithm usage

## Test Plan

- [x] All QUIC tests pass with sanitizers (26/26 tests passed)
- [x] Build succeeds with ASan/UBSan enabled
- [x] Code compiles without warnings
- [x] Documentation accurately describes the constant's purpose

## Details

The constant `0xff51afd7ed558ccdULL` is the MurmurHash3 64-bit finalizer mixing value, used to provide excellent avalanche characteristics for hash distribution. This change improves code documentation and maintainability by making the algorithm's intent explicit.

Closes #2264