### PR TITLE
fix(dns): use SocketCommon_free_addrinfo in test_dns_queue_limit

### DIFF
--- a/include/dns/SocketDNS.h
+++ b/include/dns/SocketDNS.h
@@ -153,7 +153,8 @@ extern const Except_T SocketDNS_Failed;
  * the getaddrinfo() error code.
  *
  * OWNERSHIP: The callback receives ownership of the result addrinfo structure
- * and MUST call freeaddrinfo() when done with it.
+ * and MUST call SocketCommon_free_addrinfo() when done with it.
+ * Do NOT use freeaddrinfo() - it will cause memory leaks.
  *
  * THREAD SAFETY WARNING: Callbacks are invoked from DNS WORKER THREADS,
  * NOT from the application thread. The callback implementation MUST:
@@ -342,10 +343,16 @@ extern int SocketDNS_check (T dns);
  *
  * @param[in] dns Resolver owning the request.
  * @param[in] req Request handle.
- * @return addrinfo chain (caller must freeaddrinfo()) or NULL if pending/failed.
+ * @return addrinfo chain or NULL if pending/failed. Caller must free with
+ *         SocketCommon_free_addrinfo() (NOT freeaddrinfo()).
  * @threadsafe Yes.
  *
+ * @warning Do NOT use freeaddrinfo() on the returned result. The library
+ *          allocates ai_addr separately, requiring SocketCommon_free_addrinfo()
+ *          for proper cleanup. Using freeaddrinfo() will cause memory leaks.
+ *
  * @see SocketDNS_geterror() for error code on failure.
+ * @see SocketCommon_free_addrinfo() for freeing the result.
  */
 extern struct addrinfo *SocketDNS_getresult (T dns, Request_T req);
 

--- a/src/test/test_dns_queue_limit.c
+++ b/src/test/test_dns_queue_limit.c
@@ -10,6 +10,7 @@
  */
 
 #include "dns/SocketDNS.h"
+#include "socket/SocketCommon.h"
 #include "test/Test.h"
 
 #include <stdio.h>
@@ -94,21 +95,23 @@ TEST (dns_queue_limit_excludes_completed)
     req3 = SocketDNS_resolve (dns, "127.0.0.3", 80, NULL, NULL);
     ASSERT_NOT_NULL (req3);
 
-    /* Retrieve all results to clean up */
+    /* Retrieve all results to clean up.
+     * Must use SocketCommon_free_addrinfo, not freeaddrinfo, because
+     * the library allocates ai_addr separately with calloc. */
     result = SocketDNS_getresult (dns, req1);
     if (result)
       {
-        freeaddrinfo (result);
+        SocketCommon_free_addrinfo (result);
       }
     result = SocketDNS_getresult (dns, req2);
     if (result)
       {
-        freeaddrinfo (result);
+        SocketCommon_free_addrinfo (result);
       }
     result = SocketDNS_getresult (dns, req3);
     if (result)
       {
-        freeaddrinfo (result);
+        SocketCommon_free_addrinfo (result);
       }
   }
   FINALLY


### PR DESCRIPTION
## Summary
- Fix memory leak in test_dns_queue_limit by using SocketCommon_free_addrinfo() instead of freeaddrinfo()
- Update SocketDNS.h documentation to clarify proper cleanup for DNS results

## Root Cause
The library allocates `ai_addr` separately with `calloc()` in `resolver_result_to_addrinfo()`. The standard `freeaddrinfo()` cannot properly free these separately allocated structures, causing a 48-byte memory leak (3 sockaddr_in allocations).

Fixes #2542

## Test plan
- [x] All 127 tests pass with AddressSanitizer enabled
- [x] test_dns_queue_limit specifically passes without memory leaks
- [x] Verified fix by running: `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest -j8`