### PR TITLE
refactor(util): eliminate magic numbers and use Core.h macros

### DIFF
--- a/include/core/SocketUtil/TTL.h
+++ b/include/core/SocketUtil/TTL.h
@@ -18,6 +18,8 @@
 
 #include <stdint.h>
 
+#include "core/SocketConfig.h"
+
 /**
  * @brief Check if a TTL-based entry has expired.
  * @ingroup foundation
@@ -40,7 +42,7 @@ socket_util_ttl_expired (int64_t insert_time_ms,
     return 0;
 
   int64_t age_ms = now_ms - insert_time_ms;
-  int64_t ttl_ms = (int64_t)ttl_sec * 1000;
+  int64_t ttl_ms = (int64_t)ttl_sec * SOCKET_MS_PER_SECOND;
   return age_ms >= ttl_ms;
 }
 
@@ -65,13 +67,13 @@ socket_util_ttl_remaining (int64_t insert_time_ms,
     return ttl_sec;
 
   int64_t age_ms = now_ms - insert_time_ms;
-  int64_t ttl_ms = (int64_t)ttl_sec * 1000;
+  int64_t ttl_ms = (int64_t)ttl_sec * SOCKET_MS_PER_SECOND;
   int64_t remaining_ms = ttl_ms - age_ms;
 
   if (remaining_ms <= 0)
     return 0;
 
-  return (uint32_t)(remaining_ms / 1000);
+  return (uint32_t)(remaining_ms / SOCKET_MS_PER_SECOND);
 }
 
 #endif /* SOCKETUTIL_TTL_H */

--- a/include/core/SocketUtil/Timeout.h
+++ b/include/core/SocketUtil/Timeout.h
@@ -19,6 +19,7 @@
 #include <limits.h>
 #include <stdint.h>
 
+#include "core/SocketUtil/Core.h"
 #include "core/SocketUtil/Time.h"
 
 /**
@@ -117,8 +118,7 @@ SocketTimeout_poll_timeout (int current_timeout_ms, int64_t deadline_ms)
   if (current_timeout_ms < 0)
     return (int)remaining;
 
-  return (current_timeout_ms < (int)remaining) ? current_timeout_ms
-                                               : (int)remaining;
+  return MIN (current_timeout_ms, (int)remaining);
 }
 
 /**


### PR DESCRIPTION
## Summary

Clean up utility headers to use defined constants and Core.h macros consistently.

## Changes

### TTL.h
```c
// Before:
int64_t ttl_ms = (int64_t)ttl_sec * 1000;
return (uint32_t)(remaining_ms / 1000);

// After:
int64_t ttl_ms = (int64_t)ttl_sec * SOCKET_MS_PER_SECOND;
return (uint32_t)(remaining_ms / SOCKET_MS_PER_SECOND);
```

### Timeout.h
```c
// Before:
return (current_timeout_ms < (int)remaining) ? current_timeout_ms
                                             : (int)remaining;

// After:
return MIN(current_timeout_ms, (int)remaining);
```

Fixes #2566

## Test plan
- [x] Build passes
- [x] All 127 tests pass with ASan + UBSan