### PR TITLE
refactor(tls): extract prime-31 hash to reusable utility function

### DIFF
--- a/src/tls/SocketTLS-performance.c
+++ b/src/tls/SocketTLS-performance.c
@@ -637,7 +637,7 @@ static const HashTable_Config sharded_session_config = {
 /**
  * Select shard based on session ID hash using golden ratio multiplication
  *
- * Uses hash multiplier 31 (prime, as in Java's hashCode) followed by golden
+ * Uses socket_util_hash_bytes_prime31() (multiplier 31) followed by golden
  * ratio mixing. This differs from the DJB2 hash (multiplier 33) used elsewhere
  * because:
  * 1. Session IDs are random byte sequences, not ASCII strings (DJB2 optimized
@@ -653,11 +653,10 @@ static size_t
 select_shard (TLSSessionCacheSharded_T *cache, const unsigned char *session_id,
               size_t id_len)
 {
-  unsigned hash = 0;
-  for (size_t i = 0; i < id_len && i < 16; i++)
-    {
-      hash = hash * 31 + session_id[i];  /* Prime 31: (x << 5) - x */
-    }
+  /* Hash first 16 bytes of session ID using prime-31 hash */
+  unsigned hash = socket_util_hash_bytes_prime31 (session_id, id_len, 16);
+
+  /* Apply golden ratio mixing and mask to select shard */
   return (size_t)((hash * HASH_GOLDEN_RATIO) & cache->shard_mask);
 }
 


### PR DESCRIPTION
## Summary

Extracts the manual hash implementation from `select_shard()` into a reusable utility function `socket_util_hash_bytes_prime31()`, eliminating code duplication while preserving the original behavior.

## Changes

- **Added** `socket_util_hash_bytes_prime31()` to `include/core/SocketUtil.h` as a reusable hash utility
- **Refactored** `select_shard()` in `src/tls/SocketTLS-performance.c` to use the new function
- **Preserved** original algorithm: prime multiplier 31 + golden ratio mixing
- **Added** comprehensive documentation explaining why this differs from DJB2

## Key Design Decisions

The implementation uses **prime multiplier 31** (not DJB2's 33) intentionally because:
1. TLS session IDs are random byte sequences, not ASCII strings
2. Prime 31 allows compiler optimization: `31*x = (x << 5) - x`
3. Matches Java `hashCode()` convention for byte arrays
4. Better distribution for random data vs. text strings

## Testing

- Built successfully with `-DENABLE_SANITIZERS=ON -DENABLE_TLS=ON`
- All TLS performance tests pass (12/12)
- TLS integration tests pass
- No functional changes - behavior identical to original

## Benefits

- Reduces code duplication (follows DRY principle)
- Makes hash algorithm reusable for similar use cases
- Improves code maintainability
- Clarifies design rationale through documentation

Closes #2339