### PR TITLE
refactor(reconnect): reduce nesting in check_connect_completion error handling

### DIFF
--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -456,17 +456,13 @@ check_connect_completion (T conn)
       /* Initialize error before getsockopt to avoid uninitialized read */
       error = 0;
       len = sizeof (error);
-      int connect_err;
+      int connect_err = ECONNREFUSED; /* default */
+
       if (getsockopt (fd, SOL_SOCKET, SO_ERROR, &error, &len) < 0)
-        {
-          /* getsockopt itself failed, use errno */
-          connect_err = errno;
-        }
-      else
-        {
-          /* getsockopt succeeded, use socket error or default to ECONNREFUSED */
-          connect_err = error ? error : ECONNREFUSED;
-        }
+        connect_err = errno; /* getsockopt itself failed */
+      else if (error != 0)
+        connect_err = error; /* socket error occurred */
+
       reconnect_set_socket_error (conn, "Connect poll error", connect_err);
       return -1;
     }


### PR DESCRIPTION
## Summary

Implements #2326

## Changes

- Flattened nested if-else logic in `check_connect_completion` error path
- Reduced nesting depth from 3 to 2 levels
- Used early return pattern with default value (ECONNREFUSED)
- Improved code readability following CLAUDE.md "Deep Nesting" guidelines

## Test Plan

- [x] All 67 reconnect tests pass with sanitizers enabled
- [x] Logic verified: default to ECONNREFUSED, use errno if getsockopt fails, use socket error if available
- [x] No behavioral changes, pure refactoring

Closes #2326