### PR TITLE
refactor(socket-async): extract common validation logic to reduce duplication

### DIFF
--- a/src/socket/SocketAsync.c
+++ b/src/socket/SocketAsync.c
@@ -815,15 +815,11 @@ process_async_completions_internal (T async,
 }
 
 
-static unsigned
-socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
-                     const void *send_buf, void *recv_buf, size_t len,
-                     SocketAsync_Callback cb, void *user_data,
-                     SocketAsync_Flags flags)
+static void
+validate_and_prepare_submit (T async, Socket_T socket, enum AsyncRequestType type,
+                              const void *send_buf, void *recv_buf, size_t len,
+                              SocketAsync_Callback cb)
 {
-  struct AsyncRequest *req;
-  unsigned request_id;
-
   if (!async || !socket || !cb || len == 0)
     {
       errno = EINVAL;
@@ -847,9 +843,13 @@ socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
   TRY { Socket_setnonblocking (socket); }
   EXCEPT (Socket_Failed) { }
   END_TRY;
+}
 
-  req = setup_async_request (async, socket, cb, user_data, type, send_buf,
-                             recv_buf, len, flags);
+static unsigned
+submit_validated_request (T async, struct AsyncRequest *req,
+                          enum AsyncRequestType type)
+{
+  unsigned request_id;
 
   request_id = submit_and_track_request (async, req);
   if (request_id == 0)
@@ -860,6 +860,22 @@ socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
     }
 
   return request_id;
+}
+
+static unsigned
+socket_async_submit (T async, Socket_T socket, enum AsyncRequestType type,
+                     const void *send_buf, void *recv_buf, size_t len,
+                     SocketAsync_Callback cb, void *user_data,
+                     SocketAsync_Flags flags)
+{
+  struct AsyncRequest *req;
+
+  validate_and_prepare_submit (async, socket, type, send_buf, recv_buf, len, cb);
+
+  req = setup_async_request (async, socket, cb, user_data, type, send_buf,
+                             recv_buf, len, flags);
+
+  return submit_validated_request (async, req, type);
 }
 
 T
@@ -1471,31 +1487,8 @@ socket_async_submit_with_timeout (T async, Socket_T socket,
                                   int64_t timeout_ms)
 {
   struct AsyncRequest *req;
-  unsigned request_id;
 
-  if (!async || !socket || !cb || len == 0)
-    {
-      errno = EINVAL;
-      SOCKET_ERROR_FMT ("Invalid parameters: async=%p socket=%p cb=%p len=%zu",
-                        (void *)async, (void *)socket, (void *)cb, len);
-      RAISE_MODULE_ERROR (SocketAsync_Failed);
-    }
-  if (type == REQ_SEND && !send_buf)
-    {
-      errno = EINVAL;
-      SOCKET_ERROR_MSG ("Send buffer is NULL for send operation");
-      RAISE_MODULE_ERROR (SocketAsync_Failed);
-    }
-  if (type == REQ_RECV && !recv_buf)
-    {
-      errno = EINVAL;
-      SOCKET_ERROR_MSG ("Receive buffer is NULL for recv operation");
-      RAISE_MODULE_ERROR (SocketAsync_Failed);
-    }
-
-  TRY { Socket_setnonblocking (socket); }
-  EXCEPT (Socket_Failed) { }
-  END_TRY;
+  validate_and_prepare_submit (async, socket, type, send_buf, recv_buf, len, cb);
 
   req = setup_async_request (async, socket, cb, user_data, type, send_buf,
                              recv_buf, len, flags);
@@ -1503,15 +1496,7 @@ socket_async_submit_with_timeout (T async, Socket_T socket,
   if (timeout_ms > 0)
     req->deadline_ms = Socket_get_monotonic_ms () + timeout_ms;
 
-  request_id = submit_and_track_request (async, req);
-  if (request_id == 0)
-    {
-      const char *op = (type == REQ_SEND) ? "send" : "recv";
-      SOCKET_ERROR_FMT ("Failed to submit async %s (errno=%d)", op, errno);
-      RAISE_MODULE_ERROR (SocketAsync_Failed);
-    }
-
-  return request_id;
+  return submit_validated_request (async, req, type);
 }
 
 


### PR DESCRIPTION
## Summary

Implements #2262

Extracted duplicated parameter validation and request submission logic from `socket_async_submit` and `socket_async_submit_with_timeout` into two helper functions:

- `validate_and_prepare_submit`: Validates parameters and sets socket to nonblocking mode
- `submit_validated_request`: Submits request and handles errors

This eliminates ~30 lines of duplicated code and improves maintainability by centralizing validation logic in a single location.

## Changes

- Added `validate_and_prepare_submit()` static helper function to consolidate parameter validation
- Added `submit_validated_request()` static helper function to consolidate request submission and error handling
- Refactored `socket_async_submit()` to use the new helper functions
- Refactored `socket_async_submit_with_timeout()` to use the new helper functions
- Reduced code duplication from ~60 lines to ~30 lines

## Test Plan

- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] All 40 async tests pass
- [x] No changes to API or behavior
- [x] Pure refactoring - functionality remains identical

Closes #2262