### PR TITLE
refactor(http2): flatten nested conditionals in SocketHTTP2_Priority_serialize

### DIFF
--- a/src/http/h2/SocketHTTP2-priority.c
+++ b/src/http/h2/SocketHTTP2-priority.c
@@ -369,24 +369,22 @@ SocketHTTP2_Priority_serialize (const SocketHTTP2_Priority *priority,
     }
 
   /* Write incremental if true */
-  if (priority->incremental)
+  if (!priority->incremental)
+    return (ssize_t)len; /* Early exit if nothing more to write */
+
+  /* Calculate space needed: "i" (1 char) or ", i" (3 chars) */
+  size_t needed = wrote_param ? 3 : 1;
+  if (len + needed > buf_size)
+    return -1;
+
+  /* Write separator if needed */
+  if (wrote_param)
     {
-      if (wrote_param)
-        {
-          /* ", i" needs 3 more characters */
-          if (len + 3 > buf_size)
-            return -1;
-          buf[len++] = ',';
-          buf[len++] = ' ';
-        }
-      if (len + 1 > buf_size)
-        return -1;
-      buf[len++] = 'i';
+      buf[len++] = ',';
+      buf[len++] = ' ';
     }
 
-  /* If nothing written, we could write nothing or write defaults */
-  /* RFC 9218: omitting a parameter is equivalent to the default value */
-
+  buf[len++] = 'i';
   return (ssize_t)len;
 }
 


### PR DESCRIPTION
## Summary

Implements #2820

Flattens 3-level nested conditionals in `SocketHTTP2_Priority_serialize` to improve readability and make buffer overflow checks more prominent.

## Changes

- Added early return guard clause for `!priority->incremental` case
- Consolidated buffer size calculations into single `needed` variable
- Reduced nesting depth from 3 levels to 1
- Made buffer overflow checks more visible and easier to verify

**Before**: Nested if statements obscured buffer checks:
```c
if (priority->incremental) {
    if (wrote_param) {
        if (len + 3 > buf_size)
            return -1;
        ...
    }
    if (len + 1 > buf_size)
        return -1;
    ...
}
```

**After**: Guard clause with explicit space calculation:
```c
if (!priority->incremental)
    return (ssize_t)len;

size_t needed = wrote_param ? 3 : 1;
if (len + needed > buf_size)
    return -1;

if (wrote_param) {
    buf[len++] = ',';
    buf[len++] = ' ';
}
buf[len++] = 'i';
```

## Test Plan

- [x] All HTTP/2 priority tests pass (14/14)
- [x] All HTTP integration tests pass
- [x] Tests pass with ASan/UBSan enabled
- [x] No behavioral changes - purely structural refactoring

Closes #2820