### PR TITLE
refactor(socket): remove unnecessary volatile qualifiers in Socket_sendvall and Socket_recvvall

### DIFF
--- a/src/socket/Socket-iov.c
+++ b/src/socket/Socket-iov.c
@@ -630,8 +630,8 @@ Socket_sendvall (T socket, const struct iovec *iov, int iovcnt)
 {
   struct iovec *iov_copy = NULL;
   volatile size_t total_sent = 0;
-  volatile size_t total_len;
-  volatile ssize_t sent;
+  size_t total_len;
+  ssize_t sent;
 
   assert (socket);
   assert (iov);
@@ -666,8 +666,8 @@ Socket_recvvall (T socket, struct iovec *iov, int iovcnt)
 {
   struct iovec *iov_copy = NULL;
   volatile size_t total_received = 0;
-  volatile size_t total_len;
-  volatile ssize_t received;
+  size_t total_len;
+  ssize_t received;
 
   assert (socket);
   assert (iov);


### PR DESCRIPTION
## Summary

Implements #2321

Removes unnecessary `volatile` qualifiers from variables in `Socket_sendvall()` and `Socket_recvvall()` that are not modified within TRY blocks.

## Changes

- **Socket_sendvall**: Removed `volatile` from `total_len` and `sent` (only `total_sent` needs it)
- **Socket_recvvall**: Removed `volatile` from `total_len` and `received` (only `total_received` needs it)

## Rationale

Per CLAUDE.md § Exception Safety:
> "Use volatile for variables modified inside TRY that are read after exception"

Analysis:
- `total_len` is assigned once (before TRY) → doesn't need `volatile`
- `sent`/`received` are used as output parameters, not directly modified in TRY scope → don't need `volatile`
- `total_sent`/`total_received` are incremented inside TRY → correctly retain `volatile`

This reduces unnecessary overhead and improves code clarity.

## Test Plan

- [x] All 299 tests in test_socket pass with sanitizers (ASan/UBSan)
- [x] No change in behavior - pure refactoring
- [x] Exception handling still works correctly

Closes #2321