### PR TITLE
refactor(tls): deduplicate OCSP parsing in get_ocsp_next_update

### DIFF
--- a/src/tls/SocketTLS.c
+++ b/src/tls/SocketTLS.c
@@ -2309,28 +2309,10 @@ SocketTLS_get_ocsp_next_update (Socket_T socket, time_t *next_update)
     return -1;
 
 #if !defined(OPENSSL_NO_OCSP)
-  const unsigned char *ocsp_resp;
-  long ocsp_len = SSL_get_tlsext_status_ocsp_resp (ssl, &ocsp_resp);
-
-  if (ocsp_len <= 0 || !ocsp_resp)
-    return -1;
-
-  OCSP_RESPONSE *resp = d2i_OCSP_RESPONSE (NULL, &ocsp_resp, ocsp_len);
-  if (!resp)
-    return -1;
-
-  if (OCSP_response_status (resp) != OCSP_RESPONSE_STATUS_SUCCESSFUL)
-    {
-      OCSP_RESPONSE_free (resp);
-      return -1;
-    }
-
-  OCSP_BASICRESP *basic = OCSP_response_get1_basic (resp);
+  /* Reuse existing OCSP response parser */
+  OCSP_BASICRESP *basic = ocsp_parse_response (ssl);
   if (!basic)
-    {
-      OCSP_RESPONSE_free (resp);
-      return -1;
-    }
+    return -1;
 
   int result = -1;
   int resp_count = OCSP_resp_count (basic);
@@ -2357,7 +2339,6 @@ SocketTLS_get_ocsp_next_update (Socket_T socket, time_t *next_update)
     }
 
   OCSP_BASICRESP_free (basic);
-  OCSP_RESPONSE_free (resp);
 
   return result;
 #else


### PR DESCRIPTION
## Summary

Implements #2365

Refactored `SocketTLS_get_ocsp_next_update()` to reuse the existing `ocsp_parse_response()` helper function instead of duplicating OCSP response parsing logic.

## Changes

- Replaced manual OCSP parsing code with call to `ocsp_parse_response()`
- Removed duplicate calls to `SSL_get_tlsext_status_ocsp_resp()`, `d2i_OCSP_RESPONSE()`, `OCSP_response_status()`, and `OCSP_response_get1_basic()`
- Eliminated ~20 lines of duplicated code
- Function reduced from 68 lines to 48 lines

## Test Plan

- [x] Tests pass with sanitizers (`test_tls_ocsp` - 16/16 passed)
- [x] TLS integration tests pass (`test_tls_integration` - 44/44 passed)
- [x] No behavior change - only code deduplication
- [x] OCSP next_update extraction still works correctly

Closes #2365