### PR TITLE
refactor(quic): extract magic number to named constant QUIC_HASH_KNUTH_CONSTANT

### DIFF
--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -65,6 +65,17 @@
  */
 #define QUIC_HASH_MURMUR3_MIX 0xff51afd7ed558ccdULL
 
+/**
+ * @brief Knuth's multiplicative hash constant (32-bit).
+ *
+ * Used for integer hashing in hash tables. This is the 32-bit
+ * golden ratio constant: 2^32 / φ where φ is the golden ratio.
+ * Provides excellent distribution for sequential integer inputs.
+ *
+ * @see Donald Knuth, The Art of Computer Programming, Volume 3, Section 6.4
+ */
+#define QUIC_HASH_KNUTH_CONSTANT 2654435761ULL
+
 /* ============================================================================
  * HKDF Label Constants (RFC 8446)
  * ============================================================================

--- a/src/quic/SocketQUICConnectionID-pool.c
+++ b/src/quic/SocketQUICConnectionID-pool.c
@@ -79,7 +79,7 @@ static unsigned
 hash_sequence (uint64_t sequence, uint32_t seed)
 {
   /* Multiplicative hash using Knuth's constant */
-  uint64_t hash = sequence * 2654435761ULL;
+  uint64_t hash = sequence * QUIC_HASH_KNUTH_CONSTANT;
   hash ^= seed;
   hash ^= (hash >> 33);
   hash *= QUIC_HASH_MURMUR3_MIX;


### PR DESCRIPTION
## Summary

Implements #2251 by extracting the magic number `2654435761` (Knuth's multiplicative hash constant) to a named constant `QUIC_HASH_KNUTH_CONSTANT` in `SocketQUICConstants.h`.

## Changes

- **Added**: `QUIC_HASH_KNUTH_CONSTANT` definition in `include/quic/SocketQUICConstants.h` with comprehensive documentation
- **Updated**: `hash_sequence()` in `src/quic/SocketQUICConnectionID-pool.c` to use the named constant
- **Documentation**: Added detailed comment explaining the golden ratio constant and its purpose

## Test Plan

- [x] Built successfully with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All QUIC connection ID pool tests pass (`test_quic_connid_pool`: 20/20 tests passing)
- [x] All QUIC connection ID tests pass (`test_quic_connid`: 57/57 tests passing)
- [x] Verified constant is properly used in compiled object file
- [x] No magic number instances remain in codebase

## Code Quality

- Follows project conventions for constant naming and documentation
- Consistent with existing hash constants in `SocketQUICConstants.h`
- Improves maintainability and reusability across QUIC modules

Closes #2251