### PR TITLE
refactor(http): flatten nested conditionals in retry loop

### DIFF
--- a/src/http/SocketHTTPClient.c
+++ b/src/http/SocketHTTPClient.c
@@ -1182,19 +1182,17 @@ SocketHTTPClient_Request_execute (SocketHTTPClient_Request_T req,
       /* Attempt the request */
       result = execute_single_attempt (client, req, response);
 
-      /* Success */
+      /* Success - check if we should retry on 5xx */
       if (result == 0)
         {
-          /* Check if we need to retry on 5xx */
-          if (!should_retry_5xx (client, response, attempt))
-            return 0;
+          if (should_retry_5xx (client, response, attempt))
+            continue;  /* Retry on 5xx */
+          return 0;    /* Success, no retry needed */
         }
-      else
-        {
-          /* Error - handle failed attempt */
-          if (!handle_failed_attempt (client, attempt))
-            break;
-        }
+
+      /* Error handling */
+      if (!handle_failed_attempt (client, attempt))
+        break;
     }
 
   /* All retries exhausted - raise the last error */


### PR DESCRIPTION
## Summary

Implements #2911 - Flattens deeply nested conditionals in `SocketHTTPClient_Request_execute()` retry loop.

## Changes

- Inverted 5xx retry check logic to use early `continue`
- Eliminated else-if nesting by restructuring control flow
- Reduced nesting depth from 4 to 3 levels
- Improved code readability with clearer success/retry paths

### Before
```c
if (result == 0) {
    if (!should_retry_5xx(client, response, attempt))
        return 0;
} else {
    if (!handle_failed_attempt(client, attempt))
        break;
}
```

### After
```c
if (result == 0) {
    if (should_retry_5xx(client, response, attempt))
        continue;  /* Retry on 5xx */
    return 0;    /* Success, no retry needed */
}

if (!handle_failed_attempt(client, attempt))
    break;
```

## Test Plan

- [x] Built with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] All HTTP client tests pass (47/47)
- [x] All HTTP integration tests pass
- [x] No memory leaks detected with ASan

Closes #2911