### PR TITLE
perf(simple-http): use SocketHTTP_Headers_get_n with STRLEN_LIT for header lookups

### DIFF
--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -25,6 +25,9 @@
 #define SOCKET_SIMPLE_DEFAULT_MAX_REDIRECTS 5
 #define SOCKET_SIMPLE_MAX_HEADER_NAME_LEN 256
 
+/* Performance: Compile-time string length for header lookups */
+#define STRLEN_LIT(s) (sizeof(s) - 1)
+
 /* ============================================================================
  * Shared Global HTTP Client (Lazy Initialization)
  * ============================================================================
@@ -116,7 +119,8 @@ convert_response (SocketHTTPClient_Response *src,
     }
 
   /* Extract Content-Type header */
-  ct = SocketHTTP_Headers_get (src->headers, "Content-Type");
+  ct = SocketHTTP_Headers_get_n (src->headers, "Content-Type",
+                                  STRLEN_LIT ("Content-Type"));
   if (ct)
     {
       dst->content_type = strdup (ct);
@@ -130,7 +134,8 @@ convert_response (SocketHTTPClient_Response *src,
     }
 
   /* Extract Location header */
-  loc = SocketHTTP_Headers_get (src->headers, "Location");
+  loc = SocketHTTP_Headers_get_n (src->headers, "Location",
+                                   STRLEN_LIT ("Location"));
   if (loc)
     {
       dst->location = strdup (loc);


### PR DESCRIPTION
## Summary

Implements #2293

This PR optimizes HTTP response header lookups in the Simple API by using compile-time string length calculation instead of runtime strlen() calls.

## Changes

- Add `STRLEN_LIT(s)` macro for compile-time string length: `(sizeof(s) - 1)`
- Replace `SocketHTTP_Headers_get()` with `SocketHTTP_Headers_get_n()` for "Content-Type" header
- Replace `SocketHTTP_Headers_get()` with `SocketHTTP_Headers_get_n()` for "Location" header

## Performance Impact

- Eliminates 2 runtime `strlen()` calls on every HTTP response conversion
- Follows CLAUDE.md performance best practices for hot path optimization
- Zero functional change - purely a performance optimization

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] HTTP core tests pass
- [x] No functional changes - existing tests validate correctness
- [x] Performance improvement verified: compile-time vs runtime length calculation

Closes #2293