### PR TITLE
fix(http2): replace assert() with runtime NULL check in http2_flow_validate()

### DIFF
--- a/src/http/SocketHTTP2-flow.c
+++ b/src/http/SocketHTTP2-flow.c
@@ -6,7 +6,6 @@
 
 /* SocketHTTP2-flow.c - HTTP/2 Flow Control (RFC 9113 Section 5.2) */
 
-#include <assert.h>
 #include <stdint.h>
 
 #include "core/SocketSecurity.h"
@@ -52,7 +51,11 @@ static inline int
 http2_flow_validate (const SocketHTTP2_Conn_T conn,
                      const SocketHTTP2_Stream_T stream)
 {
-  assert (conn);
+  if (conn == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG ("NULL connection pointer in flow control");
+      return -1;
+    }
 
   if (stream && stream->conn != conn)
     {


### PR DESCRIPTION
## Summary

Implements #2253

Replaces `assert(conn)` with proper runtime NULL validation in `http2_flow_validate()` to prevent NULL pointer dereferences in production builds.

## Changes

- **Fixed**: Replace `assert(conn)` with explicit `if (conn == NULL)` check in `http2_flow_validate()`
- **Added**: Error logging via `SOCKET_LOG_ERROR_MSG` for NULL connection pointer
- **Changed**: Function now returns -1 on NULL input, consistent with other validation errors
- **Removed**: Unused `<assert.h>` include

## Rationale

The `assert()` macro is compiled out when `NDEBUG` is defined (standard for release builds). This left all 5 public flow control functions vulnerable to NULL pointer dereferences in production:

- `http2_flow_consume_recv()`
- `http2_flow_update_recv()`
- `http2_flow_consume_send()`
- `http2_flow_update_send()`
- `http2_flow_available_send()`

Per CLAUDE.md § C Anti-Patterns:
- **assert()** should only be used for programming invariants guaranteed by design
- **Runtime checks** should use explicit if-statements that survive into production

## Test Plan

- [x] Built successfully with sanitizers (`-DENABLE_SANITIZERS=ON`)
- [x] HTTP/2 tests pass (`test_http2_priority`, `test_http2_rate_limit`, `test_http2_integration`)
- [x] Manual validation test confirms NULL check works correctly
- [x] No performance regression (NULL check is trivial overhead)
- [x] Code compiles without warnings

## Security Impact

- **Severity**: MEDIUM
- **Type**: NULL pointer dereference prevention
- **Impact**: Prevents DoS (application crash) in production builds
- **Risk**: LOW likelihood (callers likely validate, but not contractually guaranteed)

Closes #2253