### PR TITLE
fix(ai_chat): reduce poll timeout for faster message response

### DIFF
--- a/examples/ai_chat/main.c
+++ b/examples/ai_chat/main.c
@@ -463,7 +463,7 @@ main(int argc, char **argv)
         schedule_next_turn(poll_instance, agent_system);
 
         while (running) {
-            SocketHTTPServer_process(server, 100);
+            SocketHTTPServer_process(server, 10);
             poll_websockets();
         }
 


### PR DESCRIPTION
Reduce server poll timeout from 100ms to 10ms for snappier WebSocket message handling and lower input latency.