### PR TITLE
test(core): Add tests for Socket_get_monotonic_ms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,6 +746,7 @@ target_include_directories(test_framework PRIVATE ${CMAKE_SOURCE_DIR}/include)
 set(TEST_SOURCES
     test_new_features
     test_arena
+    test_socketutil_time
     test_except
     test_hashtable
     test_timewindow


### PR DESCRIPTION
## Summary

Implements #3017

Adds comprehensive test coverage for `Socket_get_monotonic_ms` and related time utilities.

## Changes

- **New test file**: `src/test/test_socketutil_time.c` (287 lines, 12 tests)
- **CMakeLists.txt**: Added test to build system
- **Test coverage includes**:
  - Basic functionality (non-zero return, monotonic property, reasonable values)
  - Elapsed time measurement accuracy
  - Rapid call monotonicity verification
  - Clock selection and system compatibility
  - Integration with timespec conversion utilities
  - Strict monotonicity guarantees

## Test Details

### Basic Functionality (3 tests)
- `get_monotonic_ms_returns_nonzero` - Verifies non-zero timestamp
- `get_monotonic_ms_monotonic_property` - Ensures time advances between calls
- `get_monotonic_ms_reasonable_value` - Validates returned values are sensible

### Elapsed Time Measurement (2 tests)
- `get_monotonic_ms_elapsed_time_accuracy` - Tests accuracy with nanosleep
- `get_monotonic_ms_rapid_calls` - Verifies monotonicity in tight loops

### Clock Selection (2 tests)
- `get_monotonic_ms_clock_selection` - Validates clock availability
- `get_monotonic_ms_works_on_various_systems` - Cross-platform compatibility

### Error Handling (1 test)
- `get_monotonic_ms_failure_returns_zero` - Documents zero-return behavior

### Integration (3 tests)
- `get_monotonic_ms_timespec_conversion_consistency` - Round-trip conversion
- `get_monotonic_ms_timespec_add` - Timespec addition helper
- `get_monotonic_ms_timespec_add_overflow` - Nanosecond overflow handling

### Monotonicity Guarantees (1 test)
- `get_monotonic_ms_never_decreases` - Critical for timers/rate limiting

## Test Plan

- [x] All 12 tests pass with ASan/UBSan enabled
- [x] Tests verify monotonic clock behavior
- [x] Integration with existing timespec utilities
- [x] Code formatted with clang-format

Closes #3017