### PR TITLE
feat(http): add security warning for weak random fallback in cnonce generation

### DIFF
--- a/src/http/SocketHTTPClient-auth.c
+++ b/src/http/SocketHTTPClient-auth.c
@@ -505,6 +505,11 @@ generate_cnonce (char *cnonce, size_t size)
 
   if (SocketCrypto_random_bytes (random_bytes, sizeof (random_bytes)) != 0)
     {
+      /* WARNING: Crypto RNG failed, using weak time-based fallback for cnonce.
+       * This creates a predictable nonce that weakens HTTP Digest authentication
+       * security. Attackers who know the approximate request time can guess the
+       * cnonce, potentially enabling replay attacks. In production, ensure crypto
+       * RNG is available (requires OpenSSL/LibreSSL or /dev/urandom). */
       uint64_t t = (uint64_t)time (NULL);
       memcpy (random_bytes, &t, sizeof (t));
       memset (random_bytes + sizeof (t), 0,


### PR DESCRIPTION
## Summary

Implements #2219 by adding a clear security warning comment when crypto RNG fails and fallback to `time(NULL)` is used for HTTP Digest authentication cnonce generation.

## Changes

- Added comprehensive warning comment in `src/http/SocketHTTPClient-auth.c` (lines 508-512)
- Documents security implications of predictable cnonce in fallback path
- Explains risk of replay attacks when crypto RNG is unavailable

## Security Impact

The warning clarifies that:
- Predictable cnonce weakens HTTP Digest authentication
- Attackers who know approximate request time can guess the cnonce
- Crypto RNG (OpenSSL/LibreSSL or /dev/urandom) should be available in production

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] Socket objects library builds without errors
- [x] Existing tests pass (verified test_arena and test_socket)

## Notes

There is a pre-existing build issue in `test_http_client.c` (missing `httpclient_auth_clear_header` function) that is unrelated to this change. This change only adds documentation and does not modify any logic or function behavior.

Closes #2219