### PR TITLE
refactor(common): Flatten 5-level nesting in SocketCommon_sync_iov_progress

### DIFF
--- a/src/socket/SocketCommon.c
+++ b/src/socket/SocketCommon.c
@@ -1985,47 +1985,43 @@ SocketCommon_sync_iov_progress (struct iovec *original,
 
   for (i = 0; i < iovcnt; i++)
     {
-      /* If the copy base differed from the original base, the copy was
-       * advanced. Update the original iovec to reflect bytes consumed. Be
-       * defensive: both bases may be NULL (fully consumed) or one may be NULL.
-       * Only do pointer arithmetic when both are non-NULL. */
-      if (copy[i].iov_base != original[i].iov_base)
+      /* Skip if bases are the same - nothing was consumed */
+      if (copy[i].iov_base == original[i].iov_base)
+        continue;
+
+      const char *copy_base = (const char *)copy[i].iov_base;
+      const char *orig_base = (const char *)original[i].iov_base;
+
+      /* If original is already NULL we assume it was already fully
+       * consumed earlier; nothing to do. */
+      if (orig_base == NULL)
+        continue;
+
+      /* If the copy base is NULL, the copy was advanced past the end of
+       * this vector so the original is now fully consumed. */
+      if (copy_base == NULL)
         {
-          const char *copy_base = (const char *)copy[i].iov_base;
-          const char *orig_base = (const char *)original[i].iov_base;
+          original[i].iov_len = 0;
+          original[i].iov_base = NULL;
+          continue;
+        }
 
-          /* If original is already NULL we assume it was already fully
-           * consumed earlier; nothing to do. */
-          if (orig_base == NULL)
-            continue;
+      /* Unexpected - copy base is before original base. Ignore to avoid UB. */
+      if (copy_base < orig_base)
+        continue;
 
-          /* If the copy base is NULL, the copy was advanced past the end of
-           * this vector so the original is now fully consumed. */
-          if (copy_base == NULL)
-            {
-              original[i].iov_len = 0;
-              original[i].iov_base = NULL;
-              continue;
-            }
-
-          /* Normal case: both bases non-NULL. Ensure subtraction yields a
-           * non-negative size and clamp against original length. */
-          if (copy_base >= orig_base)
-            {
-              size_t copied = (size_t)(copy_base - orig_base);
-              if (copied >= original[i].iov_len)
-                {
-                  original[i].iov_len = 0;
-                  original[i].iov_base = NULL;
-                }
-              else
-                {
-                  original[i].iov_len -= copied;
-                  original[i].iov_base = (char *)orig_base + copied;
-                }
-            }
-          /* else: Unexpected - copy base is before original base. Ignore to
-           * avoid UB. */
+      /* Normal case: both bases non-NULL. Ensure subtraction yields a
+       * non-negative size and clamp against original length. */
+      size_t copied = (size_t)(copy_base - orig_base);
+      if (copied >= original[i].iov_len)
+        {
+          original[i].iov_len = 0;
+          original[i].iov_base = NULL;
+        }
+      else
+        {
+          original[i].iov_len -= copied;
+          original[i].iov_base = (char *)orig_base + copied;
         }
     }
 }


### PR DESCRIPTION
## Summary

Implements #2727 - Refactors `SocketCommon_sync_iov_progress` to reduce deep nesting from 5 levels to 2 levels max.

## Changes

- Inverted initial condition: `if (bases same) continue` instead of wrapping all logic in `if (bases differ)`
- Made the "copy_base < orig_base" edge case explicit with a guard clause instead of relying on implicit else-comment
- Moved main logic to normal indentation for better readability
- All other logic remains functionally identical

## Benefits

1. **Reduced nesting**: From 5 levels to 2 levels max
2. **Linear flow**: Guard clauses at the top, main logic at bottom
3. **Explicit edge cases**: The `copy_base < orig_base` case is now explicitly handled
4. **Easier to test**: Each condition is clearly separated
5. **Better readability**: The "happy path" (normal case) is at normal indentation

## Test Plan

- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] All 128 tests pass
- [x] No functional changes to behavior
- [x] Code formatted with clang-format

Closes #2727