### PR TITLE
refactor(http): inline single-use function add_response_extras()

### DIFF
--- a/src/http/SocketHTTP1-serialize.c
+++ b/src/http/SocketHTTP1-serialize.c
@@ -288,22 +288,6 @@ serialize_response_line (const SocketHTTP_Response *response,
   return safe_append_crlf (buf, remaining);
 }
 
-static int
-add_response_extras (const SocketHTTP_Response *response,
-                     char **buf,
-                     size_t *remaining)
-{
-  if (append_content_length_header (buf,
-                                    remaining,
-                                    response->headers,
-                                    response->has_body,
-                                    response->content_length)
-      < 0)
-    return -1;
-
-  return safe_append_crlf (buf, remaining);
-}
-
 ssize_t
 SocketHTTP1_serialize_request (const SocketHTTP_Request *request,
                                char *output,
@@ -395,7 +379,17 @@ SocketHTTP1_serialize_response (const SocketHTTP_Response *response,
   if (serialize_headers_section (response->headers, &p, &remaining) < 0)
     return -1;
 
-  if (add_response_extras (response, &p, &remaining) < 0)
+  /* Add Content-Length header if needed */
+  if (append_content_length_header (&p,
+                                    &remaining,
+                                    response->headers,
+                                    response->has_body,
+                                    response->content_length)
+      < 0)
+    return -1;
+
+  /* Final CRLF to end headers section */
+  if (safe_append_crlf (&p, &remaining) < 0)
     return -1;
 
   *p = '\0';


### PR DESCRIPTION
## Summary

Implements #2588

Removes the `add_response_extras()` wrapper function and inlines its logic directly into `SocketHTTP1_serialize_response()`.

## Changes

- Removed `add_response_extras()` function (lines 291-305)
- Inlined its two operations into `SocketHTTP1_serialize_response()`:
  - Add Content-Length header if needed
  - Add final CRLF to end headers section
- Added clear comments explaining each operation

## Rationale

The function violated Function Design Criteria from CLAUDE.md:
- Called only once (single-use wrapper)
- Wrapped just 2 function calls without adding abstraction
- Name "extras" was vague and hid dual purpose

## Benefits

- Eliminates unnecessary indirection
- Makes the two operations explicit with clear comments
- Reduces function count by removing wrapper
- Improves readability per CLAUDE.md guidelines

## Test Plan

- [x] All 127 tests pass with sanitizers in worktree build
- [x] All 13 HTTP-specific tests pass in main repo build
- [x] Code builds successfully with no warnings
- [x] Verified no functional changes - only refactoring

Closes #2588