### PR TITLE
refactor(util): use enum for mutex state constants

### DIFF
--- a/include/core/SocketUtil/MutexArena.h
+++ b/include/core/SocketUtil/MutexArena.h
@@ -136,10 +136,22 @@
  *   }
  */
 
-/** Mutex initialization states */
-#define SOCKET_MUTEX_UNINITIALIZED 0
-#define SOCKET_MUTEX_INITIALIZED 1
-#define SOCKET_MUTEX_SHUTDOWN (-1)
+/**
+ * @brief Mutex initialization states.
+ * @ingroup foundation
+ *
+ * Tracks the lifecycle of a mutex to ensure safe cleanup.
+ * Using an enum instead of #defines provides:
+ * - Type safety (compiler catches mismatched types)
+ * - Debugger visibility (shows state names, not raw integers)
+ * - Self-documentation (groups related constants)
+ */
+typedef enum
+{
+  SOCKET_MUTEX_SHUTDOWN = -1,     /**< Mutex destroyed, module shutting down */
+  SOCKET_MUTEX_UNINITIALIZED = 0, /**< Mutex not yet initialized */
+  SOCKET_MUTEX_INITIALIZED = 1    /**< Mutex ready for use */
+} SocketMutexState;
 
 /**
  * @brief SOCKET_MUTEX_ARENA_FIELDS - Fields to embed in managed structs.
@@ -152,7 +164,7 @@
 #define SOCKET_MUTEX_ARENA_FIELDS \
   pthread_mutex_t mutex;          \
   Arena_T arena;                  \
-  int initialized
+  SocketMutexState initialized
 
 /**
  * @brief SOCKET_MUTEX_ARENA_INIT - Initialize mutex and set state.


### PR DESCRIPTION
## Summary

- Replace `#define` constants with `SocketMutexState` enum for mutex initialization states
- Update `SOCKET_MUTEX_ARENA_FIELDS` to use enum type for `initialized` field

## Benefits

| Aspect | Before (#define) | After (enum) |
|--------|------------------|--------------|
| Type safety | None | Compiler catches mismatches |
| Debugging | Shows `-1`, `0`, `1` | Shows `SOCKET_MUTEX_SHUTDOWN`, etc. |
| Documentation | Separate constants | Grouped with Doxygen comments |

## Changes

```c
// Before:
#define SOCKET_MUTEX_UNINITIALIZED 0
#define SOCKET_MUTEX_INITIALIZED 1
#define SOCKET_MUTEX_SHUTDOWN (-1)

// After:
typedef enum {
  SOCKET_MUTEX_SHUTDOWN = -1,
  SOCKET_MUTEX_UNINITIALIZED = 0,
  SOCKET_MUTEX_INITIALIZED = 1
} SocketMutexState;
```

Fixes #2562

## Test plan
- [x] Build passes with `-Wall -Wextra -Werror`
- [x] All 127 tests pass with ASan + UBSan