### PR TITLE
refactor(simple-timer): remove unnecessary volatile qualifier

### DIFF
--- a/src/simple/SocketSimple-timer.c
+++ b/src/simple/SocketSimple-timer.c
@@ -84,8 +84,6 @@ timer_add_common (SocketSimple_Poll_T poll, int64_t time_ms,
                   int allow_zero, const char *time_error_msg,
                   TimerCreateFn create_fn, const char *fail_msg)
 {
-  volatile SocketTimer_T core_timer = NULL;
-
   Socket_simple_clear_error ();
 
   if (!poll)
@@ -128,9 +126,8 @@ timer_add_common (SocketSimple_Poll_T poll, int64_t time_ms,
 
   TRY
   {
-    core_timer
+    handle->core_timer
         = create_fn (core_poll, time_ms, timer_callback_wrapper, handle);
-    handle->core_timer = core_timer;
   }
   EXCEPT (SocketTimer_Failed)
   {


### PR DESCRIPTION
## Summary

Implements #2322 by removing the unnecessary `volatile` qualifier from the `core_timer` variable in `timer_add_common` function.

## Changes

- Removed `volatile SocketTimer_T core_timer = NULL;` declaration
- Simplified code to directly assign result to `handle->core_timer` instead of using intermediate variable
- No behavior change - purely a refactoring for code clarity

## Analysis

Per CLAUDE.md exception safety guidelines:
> Use `volatile` for variables modified inside TRY that are read after exception

The `core_timer` variable violated this guideline:
- ✅ Assigned inside TRY block
- ✅ Used inside TRY block  
- ❌ NOT read in EXCEPT block
- ❌ NOT read after END_TRY

The value is only needed if the TRY succeeds, and it's immediately stored in `handle->core_timer`. If an exception occurs, we never read `core_timer` again, so `volatile` provides no benefit.

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All timer tests pass (23/23)
- [x] No memory leaks detected with ASAN
- [x] Code compiles cleanly with no warnings

## File Modified

- `src/simple/SocketSimple-timer.c` - lines 87-133

Closes #2322