### PR TITLE
refactor(http): Flatten 5-level nesting in SocketHTTP_URI_build

### DIFF
--- a/src/http/SocketHTTP-uri.c
+++ b/src/http/SocketHTTP-uri.c
@@ -925,6 +925,65 @@ SocketHTTP_URI_decode (const char *input,
     }                                      \
   while (0)
 
+/* Helper: Append scheme component */
+static ssize_t
+uri_build_scheme (const SocketHTTP_URI *uri,
+                  char *output,
+                  size_t output_size,
+                  size_t *pos)
+{
+  if (!uri->scheme || uri->scheme_len == 0)
+    return 0;
+
+  URI_APPEND_STR (output, *pos, output_size, uri->scheme, uri->scheme_len);
+  URI_APPEND_CHAR (output, *pos, output_size, ':');
+
+  /* Add "//" if we have a host */
+  if (uri->host && uri->host_len > 0)
+    {
+      URI_APPEND_CHAR (output, *pos, output_size, '/');
+      URI_APPEND_CHAR (output, *pos, output_size, '/');
+    }
+
+  return 0;
+}
+
+/* Helper: Append authority component (userinfo + host + port) */
+static ssize_t
+uri_build_authority (const SocketHTTP_URI *uri,
+                     char *output,
+                     size_t output_size,
+                     size_t *pos)
+{
+  if (!uri->host || uri->host_len == 0)
+    return 0;
+
+  /* Userinfo (optional) */
+  if (uri->userinfo && uri->userinfo_len > 0)
+    {
+      URI_APPEND_STR (output, *pos, output_size, uri->userinfo, uri->userinfo_len);
+      URI_APPEND_CHAR (output, *pos, output_size, '@');
+    }
+
+  /* Host (required) */
+  URI_APPEND_STR (output, *pos, output_size, uri->host, uri->host_len);
+
+  /* Port (optional) */
+  if (uri->port >= 0)
+    {
+      char port_buf[URI_PORT_BUFSIZE];
+      int port_len = snprintf (port_buf, sizeof (port_buf), ":%d", uri->port);
+
+      /* Early return if snprintf failed */
+      if (port_len <= 0 || (size_t)port_len >= sizeof (port_buf))
+        return 0;
+
+      URI_APPEND_STR (output, *pos, output_size, port_buf, (size_t)port_len);
+    }
+
+  return 0;
+}
+
 ssize_t
 SocketHTTP_URI_build (const SocketHTTP_URI *uri,
                       char *output,
@@ -935,49 +994,26 @@ SocketHTTP_URI_build (const SocketHTTP_URI *uri,
 
   size_t pos = 0;
 
-  if (uri->scheme && uri->scheme_len > 0)
-    {
-      URI_APPEND_STR (output, pos, output_size, uri->scheme, uri->scheme_len);
-      URI_APPEND_CHAR (output, pos, output_size, ':');
+  /* Scheme */
+  if (uri_build_scheme (uri, output, output_size, &pos) < 0)
+    return -1;
 
-      if (uri->host && uri->host_len > 0)
-        {
-          URI_APPEND_CHAR (output, pos, output_size, '/');
-          URI_APPEND_CHAR (output, pos, output_size, '/');
-        }
-    }
+  /* Authority (userinfo + host + port) */
+  if (uri_build_authority (uri, output, output_size, &pos) < 0)
+    return -1;
 
-  if (uri->host && uri->host_len > 0)
-    {
-      if (uri->userinfo && uri->userinfo_len > 0)
-        {
-          URI_APPEND_STR (
-              output, pos, output_size, uri->userinfo, uri->userinfo_len);
-          URI_APPEND_CHAR (output, pos, output_size, '@');
-        }
-
-      URI_APPEND_STR (output, pos, output_size, uri->host, uri->host_len);
-
-      if (uri->port >= 0)
-        {
-          char port_buf[URI_PORT_BUFSIZE];
-          int port_len
-              = snprintf (port_buf, sizeof (port_buf), ":%d", uri->port);
-          if (port_len > 0 && (size_t)port_len < sizeof (port_buf))
-            URI_APPEND_STR (
-                output, pos, output_size, port_buf, (size_t)port_len);
-        }
-    }
-
+  /* Path */
   if (uri->path && uri->path_len > 0)
     URI_APPEND_STR (output, pos, output_size, uri->path, uri->path_len);
 
+  /* Query */
   if (uri->query && uri->query_len > 0)
     {
       URI_APPEND_CHAR (output, pos, output_size, '?');
       URI_APPEND_STR (output, pos, output_size, uri->query, uri->query_len);
     }
 
+  /* Fragment */
   if (uri->fragment && uri->fragment_len > 0)
     {
       URI_APPEND_CHAR (output, pos, output_size, '#');


### PR DESCRIPTION
## Summary

Implements #2809 by refactoring `SocketHTTP_URI_build` to extract helper functions and flatten deeply nested conditionals.

## Changes

- Extract `uri_build_scheme()` helper to handle scheme and authority prefix
- Extract `uri_build_authority()` helper to handle userinfo, host, and port
- Reduce maximum nesting depth from 5 levels to 2 levels
- Improve code readability and maintainability
- Clear separation of RFC 3986 URI components

## Test Plan

- [x] All 295 existing tests pass with ASan/UBSan enabled
- [x] No memory leaks detected with `ASAN_OPTIONS=detect_leaks=1:abort_on_error=1`
- [x] Function behavior unchanged - refactoring only

Closes #2809