### PR TITLE
refactor(http2): extract frame header field offsets to named constants

### DIFF
--- a/include/http/SocketHTTP2.h
+++ b/include/http/SocketHTTP2.h
@@ -140,6 +140,12 @@
 /* Frame/Protocol Constants */
 
 #define HTTP2_FRAME_HEADER_SIZE 9
+
+/* Frame header field offsets (RFC 9113 Section 4.1) */
+#define HTTP2_FRAME_OFFSET_LENGTH 0     /* 3-byte length field */
+#define HTTP2_FRAME_OFFSET_TYPE 3       /* 1-byte type field */
+#define HTTP2_FRAME_OFFSET_FLAGS 4      /* 1-byte flags field */
+#define HTTP2_FRAME_OFFSET_STREAM_ID 5  /* 4-byte stream ID field */
 #define HTTP2_WINDOW_UPDATE_PAYLOAD_SIZE 4
 #define HTTP2_PUSH_PROMISE_ID_SIZE 4
 #define HTTP2_PRIORITY_PAYLOAD_SIZE 5

--- a/src/http/SocketHTTP2-frame.c
+++ b/src/http/SocketHTTP2-frame.c
@@ -167,13 +167,13 @@ SocketHTTP2_frame_header_parse (const unsigned char *data,
     return -1;
 
   /* Length: 24-bit big-endian */
-  header->length = http2_unpack_be24 (data + 0);
+  header->length = http2_unpack_be24 (data + HTTP2_FRAME_OFFSET_LENGTH);
 
-  header->type = data[3];
-  header->flags = data[4];
+  header->type = data[HTTP2_FRAME_OFFSET_TYPE];
+  header->flags = data[HTTP2_FRAME_OFFSET_FLAGS];
 
   /* Stream ID: 31-bit big-endian (R bit is reserved, must be masked) */
-  header->stream_id = http2_unpack_stream_id (data + 5);
+  header->stream_id = http2_unpack_stream_id (data + HTTP2_FRAME_OFFSET_STREAM_ID);
 
   return 0;
 }
@@ -186,13 +186,13 @@ SocketHTTP2_frame_header_serialize (const SocketHTTP2_FrameHeader *header,
     return;
 
   /* Length: 24-bit big-endian */
-  http2_pack_be24 (data + 0, header->length);
+  http2_pack_be24 (data + HTTP2_FRAME_OFFSET_LENGTH, header->length);
 
-  data[3] = header->type;
-  data[4] = header->flags;
+  data[HTTP2_FRAME_OFFSET_TYPE] = header->type;
+  data[HTTP2_FRAME_OFFSET_FLAGS] = header->flags;
 
   /* Stream ID: 31-bit big-endian (R bit always 0) */
-  http2_pack_stream_id (data + 5, header->stream_id);
+  http2_pack_stream_id (data + HTTP2_FRAME_OFFSET_STREAM_ID, header->stream_id);
 }
 
 static SocketHTTP2_ErrorCode


### PR DESCRIPTION
## Summary

Implements #2591

Replaced magic numbers (3, 4, 5) with named constants in HTTP/2 frame header parsing and serialization functions for improved code clarity and maintainability.

## Changes

- **Added constants** in `include/http/SocketHTTP2.h`:
  - `HTTP2_FRAME_OFFSET_LENGTH` (0) - 3-byte length field
  - `HTTP2_FRAME_OFFSET_TYPE` (3) - 1-byte type field
  - `HTTP2_FRAME_OFFSET_FLAGS` (4) - 1-byte flags field
  - `HTTP2_FRAME_OFFSET_STREAM_ID` (5) - 4-byte stream ID field

- **Updated functions** in `src/http/SocketHTTP2-frame.c`:
  - `SocketHTTP2_frame_header_parse()` - uses constants instead of literals
  - `SocketHTTP2_frame_header_serialize()` - uses constants instead of literals

## Benefits

1. **Self-documenting code**: Frame structure is now explicit (RFC 9113 Section 4.1)
2. **Maintainability**: Single source of truth for field positions
3. **Consistency**: Matches existing pattern of `HTTP2_FRAME_HEADER_SIZE`
4. **Follows project anti-pattern guidance**: Eliminates magic numbers per CLAUDE.md

## Test Plan

- [x] All HTTP/2 tests pass with sanitizers: `ctest -R http2 -j12`
- [x] All HTTP core tests pass: `ctest -R "http2|hpack|http_core|http1" -j12`
- [x] No behavioral changes - constants compile to same values
- [x] No other files use these magic offsets

## Test Results

```
100% tests passed, 0 tests failed out of 9
- test_http2
- test_http2_priority  
- test_http2_rate_limit
- test_http2_integration
- test_http2_server_push
- test_tls_http2
- test_hpack
- test_http1_parser
- test_http_core
```

Closes #2591