### PR TITLE
refactor(http): replace magic number 7 with STRLEN_LIT for 'chunked' string

### DIFF
--- a/src/http/SocketHTTP1-parser.c
+++ b/src/http/SocketHTTP1-parser.c
@@ -713,7 +713,7 @@ te_chunked_is_last (const char *te_value)
     return 1; /* No chunked - valid */
 
   /* Check nothing follows "chunked" except whitespace/comma */
-  const char *after = chunked + 7;
+  const char *after = chunked + STRLEN_LIT ("chunked");
   while (*after)
     {
       if (*after == ',')


### PR DESCRIPTION
## Summary

Implements #2577 - replaces hardcoded magic number 7 with `STRLEN_LIT("chunked")` in the `te_chunked_is_last()` function for better maintainability.

## Changes

- **File**: `src/http/SocketHTTP1-parser.c`
- **Line 716**: Changed `chunked + 7` to `chunked + STRLEN_LIT("chunked")`

This aligns with the existing pattern used throughout the file (lines 645, 742, 767, 827, 862, 912, 914, 920, 922, 929, 933, 988, 1003, 1005).

## Test Plan

- [x] All HTTP/1.1 parser tests pass (34/34)
- [x] Specifically tested functions that exercise `te_chunked_is_last()`:
  - `http1_te_chunked_with_extra_reject` - PASS
  - `http1_multi_te_chunked_hidden` - PASS
- [x] Build passes with sanitizers enabled
- [x] Code formatted with clang-format

Closes #2577