### PR TITLE
refactor(proxy): flatten 5-level nesting in TLS handshake case

### DIFF
--- a/src/socket/SocketProxy.c
+++ b/src/socket/SocketProxy.c
@@ -1620,6 +1620,40 @@ proxy_process_recv (struct SocketProxy_Conn_T *conn)
   return 0;
 }
 
+#if SOCKET_HAS_TLS
+static void
+proxy_process_tls_handshake (SocketProxy_Conn_T conn)
+{
+  if (proxy_check_timeout (conn) < 0)
+    return;
+
+  TLSHandshakeState hs = SocketTLS_handshake (conn->socket);
+
+  /* Guard clause: Handle error state first */
+  if (hs == TLS_HANDSHAKE_ERROR)
+    {
+      socketproxy_set_error (conn,
+                             PROXY_ERROR_PROTOCOL,
+                             "TLS handshake failed: %s",
+                             Socket_GetLastError ());
+      conn->state = PROXY_STATE_FAILED;
+      return;
+    }
+
+  /* Guard clause: Nothing to do if still in progress */
+  if (hs != TLS_HANDSHAKE_COMPLETE)
+    return;
+
+  /* Success path: flat and prominent */
+  conn->tls_enabled = 1;
+  conn->state = PROXY_STATE_HANDSHAKE_SEND;
+  conn->handshake_start_time_ms = socketproxy_get_time_ms ();
+
+  if (proxy_build_initial_request (conn) < 0)
+    return;
+}
+#endif
+
 void
 SocketProxy_Conn_process (SocketProxy_Conn_T conn)
 {
@@ -1636,27 +1670,7 @@ SocketProxy_Conn_process (SocketProxy_Conn_T conn)
 
     case PROXY_STATE_TLS_TO_PROXY:
 #if SOCKET_HAS_TLS
-      if (proxy_check_timeout (conn) < 0)
-        return;
-
-      TLSHandshakeState hs = SocketTLS_handshake (conn->socket);
-
-      if (hs == TLS_HANDSHAKE_COMPLETE)
-        {
-          conn->tls_enabled = 1;
-          conn->state = PROXY_STATE_HANDSHAKE_SEND;
-          conn->handshake_start_time_ms = socketproxy_get_time_ms ();
-          if (proxy_build_initial_request (conn) < 0)
-            return;
-        }
-      else if (hs == TLS_HANDSHAKE_ERROR)
-        {
-          socketproxy_set_error (conn,
-                                 PROXY_ERROR_PROTOCOL,
-                                 "TLS handshake failed: %s",
-                                 Socket_GetLastError ());
-          conn->state = PROXY_STATE_FAILED;
-        }
+      proxy_process_tls_handshake (conn);
 #endif
       break;
 


### PR DESCRIPTION
## Summary

Implements #2744

Refactors the `PROXY_STATE_TLS_TO_PROXY` case handler in `SocketProxy_Conn_process` by extracting deeply nested TLS handshake logic into a dedicated helper function.

## Changes

- **Added** `proxy_process_tls_handshake()` helper function
- **Reduced** nesting depth from 5 levels to 1 level
- **Applied** guard clause pattern: handle errors first, then in-progress state, then success path
- **Improved** readability: success path now at normal indentation level
- **Simplified** switch case: single function call instead of 24 lines of inline logic

## Code Structure

**Before**: 5-level nesting with success path buried deep
```c
case PROXY_STATE_TLS_TO_PROXY:
#if SOCKET_HAS_TLS
  if (proxy_check_timeout (conn) < 0)
    return;
  TLSHandshakeState hs = SocketTLS_handshake (conn->socket);
  if (hs == TLS_HANDSHAKE_COMPLETE)
    {
      // success path at level 5
    }
  else if (hs == TLS_HANDSHAKE_ERROR)
    {
      // error handling
    }
#endif
  break;
```

**After**: Clean helper function with guard clauses
```c
case PROXY_STATE_TLS_TO_PROXY:
#if SOCKET_HAS_TLS
  proxy_process_tls_handshake (conn);
#endif
  break;

// Helper function:
static void proxy_process_tls_handshake(SocketProxy_Conn_T conn)
{
  // Guard: timeout check
  // Guard: error state
  // Guard: still in progress
  // Success path at level 1
}
```

## Test Plan

- [x] All proxy tests pass with sanitizers (`test_proxy`, `test_simple_proxy_url`, `test_proxy_integration`)
- [x] Build succeeds with `-DENABLE_SANITIZERS=ON`
- [x] Code formatted with `clang-format`
- [x] No functional changes - purely structural refactoring

## Benefits

1. **Readability**: Success path is prominent, not buried
2. **Maintainability**: Easier to add new states or error conditions
3. **Consistency**: Follows anti-pattern fixes from CLAUDE.md
4. **Cognitive load**: Reduced from 5-level arrow code to flat structure

Closes #2744