### PR TITLE
refactor(http): extract magic number for Range header prefix length

### DIFF
--- a/src/http/SocketHTTPServer-static.c
+++ b/src/http/SocketHTTPServer-static.c
@@ -47,6 +47,12 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPServer);
 #define HTTPSERVER_STATIC_MAX_PATH 4096
 #endif
 
+/* String literal length macro (compile-time) */
+#define STRLEN_LIT(s) (sizeof(s) - 1)
+
+/* Range header prefix constant */
+#define RANGE_HEADER_PREFIX "bytes="
+
 /* MIME type mappings */
 static const struct
 {
@@ -223,10 +229,10 @@ parse_range_header (const char *range_str,
     return 0;
 
   /* Must start with "bytes=" */
-  if (strncmp (range_str, "bytes=", 6) != 0)
+  if (strncmp (range_str, RANGE_HEADER_PREFIX, STRLEN_LIT (RANGE_HEADER_PREFIX)) != 0)
     return 0;
 
-  p = range_str + 6;
+  p = range_str + STRLEN_LIT (RANGE_HEADER_PREFIX);
 
   /* Skip whitespace */
   while (*p == ' ')


### PR DESCRIPTION
## Summary

Implements #2587

Replace hardcoded magic number `6` with named constant and compile-time string length macro in `parse_range_header` function.

## Changes

- Add `STRLEN_LIT(s)` macro for compile-time string literal length calculation
- Add `RANGE_HEADER_PREFIX` constant for `"bytes="` prefix
- Replace magic number `6` with `STRLEN_LIT(RANGE_HEADER_PREFIX)` in two locations

## Rationale

- **Readability**: `STRLEN_LIT(RANGE_HEADER_PREFIX)` is more self-documenting than `6`
- **Maintainability**: If the prefix ever changes, only one constant needs updating
- **Performance**: Compile-time length calculation (per CLAUDE.md performance patterns)
- **Consistency**: Follows existing codebase patterns for string literal handling

## Test Plan

- [x] Build succeeds with sanitizers enabled
- [x] All HTTP server tests pass (27/27)
- [x] No new warnings or errors introduced
- [x] Verified correct usage in `parse_range_header` at lines 232 and 235

## Files Changed

- `src/http/SocketHTTPServer-static.c`: Add constants and replace magic numbers

Closes #2587