### PR TITLE
test(core): Add comprehensive tests for SocketError_is_retryable_errno

### DIFF
--- a/src/test/test_socketerror.c
+++ b/src/test/test_socketerror.c
@@ -230,6 +230,201 @@ TEST (socketerror_geterrno_thread_local)
   errno = saved_errno;
 }
 
+/* ============================================================================
+ * SocketError_is_retryable_errno tests
+ * ============================================================================
+ */
+
+TEST (socketerror_retryable_network_errors)
+{
+  /* Basic network errors - should be retryable */
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EAGAIN));
+#ifdef EWOULDBLOCK
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EWOULDBLOCK));
+#endif
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EALREADY));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ECONNREFUSED));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ECONNRESET));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EHOSTUNREACH));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EINPROGRESS));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EINTR));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ENOTCONN));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ENETUNREACH));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (EPIPE));
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ECONNABORTED));
+}
+
+TEST (socketerror_retryable_platform_specific)
+{
+  /* Platform-specific network errors */
+#ifdef ENETDOWN
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ENETDOWN));
+#endif
+#ifdef ENETRESET
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ENETRESET));
+#endif
+}
+
+TEST (socketerror_retryable_timeout)
+{
+  /* Timeout errors should be retryable */
+  ASSERT_EQ (1, SocketError_is_retryable_errno (ETIMEDOUT));
+}
+
+TEST (socketerror_non_retryable_config)
+{
+  /* Configuration errors - not retryable */
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EINVAL));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EACCES));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EADDRINUSE));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EADDRNOTAVAIL));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EAFNOSUPPORT));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EBADF));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EFAULT));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EISCONN));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (ENOTSOCK));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EOPNOTSUPP));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EPROTONOSUPPORT));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EPERM));
+}
+
+TEST (socketerror_non_retryable_platform_specific)
+{
+  /* Platform-specific non-retryable errors */
+#ifdef EPROTO
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EPROTO));
+#endif
+}
+
+TEST (socketerror_non_retryable_resource)
+{
+  /* Resource exhaustion - not retryable */
+  ASSERT_EQ (0, SocketError_is_retryable_errno (EMFILE));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (ENOMEM));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (ENOBUFS));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (ENFILE));
+#ifdef ENOSPC
+  ASSERT_EQ (0, SocketError_is_retryable_errno (ENOSPC));
+#endif
+}
+
+TEST (socketerror_retryable_edge_cases)
+{
+  /* Edge cases */
+  ASSERT_EQ (0, SocketError_is_retryable_errno (0));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (99999));
+  ASSERT_EQ (0, SocketError_is_retryable_errno (-1));
+}
+
+TEST (socketerror_categorize_network)
+{
+  /* Network category errors */
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (ECONNREFUSED));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (ECONNRESET));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (ENETUNREACH));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (EHOSTUNREACH));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (EAGAIN));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (EINPROGRESS));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (ENOTCONN));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_NETWORK,
+             SocketError_categorize_errno (EPIPE));
+}
+
+TEST (socketerror_categorize_protocol)
+{
+  /* Protocol category errors */
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (EINVAL));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (EAFNOSUPPORT));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (EBADF));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (EISCONN));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (ENOTSOCK));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (EOPNOTSUPP));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_PROTOCOL,
+             SocketError_categorize_errno (EPROTONOSUPPORT));
+}
+
+TEST (socketerror_categorize_application)
+{
+  /* Application category errors */
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_APPLICATION,
+             SocketError_categorize_errno (EACCES));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_APPLICATION,
+             SocketError_categorize_errno (EADDRINUSE));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_APPLICATION,
+             SocketError_categorize_errno (EADDRNOTAVAIL));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_APPLICATION,
+             SocketError_categorize_errno (EPERM));
+}
+
+TEST (socketerror_categorize_timeout)
+{
+  /* Timeout category */
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_TIMEOUT,
+             SocketError_categorize_errno (ETIMEDOUT));
+}
+
+TEST (socketerror_categorize_resource)
+{
+  /* Resource category errors */
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_RESOURCE,
+             SocketError_categorize_errno (EMFILE));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_RESOURCE,
+             SocketError_categorize_errno (ENOMEM));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_RESOURCE,
+             SocketError_categorize_errno (ENOBUFS));
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_RESOURCE,
+             SocketError_categorize_errno (ENFILE));
+}
+
+TEST (socketerror_categorize_unknown)
+{
+  /* Unknown category for unmapped errors */
+  ASSERT_EQ (SOCKET_ERROR_CATEGORY_UNKNOWN,
+             SocketError_categorize_errno (99999));
+}
+
+TEST (socketerror_category_name)
+{
+  /* Verify category names */
+  ASSERT (strcmp (SocketError_category_name (SOCKET_ERROR_CATEGORY_NETWORK),
+                  "NETWORK")
+          == 0);
+  ASSERT (strcmp (SocketError_category_name (SOCKET_ERROR_CATEGORY_PROTOCOL),
+                  "PROTOCOL")
+          == 0);
+  ASSERT (
+      strcmp (SocketError_category_name (SOCKET_ERROR_CATEGORY_APPLICATION),
+              "APPLICATION")
+      == 0);
+  ASSERT (strcmp (SocketError_category_name (SOCKET_ERROR_CATEGORY_TIMEOUT),
+                  "TIMEOUT")
+          == 0);
+  ASSERT (strcmp (SocketError_category_name (SOCKET_ERROR_CATEGORY_RESOURCE),
+                  "RESOURCE")
+          == 0);
+  ASSERT (strcmp (SocketError_category_name (SOCKET_ERROR_CATEGORY_UNKNOWN),
+                  "UNKNOWN")
+          == 0);
+
+  /* Out of range */
+  ASSERT (strcmp (SocketError_category_name ((SocketErrorCategory)999),
+                  "UNKNOWN")
+          == 0);
+}
+
 int
 main (void)
 {


### PR DESCRIPTION
## Summary

Implements #3046 - Adds comprehensive test coverage for `SocketError_is_retryable_errno` function and related error categorization functionality in `src/core/SocketError.c`.

## Changes

- **Added 13 new test cases** covering all aspects of error classification:
  - `socketerror_retryable_network_errors` - Tests all retryable network errors (EAGAIN, ECONNREFUSED, ECONNRESET, etc.)
  - `socketerror_retryable_platform_specific` - Tests platform-specific retryable errors (ENETDOWN, ENETRESET)
  - `socketerror_retryable_timeout` - Tests timeout error (ETIMEDOUT)
  - `socketerror_non_retryable_config` - Tests configuration errors (EINVAL, EACCES, EPERM, etc.)
  - `socketerror_non_retryable_platform_specific` - Tests platform-specific non-retryable errors (EPROTO)
  - `socketerror_non_retryable_resource` - Tests resource errors (EMFILE, ENOMEM, ENOBUFS, etc.)
  - `socketerror_retryable_edge_cases` - Tests edge cases (errno=0, invalid values)
  - `socketerror_categorize_network` - Tests NETWORK category classification
  - `socketerror_categorize_protocol` - Tests PROTOCOL category classification
  - `socketerror_categorize_application` - Tests APPLICATION category classification
  - `socketerror_categorize_timeout` - Tests TIMEOUT category classification
  - `socketerror_categorize_resource` - Tests RESOURCE category classification
  - `socketerror_categorize_unknown` - Tests UNKNOWN category for unmapped errors
  - `socketerror_category_name` - Tests category name string mapping

## Test Coverage

- **All retryable errors verified**: EAGAIN, EWOULDBLOCK, EALREADY, ECONNREFUSED, ECONNRESET, EHOSTUNREACH, EINPROGRESS, EINTR, ENOTCONN, ENETUNREACH, EPIPE, ECONNABORTED, ENETDOWN, ENETRESET, ETIMEDOUT
- **All non-retryable errors verified**: EINVAL, EACCES, EADDRINUSE, EADDRNOTAVAIL, EAFNOSUPPORT, EBADF, EFAULT, EISCONN, ENOTSOCK, EOPNOTSUPP, EPROTONOSUPPORT, EPERM, EPROTO, EMFILE, ENOMEM, ENOBUFS, ENFILE, ENOSPC
- **Edge cases tested**: errno=0, unknown errno (99999), negative errno (-1)
- **Platform differences handled**: Conditional compilation for platform-specific error codes

## Test Plan

- [x] All tests pass with sanitizers enabled (`-DENABLE_SANITIZERS=ON`)
- [x] Full test suite passes (128/128 tests)
- [x] Tests verify correct retryable flag for all mapped errno values
- [x] Tests verify error categorization matches implementation
- [x] Tests verify category name mapping is correct
- [x] Platform-specific errno values handled with `#ifdef` guards

## Verification

```bash
$ cd build && ASAN_OPTIONS=detect_leaks=1:abort_on_error=1 ./test_socketerror
Running 26 tests...
[1/26] socketerror_category_name ... PASS
[2/26] socketerror_categorize_unknown ... PASS
[3/26] socketerror_categorize_resource ... PASS
[4/26] socketerror_categorize_timeout ... PASS
[5/26] socketerror_categorize_application ... PASS
[6/26] socketerror_categorize_protocol ... PASS
[7/26] socketerror_categorize_network ... PASS
[8/26] socketerror_retryable_edge_cases ... PASS
[9/26] socketerror_non_retryable_resource ... PASS
[10/26] socketerror_non_retryable_platform_specific ... PASS
[11/26] socketerror_non_retryable_config ... PASS
[12/26] socketerror_retryable_timeout ... PASS
[13/26] socketerror_retryable_platform_specific ... PASS
[14/26] socketerror_retryable_network_errors ... PASS
...
Results: 26 passed, 0 failed, 26 total
```

Closes #3046