### PR TITLE
fix(fuzz): Use RETURN macro instead of bare return in TRY blocks

### DIFF
--- a/src/fuzz/fuzz_http_client_async.c
+++ b/src/fuzz/fuzz_http_client_async.c
@@ -142,13 +142,13 @@ create_socketpair (Socket_T *sock1_out, Socket_T *sock2_out, Arena_T arena)
 
     *sock1_out = sock1;
     *sock2_out = sock2;
-    return 0;
+    RETURN 0;
   }
   EXCEPT (Socket_Failed)
   {
     close (fds[0]);
     close (fds[1]);
-    return -1;
+    RETURN -1;
   }
   END_TRY;
 


### PR DESCRIPTION
## Summary

Fixes the `fuzz_http_client_async` crash caused by bare `return` inside TRY blocks.

### Root Cause
Using bare `return` inside TRY leaves `Except_stack` pointing to a destroyed stack frame. The next TRY block reads garbage when accessing `Except_stack->prev`, resulting in the constant corrupted address `0x0a0e000008c5`.

### Fix
Changed `return 0;` and `return -1;` to `RETURN 0;` and `RETURN -1;` in `create_socketpair()` to properly pop the exception frame before returning.

Fixes #3215

## Test plan
- [x] Crash reproducers now pass without crashing
- [x] Fuzzer runs without crashes
- [x] All 131 tests pass with sanitizers