### PR TITLE
refactor: add centralized bit manipulation macros to SocketUtil.h

### DIFF
--- a/.claude/commands/refactor.md
+++ b/.claude/commands/refactor.md
@@ -36,7 +36,13 @@ This codebase follows **C Interfaces and Implementations** patterns with:
 
 7. **Optimize Performance**: Profile the code mentally for inefficiencies. Replace slow algorithms with optimized alternatives. Use efficient data structures, minimize allocations.
 
-8. **Keep Functions Reasonably Scoped**: Prefer single-purpose functions and extract helpers when it improves clarity/testing. Do not force arbitrary line-count limits; prioritize readability, correctness, and minimal diffs.
+8. **Keep Functions Reasonably Scoped**: Apply these criteria when writing or extracting functions:
+   1. Does it do ONE cohesive thing?
+   2. Can you name it clearly without "and" or "or"?
+   3. Is it at a consistent abstraction level?
+   4. Would extracting improve readability, or just move code?
+
+   Use function length as a smell detector, not a target. A 20-line function doing one thing is better than 4 tiny functions you bounce between.
 
 ## Refactoring Categories
 
@@ -47,7 +53,7 @@ This codebase follows **C Interfaces and Implementations** patterns with:
 - Helper functions that would improve readability
 - Error handling patterns that could be centralized (use `TRY/EXCEPT/FINALLY`)
 
-**Rule**: Split when it improves clarity and keeps the change safe/reviewable; don't split purely to satisfy a line-count goal.
+**Rule**: Extract when it passes the 4 criteria above; don't split purely to satisfy a line-count goal.
 
 ### 2. Code Duplication Detection
 - Identical or near-identical code blocks across multiple functions

--- a/src/http/SocketHPACK-table.c
+++ b/src/http/SocketHPACK-table.c
@@ -238,7 +238,8 @@ static inline size_t
 hpack_table_index_to_slot (const SocketHPACK_Table_T table, size_t index)
 {
   size_t offset = index - 1;
-  return (table->tail + table->capacity - 1 - offset) & (table->capacity - 1);
+  return RINGBUF_WRAP (table->tail + table->capacity - 1 - offset,
+                       table->capacity);
 }
 
 static void
@@ -429,7 +430,7 @@ hpack_table_evict (SocketHPACK_Table_T table, size_t required_space)
         }
 
       table->size -= entry_size;
-      table->head = (table->head + 1) & (table->capacity - 1);
+      table->head = RINGBUF_WRAP (table->head + 1, table->capacity);
       table->count--;
       evicted++;
     }
@@ -661,7 +662,7 @@ SocketHPACK_Table_add (SocketHPACK_Table_T table,
   if (res != HPACK_OK)
     return res;
 
-  table->tail = (table->tail + 1) & (table->capacity - 1);
+  table->tail = RINGBUF_WRAP (table->tail + 1, table->capacity);
   table->count++;
   table->size += entry_size;
 


### PR DESCRIPTION
## Summary
- Add 8 well-documented bit manipulation macros to `SocketUtil.h`
- Refactor `SocketHPACK-huffman.c` to use bit macros instead of inline operations
- Refactor `SocketHPACK-table.c` to use `RINGBUF_WRAP` for circular buffer indexing
- Update `CLAUDE.md` with macro documentation and anti-patterns

Fixes #2550

## New Macros

| Macro | Usage |
|-------|-------|
| `BITMASK32(n)` | Create 32-bit mask with N bits set |
| `BITMASK64(n)` | Create 64-bit mask with N bits set |
| `BITS_APPEND(acc, val, n)` | Append N bits to accumulator |
| `BITS_EXTRACT_TOP(bits, avail, n)` | Extract top N bits |
| `BITS_TOP_BYTE(bits, avail)` | Extract top byte |
| `BITS_PAD_EOS(bits, pad)` | Pad with EOS 1s (RFC 7541) |
| `HASH_KEY64(hi, lo)` | Combine into 64-bit hash key |
| `RINGBUF_WRAP(idx, cap)` | Wrap index for power-of-2 ring buffer |

## Test plan
- [x] All HPACK tests pass
- [x] Build succeeds with no warnings