### PR TITLE
refactor(simple-poll): define SOCKET_POLL_TIMEOUT_USE_DEFAULT constant

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -745,6 +745,7 @@ set(TEST_SOURCES
     test_socket
     test_simple_recv_line
     test_simple_dns_overflow
+    test_simple_poll
     test_simple_poll_udp
     test_socketbuf
     test_socketdgram

--- a/include/simple/SocketSimple-poll.h
+++ b/include/simple/SocketSimple-poll.h
@@ -69,6 +69,16 @@ typedef struct SocketSimple_Poll *SocketSimple_Poll_T;
  */
 #define SOCKET_SIMPLE_POLL_DEFAULT_MAX_EVENTS 64
 
+/**
+ * @brief Sentinel value to use poll instance's default timeout.
+ *
+ * Pass this value as timeout_ms to Socket_simple_poll_wait() to use
+ * the default timeout set via Socket_simple_poll_set_timeout().
+ * This allows per-instance timeout configuration while still allowing
+ * individual wait calls to override when needed.
+ */
+#define SOCKET_POLL_TIMEOUT_USE_DEFAULT (-2)
+
 /*============================================================================
  * Event Flags
  *============================================================================*/
@@ -183,7 +193,8 @@ extern int Socket_simple_poll_modify_events(SocketSimple_Poll_T poll,
  * @param poll Poll handle.
  * @param events Output array for events.
  * @param max_events Maximum events to return.
- * @param timeout_ms Timeout in milliseconds (-1 for infinite, 0 for non-blocking).
+ * @param timeout_ms Timeout in milliseconds (-1 for infinite, 0 for non-blocking,
+ *                   SOCKET_POLL_TIMEOUT_USE_DEFAULT to use instance default).
  * @return Number of events (>=0), or -1 on error.
  */
 extern int Socket_simple_poll_wait(SocketSimple_Poll_T poll,

--- a/src/test/test_simple_poll.c
+++ b/src/test/test_simple_poll.c
@@ -1,0 +1,44 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_simple_poll.c - Simple poll module unit tests
+ */
+
+#include <assert.h>
+
+#include "simple/SocketSimple-poll.h"
+#include "test/Test.h"
+
+/* Test that SOCKET_POLL_TIMEOUT_USE_DEFAULT is defined */
+TEST (poll_timeout_constant_defined)
+{
+  /* Verify the constant compiles and has expected value */
+  int timeout = SOCKET_POLL_TIMEOUT_USE_DEFAULT;
+  ASSERT_EQ (timeout, -2);
+}
+
+/* Test poll instance creation and timeout setting */
+TEST (poll_timeout_default_usage)
+{
+  SocketSimple_Poll_T poll = Socket_simple_poll_new (64);
+  ASSERT_NOT_NULL (poll);
+
+  /* Set a custom default timeout */
+  int result = Socket_simple_poll_set_timeout (poll, 5000);
+  ASSERT_EQ (result, 0);
+
+  Socket_simple_poll_free (&poll);
+  ASSERT_NULL (poll);
+}
+
+/* Test framework boilerplate */
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Fixes #2268 - Defines the previously undefined `SOCKET_POLL_TIMEOUT_USE_DEFAULT` constant that was referenced in `SocketSimple-poll.c:316` but never declared.

## Changes

- **Header** (`include/simple/SocketSimple-poll.h`):
  - Added `SOCKET_POLL_TIMEOUT_USE_DEFAULT` constant with value `-2`
  - Added comprehensive Doxygen documentation
  - Updated `Socket_simple_poll_wait()` parameter documentation

- **Test** (`src/test/test_simple_poll.c`):
  - New test file verifying constant is properly defined
  - Tests poll instance creation and timeout setting
  - Ensures constant compiles and has expected value

- **Build** (`CMakeLists.txt`):
  - Added `test_simple_poll` to test suite

## Rationale

The sentinel value `-2` was chosen to:
- Allow callers to request the poll instance's default timeout
- Preserve existing timeout semantics:
  - `-1` = infinite timeout (block until event)
  - `0` = non-blocking (return immediately)
  - `-2` = use instance default (new)
  - `>0` = specific timeout in milliseconds

This pattern allows per-instance timeout configuration while still enabling
per-call overrides when needed.

## Test Plan

- [x] Code compiles without errors
- [x] New test passes: `test_simple_poll`
- [x] Test runs clean with AddressSanitizer and UBSan
- [x] Constant properly defined and documented

Closes #2268