### PR TITLE
fix(socket): Use RETURN macro instead of bare return in TRY block

### DIFF
--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -567,7 +567,7 @@ start_tls_handshake (T conn)
                      "%s:%d TLS enabled, starting handshake",
                      conn->host,
                      conn->port);
-    return 1;
+    RETURN 1;
   }
   EXCEPT (SocketTLS_Failed)
   {


### PR DESCRIPTION
## Summary

Changed `return 1;` to `RETURN 1;` in `start_tls_handshake()` to properly pop the exception frame before returning.

Found during codebase audit for bare return statements in TRY blocks.

Fixes #3217

## Test plan
- [x] All 131 tests pass with sanitizers