### PR TITLE
fix(http): add missing httpclient_auth_clear_header implementation

### DIFF
--- a/src/http/SocketHTTPClient-auth.c
+++ b/src/http/SocketHTTPClient-auth.c
@@ -604,3 +604,10 @@ httpclient_auth_is_stale_nonce (const char *www_authenticate)
   parse_http_auth_params(www_authenticate, 0, check_stale_cb, &is_stale);
   return is_stale;
 }
+
+void
+httpclient_auth_clear_header (char *header, size_t header_size)
+{
+  if (header != NULL && header_size > 0)
+    SocketCrypto_secure_clear (header, header_size);
+}


### PR DESCRIPTION
## Summary
- Add missing `httpclient_auth_clear_header()` function implementation
- Function was declared in header but never defined, causing linker errors

## Problem
Build failed with:
```
undefined reference to `httpclient_auth_clear_header'
```

## Solution
Implement the function using `SocketCrypto_secure_clear()` to securely zero auth header buffers, preventing sensitive credentials from remaining in memory.

## Test plan
- [x] Build passes
- [x] All 127 tests pass