### PR TITLE
refactor(reconnect): flatten nested conditionals in SocketReconnect_next_timeout_ms

### DIFF
--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -1232,15 +1232,16 @@ SocketReconnect_next_timeout_ms (T conn)
 
     case RECONNECT_CONNECTED:
       /* Health check timer */
-      if (conn->policy.health_check_interval_ms > 0)
-        {
-          remaining = (conn->last_health_check_ms
-                       + conn->policy.health_check_interval_ms)
-                      - now;
-          if (remaining <= 0)
-            return 0;
-          timeout = (int)remaining;
-        }
+      if (conn->policy.health_check_interval_ms <= 0)
+        break;
+
+      remaining = (conn->last_health_check_ms
+                   + conn->policy.health_check_interval_ms)
+                  - now;
+      if (remaining <= 0)
+        return 0;
+
+      timeout = (int)remaining;
       break;
 
     default:


### PR DESCRIPTION
## Summary

Implements #2754 - Flattens nested conditionals in the `RECONNECT_CONNECTED` case of `SocketReconnect_next_timeout_ms` using guard clause pattern.

## Changes

- Applied early-return guard clause for `health_check_interval_ms <= 0`
- Reduced nesting by one level in the success path
- Improved code readability while maintaining identical logic

### Before
```c
case RECONNECT_CONNECTED:
  /* Health check timer */
  if (conn->policy.health_check_interval_ms > 0)
    {
      remaining = (conn->last_health_check_ms
                   + conn->policy.health_check_interval_ms)
                  - now;
      if (remaining <= 0)
        return 0;
      timeout = (int)remaining;
    }
  break;
```

### After
```c
case RECONNECT_CONNECTED:
  /* Health check timer */
  if (conn->policy.health_check_interval_ms <= 0)
    break;

  remaining = (conn->last_health_check_ms
               + conn->policy.health_check_interval_ms)
              - now;
  if (remaining <= 0)
    return 0;

  timeout = (int)remaining;
  break;
```

## Test Plan

- [x] All 67 reconnect tests pass with sanitizers (`test_reconnect`)
- [x] Build succeeds with sanitizers enabled
- [x] Logic is functionally equivalent (guard clause inverts condition)
- [x] Follows CLAUDE.md "Deep Nesting (Arrow Code)" pattern

## Note on Test Suite

Three pre-existing test failures are present on main branch (unrelated to this change):
- `test_happy_eyeballs` (subprocess aborted)
- `test_tls_phase4` (timeout)
- `test_tls_security` (timeout)

These failures exist before this refactoring and are not introduced by these changes.

Closes #2754