### PR TITLE
refactor(simple-pool): define named constant for default max connections

### DIFF
--- a/src/simple/SocketSimple-pool.c
+++ b/src/simple/SocketSimple-pool.c
@@ -21,6 +21,7 @@
  */
 
 #define SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE 4096
+#define SOCKET_SIMPLE_DEFAULT_MAX_CONNECTIONS 1024
 
 /**
  * @brief Convert milliseconds to seconds, rounding up.
@@ -78,7 +79,7 @@ Socket_simple_pool_options_init (SocketSimple_PoolOptions *opts)
   if (!opts)
     return;
 
-  opts->max_connections = 1024;
+  opts->max_connections = SOCKET_SIMPLE_DEFAULT_MAX_CONNECTIONS;
   opts->buffer_size = SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE;
   opts->idle_timeout_ms = 0;
   opts->conn_rate_limit = 0;


### PR DESCRIPTION
## Summary

Implements #2370

## Changes

- Added `SOCKET_SIMPLE_DEFAULT_MAX_CONNECTIONS` constant (value: 1024)
- Replaced magic number `1024` with the named constant in `Socket_simple_pool_options_init()`
- Improves consistency with existing pattern (`SOCKET_SIMPLE_DEFAULT_BUFFER_SIZE`)

## Test Plan

- [x] Code compiles successfully with sanitizers enabled
- [x] No behavioral changes - purely refactoring
- [x] Maintains consistency with existing code patterns

Closes #2370