### PR TITLE
refactor(http): extract HPACK decompression bomb limit constants

### DIFF
--- a/src/http/SocketHPACK.c
+++ b/src/http/SocketHPACK.c
@@ -94,6 +94,11 @@ typedef struct
 
 #define HPACK_LITERAL_WITHOUT_INDEX_VAL 0x00
 
+/* HPACK decompression bomb protection limits (RFC 7541 §7.1) */
+#define HPACK_DEFAULT_EXPANSION_RATIO      10.0
+#define HPACK_DEFAULT_EXPANSION_MULTIPLIER 10
+#define HPACK_DEFAULT_MAX_OUTPUT_BYTES     (1024 * 1024)  /* 1MB */
+
 /* Field type enumeration for decode dispatch */
 typedef enum
 {
@@ -900,12 +905,13 @@ SocketHPACK_decoder_config_defaults (SocketHPACK_DecoderConfig *config)
   config->max_table_size = SOCKETHPACK_DEFAULT_TABLE_SIZE;
   config->max_header_size = SOCKETHPACK_MAX_HEADER_SIZE;
   config->max_header_list_size = SOCKETHPACK_MAX_HEADER_LIST_SIZE;
-  config->max_expansion_ratio = 10.0;
+  config->max_expansion_ratio = HPACK_DEFAULT_EXPANSION_RATIO;
   /* Default: 1MB or 10x header_list_size, whichever is smaller */
   config->max_output_bytes
-      = (SOCKETHPACK_MAX_HEADER_LIST_SIZE * 10 < (1024 * 1024))
-            ? SOCKETHPACK_MAX_HEADER_LIST_SIZE * 10
-            : (1024 * 1024);
+      = (SOCKETHPACK_MAX_HEADER_LIST_SIZE * HPACK_DEFAULT_EXPANSION_MULTIPLIER
+         < HPACK_DEFAULT_MAX_OUTPUT_BYTES)
+            ? SOCKETHPACK_MAX_HEADER_LIST_SIZE * HPACK_DEFAULT_EXPANSION_MULTIPLIER
+            : HPACK_DEFAULT_MAX_OUTPUT_BYTES;
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

Implements #2570

Extracts hardcoded magic numbers for HPACK decompression bomb protection into named constants with RFC 7541 §7.1 reference.

## Changes

- Added `HPACK_DEFAULT_EXPANSION_RATIO` (10.0) - max expansion ratio for bomb detection
- Added `HPACK_DEFAULT_EXPANSION_MULTIPLIER` (10) - expansion multiplier for output size calculation  
- Added `HPACK_DEFAULT_MAX_OUTPUT_BYTES` (1MB) - absolute maximum output size limit
- Updated `SocketHPACK_decoder_config_defaults()` to use the new constants

## Benefits

- **Clarity**: Named constants explain the security purpose of these limits
- **Maintainability**: Single point to update decompression bomb thresholds
- **Documentation**: Constants reference RFC 7541 §7.1 for context
- **Consistency**: Ensures the ratio and multiplier values stay synchronized

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All HPACK tests pass (`test_hpack`)
- [x] All HTTP/2 tests pass (`test_http2`)
- [x] 98% of test suite passes (2 pre-existing unrelated failures)

Closes #2570