### PR TITLE
refactor(http): extract HTTP quality value parsing constants per RFC 7231

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -47,6 +47,11 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTP);
 #define MEDIATYPE_CHARSET_LEN 7
 #define MEDIATYPE_BOUNDARY_LEN 8
 
+/* RFC 7231 §5.3.1 Quality Value Constants */
+#define QUALITY_DECIMAL_BASE 10.0f /* RFC 7231 §5.3.1 decimal parsing */
+#define QUALITY_MIN 0.0f           /* RFC 7231 §5.3.1 minimum qvalue */
+#define QUALITY_MAX 1.0f           /* RFC 7231 §5.3.1 maximum qvalue */
+
 /* ============================================================================
  * Validation Forward Declarations
  * ============================================================================
@@ -1552,33 +1557,33 @@ qvalue_compare (const void *a, const void *b)
 static float
 accept_parse_quality (const char *p, const char *end, const char **out_pos)
 {
-  float quality = 0.0f;
+  float quality = QUALITY_MIN;
   const char *start = p;
 
   while (p < end && *p >= '0' && *p <= '9')
     {
-      quality = quality * 10.0f + (*p - '0');
+      quality = quality * QUALITY_DECIMAL_BASE + (*p - '0');
       p++;
     }
 
   if (p < end && *p == '.')
     {
       p++;
-      float divisor = 10.0f;
+      float divisor = QUALITY_DECIMAL_BASE;
       while (p < end && *p >= '0' && *p <= '9')
         {
           quality += (*p - '0') / divisor;
-          divisor *= 10.0f;
+          divisor *= QUALITY_DECIMAL_BASE;
           p++;
         }
     }
 
   *out_pos = (p > start) ? p : start;
 
-  if (quality < 0.0f)
-    quality = 0.0f;
-  if (quality > 1.0f)
-    quality = 1.0f;
+  if (quality < QUALITY_MIN)
+    quality = QUALITY_MIN;
+  if (quality > QUALITY_MAX)
+    quality = QUALITY_MAX;
 
   return quality;
 }


### PR DESCRIPTION
## Summary

Implements #2594

Replaced hardcoded floating-point constants in the HTTP quality value parser with named constants that clearly document RFC 7231 §5.3.1 compliance.

## Changes

- Added three RFC-documented constants to `SocketHTTP-uri.c`:
  - `QUALITY_DECIMAL_BASE` (10.0f) - for decimal parsing
  - `QUALITY_MIN` (0.0f) - minimum qvalue
  - `QUALITY_MAX` (1.0f) - maximum qvalue
- Updated `accept_parse_quality()` function to use named constants instead of magic numbers
- Improved code maintainability and RFC compliance visibility

## Test Plan

- [x] All 127 tests pass with sanitizers (ASan + UBSan)
- [x] No functional changes - pure refactoring
- [x] Code builds cleanly without warnings

Closes #2594