### PR TITLE
refactor(http): remove dead code - unused alloc_and_validate function

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -134,60 +134,6 @@ uri_alloc_component (Arena_T arena,
   return URI_PARSE_OK;
 }
 
-typedef SocketHTTP_URIResult (*ComponentValidator) (const char *s, size_t len);
-
-static SocketHTTP_URIResult
-alloc_and_validate (Arena_T arena,
-                    const char *start,
-                    const char *end,
-                    size_t max_len,
-                    ComponentValidator validator,
-                    void (*post_process) (char *str, size_t len),
-                    const char **out_str,
-                    size_t *out_len,
-                    int alloc_empty)
-{
-  *out_str = NULL;
-  *out_len = 0;
-
-  /* Handle empty input */
-  if (!start || end <= start)
-    {
-      if (!alloc_empty)
-        return URI_PARSE_OK;
-
-      char *empty = arena_strndup (arena, "", 0);
-      if (!empty)
-        return URI_PARSE_ERROR;
-
-      *out_str = empty;
-      *out_len = 0;
-      return URI_PARSE_OK;
-    }
-
-  size_t len = (size_t)(end - start);
-  if (len > max_len)
-    return URI_PARSE_TOO_LONG;
-
-  if (validator)
-    {
-      SocketHTTP_URIResult vr = validator (start, len);
-      if (vr != URI_PARSE_OK)
-        return vr;
-    }
-
-  char *copy = arena_strndup (arena, start, len);
-  if (!copy)
-    return URI_PARSE_ERROR;
-
-  if (post_process)
-    post_process (copy, len);
-
-  *out_str = copy;
-  *out_len = len;
-  return URI_PARSE_OK;
-}
-
 /* ============================================================================
  * URI Parser State Machine
  * ============================================================================


### PR DESCRIPTION
## Summary

Implements #2596

Removes 53 lines of dead code from `src/http/SocketHTTP-uri.c`:
- `alloc_and_validate` function (lines 139-189) - 50 lines
- `ComponentValidator` typedef (line 137) - 1 line + surrounding whitespace

## Analysis

The `alloc_and_validate` function was designed as a generic allocate-and-validate helper for URI components, but it was **never called** anywhere in the codebase.

The actual URI component allocators (`uri_alloc_scheme`, `uri_alloc_userinfo`, `uri_alloc_host`, `uri_alloc_path`, `uri_alloc_query`, `uri_alloc_fragment`) use `uri_alloc_component` directly instead.

**Why it wasn't used:**
- `validate_host` requires extra parameter: `int *out_is_ipv6`
- `validate_path_query` requires extra parameter: `int is_path`
- Only 2 of 6 validators match the `ComponentValidator` typedef signature
- The abstraction doesn't fit actual validation needs

## Changes

- Removed `alloc_and_validate` function (50 lines)
- Removed `ComponentValidator` typedef (3 lines total with whitespace)
- No functional impact (code was already unused)

## Test Plan

- [x] All 127 tests pass with sanitizers enabled
- [x] No functional changes (removed dead code only)
- [x] Grep confirms no other references to deleted code

Closes #2596