### PR TITLE
refactor(quic): break down SocketQUIC_send_connection_close into smaller helpers

### DIFF
--- a/src/quic/SocketQUICError-handling.c
+++ b/src/quic/SocketQUICError-handling.c
@@ -93,6 +93,144 @@ SocketQUIC_error_is_connection_fatal (uint64_t code)
 }
 
 /* ============================================================================
+ * Connection Close Helper Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Validate CONNECTION_CLOSE parameters and clamp reason length.
+ *
+ * Validates the connection pointer, output buffer, and reason parameters.
+ * Clamps the reason phrase length to QUIC_MAX_REASON_LENGTH if needed.
+ *
+ * @param conn       Connection pointer (must be non-NULL).
+ * @param out        Output buffer pointer (must be non-NULL).
+ * @param reason     Reason phrase pointer (may be NULL if reason_len is 0).
+ * @param reason_len Pointer to reason length (will be clamped).
+ *
+ * @return 1 if valid, 0 if invalid.
+ */
+static inline int
+validate_connection_close_params (SocketQUICConnection_T conn,
+                                   const uint8_t *out,
+                                   const char *reason,
+                                   size_t *reason_len)
+{
+  if (!conn || !out)
+    return 0;
+
+  /* Validate reason parameters: if reason is NULL, length must be 0 */
+  if (!reason && *reason_len != 0)
+    return 0;
+
+  /* Clamp reason length to maximum allowed */
+  if (*reason_len > QUIC_MAX_REASON_LENGTH)
+    *reason_len = QUIC_MAX_REASON_LENGTH;
+
+  return 1;
+}
+
+/**
+ * @brief Calculate required buffer size for CONNECTION_CLOSE frame.
+ *
+ * Computes the minimum buffer size needed for the frame header plus
+ * reason phrase, with overflow protection.
+ *
+ * @param is_app_error Whether this is an application error (vs transport).
+ * @param reason_len   Length of reason phrase.
+ *
+ * @return Required size in bytes, or 0 on overflow.
+ */
+static inline size_t
+calculate_connection_close_size (int is_app_error, size_t reason_len)
+{
+  size_t base_size = is_app_error ? QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_APP
+                                  : QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_TRANSPORT;
+
+  /* Check for overflow before adding reason_len (CWE-190, CERT INT30-C) */
+  if (reason_len > SIZE_MAX - base_size)
+    return 0;
+
+  return base_size + reason_len;
+}
+
+/**
+ * @brief Encode CONNECTION_CLOSE frame header fields.
+ *
+ * Encodes the frame type, error code, and conditional frame type field
+ * (for transport errors only) into the output buffer.
+ *
+ * @param frame_type   Frame type (0x1c or 0x1d).
+ * @param code         Error code.
+ * @param is_app_error Whether this is an application error.
+ * @param out          Output buffer.
+ * @param offset       Current offset (updated on success).
+ * @param out_len      Output buffer size.
+ *
+ * @return 1 on success, 0 on error.
+ */
+static inline int
+encode_connection_close_header (uint64_t frame_type, uint64_t code,
+                                 int is_app_error, uint8_t *out,
+                                 size_t *offset, size_t out_len)
+{
+  /* Encode frame type */
+  if (!encode_varint_field (frame_type, out, offset, out_len))
+    return 0;
+
+  /* Encode error code */
+  if (!encode_varint_field (code, out, offset, out_len))
+    return 0;
+
+  /* For transport errors (0x1c), include triggering frame type field */
+  /* For application errors (0x1d), skip frame type field */
+  if (!is_app_error)
+    {
+      /* Frame type field - use 0 for "no specific frame" */
+      if (!encode_varint_field (0, out, offset, out_len))
+        return 0;
+    }
+
+  return 1;
+}
+
+/**
+ * @brief Encode reason phrase into CONNECTION_CLOSE frame.
+ *
+ * Encodes the reason phrase length and copies the reason data with
+ * overflow protection.
+ *
+ * @param reason     Reason phrase pointer.
+ * @param reason_len Reason phrase length.
+ * @param out        Output buffer.
+ * @param offset     Current offset (updated on success).
+ * @param out_len    Output buffer size.
+ *
+ * @return 1 on success, 0 on error.
+ */
+static inline int
+encode_reason_phrase (const char *reason, size_t reason_len,
+                      uint8_t *out, size_t *offset, size_t out_len)
+{
+  /* Encode reason phrase length */
+  if (!encode_varint_field (reason_len, out, offset, out_len))
+    return 0;
+
+  /* Copy reason phrase */
+  if (reason_len > 0)
+    {
+      /* Prevent integer overflow: check if reason_len > (out_len - offset) */
+      if (*offset > out_len || reason_len > out_len - *offset)
+        return 0;
+
+      memcpy (out + *offset, reason, reason_len);
+      *offset += reason_len;
+    }
+
+  return 1;
+}
+
+/* ============================================================================
  * Connection Close (RFC 9000 Section 19.19)
  * ============================================================================
  */
