### PR TITLE
perf(util): use strnlen in socket_util_arena_strndup

### DIFF
--- a/include/core/SocketUtil/StringUtils.h
+++ b/include/core/SocketUtil/StringUtils.h
@@ -83,6 +83,9 @@ socket_util_arena_strdup (Arena_T arena, const char *str)
  * @param maxlen Maximum characters to copy (excluding null terminator).
  * @return Duplicated string in arena, or NULL if str is NULL or alloc fails.
  * @threadsafe Yes (if arena is thread-safe)
+ *
+ * Uses strnlen() instead of strlen() to avoid scanning beyond maxlen,
+ * which is important when str may be very long but only a prefix is needed.
  */
 static inline char *
 socket_util_arena_strndup (Arena_T arena, const char *str, size_t maxlen)
@@ -93,9 +96,7 @@ socket_util_arena_strndup (Arena_T arena, const char *str, size_t maxlen)
   if (str == NULL)
     return NULL;
 
-  len = strlen (str);
-  if (len > maxlen)
-    len = maxlen;
+  len = strnlen (str, maxlen);
 
   copy = Arena_alloc (arena, len + 1, __FILE__, __LINE__);
   if (copy != NULL)


### PR DESCRIPTION
## Summary

Optimize `socket_util_arena_strndup` to use `strnlen()` instead of `strlen()` + manual check.

## Problem

```c
// Before: scans entire string even if maxlen is small
len = strlen(str);      // If str is 10MB, scans 10MB
if (len > maxlen)
  len = maxlen;
```

## Solution

```c
// After: stops at maxlen
len = strnlen(str, maxlen);  // Stops at 64 chars if maxlen=64
```

## Impact

| Scenario | Before | After |
|----------|--------|-------|
| 10MB string, maxlen=64 | Scans 10MB | Scans 64 bytes |
| 100 byte string, maxlen=1024 | Scans 100 bytes | Scans 100 bytes |

Fixes #2564

## Test plan
- [x] Build passes
- [x] All 127 tests pass with ASan + UBSan