### PR TITLE
refactor(http): extract helper functions from HTTP server

### DIFF
--- a/include/http/SocketHTTPServer-private.h
+++ b/include/http/SocketHTTPServer-private.h
@@ -330,6 +330,8 @@ void connection_transition_to_websocket (SocketHTTPServer_T server,
                                          SocketWS_T ws,
                                          SocketHTTPServer_BodyCallback callback,
                                          void *userdata);
+int select_protocol_after_handshake (SocketHTTPServer_T server,
+                                     ServerConnection *conn);
 
 /* Event loop helpers (SocketHTTPServer.c) */
 int server_check_connection_timeout (SocketHTTPServer_T server,


### PR DESCRIPTION
## Summary

Implements #2656 by extracting remaining helper functions from long HTTP server functions.

## Changes

### 1. Extract `header_contains_crlf()` helper
- **Location**: `src/http/SocketHTTPServer.c`
- **Purpose**: Centralized CRLF validation for response header injection prevention
- **Impact**: Reduces `SocketHTTPServer_Request_header` from 34 to 21 lines
- **Benefit**: Eliminates duplicate validation loops

### 2. Extract `select_protocol_after_handshake()` helper
- **Location**: `src/http/server/SocketHTTPServer-connections.c`
- **Purpose**: ALPN-based HTTP/2 vs HTTP/1.1 protocol selection
- **Impact**: Reduces `server_process_tls_handshake` from 72 to 48 lines
- **Benefit**: Separates protocol decision from TLS handshake loop

## Context

Most helpers from issue #2656 were already implemented in prior refactorings:
- Protocol-specific streaming helpers (#2671, ea74d207)
- WebSocket upgrade helpers (#2664, 6ef47908)
- Helper organization (#2666, 89f545a9)

This PR completes the refactoring by extracting the remaining two helpers.

## Test Plan

- [x] All HTTP server tests pass (27/27)
- [x] HTTP/2 tests pass
- [x] WebSocket tests pass
- [x] Tests run with ASan/UBSan enabled
- [x] Code formatted with clang-format

## Results

- **Single responsibility**: Each function does one cohesive thing
- **Reduced duplication**: CRLF check centralized
- **Improved testability**: Protocol selection can be tested independently
- **Clearer separation**: Handshake vs protocol selection concerns

Closes #2656