### PR TITLE
fix(quic): use socket_util_safe_add_u64() for overflow checking in handshake

### DIFF
--- a/src/quic/SocketQUICHandshake.c
+++ b/src/quic/SocketQUICHandshake.c
@@ -86,12 +86,12 @@ crypto_stream_insert_data(Arena_T arena, SocketQUICCryptoStream_T *stream,
   /* If contiguous with recv_offset, copy directly */
   if (offset == stream->recv_offset) {
     /* Check for overflow before updating recv_offset */
-    if (stream->recv_offset > UINT64_MAX - length) {
-      return QUIC_HANDSHAKE_ERROR_BUFFER;
+    uint64_t total_offset;
+    if (!socket_util_safe_add_u64(stream->recv_offset, length, &total_offset)) {
+      return QUIC_HANDSHAKE_ERROR_BUFFER;  /* Overflow would occur */
     }
 
     if (stream->recv_buffer) {
-      uint64_t total_offset = stream->recv_offset + length;
       if (total_offset > stream->recv_buffer_size) {
         return QUIC_HANDSHAKE_ERROR_BUFFER;
       }


### PR DESCRIPTION
## Summary

Implements #2276 by using the centralized `socket_util_safe_add_u64()` function instead of inline overflow checking in `SocketQUICHandshake.c`.

## Changes

- **File:** `src/quic/SocketQUICHandshake.c`
- **Function:** `crypto_stream_insert_data()`
- **Line:** 89-92 (previously 89-94)

Replaced inline overflow check:
```c
if (stream->recv_offset > UINT64_MAX - length) {
  return QUIC_HANDSHAKE_ERROR_BUFFER;
}
uint64_t total_offset = stream->recv_offset + length;
```

With centralized safe arithmetic function:
```c
uint64_t total_offset;
if (!socket_util_safe_add_u64(stream->recv_offset, length, &total_offset)) {
  return QUIC_HANDSHAKE_ERROR_BUFFER;  /* Overflow would occur */
}
```

## Benefits

1. **Consistency:** Uses the project's standard pattern for overflow detection
2. **Maintainability:** Single source of truth for safe arithmetic
3. **Security:** Centralized implementation is easier to audit

## Test Plan

- [x] All QUIC tests pass (26/26) with sanitizers enabled
- [x] `test_quic_handshake` passes all 9 test cases
- [x] No new ASan/UBSan warnings
- [x] Build completes successfully with `-DENABLE_SANITIZERS=ON`

## Notes

The function `socket_util_safe_add_u64()` is already defined in `include/core/SocketUtil.h` (lines 1929-1936), so no new code was needed - just consistent usage.

Closes #2276