### PR TITLE
refactor(http-client): flatten nested conditionals in pool lookup functions

### DIFF
--- a/src/http/client/SocketHTTPClient-pool.c
+++ b/src/http/client/SocketHTTPClient-pool.c
@@ -429,31 +429,44 @@ httpclient_pool_get (HTTPPool *pool, const char *host, int port, int is_secure)
   while (entry != NULL && chain_len < POOL_MAX_HASH_CHAIN_LEN)
     {
       ++chain_len;
-      if (host_port_secure_match (entry, host, port, is_secure)
-          && entry_can_handle_request (entry))
-        {
-          /* SECURITY: Verify TLS hostname matches for secure connections
-           * to prevent connection reuse across different hostnames.
-           * CVE-like vulnerability: An attacker could obtain a connection to
-           * evil.com, then reuse it for bank.com if we don't verify SNI
-           * hostname. RFC 6125 requires hostname verification on every TLS
-           * session use.
-           */
-          if (!verify_sni_hostname_match (entry, host))
-            {
-              /* Hostname mismatch - skip this connection and continue search */
-              entry = entry->hash_next;
-              continue;
-            }
 
-          clear_http1_buffers (entry);
-          entry_mark_in_use (entry);
-          pool->reused_connections++;
-          pthread_mutex_unlock (&pool->mutex);
-          return entry;
+      /* Skip if host/port/security don't match */
+      if (!host_port_secure_match (entry, host, port, is_secure))
+        {
+          entry = entry->hash_next;
+          continue;
         }
-      entry = entry->hash_next;
+
+      /* Skip if entry can't handle new requests */
+      if (!entry_can_handle_request (entry))
+        {
+          entry = entry->hash_next;
+          continue;
+        }
+
+      /* SECURITY: Verify TLS hostname matches for secure connections
+       * to prevent connection reuse across different hostnames.
+       * CVE-like vulnerability: An attacker could obtain a connection to
+       * evil.com, then reuse it for bank.com if we don't verify SNI
+       * hostname. RFC 6125 requires hostname verification on every TLS
+       * session use.
+       */
+      if (!verify_sni_hostname_match (entry, host))
+        {
+          /* Hostname mismatch - skip this connection and continue search */
+          entry = entry->hash_next;
+          continue;
+        }
+
+      /* Found usable connection - prepare and return it */
+      clear_http1_buffers (entry);
+      entry_mark_in_use (entry);
+      pool->reused_connections++;
+      pthread_mutex_unlock (&pool->mutex);
+      return entry;
     }
+
+  /* No match found - check if we hit DoS limit */
   if (chain_len >= POOL_MAX_HASH_CHAIN_LEN)
     raise_chain_too_long (chain_len, "in pool lookup", host, port);
 
@@ -484,24 +497,37 @@ httpclient_pool_get_prepared (HTTPPool *pool,
   while (entry != NULL && chain_len < POOL_MAX_HASH_CHAIN_LEN)
     {
       ++chain_len;
-      if (host_port_secure_match (entry, host, port, is_secure)
-          && entry_can_handle_request (entry))
-        {
-          /* SECURITY: Verify TLS hostname matches for secure connections */
-          if (!verify_sni_hostname_match (entry, host))
-            {
-              entry = entry->hash_next;
-              continue;
-            }
 
-          clear_http1_buffers (entry);
-          entry_mark_in_use (entry);
-          pool->reused_connections++;
-          pthread_mutex_unlock (&pool->mutex);
-          return entry;
+      /* Skip if host/port/security don't match */
+      if (!host_port_secure_match (entry, host, port, is_secure))
+        {
+          entry = entry->hash_next;
+          continue;
         }
-      entry = entry->hash_next;
+
+      /* Skip if entry can't handle new requests */
+      if (!entry_can_handle_request (entry))
+        {
+          entry = entry->hash_next;
+          continue;
+        }
+
+      /* SECURITY: Verify TLS hostname matches for secure connections */
+      if (!verify_sni_hostname_match (entry, host))
+        {
+          entry = entry->hash_next;
+          continue;
+        }
+
+      /* Found usable connection - prepare and return it */
+      clear_http1_buffers (entry);
+      entry_mark_in_use (entry);
+      pool->reused_connections++;
+      pthread_mutex_unlock (&pool->mutex);
+      return entry;
     }
+
+  /* No match found - check if we hit DoS limit */
   if (chain_len >= POOL_MAX_HASH_CHAIN_LEN)
     raise_chain_too_long (chain_len, "in pool lookup", host, port);
 


### PR DESCRIPTION
## Summary

Implements #2844

Refactored both `httpclient_pool_get` and `httpclient_pool_get_prepared` to use guard clauses instead of deeply nested if statements, reducing nesting depth from 5 levels to 2-3 levels.

## Changes

**Before** (5 levels of nesting):
```c
while (entry != NULL && chain_len < POOL_MAX_HASH_CHAIN_LEN) {
    ++chain_len;
    if (host_port_secure_match(...) && entry_can_handle_request(...)) {  // Level 3
        if (!verify_sni_hostname_match(...)) {                           // Level 4
            entry = entry->hash_next;                                    // Level 5
            continue;
        }
        // Success path buried at level 4-5
    }
    entry = entry->hash_next;
}
```

**After** (2-3 levels with guard clauses):
```c
while (entry != NULL && chain_len < POOL_MAX_HASH_CHAIN_LEN) {
    ++chain_len;
    
    /* Skip if host/port/security don't match */
    if (!host_port_secure_match(...)) {
        entry = entry->hash_next;
        continue;
    }
    
    /* Skip if entry can't handle new requests */
    if (!entry_can_handle_request(...)) {
        entry = entry->hash_next;
        continue;
    }
    
    /* SECURITY: Verify TLS hostname matches */
    if (!verify_sni_hostname_match(...)) {
        entry = entry->hash_next;
        continue;
    }
    
    /* Found usable connection - prepare and return it */
    // Success path at normal indentation
}
```

## Benefits

- Each skip condition is isolated and self-documenting
- Success path at normal indentation (easier to read)
- Security checks (SNI verification) more prominent
- All loop continuation logic consolidated in one place
- Easier to add/modify skip conditions without deep nesting

## Test Plan

- [x] All 128 tests pass with sanitizers enabled
- [x] No behavior change - refactoring only improves readability
- [x] Both functions follow same pattern for consistency

Closes #2844