### PR TITLE
refactor(simple-poll): extract duplicate poll/socket validation to helper

### DIFF
--- a/src/simple/SocketSimple-poll.c
+++ b/src/simple/SocketSimple-poll.c
@@ -27,6 +27,24 @@ struct SocketSimple_Poll
 };
 
 /* ============================================================================
+ * Helper: Validate poll and socket arguments
+ * ============================================================================
+ */
+
+static int
+validate_poll_and_socket (SocketSimple_Poll_T poll,
+                           SocketSimple_Socket_T sock)
+{
+  if (!poll || !sock)
+    {
+      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
+                        "Invalid poll or socket");
+      return -1;
+    }
+  return 0;
+}
+
+/* ============================================================================
  * Helper: Extract and validate core socket handle
  * ============================================================================
  */
@@ -164,12 +182,8 @@ Socket_simple_poll_add (SocketSimple_Poll_T poll, SocketSimple_Socket_T sock,
 {
   Socket_simple_clear_error ();
 
-  if (!poll || !sock)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid poll or socket");
-      return -1;
-    }
+  if (validate_poll_and_socket (poll, sock) != 0)
+    return -1;
 
   /* Get underlying Socket_T with validation */
   Socket_T core_sock = get_core_socket (sock);
@@ -195,12 +209,8 @@ Socket_simple_poll_mod (SocketSimple_Poll_T poll, SocketSimple_Socket_T sock,
 {
   Socket_simple_clear_error ();
 
-  if (!poll || !sock)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid poll or socket");
-      return -1;
-    }
+  if (validate_poll_and_socket (poll, sock) != 0)
+    return -1;
 
   /* Get underlying Socket_T with validation */
   Socket_T core_sock = get_core_socket (sock);
@@ -226,12 +236,8 @@ Socket_simple_poll_del (SocketSimple_Poll_T poll, SocketSimple_Socket_T sock)
 {
   Socket_simple_clear_error ();
 
-  if (!poll || !sock)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid poll or socket");
-      return -1;
-    }
+  if (validate_poll_and_socket (poll, sock) != 0)
+    return -1;
 
   /* Get underlying Socket_T with validation */
   Socket_T core_sock = get_core_socket (sock);
@@ -257,12 +263,8 @@ Socket_simple_poll_modify_events (SocketSimple_Poll_T poll,
 {
   Socket_simple_clear_error ();
 
-  if (!poll || !sock)
-    {
-      simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
-                        "Invalid poll or socket");
-      return -1;
-    }
+  if (validate_poll_and_socket (poll, sock) != 0)
+    return -1;
 
   /* Get underlying Socket_T with validation */
   Socket_T core_sock = get_core_socket (sock);


### PR DESCRIPTION
## Summary

Implements #2282

Eliminates duplicate validation pattern in `src/simple/SocketSimple-poll.c` by extracting repeated NULL checks into a centralized `validate_poll_and_socket()` helper function.

## Changes

- Added `validate_poll_and_socket()` helper function
- Replaced 4 duplicate validation blocks in:
  - `Socket_simple_poll_add()`
  - `Socket_simple_poll_mod()`
  - `Socket_simple_poll_del()`
  - `Socket_simple_poll_modify_events()`
- Reduces code duplication from 4 instances to 1 helper
- Ensures consistent error messages across all poll functions

## Test Plan

- [x] Tests pass with sanitizers (`test_simple_poll_udp`, `test_socketpoll`)
- [x] All poll-related tests verified
- [x] No behavior changes - pure refactoring

Closes #2282