### PR TITLE
fix(core): add NULL check in socketevent_init_connection

### DIFF
--- a/src/core/SocketEvent.c
+++ b/src/core/SocketEvent.c
@@ -180,6 +180,13 @@ socketevent_init_connection (SocketEventRecord *event, SocketEventType type,
                              const char *peer_addr, int peer_port,
                              const char *local_addr, int local_port)
 {
+  if (event == NULL)
+    {
+      SocketLog_emit (SOCKET_LOG_WARN, "SocketEvents",
+                      "NULL event passed to socketevent_init_connection");
+      return;
+    }
+
   event->type = type;
   event->component = component;
   event->data.connection.fd = fd;


### PR DESCRIPTION
## Summary

Fixes #2206 by adding defensive NULL pointer check in `socketevent_init_connection()`.

## Changes

- Add NULL check before dereferencing `event` parameter
- Log warning if NULL is passed
- Return early to prevent NULL dereference
- Improves defensive programming and code safety

## Background

While current callers pass stack-allocated structs (making NULL impossible in practice), this defensive check:
- Follows defensive programming best practices
- Maintains consistency with other parameter validation in the module (e.g., lines 120, 158)
- Prevents future bugs if the function is reused or modified
- Provides clear error messages for debugging

## Test Plan

- [x] Tests pass with sanitizers enabled
- [x] Existing test_socketevent tests pass
- [x] Code follows project conventions (SOCKET_LOG_WARN for parameter validation)

Closes #2206