### PR TITLE
fix(simple-timer): add missing error clear in unsupported functions

### DIFF
--- a/src/simple/SocketSimple-timer.c
+++ b/src/simple/SocketSimple-timer.c
@@ -377,6 +377,8 @@ int
 Socket_simple_timer_cancel_all (SocketSimple_Poll_T poll
                                  __attribute__ ((unused)))
 {
+  Socket_simple_clear_error ();
+
   /* Not currently supported - timers must be cancelled individually. */
   simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
                     "Cancel all timers not supported");
@@ -390,6 +392,8 @@ Socket_simple_timer_cancel_all (SocketSimple_Poll_T poll
 int
 Socket_simple_timer_count (SocketSimple_Poll_T poll __attribute__ ((unused)))
 {
+  Socket_simple_clear_error ();
+
   /* Timer count not available from core API. */
   simple_set_error (SOCKET_SIMPLE_ERR_UNSUPPORTED,
                     "Timer count not supported");


### PR DESCRIPTION
## Summary

Fixes #2300

Adds missing `Socket_simple_clear_error()` calls to two functions that were breaking API consistency:
- `Socket_simple_timer_cancel_all()`
- `Socket_simple_timer_count()`

## Changes

Both functions now clear previous error state before setting their own error, consistent with all other public functions in SocketSimple-timer.c:
- `Socket_simple_timer_add()` (line 89)
- `Socket_simple_timer_cancel()` (line 175)
- `Socket_simple_timer_reschedule()` (line 213)
- `Socket_simple_timer_pause()` (line 249)
- `Socket_simple_timer_resume()` (line 285)

## Test Plan

- [x] Library builds successfully with sanitizers
- [x] All core tests pass (test_socket, test_timer, test_arena, test_except)
- [x] No existing tests exercise these functions (they return UNSUPPORTED)
- [x] Change is minimal and follows established pattern

Closes #2300