### PR TITLE
refactor(http): extract helpers from upgrade_websocket

### DIFF
--- a/include/http/SocketHTTPServer-private.h
+++ b/include/http/SocketHTTPServer-private.h
@@ -325,6 +325,11 @@ connection_parse_request (SocketHTTPServer_T server, ServerConnection *conn);
 void connection_close (SocketHTTPServer_T server, ServerConnection *conn);
 void connection_free_pending (SocketHTTPServer_T server);
 ServerConnection *connection_new (SocketHTTPServer_T server, Socket_T socket);
+void connection_transition_to_websocket (SocketHTTPServer_T server,
+                                         ServerConnection *conn,
+                                         SocketWS_T ws,
+                                         SocketHTTPServer_BodyCallback callback,
+                                         void *userdata);
 
 /* Event loop helpers (SocketHTTPServer.c) */
 int server_check_connection_timeout (SocketHTTPServer_T server,

--- a/src/http/server/SocketHTTPServer-connections.c
+++ b/src/http/server/SocketHTTPServer-connections.c
@@ -1444,3 +1444,20 @@ server_process_client_event (SocketHTTPServer_T server,
 
   return requests_processed;
 }
+
+void
+connection_transition_to_websocket (SocketHTTPServer_T server,
+                                    ServerConnection *conn,
+                                    SocketWS_T ws,
+                                    SocketHTTPServer_BodyCallback callback,
+                                    void *userdata)
+{
+  conn->websocket = ws;
+  conn->ws_callback = callback;
+  conn->ws_callback_userdata = userdata;
+  conn->response_streaming = 1;
+  conn->state = CONN_STATE_WEBSOCKET;
+
+  unsigned ws_events = SocketWS_poll_events (ws);
+  SocketPoll_mod (server->poll, conn->socket, ws_events, conn);
+}


### PR DESCRIPTION
## Summary
- Extract `complete_websocket_handshake()` - static helper for handshake loop, error handling, and final flush
- Extract `connection_transition_to_websocket()` - exported helper for connection state changes

Reduces TRY block from ~45 lines to ~10 lines with clear, single-purpose operations.

Fixes #2667

## Test plan
- [x] Build succeeds with sanitizers
- [x] All WebSocket tests pass (test_websocket, test_httpserver_websocket, test_websocket_h2)
- [x] All HTTP server tests pass