### PR TITLE
refactor(dns-cookie): extract big-endian serialization helper

### DIFF
--- a/src/dns/SocketDNSCookie.c
+++ b/src/dns/SocketDNSCookie.c
@@ -13,6 +13,7 @@
 #include "dns/SocketDNSWire.h"
 #include "core/Arena.h"
 #include "core/SocketCrypto.h"
+#include "core/SocketUtil.h"
 #include <arpa/inet.h>
 #include <string.h>
 #include <sys/random.h>
@@ -804,15 +805,8 @@ generate_client_cookie_fnv (T cache, const struct sockaddr *server_addr,
       hash *= prime;
     }
 
-  /* Store as big-endian */
-  cookie[0] = (hash >> 56) & 0xFF;
-  cookie[1] = (hash >> 48) & 0xFF;
-  cookie[2] = (hash >> 40) & 0xFF;
-  cookie[3] = (hash >> 32) & 0xFF;
-  cookie[4] = (hash >> 24) & 0xFF;
-  cookie[5] = (hash >> 16) & 0xFF;
-  cookie[6] = (hash >> 8) & 0xFF;
-  cookie[7] = hash & 0xFF;
+  /* Store as big-endian using centralized helper */
+  socket_util_pack_be64 (cookie, hash);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Implements #1882

Replaces manual 8-line big-endian serialization in `generate_client_cookie_fnv()` with the existing `socket_util_pack_be64()` helper function.

## Changes

- Added `#include "core/SocketUtil.h"` to SocketDNSCookie.c
- Replaced 8 manual shift operations with single `socket_util_pack_be64()` call
- Updated comment to indicate use of centralized helper

## Benefits

- **Reduced code duplication**: 8 lines → 1 line
- **More maintainable**: Changes to endian handling happen in one place
- **Less error-prone**: No magic shift values to maintain
- **Consistent pattern**: Uses same helper as other network protocols (DNS, HTTP/2, QUIC)

## Test Plan

- [x] DNS cookie tests pass with sanitizers (`test_dnscookie`: 23/23 passed)
- [x] Module compiles without warnings
- [x] No functional changes - purely refactoring

## Technical Details

The `socket_util_pack_be64()` helper (from SocketUtil.h line 1450) performs the exact same big-endian serialization:

```c
static inline void
socket_util_pack_be64 (unsigned char *p, uint64_t v)
{
  p[0] = (unsigned char)((v >> 56) & 0xFF);
  p[1] = (unsigned char)((v >> 48) & 0xFF);
  p[2] = (unsigned char)((v >> 40) & 0xFF);
  p[3] = (unsigned char)((v >> 32) & 0xFF);
  p[4] = (unsigned char)((v >> 24) & 0xFF);
  p[5] = (unsigned char)((v >> 16) & 0xFF);
  p[6] = (unsigned char)((v >> 8) & 0xFF);
  p[7] = (unsigned char)(v & 0xFF);
}
```

This is the standard pattern already used throughout the codebase for network byte order serialization.

Closes #1882