### PR TITLE
fix(proxy): add defensive bounds checks in SOCKS4/4a request building

### DIFF
--- a/src/socket/SocketProxy-socks4.c
+++ b/src/socket/SocketProxy-socks4.c
@@ -244,9 +244,21 @@ proxy_socks4_send_connect (struct SocketProxy_Conn_T *conn)
     }
 
   /* Write header: version + command + port */
+  if (len + 4 > sizeof (conn->send_buf))
+    {
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             "SOCKS4 request too large");
+      return -1;
+    }
   len += socks4_write_header (buf + len, conn->target_port);
 
   /* Write destination IP (network byte order) */
+  if (len + 4 > sizeof (conn->send_buf))
+    {
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             "SOCKS4 request too large");
+      return -1;
+    }
   memcpy (buf + len, &ipv4, 4);
   len += 4;
 
@@ -308,9 +320,21 @@ proxy_socks4a_send_connect (struct SocketProxy_Conn_T *conn)
   /* Additional validation (UTF-8, etc.) already performed in socks4_validate_inputs() */
 
   /* Write header: version + command + port */
+  if (len + 4 > sizeof (conn->send_buf))
+    {
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             "SOCKS4a request too large");
+      return -1;
+    }
   len += socks4_write_header (buf + len, conn->target_port);
 
   /* Write SOCKS4a marker IP: 0.0.0.1 signals hostname follows */
+  if (len + 4 > sizeof (conn->send_buf))
+    {
+      socketproxy_set_error (conn, PROXY_ERROR_PROTOCOL,
+                             "SOCKS4a request too large");
+      return -1;
+    }
   memcpy (buf + len, SOCKS4A_MARKER_IP, 4);
   len += 4;
 


### PR DESCRIPTION
## Summary

Implements #2337 by adding defensive bounds checks before buffer write operations in SOCKS4/4a proxy request building.

## Changes

- Added bounds check before `socks4_write_header()` call in `proxy_socks4_send_connect()` (4 bytes)
- Added bounds check before IPv4 address `memcpy()` in `proxy_socks4_send_connect()` (4 bytes)
- Added bounds check before `socks4_write_header()` call in `proxy_socks4a_send_connect()` (4 bytes)
- Added bounds check before SOCKS4a marker IP `memcpy()` in `proxy_socks4a_send_connect()` (4 bytes)

All checks follow the existing pattern at line 329 for hostname validation and use consistent error messages.

## Risk Assessment

**Current Risk**: NONE - The buffer size (65536 bytes) is over 100x larger than the maximum SOCKS4a request (~521 bytes)

**Benefit**: Defensive programming - prevents future regressions if `SOCKET_PROXY_BUFFER_SIZE` is ever reduced below safe thresholds

## Test Plan

- [x] All proxy tests pass with sanitizers enabled (`test_proxy`: 84/84 passed)
- [x] Proxy integration tests pass (`test_proxy_integration`: 5/5 passed)
- [x] No memory leaks detected (ASan clean)
- [x] No undefined behavior detected (UBSan clean)

Closes #2337