### PR TITLE
chore: add .claude/issue-state to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,6 @@ todo_ssl.md
 examples/tags
 
 clean.md
+
+# Claude Code state files
+.claude/issue-state/


### PR DESCRIPTION
Ignore Claude Code issue state files that shouldn't be tracked in version control.