### PR TITLE
refactor(server): flatten nested if in server_find_static_route() (#2878)

### DIFF
--- a/src/http/server/SocketHTTPServer-static.c
+++ b/src/http/server/SocketHTTPServer-static.c
@@ -48,7 +48,7 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPServer);
 #endif
 
 /* String literal length macro (compile-time) */
-#define STRLEN_LIT(s) (sizeof(s) - 1)
+#define STRLEN_LIT(s) (sizeof (s) - 1)
 
 /* Range header prefix constant */
 #define RANGE_HEADER_PREFIX "bytes="
@@ -169,7 +169,8 @@ validate_static_path (const char *path)
       if (p[1] == '.' && (p[2] == '/' || p[2] == '\0'))
         return 0;
 
-      /* Handle "." (valid, skip it) - flatten nesting with direct calculation */
+      /* Handle "." (valid, skip it) - flatten nesting with direct calculation
+       */
       if (p[1] == '/')
         {
           p += 2;
@@ -289,9 +290,8 @@ handle_conditional_get (ServerConnection *conn,
   conn->response_status = 304;
   conn->response_body = NULL;
   conn->response_body_len = 0;
-  SocketHTTP_Headers_set (conn->response_headers,
-                          "Date",
-                          format_http_date (time (NULL), date_buf));
+  SocketHTTP_Headers_set (
+      conn->response_headers, "Date", format_http_date (time (NULL), date_buf));
   SocketHTTP_Headers_set (conn->response_headers,
                           "Last-Modified",
                           format_http_date (file_mtime, last_modified_buf));
@@ -360,7 +360,8 @@ parse_range_header (const char *range_str,
     return 0;
 
   /* Must start with "bytes=" */
-  if (strncmp (range_str, RANGE_HEADER_PREFIX, STRLEN_LIT (RANGE_HEADER_PREFIX)) != 0)
+  if (strncmp (range_str, RANGE_HEADER_PREFIX, STRLEN_LIT (RANGE_HEADER_PREFIX))
+      != 0)
     return 0;
 
   p = range_str + STRLEN_LIT (RANGE_HEADER_PREFIX);
@@ -439,13 +440,11 @@ server_find_static_route (SocketHTTPServer_T server, const char *path)
   /* Find longest matching prefix */
   for (route = server->static_routes; route != NULL; route = route->next)
     {
-      if (strncmp (path, route->prefix, route->prefix_len) == 0)
+      if (strncmp (path, route->prefix, route->prefix_len) == 0
+          && route->prefix_len > best_len)
         {
-          if (route->prefix_len > best_len)
-            {
-              best = route;
-              best_len = route->prefix_len;
-            }
+          best = route;
+          best_len = route->prefix_len;
         }
     }
 


### PR DESCRIPTION
## Summary

Refactors the `server_find_static_route()` function to flatten deeply nested if statements. The two logically independent checks (prefix match and length comparison) are now combined into a single compound condition, reducing nesting depth from 4 levels to 2 levels.

## Changes

- Combined nested if conditions into single compound condition in `server_find_static_route()`
- Reduces code nesting depth for improved readability
- No behavioral changes - refactoring only

## Test Plan

- [x] All 128 tests pass with ASan/UBSan sanitizers enabled
- [x] Static route matching logic verified to work correctly
- [x] Code formatted with clang-format per project standards

Closes #2878