### PR TITLE
refactor(tls): replace magic timeout 1000ms with named constant

### DIFF
--- a/include/tls/SocketTLSConfig.h
+++ b/include/tls/SocketTLSConfig.h
@@ -603,6 +603,37 @@ extern void SocketTLS_config_defaults (SocketTLSConfig_T *config);
 #endif
 
 /**
+ * @brief Minimum TLS shutdown timeout for best-effort shutdown operations
+ * @ingroup tls_config
+ *
+ * Minimum timeout (in milliseconds) enforced for TLS shutdown operations to
+ * ensure a reasonable grace period even when the default timeout is reduced.
+ * Used by SocketTLS_disable() when computing best-effort shutdown timeout.
+ *
+ * ## Rationale for 1000ms (1 second)
+ *
+ * - **Protocol compliance**: Allows time for bidirectional close_notify exchange
+ * - **Network variance**: Accommodates typical RTT + processing time
+ * - **Graceful degradation**: Prevents premature connection termination
+ * - **Resource cleanup**: Ensures peer has reasonable time to acknowledge
+ *
+ * ## Override Example
+ *
+ * @code{.c}
+ * // Aggressive timeout for high-churn servers (500ms)
+ * #define SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS 500
+ * @endcode
+ *
+ * @note This is a lower bound; actual timeout may be higher based on
+ *       SOCKET_TLS_DEFAULT_SHUTDOWN_TIMEOUT_MS.
+ * @see SocketTLS_disable() for best-effort shutdown implementation.
+ * @see SOCKET_TLS_DEFAULT_SHUTDOWN_TIMEOUT_MS for default timeout.
+ */
+#ifndef SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS
+#define SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS 1000 /* 1 second */
+#endif
+
+/**
  * @brief TLS handshake poll interval for non-blocking operations
  * @ingroup tls_config
  *

--- a/src/tls/SocketTLS.c
+++ b/src/tls/SocketTLS.c
@@ -529,15 +529,15 @@ do_handshake_poll (Socket_T socket, unsigned events, int timeout_ms)
 /**
  * disable_compute_shutdown_timeout - Calculate timeout for best-effort shutdown
  *
- * Returns: Timeout in milliseconds (minimum 1 second)
+ * Returns: Timeout in milliseconds (minimum SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS)
  * Thread-safe: Yes
  */
 static int
 disable_compute_shutdown_timeout (void)
 {
   int timeout_ms = SOCKET_TLS_DEFAULT_SHUTDOWN_TIMEOUT_MS / 4;
-  if (timeout_ms < 1000)
-    timeout_ms = 1000; /* Minimum 1 second for disable */
+  if (timeout_ms < SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS)
+    timeout_ms = SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS;
   return timeout_ms;
 }
 


### PR DESCRIPTION
## Summary

Implements #2352 - Replaces hardcoded magic number `1000` (1 second in milliseconds) in `SocketTLS_disable()` with a named constant `SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS` for improved code maintainability.

## Changes

- **Added constant**: `SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS` in `include/tls/SocketTLSConfig.h`
  - Value: 1000ms (1 second)
  - Comprehensive documentation with rationale and override examples
  - Follows existing pattern of other TLS timeout constants in the file
  
- **Updated code**: `src/tls/SocketTLS.c`
  - Replaced magic number `1000` with `SOCKET_TLS_MIN_SHUTDOWN_TIMEOUT_MS` in `disable_compute_shutdown_timeout()`
  - Updated function documentation to reference the constant
  - No functional changes - purely a refactoring improvement

## Impact

- **Category**: Code quality / Refactoring
- **Severity**: LOW
- **Breaking changes**: None
- **Compatibility**: Fully backward compatible

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] SocketTLS.c module builds without errors
- [x] Constant is properly defined and accessible through existing includes
- [x] No functional changes - behavior remains identical

## Documentation

The new constant includes comprehensive documentation explaining:
- Purpose and usage context
- Rationale for the 1-second minimum timeout
- Override examples for different use cases
- Cross-references to related functions and constants

Closes #2352