### PR TITLE
refactor(simple-http): replace magic timeout numbers with named constants

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -24,6 +24,8 @@
 
 #define SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS 5
 #define SOCKET_SIMPLE_MAX_HEADER_NAME_LEN 256
+#define SOCKET_SIMPLE_DEFAULT_CONNECT_TIMEOUT_MS 30000
+#define SOCKET_SIMPLE_DEFAULT_REQUEST_TIMEOUT_MS 60000
 
 /* ============================================================================
  * Shared Global HTTP Client (Lazy Initialization)
@@ -69,8 +71,8 @@ Socket_simple_http_options_init (SocketSimple_HTTPOptions *opts)
   if (!opts)
     return;
   memset (opts, 0, sizeof (*opts));
-  opts->connect_timeout_ms = 30000;
-  opts->request_timeout_ms = 60000;
+  opts->connect_timeout_ms = SOCKET_SIMPLE_DEFAULT_CONNECT_TIMEOUT_MS;
+  opts->request_timeout_ms = SOCKET_SIMPLE_DEFAULT_REQUEST_TIMEOUT_MS;
   opts->max_redirects = SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS;
   opts->verify_ssl = 1;
 }


### PR DESCRIPTION
## Summary

Implements #2255

Replaces hardcoded magic numbers (30000 and 60000) with named constants for HTTP timeout values in `Socket_simple_http_options_init()`.

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_CONNECT_TIMEOUT_MS` constant (30000)
- Added `SOCKET_SIMPLE_DEFAULT_REQUEST_TIMEOUT_MS` constant (60000)
- Updated `Socket_simple_http_options_init()` to use the new constants

## Test Plan

- [x] Code compiles successfully
- [x] Verified pre-existing build errors are unrelated to this change
- [x] Changes follow project code style guidelines from CLAUDE.md

Closes #2255