### PR TITLE
feat(http): add time() failure checks in cookie handling

### DIFF
--- a/src/http/client/SocketHTTPClient-cookie.c
+++ b/src/http/client/SocketHTTPClient-cookie.c
@@ -224,6 +224,11 @@ parse_max_age (const char *value, const size_t len)
 
   /* Calculate expiration time with overflow protection */
   now = time (NULL);
+  if (now == (time_t)-1)
+    {
+      HTTPCLIENT_ERROR_MSG ("time() failed");
+      return 0; /* Time failure - reject cookie */
+    }
   if (!SocketSecurity_check_add ((size_t)now, (size_t)age, &temp))
     return 1; /* Overflow in time calculation - treat as expired */
   expires = (time_t)temp;
@@ -456,6 +461,12 @@ SocketHTTPClient_CookieJar_set (SocketHTTPClient_CookieJar_T jar,
       }
 
     time_t now_t = time (NULL);
+    if (now_t == (time_t)-1)
+      {
+        HTTPCLIENT_ERROR_MSG ("time() failed");
+        result = -1;
+        goto unlock;
+      }
     size_t name_l = strlen (cookie->name);
     size_t value_l = strlen (cookie->value);
     size_t domain_l = strlen (cookie->domain);
@@ -620,6 +631,12 @@ SocketHTTPClient_CookieJar_set (SocketHTTPClient_CookieJar_T jar,
         entry->cookie.same_site = cookie->same_site;
 
         entry->created = time (NULL);
+        if (entry->created == (time_t)-1)
+          {
+            HTTPCLIENT_ERROR_MSG ("time() failed");
+            result = -1;
+            goto unlock;
+          }
 
         entry->next = jar->hash_table[hash];
         jar->hash_table[hash] = entry;
@@ -677,6 +694,11 @@ SocketHTTPClient_CookieJar_clear_expired (SocketHTTPClient_CookieJar_T jar)
   assert (jar != NULL);
 
   const time_t now = time (NULL);
+  if (now == (time_t)-1)
+    {
+      HTTPCLIENT_ERROR_MSG ("time() failed");
+      return; /* Cannot determine expiry without valid time */
+    }
 
   pthread_mutex_lock (&jar->mutex);
 
@@ -918,6 +940,11 @@ httpclient_cookies_for_request (SocketHTTPClient_CookieJar_T jar,
 
   output[0] = '\0';
   now = time (NULL);
+  if (now == (time_t)-1)
+    {
+      HTTPCLIENT_ERROR_MSG ("time() failed");
+      return -1; /* Cannot determine cookie validity without valid time */
+    }
   is_secure = SocketHTTP_URI_is_secure (uri);
   request_path = uri->path ? uri->path : "/";
 
@@ -1325,6 +1352,11 @@ httpclient_parse_set_cookie (const char *value,
     }
 
   time_t now = time (NULL);
+  if (now == (time_t)-1)
+    {
+      HTTPCLIENT_ERROR_MSG ("time() failed");
+      return -1; /* Cannot validate cookie expiry without valid time */
+    }
   if (cookie->expires != 0 && !cookie_expiry_is_valid (cookie->expires, now))
     {
       SocketLog_emitf (SOCKET_LOG_WARN,


### PR DESCRIPTION
## Summary

Implements #2680

Adds defensive checks for `time(NULL)` return value in 6 locations within cookie handling code. While extremely rare on modern systems, `time()` can return `(time_t)-1` on failure per POSIX specification.

## Changes

Added error checking for all 6 `time(NULL)` calls identified in the issue:

1. **parse_max_age (line 226)**: Return 0 to reject cookie when time() fails
2. **CookieJar_set (line 458)**: Return -1 via goto unlock for validation timestamp
3. **CookieJar_set (line 622)**: Return -1 via goto unlock for created timestamp  
4. **CookieJar_clear_expired (line 679)**: Return early without modification
5. **httpclient_cookies_for_request (line 920)**: Return -1 for validity check failure
6. **httpclient_parse_set_cookie (line 1327)**: Return -1 for expiry validation failure

All failures are logged via `HTTPCLIENT_ERROR_MSG` and handled gracefully by rejecting the operation.

## Test Plan

- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] Existing cookie tests continue to pass
- [x] Error handling follows project conventions
- [x] Code formatted with clang-format

## Impact

This is a defensive hardening change with:
- **Likelihood**: Extremely low (time() failure is very rare)
- **Impact**: Low to medium (affects cookie validation, not memory safety)
- **Priority**: Robustness improvement for security-critical cookie handling

Closes #2680