### PR TITLE
refactor(dns): extract helper from SocketDNS_rdata_parse_soa

### DIFF
--- a/src/dns/SocketDNSWire.c
+++ b/src/dns/SocketDNSWire.c
@@ -912,6 +912,27 @@ SocketDNS_rdata_parse_cname (const unsigned char *msg, size_t msglen,
  * full message context for resolution.
  */
 
+/*
+ * Parse SOA fixed 32-bit fields (SERIAL, REFRESH, RETRY, EXPIRE, MINIMUM)
+ *
+ * Extracts the five fixed-size fields from SOA RDATA, starting at the
+ * specified offset. All fields are 32-bit values in network byte order.
+ */
+static void
+parse_soa_fixed_fields (const unsigned char *msg, size_t offset,
+                        SocketDNS_SOA *soa)
+{
+  soa->serial = dns_unpack_be32 (msg + offset);
+  offset += 4;
+  soa->refresh = dns_unpack_be32 (msg + offset);
+  offset += 4;
+  soa->retry = dns_unpack_be32 (msg + offset);
+  offset += 4;
+  soa->expire = dns_unpack_be32 (msg + offset);
+  offset += 4;
+  soa->minimum = dns_unpack_be32 (msg + offset);
+}
+
 int
 SocketDNS_rdata_parse_soa (const unsigned char *msg, size_t msglen,
                            const SocketDNS_RR *rr, SocketDNS_SOA *soa)
@@ -963,24 +984,8 @@ SocketDNS_rdata_parse_soa (const unsigned char *msg, size_t msglen,
   if (offset + DNS_SOA_FIXED_SIZE > msglen)
     return -1;
 
-  /* Extract SERIAL (32-bit, network byte order) */
-  soa->serial = dns_unpack_be32(msg + offset);
-  offset += 4;
-
-  /* Extract REFRESH (32-bit, network byte order) */
-  soa->refresh = dns_unpack_be32(msg + offset);
-  offset += 4;
-
-  /* Extract RETRY (32-bit, network byte order) */
-  soa->retry = dns_unpack_be32(msg + offset);
-  offset += 4;
-
-  /* Extract EXPIRE (32-bit, network byte order) */
-  soa->expire = dns_unpack_be32(msg + offset);
-  offset += 4;
-
-  /* Extract MINIMUM (32-bit, network byte order) */
-  soa->minimum = dns_unpack_be32(msg + offset);
+  /* Parse the five 32-bit fixed fields */
+  parse_soa_fixed_fields (msg, offset, soa);
 
   return 0;
 }


### PR DESCRIPTION
## Summary

Implements #1860 by extracting a helper function for parsing the fixed 32-bit fields from SOA RDATA.

## Changes

- Extracted `parse_soa_fixed_fields()` static helper function
- Parses SERIAL, REFRESH, RETRY, EXPIRE, and MINIMUM fields
- Main function reduced from 72 to 56 lines (closer to 50-line guideline)

## Benefits

- Separates variable-length parsing (domain names) from fixed-length parsing (32-bit fields)
- Improves code readability and structure
- Makes the SOA parsing logic clearer

## Test Plan

- [x] DNS wire tests pass (`test_dns_wire`)
- [x] All DNS tests pass (except pre-existing failures)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - only refactoring

Closes #1860