### PR TITLE
fix: Use default Grok model

### DIFF
--- a/examples/ai_chat/main.c
+++ b/examples/ai_chat/main.c
@@ -258,7 +258,7 @@ main(int argc, char **argv)
 
     GrokClient_Config grok_config = {
         .api_key = api_key,
-        .model = "grok-beta",
+        .model = NULL,  /* Use default model */
         .timeout_ms = 30000
     };
 


### PR DESCRIPTION
Remove hardcoded grok-beta from main.c, use DEFAULT_MODEL from grok_client.c