### PR TITLE
refactor(http): extract MIME type detection to reduce nesting

### DIFF
--- a/src/http/SocketHTTPServer-static.c
+++ b/src/http/SocketHTTPServer-static.c
@@ -201,6 +201,44 @@ format_http_date (time_t t, char *buf)
 
 
 /**
+ * get_mime_type - Determine MIME type from file path extension
+ * @file_path: Path to file (extension will be extracted)
+ *
+ * Performs case-insensitive lookup of file extension against known MIME types.
+ *
+ * Returns: MIME type string, or "application/octet-stream" if unknown
+ */
+static const char *
+get_mime_type (const char *file_path)
+{
+  const char *ext;
+  size_t path_len;
+  size_t ext_len;
+
+  if (file_path == NULL)
+    return "application/octet-stream";
+
+  ext = strrchr (file_path, '.');
+  if (ext == NULL)
+    return "application/octet-stream";
+
+  path_len = strlen (file_path);
+  ext_len = path_len - (size_t)(ext - file_path);
+
+  /* Check against known extensions (case-insensitive) */
+  for (int i = 0; mime_types[i].extension != NULL; i++)
+    {
+      if (strlen (mime_types[i].extension) == ext_len
+          && strcasecmp (ext, mime_types[i].extension) == 0)
+        {
+          return mime_types[i].mime_type;
+        }
+    }
+
+  return "application/octet-stream";
+}
+
+/**
  * parse_range_header - Parse Range header for partial content
  * @range_str: Range header value (e.g., "bytes=0-499")
  * @file_size: Total file size
@@ -401,26 +439,7 @@ server_serve_static_file (SocketHTTPServer_T server,
     }
 
   /* Determine MIME type from file extension */
-  mime_type = "application/octet-stream"; /* Default for unknown types */
-  {
-    const char *ext = strrchr (resolved_path, '.');
-    if (ext != NULL)
-      {
-        size_t path_len = strlen (resolved_path);
-        size_t ext_len = path_len - (size_t)(ext - resolved_path);
-
-        /* Check against known extensions (case-insensitive) */
-        for (int i = 0; mime_types[i].extension != NULL; i++)
-          {
-            if (strlen (mime_types[i].extension) == ext_len
-                && strcasecmp (ext, mime_types[i].extension) == 0)
-              {
-                mime_type = mime_types[i].mime_type;
-                break;
-              }
-          }
-      }
-  }
+  mime_type = get_mime_type (resolved_path);
 
   /* Check If-Modified-Since header */
   if_modified_since


### PR DESCRIPTION
## Summary

Implements #2581 by extracting deeply nested MIME type detection logic into a dedicated function.

## Changes

- Add `get_mime_type()` static function to encapsulate MIME type lookup
- Replace 20-line nested block (4 levels deep) with single function call
- Reduce nesting from 4 levels to 1 level in `server_serve_static_file()`
- Maintain identical behavior with NULL-safe guards and case-insensitive matching

## Before (4 levels of nesting)

```c
mime_type = "application/octet-stream";
{                                        // Level 1: block scope
  const char *ext = strrchr (resolved_path, '.');
  if (ext != NULL)                      // Level 2
    {
      size_t path_len = strlen (resolved_path);
      size_t ext_len = path_len - (size_t)(ext - resolved_path);
      for (int i = 0; mime_types[i].extension != NULL; i++)  // Level 3
        {
          if (strlen (mime_types[i].extension) == ext_len
              && strcasecmp (ext, mime_types[i].extension) == 0)  // Level 4
            {
              mime_type = mime_types[i].mime_type;
              break;
            }
        }
    }
}
```

## After (1 level)

```c
mime_type = get_mime_type (resolved_path);
```

## Test Plan

- [x] Build succeeds with sanitizers
- [x] HTTP server tests pass (27/27)
- [x] No behavior changes - identical MIME type detection
- [x] NULL-safe with proper default fallback

Closes #2581