### PR TITLE
refactor(http2-priority): remove redundant bounds check for urgency value

### DIFF
--- a/src/http/SocketHTTP2-priority.c
+++ b/src/http/SocketHTTP2-priority.c
@@ -214,13 +214,7 @@ SocketHTTP2_Priority_parse (const char *value, size_t len,
               return -1;
             }
 
-          if (urgency < 0 || urgency > SOCKETHTTP2_PRIORITY_MAX_URGENCY)
-            {
-              SOCKET_LOG_DEBUG_MSG (
-                  "Priority parse error: u=%d out of range [0-7]", urgency);
-              return -1;
-            }
-
+          /* Note: urgency bounds already validated in parsing loop above (line 196) */
           priority->urgency = (uint8_t)urgency;
           found_urgency = 1;
         }


### PR DESCRIPTION
## Summary

Implements #2376

Removed redundant bounds check for the urgency value in HTTP/2 priority parsing that was unreachable due to earlier validation in the parsing loop.

## Changes

- Removed redundant `if (urgency < 0 || urgency > SOCKETHTTP2_PRIORITY_MAX_URGENCY)` check at line 217
- Added explanatory comment referencing the actual validation location (line 196)

## Analysis

The removed check was redundant because:
1. **`urgency < 0` is dead code**: The variable is initialized to 0 and only incremented via `urgency = urgency * 10 + digit` where digit is 0-9, so it can never become negative
2. **`urgency > SOCKETHTTP2_PRIORITY_MAX_URGENCY` is already checked**: The parsing loop contains an early bounds check at line 196 that returns -1 if this condition is met

## Test Plan

- [x] HTTP2 priority tests pass: `test_http2_priority` (14/14 tests)
- [x] General HTTP2 tests pass: `test_http2` (29/29 tests)  
- [x] Tests pass with ASan/UBSan enabled
- [x] No functional changes - purely code cleanup

Closes #2376