### PR TITLE
refactor(simple-async): remove unnecessary volatile on safe_socket

### DIFF
--- a/src/simple/SocketSimple-async.c
+++ b/src/simple/SocketSimple-async.c
@@ -188,8 +188,7 @@ async_operation_common (SocketSimple_Async_T async,
                         AsyncOpFunc op_func, AsyncOpTimeoutFunc op_timeout_func,
                         const char *error_msg)
 {
-  /* Volatile copy to survive potential longjmp in TRY/EXCEPT */
-  SocketSimple_Socket_T volatile safe_socket = socket;
+  SocketSimple_Socket_T safe_socket = socket;
   Socket_T core_socket;
   struct CallbackContext *ctx;
   volatile unsigned request_id = 0;


### PR DESCRIPTION
## Summary

Implements #2277

Removes the unnecessary `volatile` qualifier from `safe_socket` in `async_operation_common()`. The variable is assigned once and never modified in the TRY block, so volatile is not needed.

## Changes

- Removed `volatile` from `safe_socket` declaration in `src/simple/SocketSimple-async.c:191`
- Removed outdated comment about longjmp survival
- Kept `volatile` on `request_id` which IS modified inside TRY (correct usage)

## Analysis

Per CLAUDE.md exception safety guidelines:
> Use `volatile` for variables modified inside TRY that are read after exception

Variables that need `volatile`:
- `request_id` - Modified at lines 236, 243 inside TRY block ✓

Variables that don't need `volatile`:
- `safe_socket` - Assigned once at line 191, only read (never modified) ✗
- `core_socket` - Assigned before TRY, not modified ✗

## Test Plan

- [x] Tests pass with sanitizers enabled (`test_async`)
- [x] Code compiles cleanly with `-Wall -Wextra -Werror`
- [x] Integration tests pass (`test_integration`, `test_socketpool`, etc.)
- [x] Allows compiler optimizations on read-only variable

Closes #2277