### PR TITLE
refactor(simple-ratelimit): use ceil() for proper rounding instead of +1

### DIFF
--- a/src/http/SocketHTTP2-validate.c
+++ b/src/http/SocketHTTP2-validate.c
@@ -179,48 +179,10 @@ http2_is_connection_header_forbidden (const SocketHPACK_Header *header)
   if (header == NULL || header->name == NULL)
     return 0;
 
-<<<<<<< HEAD
   /* Binary search in sorted forbidden headers array */
   const void *found
       = bsearch (header, http2_forbidden_headers, HTTP2_FORBIDDEN_HEADER_COUNT,
                  sizeof (http2_forbidden_headers[0]), compare_forbidden_header);
-||||||| parent of 34852df6 (refactor(http2): extract magic numbers to named constants in validation code)
-  for (size_t i = 0; i < HTTP2_FORBIDDEN_HEADER_COUNT; i++)
-    {
-      if (header->name_len == http2_forbidden_headers[i].len
-          && strncasecmp (header->name, http2_forbidden_headers[i].name,
-                          http2_forbidden_headers[i].len)
-                 == 0)
-        {
-          /*
-           * TE header is a special case: it's allowed only with "trailers"
-           * value. Return 0 here (not forbidden) and let caller validate
-           * the value separately via http2_validate_te_header().
-           */
-          if (http2_forbidden_headers[i].len == 2)
-            return 0;
-          return 1;
-        }
-    }
-=======
-  for (size_t i = 0; i < HTTP2_FORBIDDEN_HEADER_COUNT; i++)
-    {
-      if (header->name_len == http2_forbidden_headers[i].len
-          && strncasecmp (header->name, http2_forbidden_headers[i].name,
-                          http2_forbidden_headers[i].len)
-                 == 0)
-        {
-          /*
-           * TE header is a special case: it's allowed only with "trailers"
-           * value. Return 0 here (not forbidden) and let caller validate
-           * the value separately via http2_validate_te_header().
-           */
-          if (http2_forbidden_headers[i].len == HTTP2_TE_HEADER_LEN)
-            return 0;
-          return 1;
-        }
-    }
->>>>>>> 34852df6 (refactor(http2): extract magic numbers to named constants in validation code)
 
   if (found == NULL)
     return 0; /* Not forbidden */
@@ -236,7 +198,7 @@ http2_is_connection_header_forbidden (const SocketHPACK_Header *header)
     size_t len;
   } *entry = found;
 
-  if (entry->len == 2) /* "te" */
+  if (entry->len == HTTP2_TE_HEADER_LEN) /* "te" */
     return 0;
 
   return 1; /* Forbidden */
@@ -499,29 +461,9 @@ http2_parse_status_code (const char *value, size_t len, int *status)
   if (status == NULL || len != 3)
     return -1;
 
-<<<<<<< HEAD
   uint64_t code;
   if (parse_decimal_uint64 (value, len, &code, 599) < 0)
     return -1;
-||||||| parent of 34852df6 (refactor(http2): extract magic numbers to named constants in validation code)
-  int code = 0;
-  for (size_t i = 0; i < 3; i++)
-    {
-      unsigned char c = (unsigned char)value[i];
-      if (c < '0' || c > '9')
-        return -1;
-      code = code * 10 + (c - '0');
-    }
-=======
-  int code = 0;
-  for (size_t i = 0; i < 3; i++)
-    {
-      unsigned char c = (unsigned char)value[i];
-      if (c < '0' || c > '9')
-        return -1;
-      code = code * DECIMAL_BASE + (c - '0');
-    }
->>>>>>> 34852df6 (refactor(http2): extract magic numbers to named constants in validation code)
 
   /* Valid HTTP status codes are 100-599 */
   if (code < 100)
@@ -542,27 +484,7 @@ http2_parse_content_length (const char *value, size_t len, int64_t *cl)
   if (parse_decimal_uint64 (value, len, &length, INT64_MAX) < 0)
     return -1;
 
-<<<<<<< HEAD
   *cl = (int64_t)length;
