### PR TITLE
refactor(http): extract protocol-specific helpers from streaming functions

### DIFF
--- a/include/http/SocketHTTPServer-private.h
+++ b/include/http/SocketHTTPServer-private.h
@@ -401,6 +401,32 @@ void setup_ws_over_h2_streaming (ServerHTTP2Stream *s,
                                  SocketHTTPServer_BodyCallback callback,
                                  void *userdata);
 
+/* HTTP/2 streaming helpers (SocketHTTPServer-h2.c) */
+int server_h2_begin_stream (ServerConnection *conn, ServerHTTP2Stream *s);
+int server_h2_send_chunk (ServerConnection *conn,
+                          ServerHTTP2Stream *s,
+                          const void *data,
+                          size_t len);
+int server_h2_end_stream (ServerConnection *conn, ServerHTTP2Stream *s);
+
+/* HTTP/2 server push helpers (SocketHTTPServer-h2.c) */
+int server_h2_validate_push (SocketHTTPServer_Request_T req, const char *path);
+SocketHPACK_Header *
+server_h2_build_push_headers (Arena_T arena,
+                              const SocketHTTP_Request *parent,
+                              const char *path,
+                              SocketHTTP_Headers_T extra_headers,
+                              size_t *out_count);
+
+/* HTTP/1.1 streaming helpers (SocketHTTPServer-http1.c) */
+int
+server_http1_begin_stream (SocketHTTPServer_T server, ServerConnection *conn);
+int server_http1_send_chunk (SocketHTTPServer_T server,
+                             ServerConnection *conn,
+                             const void *data,
+                             size_t len);
+int server_http1_end_stream (SocketHTTPServer_T server, ServerConnection *conn);
+
 /* Rate limiting and validation (SocketHTTPServer-http1.c) */
 int server_check_rate_limit (SocketHTTPServer_T server, ServerConnection *conn);
 int server_run_validator (SocketHTTPServer_T server, ServerConnection *conn);


### PR DESCRIPTION
## Summary

Refactors four HTTP server streaming functions to separate concerns and eliminate mixed protocol logic:

- **`SocketHTTPServer_Request_begin_stream`**: 57 lines → 4 lines
- **`SocketHTTPServer_Request_send_chunk`**: 56 lines → 4 lines  
- **`SocketHTTPServer_Request_end_stream`**: 45 lines → 4 lines
- **`SocketHTTPServer_Request_push`**: 102 lines → 40 lines

### Changes

**New HTTP/2 helpers** (`src/http/server/SocketHTTPServer-h2.c`):
- `server_h2_begin_stream()` - Send response headers, set streaming flags
- `server_h2_send_chunk()` - Send data frame with buffering overflow handling
- `server_h2_end_stream()` - Finalize stream with END_STREAM flag
- `server_h2_validate_push()` - Check HTTP/2, SETTINGS_ENABLE_PUSH, path format
- `server_h2_build_push_headers()` - Build HPACK headers for push promise

**New HTTP/1.1 helpers** (`src/http/server/SocketHTTPServer-http1.c`):
- `server_http1_begin_stream()` - Add Transfer-Encoding, serialize headers, send
- `server_http1_send_chunk()` - Chunk-encode and send data
- `server_http1_end_stream()` - Send final chunk, finish request

**Simplified public API** (`src/http/SocketHTTPServer.c`):
- Public functions now dispatch to protocol-specific helpers
- Protocol selection via `req->h2_stream ? h2_helper() : http1_helper()`

Fixes #2669

## Test plan

- [x] All 128 tests pass with AddressSanitizer + UBSanitizer enabled
- [x] Public API unchanged - existing callers continue to work
- [x] Code formatted with clang-format