### PR TITLE
fix(websocket): add overflow check to append_deflate_trailer for defense-in-depth

### DIFF
--- a/src/socket/SocketWS-deflate.c
+++ b/src/socket/SocketWS-deflate.c
@@ -167,7 +167,10 @@ append_deflate_trailer (Arena_T arena, const unsigned char *input,
 {
   unsigned char *buf;
 
-  *output_len = input_len + WS_DEFLATE_TRAILER_SIZE;
+  /* Defense-in-depth: check overflow even though caller checks (issue #2347) */
+  if (!SocketSecurity_check_add (input_len, WS_DEFLATE_TRAILER_SIZE, output_len))
+    return NULL;
+
   buf = ALLOC (arena, *output_len);
   if (!buf)
     return NULL;


### PR DESCRIPTION
## Summary

Implements #2347 - adds overflow checking to `append_deflate_trailer()` in WebSocket permessage-deflate compression.

## Changes

- Added `SocketSecurity_check_add()` call at the start of `append_deflate_trailer()` to validate integer addition before performing `input_len + WS_DEFLATE_TRAILER_SIZE`
- Function now returns `NULL` on overflow, making it self-contained and safe for standalone use
- Implements defense-in-depth security principle: even though the current caller (`prepare_decompress_input`) already checks for overflow, the function itself should validate its inputs independently

## Test Plan

- [x] Built successfully with `ENABLE_SANITIZERS=ON`
- [x] WebSocket integration tests pass (`test_ws_integration`)
- [x] No functional changes to behavior - only adds safety check
- [x] Existing fuzz tests (`fuzz_ws_deflate`) will exercise decompression paths

## Security Impact

- Severity: MEDIUM (defense-in-depth improvement)
- Not an active vulnerability due to caller protection
- Improves code maintainability and future safety if function is reused

Closes #2347