### PR TITLE
refactor(simple-ws): define constants for WebSocket frame/message size limits

### DIFF
--- a/src/simple/SocketSimple-internal.h
+++ b/src/simple/SocketSimple-internal.h
@@ -87,6 +87,22 @@ struct SocketSimple_WS
  */
 #define SOCKET_SIMPLE_DEFAULT_BACKLOG 128
 
+/**
+ * @brief Default maximum WebSocket frame size (16MB).
+ *
+ * Used by Socket_simple_ws_server_config_init() to initialize the default
+ * max_frame_size in SocketSimple_WSServerConfig.
+ */
+#define SOCKET_SIMPLE_WS_DEFAULT_MAX_FRAME_SIZE (16 * 1024 * 1024)
+
+/**
+ * @brief Default maximum WebSocket message size (64MB).
+ *
+ * Used by Socket_simple_ws_server_config_init() to initialize the default
+ * max_message_size in SocketSimple_WSServerConfig.
+ */
+#define SOCKET_SIMPLE_WS_DEFAULT_MAX_MESSAGE_SIZE (64 * 1024 * 1024)
+
 /* ============================================================================
  * Thread-Local Error State
  * ============================================================================

--- a/src/simple/SocketSimple-ws.c
+++ b/src/simple/SocketSimple-ws.c
@@ -464,8 +464,8 @@ Socket_simple_ws_server_config_init (SocketSimple_WSServerConfig *config)
   if (!config)
     return;
   memset (config, 0, sizeof (*config));
-  config->max_frame_size = 16 * 1024 * 1024;   /* 16MB */
-  config->max_message_size = 64 * 1024 * 1024; /* 64MB */
+  config->max_frame_size = SOCKET_SIMPLE_WS_DEFAULT_MAX_FRAME_SIZE;
+  config->max_message_size = SOCKET_SIMPLE_WS_DEFAULT_MAX_MESSAGE_SIZE;
   config->validate_utf8 = 1;
   config->enable_compression = 0;
   config->ping_interval_ms = 0;


### PR DESCRIPTION
## Summary

Implements #2314 by replacing magic numbers with named constants for WebSocket default size limits.

## Changes

- Added `SOCKET_SIMPLE_WS_DEFAULT_MAX_FRAME_SIZE` (16MB) to `src/simple/SocketSimple-internal.h`
- Added `SOCKET_SIMPLE_WS_DEFAULT_MAX_MESSAGE_SIZE` (64MB) to `src/simple/SocketSimple-internal.h`
- Updated `Socket_simple_ws_server_config_init()` to use the new constants instead of inline calculations

## Benefits

- Self-documenting code - the constant names clearly indicate their purpose
- Single source of truth for default WebSocket limits
- Easier to adjust limits across the codebase in the future
- Follows C Anti-Patterns guidance from CLAUDE.md (avoiding magic numbers)

## Test Plan

- [x] Code compiles successfully
- [x] WebSocket tests pass (`test_websocket`)
- [x] Constants evaluate to correct values (verified with standalone test)
- [x] No functional changes - purely refactoring

Closes #2314