### PR TITLE
test(core): add validation tests for NULL compare and next_ptr functions in HashTable

### DIFF
--- a/src/test/test_hashtable.c
+++ b/src/test/test_hashtable.c
@@ -486,6 +486,42 @@ TEST (hashtable_bucket_count_overflow_raises)
   ASSERT_EQ (raised, 1);
 }
 
+TEST (hashtable_null_compare_raises)
+{
+  volatile int raised = 0;
+  HashTable_Config config = make_config (16);
+  config.compare = NULL;
+
+  TRY
+  {
+    HashTable_new (NULL, &config);
+  }
+  EXCEPT (HashTable_Failed)
+  {
+    raised = 1;
+  }
+  END_TRY;
+  ASSERT_EQ (raised, 1);
+}
+
+TEST (hashtable_null_next_ptr_raises)
+{
+  volatile int raised = 0;
+  HashTable_Config config = make_config (16);
+  config.next_ptr = NULL;
+
+  TRY
+  {
+    HashTable_new (NULL, &config);
+  }
+  EXCEPT (HashTable_Failed)
+  {
+    raised = 1;
+  }
+  END_TRY;
+  ASSERT_EQ (raised, 1);
+}
+
 /* ============================================================================
  * Main
  * ============================================================================


### PR DESCRIPTION
## Summary

Implements #3022

Adds comprehensive test coverage for HashTable configuration validation:
- `hashtable_null_compare_raises`: Validates that NULL compare function raises `HashTable_Failed`
- `hashtable_null_next_ptr_raises`: Validates that NULL next_ptr function raises `HashTable_Failed`

## Changes

- Added 2 new test cases to `src/test/test_hashtable.c`
- Tests follow existing validation test patterns
- Both tests verify exception handling for invalid configuration

## Test Plan

- [x] Tests pass with sanitizers (`ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ctest -j$(nproc)`)
- [x] All 128 tests in the suite pass
- [x] New tests confirm proper exception raising for NULL function pointers
- [x] Code formatted with clang-format

## Coverage

This completes test coverage for all validation paths in `validate_config()` (src/core/HashTable.c lines 36-53):
- ✅ NULL config
- ✅ Zero bucket count
- ✅ NULL hash function
- ✅ NULL compare function (NEW)
- ✅ NULL next_ptr function (NEW)
- ✅ Bucket count overflow

Closes #3022