### PR TITLE
refactor(http): extract magic numbers to named constants in HTTP/2 validation

### DIFF
--- a/include/http/SocketHTTP.h
+++ b/include/http/SocketHTTP.h
@@ -138,6 +138,31 @@
 #define HTTPS_DEFAULT_PORT 443
 
 /**
+ * @brief ASCII character constants for HTTP validation.
+ *
+ * Used for header validation and protocol parsing per RFC 9110/9113.
+ */
+#define HTTP_CHAR_NUL   0x00 /**< Null character (prohibited in headers) */
+#define HTTP_CHAR_CR    0x0D /**< Carriage return (prohibited in headers) */
+#define HTTP_CHAR_LF    0x0A /**< Line feed (prohibited in headers) */
+#define HTTP_CHAR_SPACE 0x20 /**< Space character */
+#define HTTP_CHAR_DEL   0x7F /**< Delete character (prohibited in headers) */
+
+/**
+ * @brief Uppercase letter range (ASCII).
+ *
+ * Used for case validation in HTTP/2 field names (RFC 9113 §8.2.1).
+ */
+#define HTTP_CHAR_UPPER_A 0x41 /**< 'A' */
+#define HTTP_CHAR_UPPER_Z 0x5A /**< 'Z' */
+
+/**
+ * @brief HTTP status code constraints per RFC 9110.
+ */
+#define HTTP_STATUS_CODE_MIN 100 /**< Minimum valid HTTP status code */
+#define HTTP_STATUS_CODE_MAX 599 /**< Maximum valid HTTP status code */
+
+/**
  * @brief Generic HTTP module failure.
  *
  * Use for general errors in HTTP core utilities. Specific errors should use


### PR DESCRIPTION
## Summary

Implements #2590

Replaces 10 instances of magic numbers with descriptive named constants in `SocketHTTP2-validate.c` to improve code readability and maintainability per RFC 9113 requirements.

## Changes

### New Constants in `SocketHTTP.h`
- `HTTP_CHAR_NUL` (0x00) - Null character
- `HTTP_CHAR_CR` (0x0D) - Carriage return
- `HTTP_CHAR_LF` (0x0A) - Line feed
- `HTTP_CHAR_SPACE` (0x20) - Space character
- `HTTP_CHAR_DEL` (0x7F) - Delete character
- `HTTP_CHAR_UPPER_A` (0x41) - Uppercase 'A'
- `HTTP_CHAR_UPPER_Z` (0x5A) - Uppercase 'Z'
- `HTTP_STATUS_CODE_MIN` (100) - Minimum valid HTTP status code
- `HTTP_STATUS_CODE_MAX` (599) - Maximum valid HTTP status code

### New Constants in `SocketHTTP2-validate.c`
- `HTTP2_STATUS_CODE_LEN` (3) - Length of HTTP status code string
- `HTTP2_TRAILERS_LEN` - Length of "trailers" string (using STRLEN_LIT)
- `HTTP2_CONNECT_METHOD_LEN` - Length of "CONNECT" method (using STRLEN_LIT)

### Refactored Code Locations
- Line 90: Uppercase check uses `HTTP_CHAR_UPPER_A/Z`
- Line 103: Prohibited chars uses `HTTP_CHAR_NUL/CR/LF`
- Lines 128-136: RFC 9113 §8.2.1 validation uses `HTTP_CHAR_SPACE/UPPER_A/UPPER_Z/DEL`
- Line 202: Now uses existing `HTTP2_TE_HEADER_LEN` constant
- Line 216: Uses `HTTP2_TRAILERS_LEN` with STRLEN_LIT
- Line 248: Uses `STRLEN_LIT("te")` for compile-time length
- Lines 463, 467, 471: Status code validation uses `HTTP2_STATUS_CODE_LEN/MIN/MAX`
- Line 508: CONNECT method check uses `HTTP2_CONNECT_METHOD_LEN`

## Benefits

- **Readability**: Named constants are self-documenting (e.g., `HTTP_CHAR_CR` vs `0x0D`)
- **Maintainability**: Changes to values only require updating one location
- **Consistency**: Uses existing patterns (STRLEN_LIT macro already defined)
- **Bug Prevention**: Reduces chance of typos in magic numbers

## Test Plan

- [x] All HTTP/2 tests pass (29/29)
- [x] Build succeeds with sanitizers enabled
- [x] No behavioral changes - all constants match original values
- [x] Code compiles cleanly with -Wall -Wextra -Werror

Closes #2590