### PR TITLE
refactor(simple-proxy): add clarifying comment for PROXY_ERROR usage

### DIFF
--- a/src/simple/SocketSimple-proxy.c
+++ b/src/simple/SocketSimple-proxy.c
@@ -526,6 +526,8 @@ Socket_simple_proxy_connect_timeout (const SocketSimple_ProxyConfig *config,
   TRY { sock = SocketProxy_connect (&core_config, target_host, target_port); }
   EXCEPT (SocketProxy_Failed)
   {
+    /* Use generic PROXY_ERROR since specific SocketProxy_Result is not
+     * available in this exception handler - only the exception itself */
     set_proxy_error (PROXY_ERROR, "Proxy connection failed");
     if (sock)
       Socket_free ((Socket_T *)&sock);


### PR DESCRIPTION
## Summary

Implements #2368

Adds a clarifying comment to explain why the generic `PROXY_ERROR` constant is used in the `SocketProxy_Failed` exception handler at line 531 (previously 468).

## Changes

- Added inline comment explaining that `PROXY_ERROR` is used because specific `SocketProxy_Result` codes are not available in the exception handler
- No functional changes - purely documentation/clarity improvement

## Context

The issue identified that while `PROXY_ERROR` is correctly used as a generic fallback error, the name doesn't clearly convey its "generic/unspecified" nature. Since renaming would be a breaking change and the code is functionally correct, a clarifying comment is the best approach.

The comment makes explicit that:
1. Only the exception itself is available in this handler
2. Specific error codes require access to the `SocketProxy_Result` value
3. This is intentional use of the generic error constant

## Test Plan

- [x] Built successfully with sanitizers enabled
- [x] All 84 proxy unit tests pass
- [x] All 5 proxy integration tests pass
- [x] No functional changes to test - only added documentation comment

Closes #2368