### PR TITLE
refactor(http2): replace magic number 4 with named constant in PRIORITY_UPDATE handling

### DIFF
--- a/src/http/SocketHTTP2-priority.c
+++ b/src/http/SocketHTTP2-priority.c
@@ -30,6 +30,9 @@
 /* PRIORITY_UPDATE frame minimum payload size: 4 bytes for stream ID */
 #define PRIORITY_UPDATE_MIN_PAYLOAD_SIZE 4
 
+/* Stream ID size in PRIORITY_UPDATE payload (always 4 bytes) */
+#define PRIORITY_UPDATE_STREAM_ID_SIZE 4
+
 void
 SocketHTTP2_Priority_init (SocketHTTP2_Priority *priority)
 {
@@ -390,7 +393,7 @@ SocketHTTP2_send_priority_update (SocketHTTP2_Conn_T conn, uint32_t stream_id,
     return -1;
 
   /* Build payload: Prioritized Stream ID (4 bytes) + Priority Field Value */
-  payload_len = 4 + (size_t)priority_len;
+  payload_len = PRIORITY_UPDATE_STREAM_ID_SIZE + (size_t)priority_len;
   if (payload_len > sizeof (payload))
     return -1;
 
@@ -399,7 +402,7 @@ SocketHTTP2_send_priority_update (SocketHTTP2_Conn_T conn, uint32_t stream_id,
 
   /* Copy priority field value */
   if (priority_len > 0)
-    memcpy (payload + 4, priority_field, (size_t)priority_len);
+    memcpy (payload + PRIORITY_UPDATE_STREAM_ID_SIZE, priority_field, (size_t)priority_len);
 
   /* Build frame header */
   header.length = (uint32_t)payload_len;
@@ -472,8 +475,8 @@ http2_process_priority_update (SocketHTTP2_Conn_T conn,
   SocketHTTP2_Priority_init (&priority);
   if (header->length > PRIORITY_UPDATE_MIN_PAYLOAD_SIZE)
     {
-      const char *priority_value = (const char *)(payload + 4);
-      size_t priority_len = header->length - 4;
+      const char *priority_value = (const char *)(payload + PRIORITY_UPDATE_STREAM_ID_SIZE);
+      size_t priority_len = header->length - PRIORITY_UPDATE_STREAM_ID_SIZE;
 
       if (SocketHTTP2_Priority_parse (priority_value, priority_len, &priority)
           < 0)


### PR DESCRIPTION
## Summary

Implements #2350 by replacing hardcoded magic number `4` with a semantically meaningful named constant `PRIORITY_UPDATE_STREAM_ID_SIZE` in PRIORITY_UPDATE frame handling.

## Changes

- **Added** `PRIORITY_UPDATE_STREAM_ID_SIZE` constant (value: 4) in `src/http/SocketHTTP2-priority.c`
- **Replaced** magic number `4` in four locations:
  - Line 396: payload length calculation
  - Line 405: memcpy offset for priority field
  - Line 478: priority value pointer offset
  - Line 479: priority length calculation

## Rationale

While `PRIORITY_UPDATE_MIN_PAYLOAD_SIZE` was already defined as `4`, its semantic meaning is "minimum payload size", not "stream ID size". The new constant makes the code self-documenting and clarifies that these offsets represent the 4-byte stream ID that precedes the priority field in PRIORITY_UPDATE frames (RFC 9218).

## Test Plan

- [x] All existing HTTP/2 priority tests pass with sanitizers
- [x] Built successfully with `-DENABLE_SANITIZERS=ON`
- [x] Ran `test_http2_priority` with ASan/UBSan (14/14 tests passed)
- [x] No functional changes, refactoring only

Closes #2350