### PR TITLE
refactor(simple-http): add const qualifier to convert_response src parameter

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -81,7 +81,7 @@ Socket_simple_http_options_init (SocketSimple_HTTPOptions *opts)
  */
 
 static int
-convert_response (SocketHTTPClient_Response *src,
+convert_response (const SocketHTTPClient_Response *src,
                   SocketSimple_HTTPResponse *dst)
 {
   const char *ct;


### PR DESCRIPTION
## Summary

Adds const qualifier to the `convert_response` function's `src` parameter in `src/simple/SocketSimple-http.c`.

## Changes

- Changed `SocketHTTPClient_Response *src` to `const SocketHTTPClient_Response *src`
- Function only reads from `src` parameter without modifying it
- Improves const correctness following CLAUDE.md guidelines

## Benefits

- Makes API intent clearer (parameter is read-only)
- Follows project code style guidelines
- Enables potential compiler optimizations
- Prevents accidental modifications

## Test Plan

- [x] Code compiles without warnings with `-Wall -Wextra -Werror`
- [x] Syntax check passes
- [x] Simple tests execute successfully
- [x] No functional changes - purely a type safety improvement

Closes #2280