### PR TITLE
refactor(http): extract magic number 10 to HTTP1_DECIMAL_BASE constant

### DIFF
--- a/src/http/SocketHTTP1-parser.c
+++ b/src/http/SocketHTTP1-parser.c
@@ -20,6 +20,9 @@
 /* Compile-time string literal length (avoids strlen at runtime) */
 #define STRLEN_LIT(s) (sizeof (s) - 1)
 
+/* Decimal base for numeric conversion */
+#define HTTP1_DECIMAL_BASE 10
+
 /* clang-format off */
 
 /* Common row macros for state tables to reduce duplication */
@@ -599,9 +602,9 @@ parse_cl_value (const char *str, size_t len)
   while (i < len && http1_is_digit (p[i]))
     {
       int digit = p[i] - '0';
-      if (value > (INT64_MAX - digit) / 10)
+      if (value > (INT64_MAX - digit) / HTTP1_DECIMAL_BASE)
         return -1;
-      value = value * 10 + digit;
+      value = value * HTTP1_DECIMAL_BASE + digit;
       i++;
     }
 


### PR DESCRIPTION
## Summary

Implements #2576

Extracts hardcoded decimal base literal (10) in `parse_cl_value()` to a named constant `HTTP1_DECIMAL_BASE` for improved code clarity and self-documentation.

## Changes

- Added `HTTP1_DECIMAL_BASE` constant definition in `src/http/SocketHTTP1-parser.c`
- Replaced two instances of magic number `10` with `HTTP1_DECIMAL_BASE` in the Content-Length parsing overflow check

## Test Plan

- [x] All HTTP/1.1 parser tests pass (34/34)
- [x] All HTTP core tests pass (225/225)
- [x] Build succeeds with sanitizers enabled
- [x] No functional changes - pure refactoring

Closes #2576