### PR TITLE
refactor(simple-ratelimit): extract duplicated timespec conversion to helper function

### DIFF
--- a/src/simple/SocketSimple-ratelimit.c
+++ b/src/simple/SocketSimple-ratelimit.c
@@ -84,6 +84,13 @@ refill_tokens (SocketSimple_RateLimit_T limit)
     }
 }
 
+static void
+ms_to_timespec (int ms, struct timespec *ts)
+{
+  ts->tv_sec = ms / 1000;
+  ts->tv_nsec = (ms % 1000) * NANOSECONDS_PER_MILLISECOND;
+}
+
 /* ============================================================================
  * Rate Limiter Lifecycle
  * ============================================================================
@@ -222,8 +229,7 @@ Socket_simple_ratelimit_acquire (SocketSimple_RateLimit_T limit, int tokens)
       if (wait_ms > 0)
         {
           struct timespec ts;
-          ts.tv_sec = wait_ms / 1000;
-          ts.tv_nsec = (wait_ms % 1000) * 1000000;
+          ms_to_timespec (wait_ms, &ts);
           nanosleep (&ts, NULL);
           pthread_mutex_lock (&limit->mutex);
           limit->total_waited_ms += wait_ms;
@@ -281,8 +287,7 @@ Socket_simple_ratelimit_acquire_timeout (SocketSimple_RateLimit_T limit,
       if (wait_ms > 0)
         {
           struct timespec ts;
-          ts.tv_sec = wait_ms / 1000;
-          ts.tv_nsec = (wait_ms % 1000) * 1000000;
+          ms_to_timespec (wait_ms, &ts);
           nanosleep (&ts, NULL);
           pthread_mutex_lock (&limit->mutex);
           limit->total_waited_ms += wait_ms;


### PR DESCRIPTION
## Summary

Implements #2265 by extracting duplicated milliseconds-to-timespec conversion logic into a static helper function.

## Changes

- Added `ms_to_timespec()` static helper function in `src/simple/SocketSimple-ratelimit.c`
- Replaced duplicated conversion code in `Socket_simple_ratelimit_acquire()` (lines 232-233)
- Replaced duplicated conversion code in `Socket_simple_ratelimit_acquire_timeout()` (lines 290-291)
- Helper now uses existing `NANOSECONDS_PER_MILLISECOND` constant instead of magic number `1000000`

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All 10 ratelimit tests pass with ASan/UBSan
- [x] No memory leaks detected
- [x] Verified compilation of related modules

## Benefits

- Eliminates code duplication (DRY principle)
- Centralizes conversion logic for easier maintenance
- Replaces magic number with named constant
- Makes future enhancements easier (e.g., overflow checking)

Closes #2265