### PR TITLE
refactor(quic): replace magic number 63 with named constant in transport params

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -413,6 +413,20 @@
  */
 #define QUIC_TP_TYPICAL_ACTIVE_CONNID_LIMIT 8
 
+/**
+ * @brief Maximum parameter ID trackable for duplicate detection.
+ *
+ * Limited to 63 because duplicate checking uses a 64-bit bitmap.
+ * Parameters with ID >= 64 bypass duplicate detection, which is
+ * acceptable per RFC 9000 Section 18.1 (ignore unknown parameters).
+ *
+ * Current known parameters (all < 64):
+ *   0x00-0x10: Core parameters (RFC 9000)
+ *   0x11: VERSION_INFO (RFC 9369)
+ *   0x20: MAX_DATAGRAM_FRAME_SIZE (RFC 9221)
+ */
+#define QUIC_TP_DUPLICATE_CHECK_MAX_ID 63
+
 /* ============================================================================
  * Utility Macros
  * ============================================================================

--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -1044,7 +1044,7 @@ decode_single_param (const uint8_t *data, size_t len, size_t *pos,
    * Parameters with ID >= 64 bypass duplicate detection, but this is
    * acceptable since RFC 9000 permits ignoring unknown parameters.
    */
-  if (param_id <= 63)
+  if (param_id <= QUIC_TP_DUPLICATE_CHECK_MAX_ID)
     {
       uint64_t mask = 1ULL << param_id;
       if (*seen_params & mask)


### PR DESCRIPTION
## Summary

Implements #2278

Replaces hardcoded magic number `63` with the named constant `QUIC_TP_DUPLICATE_CHECK_MAX_ID` in QUIC transport parameter duplicate detection logic.

## Changes

- **Added constant**: `QUIC_TP_DUPLICATE_CHECK_MAX_ID` (63) in `include/quic/SocketQUICConstants.h`
- **Updated usage**: Modified `decode_single_param()` in `src/quic/SocketQUICTransportParams.c` to use the constant
- **Documentation**: Added comprehensive documentation explaining the 64-bit bitmap limitation for duplicate parameter detection
- **RFC compliance**: Notes that parameters with ID >= 64 bypass duplicate detection per RFC 9000 Section 18.1

## Rationale

The duplicate parameter detection uses a 64-bit bitmap (`uint64_t`) to track seen parameters, limiting tracking to parameter IDs 0-63. While there was an excellent comment explaining this limitation, using a named constant makes the code self-documenting and easier to maintain.

Current known QUIC parameters (all < 64):
- 0x00-0x10: Core parameters (RFC 9000)
- 0x11: VERSION_INFO (RFC 9369)  
- 0x20: MAX_DATAGRAM_FRAME_SIZE (RFC 9221)

## Test Plan

- [x] All 36 QUIC transport params tests pass: `test_quic_transport_params`
- [x] Tests pass with AddressSanitizer (ASan)
- [x] Tests pass with UndefinedBehaviorSanitizer (UBSan)
- [x] Duplicate detection still works correctly for params 0-63
- [x] Unknown parameters >= 64 are still properly ignored

## Verification

```bash
cd build
ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ./test_quic_transport_params
# Result: 36 passed, 0 failed, 36 total
```

Closes #2278