### PR TITLE
refactor(http): document stack usage for HTTP/2 header arrays

### DIFF
--- a/include/http/SocketHTTP2.h
+++ b/include/http/SocketHTTP2.h
@@ -61,6 +61,15 @@
 #define SOCKETHTTP2_MAX_CONTINUATION_FRAMES 32
 #define HTTP2_REQUEST_PSEUDO_HEADER_COUNT 4
 
+/*
+ * Stack usage check: Ensure SOCKETHTTP2_MAX_DECODED_HEADERS doesn't exceed
+ * safe stack limits. With SocketHPACK_Header ~40 bytes, limit to 256 headers
+ * (~10KB stack) to stay well within typical 8MB stack size.
+ */
+#if SOCKETHTTP2_MAX_DECODED_HEADERS > 256
+#error "SOCKETHTTP2_MAX_DECODED_HEADERS exceeds safe stack limit (>10KB)"
+#endif
+
 #endif
 
 #ifndef SOCKETHTTP2_MAX_STREAMS

--- a/src/http/client/SocketHTTPClient-http2.c
+++ b/src/http/client/SocketHTTPClient-http2.c
@@ -120,6 +120,12 @@ httpclient_http2_recv_headers (SocketHTTP2_Stream_T stream,
                                SocketHTTPClient_Response *response,
                                int *end_stream)
 {
+  /*
+   * Stack allocation: ~5KB (128 headers * ~40 bytes per SocketHPACK_Header).
+   * This is acceptable for modern systems (Linux default: 8MB stack).
+   * Chosen over heap allocation for performance (no malloc overhead).
+   * If stack pressure becomes an issue, consider arena allocation.
+   */
   SocketHPACK_Header headers[SOCKETHTTP2_MAX_DECODED_HEADERS];
   size_t header_count = 0;
   Arena_T arena;

--- a/src/http/h2/SocketHTTP2-stream.c
+++ b/src/http/h2/SocketHTTP2-stream.c
@@ -1246,6 +1246,7 @@ http2_decode_headers (SocketHTTP2_Conn_T conn,
                       const unsigned char *block,
                       size_t len)
 {
+  /* Stack allocation: ~5KB (see SocketHTTP2.h for rationale) */
   SocketHPACK_Header decoded_headers[HTTP2_MAX_DECODED_HEADERS];
   size_t header_count = 0;
   SocketHPACK_Result result;

--- a/src/http/server/SocketHTTPServer-h2.c
+++ b/src/http/server/SocketHTTPServer-h2.c
@@ -660,6 +660,12 @@ server_http2_stream_cb (SocketHTTP2_Conn_T http2_conn,
 
   if (event == HTTP2_EVENT_HEADERS_RECEIVED)
     {
+      /*
+       * Stack allocation: ~5KB (128 headers * ~40 bytes per SocketHPACK_Header).
+       * This is acceptable for modern systems (Linux default: 8MB stack).
+       * Chosen over heap allocation for performance (no malloc overhead).
+       * If stack pressure becomes an issue, consider arena allocation.
+       */
       SocketHPACK_Header hdrs[SOCKETHTTP2_MAX_DECODED_HEADERS];
       size_t hdr_count = 0;
       int end_stream = 0;
@@ -679,6 +685,7 @@ server_http2_stream_cb (SocketHTTP2_Conn_T http2_conn,
     }
   else if (event == HTTP2_EVENT_TRAILERS_RECEIVED)
     {
+      /* Stack allocation: Same rationale as headers above (~5KB) */
       SocketHPACK_Header trailers[SOCKETHTTP2_MAX_DECODED_HEADERS];
       size_t trailer_count = 0;
 


### PR DESCRIPTION
## Summary

Implements #2683

This PR addresses the documentation/awareness issue regarding ~5KB stack allocation for HTTP/2 header arrays.

## Changes

- **Added documentation comments** in 4 locations explaining stack usage rationale:
  - `src/http/client/SocketHTTPClient-http2.c`: `httpclient_http2_recv_headers()`
  - `src/http/server/SocketHTTPServer-h2.c`: Headers and trailers in `server_http2_stream_cb()`
  - `src/http/h2/SocketHTTP2-stream.c`: `http2_decode_headers()`

- **Added compile-time safety check** in `include/http/SocketHTTP2.h`:
  - Prevents `SOCKETHTTP2_MAX_DECODED_HEADERS` from exceeding 256 (>10KB stack)
  - Current value of 128 headers = ~5KB stack (128 * 40 bytes)

## Rationale

- **Current allocation (5KB)** is acceptable for modern systems:
  - Linux default stack: 8MB
  - 5KB = 0.06% of stack
  - Fast (no malloc overhead)
  - Bounded (fixed size, no growth)

- **Safety check** ensures future changes don't inadvertently increase stack pressure

- **Arena allocation** remains an option if stack pressure becomes an issue

## Test Plan

- [x] Tests pass with sanitizers (HTTP/2 and HPACK tests: 100%)
- [x] Build succeeds with no warnings
- [x] Compile-time check validated
- [x] No functional changes - documentation only

## Notes

This is a LOW priority documentation/awareness issue per #2683. The current implementation is pragmatic and performant.

Closes #2683