### PR TITLE
perf(http): cache path_prefix length in RateLimitEntry

### DIFF
--- a/include/http/SocketHTTPServer-private.h
+++ b/include/http/SocketHTTPServer-private.h
@@ -79,6 +79,7 @@ typedef struct SocketHTTPServer_InstanceMetrics
 typedef struct RateLimitEntry
 {
   char *path_prefix;
+  size_t prefix_len;
   SocketRateLimit_T limiter;
   struct RateLimitEntry *next;
 } RateLimitEntry;

--- a/src/http/SocketHTTPServer.c
+++ b/src/http/SocketHTTPServer.c
@@ -62,7 +62,7 @@ find_rate_limiter (SocketHTTPServer_T server, const char *path)
 
   for (RateLimitEntry *e = server->rate_limiters; e != NULL; e = e->next)
     {
-      size_t len = strlen (e->path_prefix);
+      size_t len = e->prefix_len;
       if (strncmp (path, e->path_prefix, len) == 0 && len > best_len)
         {
           best = e;

--- a/src/http/server/SocketHTTPServer-core.c
+++ b/src/http/server/SocketHTTPServer-core.c
@@ -383,6 +383,7 @@ SocketHTTPServer_set_rate_limit (SocketHTTPServer_T server,
           return;
         }
 
+      entry->prefix_len = strlen (path_prefix);
       entry->limiter = limiter;
       entry->next = server->rate_limiters;
       server->rate_limiters = entry;


### PR DESCRIPTION
## Summary

Eliminates redundant `strlen()` calls in the `find_rate_limiter` hot path by caching the prefix length at initialization time.

## Problem

The `find_rate_limiter` function (called on every HTTP request) performed `strlen(e->path_prefix)` on every iteration of the rate limiter lookup loop:

```c
for (RateLimitEntry *e = server->rate_limiters; e != NULL; e = e->next) {
    size_t len = strlen(e->path_prefix);  // Called for every lookup!
    if (strncmp(path, e->path_prefix, len) == 0 && len > best_len) {
        ...
    }
}
```

For servers with N rate limit rules and average prefix length M, this added **O(N*M) character scans per request**.

## Solution

- Added `prefix_len` field to `RateLimitEntry` struct
- Compute length once in `SocketHTTPServer_set_rate_limit` during initialization
- Use cached length in `find_rate_limiter` loop (O(1) instead of O(M))

## Changes

**Files modified:**
- `include/http/SocketHTTPServer-private.h` - Added `prefix_len` field
- `src/http/server/SocketHTTPServer-core.c` - Cache length on initialization
- `src/http/SocketHTTPServer.c` - Use cached length in hot path

## Performance Impact

- **Before:** O(N*M) character scans per request (N rules, M avg prefix length)
- **After:** O(N) comparisons per request
- **Memory cost:** 8 bytes per rate limit rule (negligible)
- **Benefit:** Scales with number of rate limit rules and prefix complexity

## Testing

- [x] All 127 tests pass with ASan/UBSan enabled
- [x] No functional changes - pure performance optimization
- [x] Existing HTTP server tests verify correctness

## Verification

```bash
cmake -B build -DENABLE_SANITIZERS=ON
cmake --build build -j$(nproc)
cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest --output-on-failure
```

Result: 100% tests passed (127/127)

Closes #2642