### PR TITLE
refactor(websocket): deduplicate UINT_MAX validation for zlib size limits

### DIFF
--- a/src/socket/SocketWS-deflate.c
+++ b/src/socket/SocketWS-deflate.c
@@ -540,6 +540,19 @@ ws_compression_free (SocketWS_T ws)
   /* Buffers not allocated; no action needed */
 }
 
+static int
+check_zlib_size_limit (SocketWS_T ws, size_t size, const char *type_name)
+{
+  if (size > UINT_MAX)
+    {
+      ws_set_error (ws, WS_ERROR_COMPRESSION,
+                    "%s size %zu exceeds zlib limit %u", type_name, size,
+                    UINT_MAX);
+      return -1;
+    }
+  return 0;
+}
+
 static unsigned char *
 setup_compress_buffer (SocketWS_T ws, size_t input_len, size_t *buf_size)
 {
@@ -568,20 +581,11 @@ setup_deflate_stream (SocketWS_T ws, z_stream *strm, const unsigned char *input,
                       size_t output_size)
 {
   /* Check for overflow before casting size_t to uInt (zlib limitation) */
-  if (input_len > UINT_MAX)
-    {
-      ws_set_error (ws, WS_ERROR_COMPRESSION,
-                    "Input size %zu exceeds zlib limit %u", input_len,
-                    UINT_MAX);
-      return -1;
-    }
-  if (output_size > UINT_MAX)
-    {
-      ws_set_error (ws, WS_ERROR_COMPRESSION,
-                    "Buffer size %zu exceeds zlib limit %u", output_size,
-                    UINT_MAX);
-      return -1;
-    }
+  if (check_zlib_size_limit (ws, input_len, "Input") < 0)
+    return -1;
+  if (check_zlib_size_limit (ws, output_size, "Buffer") < 0)
+    return -1;
+
   strm->next_in = (Bytef *)input;
   strm->avail_in = (uInt)input_len;
   strm->next_out = output;
@@ -674,20 +678,11 @@ ws_decompress_message (SocketWS_T ws, const unsigned char *input,
 
   /* Set up zlib stream */
   /* Check for overflow before casting size_t to uInt (zlib limitation, issue #566) */
-  if (input_with_trailer_len > UINT_MAX)
-    {
-      ws_set_error (ws, WS_ERROR_COMPRESSION,
-                    "Input size %zu exceeds zlib limit %u",
-                    input_with_trailer_len, UINT_MAX);
-      return -1;
-    }
-  if (buf_size > UINT_MAX)
-    {
-      ws_set_error (ws, WS_ERROR_COMPRESSION,
-                    "Buffer size %zu exceeds zlib limit %u", buf_size,
-                    UINT_MAX);
-      return -1;
-    }
+  if (check_zlib_size_limit (ws, input_with_trailer_len, "Input") < 0)
+    return -1;
+  if (check_zlib_size_limit (ws, buf_size, "Buffer") < 0)
+    return -1;
+
   setup_inflate_stream (strm, input_with_trailer, input_with_trailer_len,
                        buf, buf_size);
 


### PR DESCRIPTION
## Summary

Implements #2349 by extracting duplicate UINT_MAX validation logic into a helper function.

## Changes

- Add static helper function `check_zlib_size_limit()` that validates size against UINT_MAX and sets appropriate error messages
- Replace duplicate validation blocks in `setup_deflate_stream()` with calls to helper function
- Replace duplicate validation blocks in `ws_decompress_message()` with calls to helper function

## Benefits

- **Maintainability**: Single source of truth for zlib size validation
- **Consistency**: Guaranteed identical error messages across call sites  
- **Extensibility**: Easy to add logging or metrics in one place

## Test Plan

- [x] Built successfully with sanitizers enabled
- [x] All WebSocket tests pass (`test_websocket` - 24/24 tests)
- [x] All WebSocket integration tests pass (`test_ws_integration` - 6/6 tests)
- [x] Code compiles without warnings
- [x] No behavior changes - purely refactoring

Closes #2349