### PR TITLE
fix: Update examples for API changes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -103,10 +103,10 @@ add_executable(example_connection_pool connection_pool.c)
 target_link_libraries(example_connection_pool ${EXAMPLE_LIBS})
 
 # =============================================================================
-# Simple API Examples (subdirectory)
+# Simple API Examples (subdirectory) - DISABLED: Simple API was removed
 # =============================================================================
 
-add_subdirectory(simple)
+# add_subdirectory(simple)
 
 # =============================================================================
 # Installation (optional)

--- a/examples/websocket_server.c
+++ b/examples/websocket_server.c
@@ -110,7 +110,7 @@ request_handler (SocketHTTPServer_Request_T req, void *userdata)
       printf ("[%s] WebSocket upgrade requested\n", client);
 
       /* Accept the upgrade */
-      SocketWS_T ws = SocketHTTPServer_Request_upgrade_websocket (req);
+      SocketWS_T ws = SocketHTTPServer_Request_upgrade_websocket (req, NULL, NULL);
 
       if (ws)
         {


### PR DESCRIPTION
## Summary
- Update SocketHTTPServer_Request_upgrade_websocket call in websocket_server.c to include callback and userdata parameters
- Disable simple API examples since Simple API was removed

## Test plan
- [x] Build passes with sanitizers
- [x] All 131 tests pass