### PR TITLE
feat(ai_chat): add user chat participation and IRC-style UI

### DIFF
--- a/examples/ai_chat/agents.c
+++ b/examples/ai_chat/agents.c
@@ -199,3 +199,16 @@ AgentSystem_current_agent_index(AgentSystem_T system)
 {
     return system ? system->current_agent : 0;
 }
+
+void
+AgentSystem_add_user_message(AgentSystem_T system, const char *nick, const char *text)
+{
+    if (!system || !nick || !text) return;
+
+    add_to_history(system, nick, text);
+
+    /* Broadcast user message to all clients */
+    if (system->hub) {
+        WebSocketHub_broadcast_json(system->hub, "msg", nick, NULL, text);
+    }
+}

--- a/examples/ai_chat/agents.h
+++ b/examples/ai_chat/agents.h
@@ -30,4 +30,6 @@ int AgentSystem_current_agent_index(AgentSystem_T system);
 
 const char *AgentSystem_random_topic(void);
 
+void AgentSystem_add_user_message(AgentSystem_T system, const char *nick, const char *text);
+
 #endif /* AGENTS_H */

--- a/examples/ai_chat/websocket_hub.h
+++ b/examples/ai_chat/websocket_hub.h
@@ -5,6 +5,7 @@
 #include <stddef.h>
 
 #define MAX_CLIENTS 64
+#define MAX_NICK_LEN 32
 
 typedef struct WebSocketHub *WebSocketHub_T;
 
@@ -14,12 +15,18 @@ void WebSocketHub_free(WebSocketHub_T *hub);
 int WebSocketHub_add(WebSocketHub_T hub, SocketWS_T ws);
 void WebSocketHub_remove(WebSocketHub_T hub, SocketWS_T ws);
 
+void WebSocketHub_set_nick(WebSocketHub_T hub, SocketWS_T ws, const char *nick);
+const char *WebSocketHub_get_nick(WebSocketHub_T hub, SocketWS_T ws);
+
 void WebSocketHub_broadcast(WebSocketHub_T hub, const char *message, size_t len);
 void WebSocketHub_broadcast_json(WebSocketHub_T hub,
                                   const char *type,
                                   const char *agent,
                                   const char *avatar,
                                   const char *text);
+void WebSocketHub_broadcast_userlist(WebSocketHub_T hub);
+void WebSocketHub_broadcast_userjoin(WebSocketHub_T hub, const char *nick);
+void WebSocketHub_broadcast_userpart(WebSocketHub_T hub, const char *nick);
 
 int WebSocketHub_count(WebSocketHub_T hub);
 


### PR DESCRIPTION
## Summary
- Add input bar for users to type and send messages to AI agents
- Add user list panel on right side (IRC channel style)
- Track user nicknames with join/part notifications
- Add user messages to agent conversation history so AI agents respond to users
- IRC-style formatting with timestamps `[HH:MM:SS]` and colored nicks `<Nick>`
- Auto-scroll chat to latest messages

## New WebSocket Protocol Messages

### Client → Server
- `{"type":"join","nick":"username"}` - Join chat with nickname
- `{"type":"user","nick":"username","text":"message"}` - Send chat message

### Server → Clients
- `{"type":"userjoin","nick":"username"}` - User joined notification
- `{"type":"userpart","nick":"username"}` - User left notification
- `{"type":"userlist","users":["user1","user2"]}` - Current user list

## Test plan
- [ ] Build with `cmake --build build -j$(nproc)`
- [ ] Run `./build/ai_chat` with `XAI_API_KEY` set
- [ ] Open http://localhost:8080 in browser
- [ ] Enter nickname when prompted
- [ ] Verify user appears in user list
- [ ] Type message and press Enter/Send
- [ ] Verify AI agents respond to user messages