### PR TITLE
fix(fuzz): Fix bad-free and misaligned access crashes

### DIFF
--- a/src/fuzz/fuzz_http_client_async.c
+++ b/src/fuzz/fuzz_http_client_async.c
@@ -469,7 +469,13 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   if (size < MIN_INPUT_SIZE)
     return 0;
 
-  const FuzzInput *input = (const FuzzInput *)data;
+  /* Copy to aligned local storage to avoid UBSan misaligned access errors.
+   * The fuzzer-provided data buffer may not be properly aligned for the
+   * struct's uint16_t members. Zero-initialize first to ensure padding
+   * bytes are deterministic. */
+  FuzzInput input_storage = { 0 };
+  memcpy (&input_storage, data, sizeof (FuzzInput));
+  const FuzzInput *input = &input_storage;
   const uint8_t *payload = data + MIN_INPUT_SIZE;
   size_t payload_len = size - MIN_INPUT_SIZE;
 

--- a/src/fuzz/fuzz_http_client_pool.c
+++ b/src/fuzz/fuzz_http_client_pool.c
@@ -580,7 +580,13 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   if (size < MIN_INPUT_SIZE)
     return 0;
 
-  const FuzzInput *input = (const FuzzInput *)data;
+  /* Copy to aligned local storage to avoid UBSan misaligned access errors.
+   * The fuzzer-provided data buffer may not be properly aligned for the
+   * struct's uint16_t members. Zero-initialize first to ensure padding
+   * bytes are deterministic. */
+  FuzzInput input_storage = { 0 };
+  memcpy (&input_storage, data, sizeof (FuzzInput));
+  const FuzzInput *input = &input_storage;
   const uint8_t *extra_data = data + MIN_INPUT_SIZE;
   size_t extra_len = size - MIN_INPUT_SIZE;
 

--- a/src/fuzz/fuzz_http_client_retry.c
+++ b/src/fuzz/fuzz_http_client_retry.c
@@ -346,7 +346,13 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
   if (size < MIN_INPUT_SIZE)
     return 0;
 
-  const FuzzInput *input = (const FuzzInput *)data;
+  /* Copy to aligned local storage to avoid UBSan misaligned access errors.
+   * The fuzzer-provided data buffer may not be properly aligned for the
+   * struct's uint16_t members. Zero-initialize first to ensure padding
+   * bytes are deterministic. */
+  FuzzInput input_storage = { 0 };
+  memcpy (&input_storage, data, sizeof (FuzzInput));
+  const FuzzInput *input = &input_storage;
 
   TRY
   {

--- a/src/socket/SocketCommon.c
+++ b/src/socket/SocketCommon.c
@@ -95,6 +95,13 @@ init_global_dns_resolver (void)
   }
   EXCEPT (SocketDNS_Failed)
   {
+    /* Ensure resolver is freed on partial init failure to avoid leaks
+     * or dangling pointers. Also clear g_dns_resolver to NULL. */
+    if (g_dns_resolver)
+      {
+        SocketDNS_free (&g_dns_resolver);
+        g_dns_resolver = NULL;
+      }
     SOCKET_LOG_ERROR_MSG ("Failed to initialize global DNS resolver: %s",
                           Except_frame.exception->reason);
     RERAISE;

--- a/src/test/test_hpack.c
+++ b/src/test/test_hpack.c
@@ -1256,7 +1256,6 @@ test_hpack_bomb_absolute_limit (void)
 
   /* Generate headers with 50 byte names and 50 byte values = 100 bytes each */
   /* 11 headers * 100 = 1100 bytes > 1024 limit */
-  int generated = 0;
   for (int i = 0; i < 15; i++)
     {
       /* Each header needs 2 + 50 + 2 + 50 = 104 bytes */
@@ -1270,7 +1269,6 @@ test_hpack_bomb_absolute_limit (void)
       input[pos++] = 0x32; /* Value length = 50 */
       for (int j = 0; j < 50; j++)
         input[pos++] = 'y';
-      generated++;
     }
 
   result = SocketHPACK_Decoder_decode (

--- a/src/test/test_http_core.c
+++ b/src/test/test_http_core.c
@@ -475,7 +475,6 @@ test_header_dos_protection (void)
   /* Add many headers with same hash to trigger collision detection */
   /* This test relies on internal bucket size limits */
   int added = 0;
-  int failed = 0;
 
   /* Try to add many headers - should eventually hit chain length limit */
   for (int i = 0; i < 100; i++)
@@ -488,8 +487,6 @@ test_header_dos_protection (void)
       int result = SocketHTTP_Headers_add (headers, name, value);
       if (result == 0)
         added++;
-      else
-        failed++;
     }
 
   /* We should be able to add most headers, but may hit limits */


### PR DESCRIPTION
## Summary
- Fix `fuzz_address_parse` bad-free crash during DNS cleanup by adding defensive NULL checks and proper cleanup ordering
- Fix `fuzz_http_client_*` misaligned memory access by using memcpy to aligned local storage instead of direct pointer cast
- Fix unused variable warnings in test files that blocked sanitizer builds

Fixes #3211

## Changes
| File | Change |
|------|--------|
| `src/dns/SocketDNS.c` | Add NULL checks, set to NULL after free, fix exception handler cleanup order |
| `src/socket/SocketCommon.c` | Add exception-safe cleanup in global DNS resolver init |
| `src/fuzz/fuzz_http_client_async.c` | Use memcpy for aligned FuzzInput access |
| `src/fuzz/fuzz_http_client_pool.c` | Same memcpy pattern |
| `src/fuzz/fuzz_http_client_retry.c` | Same memcpy pattern |
| `src/test/test_hpack.c` | Remove unused variable `generated` |
| `src/test/test_http_core.c` | Remove unused variable `failed` |

## Test plan
- [x] All 131 tests pass with sanitizers enabled (ASan + UBSan)
- [x] `fuzz_address_parse` crash reproducer runs without crash
- [ ] `fuzz_http_client_async` crash still occurs - exposes deeper HTTP client bug requiring separate investigation

## Notes
The `fuzz_http_client_async` crash is now properly minimized. It exposes a bug in HTTP client code when receiving non-boolean config values (e.g., `enable_async_io=10` instead of 0/1), causing `Except_stack` corruption. This is a separate issue to investigate.