### PR TITLE
test(core): Add unit tests for populate_memory_limits

### DIFF
--- a/src/test/test_security.c
+++ b/src/test/test_security.c
@@ -94,6 +94,83 @@ TEST (security_limits_reasonable)
   ASSERT (limits.http2_max_concurrent_streams <= 1000); /* <= 1000 streams */
 }
 
+/* ============================================================================
+ * Memory Limits Tests (populate_memory_limits coverage)
+ * ============================================================================
+ */
+
+TEST (security_memory_limits_max_allocation)
+{
+  SocketSecurityLimits limits;
+  memset (&limits, 0, sizeof (limits));
+
+  SocketSecurity_get_limits (&limits);
+
+  /* Verify max_allocation is set correctly */
+  ASSERT_EQ (SOCKET_SECURITY_MAX_ALLOCATION, limits.max_allocation);
+  ASSERT (limits.max_allocation > 0);
+}
+
+TEST (security_memory_limits_max_buffer_size)
+{
+  SocketSecurityLimits limits;
+  memset (&limits, 0, sizeof (limits));
+
+  SocketSecurity_get_limits (&limits);
+
+  /* Verify max_buffer_size is set correctly */
+  ASSERT_EQ (SOCKET_MAX_BUFFER_SIZE, limits.max_buffer_size);
+  ASSERT (limits.max_buffer_size > 0);
+}
+
+TEST (security_memory_limits_max_connections)
+{
+  SocketSecurityLimits limits;
+  memset (&limits, 0, sizeof (limits));
+
+  SocketSecurity_get_limits (&limits);
+
+  /* Verify max_connections is set correctly */
+  ASSERT_EQ (SOCKET_MAX_CONNECTIONS, limits.max_connections);
+  ASSERT (limits.max_connections > 0);
+}
+
+TEST (security_memory_limits_arena_max_alloc_size)
+{
+  SocketSecurityLimits limits;
+  memset (&limits, 0, sizeof (limits));
+
+  SocketSecurity_get_limits (&limits);
+
+  /* Verify arena_max_alloc_size is set correctly */
+  ASSERT_EQ (ARENA_MAX_ALLOC_SIZE, limits.arena_max_alloc_size);
+  ASSERT (limits.arena_max_alloc_size > 0);
+}
+
+TEST (security_memory_limits_all_fields_populated)
+{
+  SocketSecurityLimits limits;
+  memset (&limits, 0, sizeof (limits));
+
+  SocketSecurity_get_limits (&limits);
+
+  /* Verify all four memory-related fields are non-zero after population */
+  ASSERT (limits.max_allocation > 0);
+  ASSERT (limits.max_buffer_size > 0);
+  ASSERT (limits.max_connections > 0);
+  ASSERT (limits.arena_max_alloc_size > 0);
+}
+
+TEST (security_memory_limits_arena_matches_max_allocation)
+{
+  SocketSecurityLimits limits;
+  SocketSecurity_get_limits (&limits);
+
+  /* ARENA_MAX_ALLOC_SIZE is defined as SOCKET_SECURITY_MAX_ALLOCATION */
+  /* Verify they match in the populated structure */
+  ASSERT_EQ (limits.arena_max_alloc_size, limits.max_allocation);
+}
+
 TEST (security_http_limits_query)
 {
   size_t max_uri, max_header_size, max_headers, max_body;


### PR DESCRIPTION
## Summary

Implements #3012 by adding dedicated unit test coverage for the `populate_memory_limits` helper function in `src/core/SocketSecurity.c`.

## Changes

Added 6 new test functions to `src/test/test_security.c`:

1. `security_memory_limits_max_allocation` - Verifies `max_allocation` is set to `SOCKET_SECURITY_MAX_ALLOCATION` (256MB)
2. `security_memory_limits_max_buffer_size` - Verifies `max_buffer_size` is set to `SOCKET_MAX_BUFFER_SIZE` (1MB)
3. `security_memory_limits_max_connections` - Verifies `max_connections` is set to `SOCKET_MAX_CONNECTIONS` (10000)
4. `security_memory_limits_arena_max_alloc_size` - Verifies `arena_max_alloc_size` is set to `ARENA_MAX_ALLOC_SIZE`
5. `security_memory_limits_all_fields_populated` - Verifies all four memory fields are non-zero
6. `security_memory_limits_arena_matches_max_allocation` - Verifies arena limit matches global allocation limit

## Test Approach

Since `populate_memory_limits` is a static function, tests use the public `SocketSecurity_get_limits()` API which internally calls the helper function. This provides indirect but comprehensive coverage of the function's behavior.

Each test:
- Initializes a `SocketSecurityLimits` structure with zeros
- Calls `SocketSecurity_get_limits()` to populate it
- Verifies the specific field(s) match expected constants
- Confirms values are non-zero (defense against future bugs)

## Test Results

All tests pass with sanitizers enabled:

```
=== Socket Library Security Test Suite ===
Running 71 tests...
...
[64/71] security_memory_limits_arena_matches_max_allocation ... PASS
[65/71] security_memory_limits_all_fields_populated ... PASS
[66/71] security_memory_limits_arena_max_alloc_size ... PASS
[67/71] security_memory_limits_max_connections ... PASS
[68/71] security_memory_limits_max_buffer_size ... PASS
[69/71] security_memory_limits_max_allocation ... PASS
...
Results: 71 passed, 0 failed, 71 total
```

Full suite: **128/128 tests pass** with ASan + UBSan

## Notes

- Tests follow existing patterns in `test_security.c`
- No changes to production code - test-only addition
- Coverage validates correct population of critical security limits
- Arena limit correctly equals global max allocation as designed

Closes #3012