### PR TITLE
refactor(http): flatten 5-level nesting in validate_pct_encoded

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -1038,20 +1038,25 @@ validate_pct_encoded (const char *s, size_t len)
   size_t i = 0;
   while (i < len)
     {
-      if (s[i] == '%')
-        {
-          if (i + 2 >= len)
-            return URI_PARSE_ERROR;
-          unsigned char hi = SOCKETHTTP_HEX_VALUE (s[i + 1]);
-          unsigned char lo = SOCKETHTTP_HEX_VALUE (s[i + 2]);
-          if (hi == HEX_INVALID || lo == HEX_INVALID)
-            return URI_PARSE_ERROR;
-          i += 3;
-        }
-      else
+      /* Skip non-encoded characters */
+      if (s[i] != '%')
         {
           i++;
+          continue;
         }
+
+      /* Guard clause: Ensure enough characters remain for hex pair */
+      if (i + 2 >= len)
+        return URI_PARSE_ERROR;
+
+      /* Validate hex pair */
+      unsigned char hi = SOCKETHTTP_HEX_VALUE (s[i + 1]);
+      unsigned char lo = SOCKETHTTP_HEX_VALUE (s[i + 2]);
+
+      if (hi == HEX_INVALID || lo == HEX_INVALID)
+        return URI_PARSE_ERROR;
+
+      i += 3;
     }
   return URI_PARSE_OK;
 }


### PR DESCRIPTION
## Summary

Implements #2802 - Flattens the 5-level nesting in the `validate_pct_encoded` function to improve code readability.

## Changes

- Inverted the main condition in `validate_pct_encoded` from `if (s[i] == '%')` to `if (s[i] != '%')`
- Used early `continue` to skip non-encoded characters and return to top of loop
- Moved percent-encoding validation logic to normal indentation levels (3 levels instead of 5)
- Added clear comments to separate concerns (skip non-encoded, guard clause, validate hex pair)

## Behavior

The function behavior is identical to the original:
- Non-percent-encoded characters are validated (single increment)
- Percent-encoded sequences are validated with proper bounds checking
- Invalid hex sequences return `URI_PARSE_ERROR`
- Valid URIs still return `URI_PARSE_OK`

## Test Plan

- [x] URL utilities test passes (`test_url_utils`)
- [x] Build succeeds with sanitizers enabled
- [x] Refactoring reduces nesting from 5 to 3 levels
- [x] No changes to validation logic or error handling

Closes #2802