-||||||| parent of 34852df6 (refactor(http2): extract magic numbers to named constants in validation code)
-      /* Overflow check before multiplication */
-      if (result > (INT64_MAX - (c - '0')) / 10)
-        return -1;
-
-      result = result * 10 + (c - '0');
-    }
-
-  *cl = result;
-=======
-      /* Overflow check before multiplication */
-      if (result > (INT64_MAX - (c - '0')) / DECIMAL_BASE)
-        return -1;
-
-      result = result * DECIMAL_BASE + (c - '0');
-    }
-
-  *cl = result;
->>>>>>> 34852df6 (refactor(http2): extract magic numbers to named constants in validation code)
   return 0;
 }
 

--- a/src/simple/SocketSimple-pool.c
+++ b/src/simple/SocketSimple-pool.c
@@ -377,49 +377,6 @@ wrap_and_add_to_pool (SocketSimple_Pool_T pool, Socket_T client)
  * ============================================================================
  */
 
-/* Helper: Validate listener socket for accept operations */
-static int
-validate_listener_for_accept (SocketSimple_Pool_T pool,
-                               SocketSimple_Socket_T listener)
-{
-  if (!pool || !listener)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid pool or listener");
-      return -1;
-    }
-
-  if (!listener->socket || !listener->is_server)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid listener socket");
-      return -1;
-    }
-
-  return 0;
-}
-
-/* Helper: Create simple wrapper and add to pool */
-static SocketSimple_Conn_T
-wrap_and_add_to_pool (SocketSimple_Pool_T pool, Socket_T client)
-{
-  SocketSimple_Socket_T simple_sock = simple_create_handle (client, 0, 0);
-  if (!simple_sock)
-    {
-      Socket_free ((Socket_T *)&client);
-      return NULL;
-    }
-
-  SocketSimple_Conn_T conn = Socket_simple_pool_add (pool, simple_sock);
-  if (!conn)
-    {
-      Socket_simple_close (&simple_sock);
-      return NULL;
-    }
-
-  return conn;
-}
-
 SocketSimple_Conn_T
 Socket_simple_pool_accept (SocketSimple_Pool_T pool,
                            SocketSimple_Socket_T listener)

--- a/src/simple/SocketSimple-ratelimit.c
+++ b/src/simple/SocketSimple-ratelimit.c
@@ -12,6 +12,7 @@
 #include "SocketSimple-internal.h"
 #include "simple/SocketSimple-ratelimit.h"
 
+#include <math.h>
 #include <pthread.h>
 #include <time.h>
 #include <unistd.h>
@@ -187,7 +188,7 @@ Socket_simple_ratelimit_wait_ms (SocketSimple_RateLimit_T limit, int tokens)
     {
       double needed = tokens - limit->tokens;
       double seconds = needed / limit->tokens_per_sec;
-      wait_ms = (int)(seconds * 1000.0) + 1; /* Round up */
+      wait_ms = (int)ceil(seconds * 1000.0);
     }
 
   pthread_mutex_unlock (&limit->mutex);


### PR DESCRIPTION
## Summary

Implements #2286

Replaces crude `+1` rounding approximation with proper `ceil()` function for more accurate wait time calculation in `Socket_simple_ratelimit_wait_ms()`.

## Changes

- Added `#include <math.h>` to `src/simple/SocketSimple-ratelimit.c`
- Replaced `(int)(seconds * 1000.0) + 1` with `(int)ceil(seconds * 1000.0)` at line 191
- Also resolved merge conflicts in `SocketHTTP2-validate.c` (chose bsearch version with named constants)
- Fixed duplicate function definitions in `SocketSimple-pool.c` (pre-existing build error)

## Benefits

- More accurate wait time calculation
- Standard mathematical approach
- Avoids unnecessary delays when calculated value is already close to an integer

## Test Plan

- [x] All 9 tests in test_simple_ratelimit pass with sanitizers
- [x] All 28 tests in test_ratelimit pass with sanitizers
- [x] No memory leaks detected by ASan
- [x] No undefined behavior detected by UBSan

Closes #2286