### PR TITLE
fix(dns-tls): check socket_util_safe_strncpy() return values in configure

### DIFF
--- a/src/dns/SocketDNSSEC.c
+++ b/src/dns/SocketDNSSEC.c
@@ -1498,7 +1498,8 @@ parse_bind_dnskey (const char *zone, const char *fields[], int field_count,
   memcpy (rdata + 4, key_buffer, pubkey_len);
 
   /* Fill anchor structure */
-  socket_util_safe_strncpy (anchor->zone, zone, sizeof (anchor->zone));
+  if (!socket_util_safe_strncpy (anchor->zone, zone, sizeof (anchor->zone)))
+    return -1; /* Zone name truncated */
   anchor->type = TRUST_ANCHOR_DNSKEY;
   anchor->data.dnskey.flags = (uint16_t)flags;
   anchor->data.dnskey.protocol = (uint8_t)protocol;
@@ -1554,7 +1555,8 @@ parse_bind_ds (const char *zone, const char *fields[], int field_count,
     }
 
   /* Fill anchor structure */
-  socket_util_safe_strncpy (anchor->zone, zone, sizeof (anchor->zone));
+  if (!socket_util_safe_strncpy (anchor->zone, zone, sizeof (anchor->zone)))
+    return -1; /* Zone name truncated */
   anchor->type = TRUST_ANCHOR_DS;
   anchor->data.ds.key_tag = (uint16_t)keytag;
   anchor->data.ds.algorithm = (uint8_t)algorithm;
@@ -1608,7 +1610,8 @@ SocketDNSSEC_validator_load_anchors (SocketDNSSEC_Validator_T validator,
 
       /* Extract zone name (fields[0]) */
       char zone[DNS_MAX_NAME_LEN];
-      socket_util_safe_strncpy (zone, fields[0], sizeof (zone));
+      if (!socket_util_safe_strncpy (zone, fields[0], sizeof (zone)))
+        continue; /* Skip entry if zone name truncated */
 
       /* Check for IN class (fields[1]) and record type (fields[2] or fields[3])
        */

--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -1207,32 +1207,41 @@ SocketDNSoverTLS_configure (T transport, const SocketDNSoverTLS_Config *config)
   server = &transport->servers[transport->server_count];
   memset (server, 0, sizeof (*server));
 
-  socket_util_safe_strncpy (server->address, config->server_address, sizeof (server->address));
+  if (!socket_util_safe_strncpy (server->address, config->server_address,
+                                  sizeof (server->address)))
+    return -1; /* Server address truncated */
+
   server->port = (config->port > 0) ? config->port : DOT_PORT;
   server->family = family;
   server->mode = config->mode;
 
   if (config->server_name)
     {
-      socket_util_safe_strncpy (server->server_name, config->server_name,
-                                sizeof (server->server_name));
+      if (!socket_util_safe_strncpy (server->server_name, config->server_name,
+                                      sizeof (server->server_name)))
+        return -1; /* Server name truncated */
     }
   else
     {
       /* Use address as SNI if no server name provided */
-      socket_util_safe_strncpy (server->server_name, config->server_address,
-                                sizeof (server->server_name));
+      if (!socket_util_safe_strncpy (server->server_name, config->server_address,
+                                      sizeof (server->server_name)))
+        return -1; /* Server name (from address) truncated */
     }
 
   if (config->spki_pin)
     {
-      socket_util_safe_strncpy (server->spki_pin, config->spki_pin, sizeof (server->spki_pin));
+      if (!socket_util_safe_strncpy (server->spki_pin, config->spki_pin,
+                                      sizeof (server->spki_pin)))
+        return -1; /* SPKI pin truncated */
     }
 
   if (config->spki_pin_backup)
     {
-      socket_util_safe_strncpy (server->spki_pin_backup, config->spki_pin_backup,
-                                sizeof (server->spki_pin_backup));
+      if (!socket_util_safe_strncpy (server->spki_pin_backup,
+                                      config->spki_pin_backup,
+                                      sizeof (server->spki_pin_backup)))
+        return -1; /* SPKI backup pin truncated */
     }
 
   transport->server_count++;

--- a/src/http/SocketHTTPServer-connections.c
+++ b/src/http/SocketHTTPServer-connections.c
@@ -759,7 +759,7 @@ connection_new (SocketHTTPServer_T server, Socket_T socket)
     const char *addr = Socket_getpeeraddr (conn->socket);
     if (addr != NULL)
       {
-        socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
+        (void)socket_util_safe_strncpy (conn->client_addr, addr, sizeof (conn->client_addr));
       }
 
     conn->parser = connection_create_parser (arena, &server->config);

--- a/src/socket/SocketHappyEyeballs.c
+++ b/src/socket/SocketHappyEyeballs.c
@@ -1755,7 +1755,7 @@ he_connect_extract_result (T he, const char *volatile *err_msg)
       if (tmp_err)
         {
           static _Thread_local char err_buf[SOCKET_HE_CONNECT_ERROR_BUFSIZE];
-          socket_util_safe_strncpy (err_buf, tmp_err, sizeof (err_buf));
+          (void)socket_util_safe_strncpy (err_buf, tmp_err, sizeof (err_buf));
           *err_msg = err_buf;
         }
       else


### PR DESCRIPTION
## Summary

Implements #2207 - Adds missing return value checks for `socket_util_safe_strncpy()` to prevent security issues from string truncation in DNS-over-TLS configuration and other critical code paths.

## Changes

### Core Function Enhancement
- Modified `socket_util_safe_strncpy()` to return `bool` (true on success, false on truncation)
- Added `strlen()` check to detect when source string exceeds buffer size
- Updated documentation with return value semantics

### Security-Critical Checks Added
1. **SocketDNSoverTLS_configure()** (5 checks):
   - Server address truncation → prevents wrong server connection
   - Server name (SNI) truncation → prevents TLS handshake failures
   - SPKI pin truncation → prevents pin validation failures
   - All return -1 on truncation

2. **SocketDNSSEC trust anchors** (3 checks):
   - DNSKEY zone name truncation
   - DS zone name truncation  
   - BIND format zone name truncation
   - Skip/fail anchor loading on truncation

3. **SocketDNSServfailCache_add()** (2 checks):
   - Query name truncation
   - Nameserver address truncation
   - Return -1 on truncation

### Non-Critical Uses (Explicit Ignore)
- Error message formatting (SocketTLS, SocketHappyEyeballs)
- HTTP Digest auth parsing (void functions, no error path)
- HTTP server logging (client address caching)

All cast to `(void)` to acknowledge intentional ignoring of return value.

## Test Plan

- [x] New test `dot_configure_truncation` in `test_dns_over_tls.c`
  - Verifies truncation detection for server address (64 byte buffer)
  - Verifies truncation detection for server name (256 byte buffer)
  - Verifies truncation detection for SPKI pins (64 byte buffer)
  - Confirms valid configs still work
- [x] All DNS-over-TLS tests pass (17/17)
- [x] All DNSSEC tests pass (20/20)
- [x] Compiled with ASan/UBSan, no memory errors

## Impact

Prevents security issues (CWE-252, CWE-119):
- DoS from connection failures due to truncated addresses
- Security bypass from truncated SNI matching wrong certificates
- Pin validation bypass from truncated SPKI pins

Closes #2207