### PR TITLE
refactor(http): define HEX_INVALID constant and reuse is_control_char helper

### DIFF
--- a/include/http/SocketHTTP-private.h
+++ b/include/http/SocketHTTP-private.h
@@ -80,6 +80,7 @@ extern const unsigned char sockethttp_uri_unreserved[256];
 
 extern const unsigned char sockethttp_hex_value[256];
 #define SOCKETHTTP_HEX_VALUE(c) (sockethttp_hex_value[(unsigned char)(c)])
+#define HEX_INVALID 255 /* Invalid hex digit sentinel from SOCKETHTTP_HEX_VALUE */
 
 static inline const char *
 sockethttp_skip_whitespace (const char *p)

--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -923,7 +923,7 @@ SocketHTTP_URI_decode (const char *input,
           unsigned char hi = SOCKETHTTP_HEX_VALUE (input[i + 1]);
           unsigned char lo = SOCKETHTTP_HEX_VALUE (input[i + 2]);
 
-          if (hi == 255 || lo == 255)
+          if (hi == HEX_INVALID || lo == HEX_INVALID)
             return -1;
 
           if (out_len + 1 > output_size)
@@ -1093,7 +1093,7 @@ validate_pct_encoded (const char *s, size_t len)
             return URI_PARSE_ERROR;
           unsigned char hi = SOCKETHTTP_HEX_VALUE (s[i + 1]);
           unsigned char lo = SOCKETHTTP_HEX_VALUE (s[i + 2]);
-          if (hi == 255 || lo == 255)
+          if (hi == HEX_INVALID || lo == HEX_INVALID)
             return URI_PARSE_ERROR;
           i += 3;
         }
@@ -1335,7 +1335,7 @@ parse_quoted_value (const char *p,
 
       p++;
       unsigned char esc = (unsigned char)*p;
-      if (esc < 0x20 || esc == 0x7F)
+      if (is_control_char (esc))
         {
           *value_start = NULL;
           *value_len = 0;


### PR DESCRIPTION
## Summary

Implements #2595 by improving code clarity and eliminating duplication in HTTP URI validation.

## Changes

- **Added HEX_INVALID constant** to `SocketHTTP-private.h` near `SOCKETHTTP_HEX_VALUE` macro
- **Replaced magic number 255** with `HEX_INVALID` at two locations in `SocketHTTP-uri.c` (lines 926, 1096)
- **Replaced duplicate control char check** with call to existing `is_control_char()` helper (line 1338)

## Benefits

1. **Semantic clarity**: `HEX_INVALID` documents intent better than magic `255`
2. **DRY principle**: Reusing `is_control_char()` eliminates duplication  
3. **Maintainability**: Single source of truth for control character detection
4. **Consistency**: Aligns with CLAUDE.md anti-pattern guidance

## Test Plan

- [x] Tests pass with sanitizers (225/225 HTTP core tests, 34/34 HTTP1 parser tests)
- [x] URI encoding/decoding validation still works correctly
- [x] Control character detection behaves identically

Closes #2595