### PR TITLE
refactor(http): replace magic number with named constant for :status header

### DIFF
--- a/src/http/client/SocketHTTPClient-http2.c
+++ b/src/http/client/SocketHTTPClient-http2.c
@@ -22,6 +22,10 @@
 #include "http/SocketHTTP2.h"
 #include "http/SocketHTTPClient-private.h"
 
+/* HTTP/2 pseudo-header constants */
+#define PSEUDO_HEADER_STATUS ":status"
+#define PSEUDO_HEADER_STATUS_LEN 7
+
 void
 httpclient_http2_build_request (const SocketHTTPClient_Request_T req,
                                 SocketHTTP_Request *http_req)
@@ -51,8 +55,10 @@ httpclient_http2_parse_response_headers (const SocketHPACK_Header *headers,
   /* Find :status pseudo-header first */
   for (i = 0; i < header_count; i++)
     {
-      if (headers[i].name_len == 7
-          && memcmp (headers[i].name, ":status", 7) == 0)
+      if (headers[i].name_len == PSEUDO_HEADER_STATUS_LEN
+          && memcmp (headers[i].name, PSEUDO_HEADER_STATUS,
+                     PSEUDO_HEADER_STATUS_LEN)
+             == 0)
         {
           /* Parse status code */
           response->status_code = (int)strtol (headers[i].value, NULL, 10);


### PR DESCRIPTION
## Summary

Implements #2682

Replaces hardcoded magic number `7` with named constant when parsing HTTP/2 `:status` pseudo-header in the client response parser.

## Changes

- Added `PSEUDO_HEADER_STATUS` constant (":status")
- Added `PSEUDO_HEADER_STATUS_LEN` constant (7)
- Updated `httpclient_http2_parse_response_headers()` to use named constants instead of magic number

## Benefits

1. **Improved readability** - Intent is immediately clear
2. **Reduced error potential** - Only one place to change if the constant changes
3. **Consistency** - Follows existing codebase patterns (e.g., `HTTPCLIENT_DIGEST_PREFIX_LEN`)
4. **Better grep-ability** - Easy to search for `:status` references

## Test Plan

- [x] All 128 tests pass with sanitizers enabled
- [x] HTTP/2 client tests specifically verified
- [x] No functional changes - pure refactoring

Closes #2682