### PR TITLE
refactor(ws-handshake): flatten nested conditionals in ws_write_subprotocol_header

### DIFF
--- a/src/socket/SocketWS-handshake.c
+++ b/src/socket/SocketWS-handshake.c
@@ -28,6 +28,7 @@
 
 #include <assert.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -147,6 +148,7 @@ ws_write_subprotocol_header (char *buf,
                              const char *const *subprotocols)
 {
   const char *const *proto;
+  bool need_comma;
 
   if (!subprotocols || !subprotocols[0])
     return 0;
@@ -154,16 +156,17 @@ ws_write_subprotocol_header (char *buf,
   if (ws_snprintf_checked (buf, size, offset, "Sec-WebSocket-Protocol: ") < 0)
     return -1;
 
+  need_comma = false;
   for (proto = subprotocols; *proto; proto++)
     {
-      /* Add comma separator after first element */
-      if (proto != subprotocols)
-        {
-          if (ws_snprintf_checked (buf, size, offset, ", ") < 0)
-            return -1;
-        }
+      /* Add comma separator between elements */
+      if (need_comma && ws_snprintf_checked (buf, size, offset, ", ") < 0)
+        return -1;
+
       if (ws_snprintf_checked (buf, size, offset, "%s", *proto) < 0)
         return -1;
+
+      need_comma = true;
     }
 
   return ws_snprintf_checked (buf, size, offset, "\r\n");


### PR DESCRIPTION
## Summary

Implements #2741

Reduces nesting depth from 3 to 2 levels in `ws_write_subprotocol_header` by using a boolean flag instead of checking pointer equality for comma separation logic.

## Changes

- Added `bool need_comma` flag to track when to insert comma separators
- Replaced nested `if (proto != subprotocols)` check with single-line conditional
- Added `stdbool.h` include for boolean type support
- Improved code readability by making comma logic more explicit

## Benefits

1. **Reduced nesting**: Eliminates one level of nesting (from 3 to 2 levels)
2. **Clearer logic**: Comma handling is explicit with `need_comma` flag
3. **Better flow**: All error returns at same indentation level
4. **More maintainable**: Logic is linear and easier to follow

## Test Plan

- [x] All WebSocket tests pass (24/24)
- [x] WebSocket integration tests pass (6/6)
- [x] Tests run with sanitizers enabled (ASan + UBSan)
- [x] No functional changes to handshake behavior

Closes #2741