### PR TITLE
fix(simple): add error handling for calloc failure in Socket_simple_reconnect_get_socket

### DIFF
--- a/src/simple/SocketSimple-reconnect.c
+++ b/src/simple/SocketSimple-reconnect.c
@@ -464,7 +464,11 @@ Socket_simple_reconnect_get_socket (SocketSimple_Reconnect_T conn)
     {
       conn->simple_socket = calloc (1, sizeof (struct SocketSimple_Socket));
       if (!conn->simple_socket)
-        return NULL;
+        {
+          simple_set_error (SOCKET_SIMPLE_ERR_MEMORY,
+                            "Failed to allocate socket wrapper");
+          return NULL;
+        }
     }
 
   conn->simple_socket->socket = core_sock;


### PR DESCRIPTION
## Summary

Implements #2303

- Added `simple_set_error()` call on socket wrapper allocation failure
- Uses `SOCKET_SIMPLE_ERR_MEMORY` error code for consistency
- Maintains Simple API contract that errors are retrievable via `Socket_simple_error()`

## Changes

- Modified `Socket_simple_reconnect_get_socket()` in `src/simple/SocketSimple-reconnect.c`
- Added error reporting before returning NULL on `calloc()` failure

## Test Plan

- [x] Tests pass with sanitizers (test_reconnect: 67 passed, 0 failed)
- [x] Code compiles without warnings
- [x] Follows existing Simple API error handling patterns
- [x] Change is minimal and focused on the issue

Closes #2303