### PR TITLE
fix(dns-tls): add missing return value check for getsockopt() in check_tcp_connect_complete

### DIFF
--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -427,7 +427,13 @@ check_tcp_connect_complete (T transport, struct Connection *conn)
   /* Check socket error */
   int error = 0;
   socklen_t errlen = sizeof (error);
-  getsockopt (fd, SOL_SOCKET, SO_ERROR, &error, &errlen);
+  if (getsockopt (fd, SOL_SOCKET, SO_ERROR, &error, &errlen) != 0)
+    {
+      close_connection (transport, conn);
+      transport->stats.handshake_failures++;
+      return -1;
+    }
+
   if (error != 0)
     {
       close_connection (transport, conn);


### PR DESCRIPTION
## Summary

Fixes #2205 - Adds missing return value check for `getsockopt()` in `check_tcp_connect_complete()` function.

## Changes

- Added check for `getsockopt()` return value before examining the error code
- If `getsockopt()` fails, the connection is closed and -1 is returned
- This prevents proceeding with TLS handshake on a broken socket

## Security Impact

**CWE-252: Unchecked Return Value**

Without this fix:
- If `getsockopt()` fails (returns -1), the `error` variable remains 0
- The function incorrectly treats a failed connection as successful
- TLS handshake proceeds on a broken socket
- May lead to connection failures, crashes, or security bypasses

This is particularly critical in DNS-over-TLS where secure connection validation is essential.

## Test Plan

- [x] Compiled successfully with `-DENABLE_SANITIZERS=ON`
- [x] All DNS-over-TLS tests pass (16/16)
- [x] All DNS transport tests pass (23/23)
- [x] No memory leaks detected with ASan
- [x] No undefined behavior detected with UBSan

## Code Review

Before:
```c
int error = 0;
socklen_t errlen = sizeof(error);
getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &errlen);  // Unchecked!
if (error != 0) { ... }
```

After:
```c
int error = 0;
socklen_t errlen = sizeof(error);
if (getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &errlen) != 0) {
    close_connection(transport, conn);
    transport->stats.handshake_failures++;
    return -1;
}

if (error != 0) {
    close_connection(transport, conn);
    transport->stats.handshake_failures++;
    return -1;
}
```

Closes #2205