### PR TITLE
refactor(http): extract magic numbers for date and content-range buffer sizes

### DIFF
--- a/include/http/SocketHTTP.h
+++ b/include/http/SocketHTTP.h
@@ -124,6 +124,15 @@
 #define SOCKETHTTP_DATE_BUFSIZE 30
 
 /**
+ * @brief Recommended buffer size for Content-Range header formatting.
+ *
+ * Supports "bytes START-END/TOTAL" format with up to 20-digit numbers.
+ * Format: "bytes " (6) + START (20) + "-" (1) + END (20) + "/" (1) + TOTAL
+ * (20) = 68 bytes + null terminator requires 69, rounded to 80 for safety.
+ */
+#define SOCKETHTTP_CONTENT_RANGE_BUFSIZE 80
+
+/**
  * @brief Default HTTP port per RFC 9110 Section 4.2.3.
  *
  * Standard port for http:// scheme. Used when port is omitted in URI.

--- a/src/http/SocketHTTPServer-static.c
+++ b/src/http/SocketHTTPServer-static.c
@@ -339,10 +339,10 @@ server_serve_static_file (SocketHTTPServer_T server,
 {
   char full_path[HTTPSERVER_STATIC_MAX_PATH];
   char resolved_path[HTTPSERVER_STATIC_MAX_PATH];
-  char date_buf[32];
-  char last_modified_buf[32];
+  char date_buf[SOCKETHTTP_DATE_BUFSIZE];
+  char last_modified_buf[SOCKETHTTP_DATE_BUFSIZE];
   char content_length_buf[32];
-  char content_range_buf[64];
+  char content_range_buf[SOCKETHTTP_CONTENT_RANGE_BUFSIZE];
   struct stat st;
   const char *mime_type;
   const char *if_modified_since;


### PR DESCRIPTION
## Summary

Implements #2592

Replaces hardcoded buffer sizes with named constants in the HTTP server static file handler for improved code readability and maintainability.

## Changes

- **Added** `SOCKETHTTP_CONTENT_RANGE_BUFSIZE` (80) constant to `include/http/SocketHTTP.h`
  - Sized to support "bytes START-END/TOTAL" format with up to 20-digit numbers
  - Sufficient for exabyte-scale file sizes
  - Includes safety margin (calculated 68 bytes + null, rounded to 80)

- **Updated** `src/http/SocketHTTPServer-static.c` to use constants:
  - `date_buf[32]` → `date_buf[SOCKETHTTP_DATE_BUFSIZE]` (30 bytes)
  - `last_modified_buf[32]` → `last_modified_buf[SOCKETHTTP_DATE_BUFSIZE]` (30 bytes)
  - `content_range_buf[64]` → `content_range_buf[SOCKETHTTP_CONTENT_RANGE_BUFSIZE]` (80 bytes)

## Rationale

The existing `SOCKETHTTP_DATE_BUFSIZE` constant was already defined but not being used. This change:
1. Makes use of the existing date buffer constant
2. Introduces a parallel constant for Content-Range headers
3. Documents the buffer size calculation with clear comments
4. Improves code maintainability by centralizing these values

## Test Plan

- [x] Full test suite passes (126/127 tests, 1 flaky test unrelated to changes)
- [x] HTTP server tests pass (27/27 tests)
- [x] Built with sanitizers enabled (ASan + UBSan)
- [x] No new warnings or errors

Closes #2592