@@ -105,11 +243,10 @@ SocketQUIC_send_connection_close (SocketQUICConnection_T conn, uint64_t code,
   size_t offset;
   uint64_t frame_type;
   int is_app_error;
+  size_t min_size;
 
-  VALIDATE_FRAME_PARAMS(conn, out);
-
-  /* Validate reason parameters: if reason is NULL, length must be 0 */
-  if (!reason && reason_len != 0)
+  /* Validate parameters and clamp reason length */
+  if (!validate_connection_close_params (conn, out, reason, &reason_len))
     return 0;
 
   /* Determine if this is an application error (0x1d) or transport error (0x1c) */
@@ -120,56 +257,21 @@ SocketQUIC_send_connection_close (SocketQUICConnection_T conn, uint64_t code,
   frame_type = is_app_error ? QUIC_FRAME_CONNECTION_CLOSE_APP
                             : QUIC_FRAME_CONNECTION_CLOSE;
 
-  /* Clamp reason length to maximum allowed */
-  if (reason_len > QUIC_MAX_REASON_LENGTH)
-    reason_len = QUIC_MAX_REASON_LENGTH;
-
-  /* Check minimum buffer size for frame header plus reason phrase */
-  size_t base_size = is_app_error ? QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_APP
-                                  : QUIC_FRAME_MIN_SIZE_CONNECTION_CLOSE_TRANSPORT;
-
-  /* Check for overflow before adding reason_len (CWE-190, CERT INT30-C) */
-  if (reason_len > SIZE_MAX - base_size)
-    return 0;
-
-  size_t min_size = base_size + reason_len;
-
-  if (!validate_frame_buffer (out, out_len, min_size))
+  /* Calculate required buffer size with overflow protection */
+  min_size = calculate_connection_close_size (is_app_error, reason_len);
+  if (min_size == 0 || out_len < min_size)
     return 0;
 
   offset = 0;
 
-  /* Encode frame type */
-  if (!encode_varint_field (frame_type, out, &offset, out_len))
+  /* Encode frame header (type, code, optional frame type field) */
+  if (!encode_connection_close_header (frame_type, code, is_app_error,
+                                        out, &offset, out_len))
     return 0;
 
-  /* Encode error code */
-  if (!encode_varint_field (code, out, &offset, out_len))
+  /* Encode reason phrase (length + data) */
+  if (!encode_reason_phrase (reason, reason_len, out, &offset, out_len))
     return 0;
-
-  /* For transport errors (0x1c), include triggering frame type field */
-  /* For application errors (0x1d), skip frame type field */
-  if (!is_app_error)
-    {
-      /* Frame type field - use 0 for "no specific frame" */
-      if (!encode_varint_field (0, out, &offset, out_len))
-        return 0;
-    }
-
-  /* Encode reason phrase length */
-  if (!encode_varint_field (reason_len, out, &offset, out_len))
-    return 0;
-
-  /* Copy reason phrase */
-  if (reason_len > 0)
-    {
-      /* Prevent integer overflow: check if reason_len > (out_len - offset) */
-      if (offset > out_len || reason_len > out_len - offset)
-        return 0;
-
-      memcpy (out + offset, reason, reason_len);
-      offset += reason_len;
-    }
 
   return offset;
 }


### PR DESCRIPTION
## Summary

Implements #2243

Refactors the 76-line `SocketQUIC_send_connection_close` function in 
`src/quic/SocketQUICError-handling.c` into four focused helper functions:

- `validate_connection_close_params`: Validates inputs and clamps reason length (14 lines)
- `calculate_connection_close_size`: Calculates buffer size with overflow checks (12 lines)
- `encode_connection_close_header`: Encodes frame type, error code, and optional frame type field (18 lines)
- `encode_reason_phrase`: Encodes reason phrase length and copies data (18 lines)

The main function is now reduced to 38 lines and reads as a clear sequence of operations.

## Changes

- Added 4 static inline helper functions with clear documentation
- Refactored `SocketQUIC_send_connection_close` to use these helpers
- Maintained all existing overflow protection and validation logic
- No changes to function signature or behavior

## Benefits

- **Improved testability**: Each helper can be unit tested independently
- **Enhanced readability**: Each function has a single, clear purpose
- **Better auditability**: Overflow protection logic is more isolated
- **Follows single responsibility principle**: Each function does one thing well

## Test Plan

- [x] All 54 QUIC error tests pass with sanitizers enabled
- [x] All 15 QUIC frame close tests pass with sanitizers enabled
- [x] Code compiles without warnings with `-Wall -Wextra -Werror`
- [x] No functional changes - all existing tests pass

Closes #2243