### PR TITLE
refactor(tls): replace magic poll interval 100ms with named constant

### DIFF
--- a/src/tls/SocketTLS.c
+++ b/src/tls/SocketTLS.c
@@ -606,7 +606,7 @@ disable_handle_io_wait (Socket_T socket, SSL *ssl, int result, int64_t deadline)
     {
       /* Brief poll then retry */
       unsigned events = (err == SSL_ERROR_WANT_READ) ? POLL_READ : POLL_WRITE;
-      int poll_timeout = SocketTimeout_poll_timeout (100, deadline);
+      int poll_timeout = SocketTimeout_poll_timeout (SOCKET_TLS_POLL_INTERVAL_MS, deadline);
 
       if (poll_timeout > 0)
         {


### PR DESCRIPTION
## Summary

Implements #2353

Replaces hardcoded magic number `100` with `SOCKET_TLS_POLL_INTERVAL_MS` constant in TLS shutdown retry logic (`SocketTLS_disable()` function).

## Changes

- **File**: `src/tls/SocketTLS.c` (line 609)
- **Before**: `SocketTimeout_poll_timeout(100, deadline)`
- **After**: `SocketTimeout_poll_timeout(SOCKET_TLS_POLL_INTERVAL_MS, deadline)`

The constant `SOCKET_TLS_POLL_INTERVAL_MS` is defined in `include/tls/SocketTLSConfig.h` as 100ms and represents the standard poll interval for non-blocking TLS operations throughout the module.

## Test Plan

- [x] Built successfully with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] TLS integration tests pass (44/44 tests passed)
- [x] TLS phase4 tests pass (82/82 tests passed)
- [x] No functional changes - pure refactoring

Closes #2353