### PR TITLE
fix(http): use strnlen() instead of strlen() on password in auth logging

### DIFF
--- a/src/http/SocketHTTPClient-auth.c
+++ b/src/http/SocketHTTPClient-auth.c
@@ -296,7 +296,7 @@ httpclient_auth_basic_header (const char *username, const char *password,
     {
       SOCKET_LOG_WARN_MSG (
           "Basic auth credentials too long: username='%.*s' password_len=%zu",
-          (int)strnlen (username, 32), username, strlen (password));
+          (int)strnlen (username, 32), username, strnlen (password, 1024));
       return -1;
     }
 


### PR DESCRIPTION
## Summary

Fixes #2215 - Prevents DoS attack via extremely long password strings in HTTP Basic Auth logging.

## Changes

- Replace `strlen(password)` with `strnlen(password, 1024)` in warning log message
- Location: `src/http/SocketHTTPClient-auth.c` line 299
- Consistent with existing use of `strnlen(username, 32)` on same line

## Security Impact

**Before**: Attacker could provide multi-GB password string to hang application  
**After**: Password length computation bounded to 1024 characters max

## Test Plan

- [x] Code compiles with sanitizers enabled
- [x] Fix follows project pattern (strnlen already used for username)
- [x] No functional change - only limits length computation in error path
- [x] Pre-existing test_http_client build failure is unrelated to this fix

## Severity

MEDIUM - DoS vector through untrusted input processing

Closes #2215