### PR TITLE
fix(http): prevent 32-bit pointer truncation in hash seed initialization

### DIFF
--- a/src/http/SocketHTTP-headers.c
+++ b/src/http/SocketHTTP-headers.c
@@ -56,7 +56,13 @@ init_header_hash_seed (void)
       uint32_t pid_seed = (uint32_t)getpid ();
       /* Use stack address for ASLR entropy */
       uintptr_t stack_addr = (uintptr_t)&header_hash_seed;
+#if UINTPTR_MAX > UINT32_MAX
+      /* 64-bit system: mix high and low bits */
       uint32_t stack_seed = (uint32_t)(stack_addr ^ (stack_addr >> 32));
+#else
+      /* 32-bit system: use full address */
+      uint32_t stack_seed = (uint32_t)stack_addr;
+#endif
 
       header_hash_seed = time_seed ^ pid_seed ^ stack_seed;
 


### PR DESCRIPTION
## Summary

Fixes #2235

Prevents undefined behavior in the fallback hash seed initialization on 32-bit systems by using conditional compilation to handle pointer width differences.

## Changes

- Modified `src/http/SocketHTTP-headers.c` to use `#if UINTPTR_MAX > UINT32_MAX` to detect platform width
- On 64-bit systems: mix high and low 32 bits of stack address for entropy
- On 32-bit systems: use the full 32-bit address directly
- Eliminates undefined behavior from right-shifting a 32-bit value by 32 bits

## Test Plan

- [x] All HTTP core tests pass (225/225)
- [x] Arena tests pass (25/25)
- [x] Exception tests pass (39/39)
- [x] Builds successfully with sanitizers enabled
- [x] No new compiler warnings

## Security Impact

- **Severity**: MEDIUM
- **Scope**: Fallback entropy source (only used if `SocketCrypto_random_bytes()` fails)
- **Before**: Undefined behavior on 32-bit platforms
- **After**: Well-defined behavior on all platforms with proper entropy extraction

Closes #2235