### PR TITLE
refactor(http): extract repeated delimiter checks to helper function

### DIFF
--- a/src/http/SocketHTTP1-parser.c
+++ b/src/http/SocketHTTP1-parser.c
@@ -659,10 +659,17 @@ parse_content_length (SocketHTTP_Headers_T headers)
   return cl_val;
 }
 
+/* HTTP/1.1 token delimiter predicate (space, tab, comma per RFC 9110) */
+static inline int
+http1_is_token_delimiter (char c)
+{
+  return c == ' ' || c == '\t' || c == ',';
+}
+
 static const char *
 http1_skip_token_delimiters (const char *p)
 {
-  while (*p == ' ' || *p == '\t' || *p == ',')
+  while (http1_is_token_delimiter (*p))
     p++;
   return p;
 }
@@ -671,7 +678,7 @@ static size_t
 http1_extract_token_bounds (const char *start, const char **end)
 {
   const char *p = start;
-  while (*p && *p != ',' && *p != ' ' && *p != '\t')
+  while (*p && !http1_is_token_delimiter (*p))
     p++;
   *end = p;
   return (size_t)(p - start);


### PR DESCRIPTION
## Summary

Implements #2578

Extracted duplicated delimiter character checks for ` `, `\t`, and `,` into a single inline helper function `http1_is_token_delimiter()`.

## Changes

- Added `http1_is_token_delimiter()` inline helper function
- Updated `http1_skip_token_delimiters()` to use the helper
- Updated `http1_extract_token_bounds()` to use the helper
- Replaced hardcoded delimiter checks with semantic function call

## Benefits

- Single source of truth for HTTP/1.1 token delimiter definition (RFC 9110)
- Improved code maintainability
- Self-documenting code
- Follows CLAUDE.md guidance on avoiding magic numbers

## Test Plan

- [x] All HTTP parser tests pass (34/34)
- [x] All HTTP core tests pass (225/225)
- [x] Build succeeds with sanitizers enabled
- [x] 98% of test suite passes (125/127 - pre-existing flakes unrelated to changes)

Closes #2578