### PR TITLE
fix(simple-timer): add missing error clear in two functions

### DIFF
--- a/src/simple/SocketSimple-timer.c
+++ b/src/simple/SocketSimple-timer.c
@@ -377,6 +377,8 @@ int
 Socket_simple_timer_cancel_all (SocketSimple_Poll_T poll
                                  __attribute__ ((unused)))
 {
+  Socket_simple_clear_error ();
+
   /* Not currently supported - timers must be cancelled individually. */
   simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
                     "Cancel all timers not supported");
@@ -390,6 +392,8 @@ Socket_simple_timer_cancel_all (SocketSimple_Poll_T poll
 int
 Socket_simple_timer_count (SocketSimple_Poll_T poll __attribute__ ((unused)))
 {
+  Socket_simple_clear_error ();
+
   /* Timer count not available from core API. */
   simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
                     "Timer count not supported");


### PR DESCRIPTION
## Summary

Fixes #2306

Adds missing `Socket_simple_clear_error()` calls to two functions that were inconsistent with the rest of the file:
- `Socket_simple_timer_cancel_all()`
- `Socket_simple_timer_count()`

## Changes

- Added `Socket_simple_clear_error()` at the start of both functions
- Ensures consistent error handling pattern across all public API functions in SocketSimple-timer.c

## Impact

- Prevents confusing error state when previous errors existed before calling these functions
- Maintains API consistency with all other functions in this module

## Test Plan

- [x] Library compiles successfully with changes
- [x] No functional changes - just adds missing error clearing
- [x] Follows pattern used by all other functions in the file (Socket_simple_timer_cancel, Socket_simple_timer_reschedule, Socket_simple_timer_pause, Socket_simple_timer_resume)

Closes #2306