### PR TITLE
feat: Add tcurl example with standalone build support

### DIFF
--- a/examples/curl/CMakeLists.txt
+++ b/examples/curl/CMakeLists.txt
@@ -1,0 +1,186 @@
+cmake_minimum_required(VERSION 3.14)
+project(tcurl VERSION 1.0.0 LANGUAGES C)
+
+# Generate compile_commands.json for IDE integration
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# C11 with GNU extensions (required by tetsuo-socket)
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS ON)
+
+# Compiler flags
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -D_GNU_SOURCE -pthread -fno-strict-aliasing")
+set(CMAKE_C_FLAGS_DEBUG "-g -Og")
+set(CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG")
+
+# Default to Release build
+if(NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Release)
+endif()
+
+# Option to enable sanitizers for development
+option(ENABLE_SANITIZERS "Enable ASan + UBSan" OFF)
+
+if(ENABLE_SANITIZERS)
+    message(STATUS "Sanitizers enabled (ASan + UBSan)")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address,undefined -fno-omit-frame-pointer")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -fsanitize=address,undefined")
+endif()
+
+#==============================================================================
+# Find tetsuo-socket library
+#==============================================================================
+
+# Check if we're building from within the tetsuo-socket repo
+set(SOCKET_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../..")
+set(SOCKET_BUILD_DIR "${SOCKET_SOURCE_DIR}/build")
+
+if(EXISTS "${SOCKET_SOURCE_DIR}/include/socket/Socket.h" AND EXISTS "${SOCKET_BUILD_DIR}/libsocket.a")
+    # We're in examples/curl/ within the main repo and library is built
+    message(STATUS "Using local tetsuo-socket build")
+    message(STATUS "  Source:  ${SOCKET_SOURCE_DIR}")
+    message(STATUS "  Build:   ${SOCKET_BUILD_DIR}")
+
+    set(SOCKET_INCLUDE_DIRS "${SOCKET_SOURCE_DIR}/include")
+    set(SOCKET_LIBRARIES "${SOCKET_BUILD_DIR}/libsocket.a")
+    set(SOCKET_FOUND TRUE)
+
+elseif(EXISTS "${SOCKET_SOURCE_DIR}/include/socket/Socket.h")
+    # Source exists but not built - tell user to build first
+    message(FATAL_ERROR
+        "tetsuo-socket library not built.\n"
+        "Please build the library first:\n"
+        "  cd ${SOCKET_SOURCE_DIR}\n"
+        "  cmake -S . -B build -DENABLE_TLS=ON\n"
+        "  cmake --build build -j$(nproc)\n"
+        "Then return here and run cmake again.")
+
+else()
+    # Not in repo - try pkg-config
+    find_package(PkgConfig QUIET)
+    if(PkgConfig_FOUND)
+        pkg_check_modules(SOCKET libsocket)
+    endif()
+
+    if(SOCKET_FOUND)
+        message(STATUS "Using system tetsuo-socket via pkg-config")
+        message(STATUS "  Include dirs: ${SOCKET_INCLUDE_DIRS}")
+        message(STATUS "  Libraries: ${SOCKET_LIBRARIES}")
+    else()
+        # Try FetchContent as last resort
+        message(STATUS "Fetching tetsuo-socket from GitHub...")
+        include(FetchContent)
+
+        FetchContent_Declare(
+            tetsuo_socket
+            GIT_REPOSITORY https://github.com/7etsuo/tetsuo-pulse.git
+            GIT_TAG        main
+            GIT_SHALLOW    TRUE
+        )
+
+        # Configure tetsuo-socket options before fetching
+        set(ENABLE_TLS ON CACHE BOOL "Enable TLS support" FORCE)
+        set(BUILD_TESTING OFF CACHE BOOL "Disable tests for subdirectory build" FORCE)
+
+        FetchContent_MakeAvailable(tetsuo_socket)
+
+        set(SOCKET_INCLUDE_DIRS "${tetsuo_socket_SOURCE_DIR}/include")
+        set(SOCKET_LIBRARIES socket_static)
+        set(SOCKET_FOUND TRUE)
+    endif()
+endif()
+
+#==============================================================================
+# Dependencies
+#==============================================================================
+
+# Find OpenSSL for TLS support
+find_package(OpenSSL QUIET)
+if(OpenSSL_FOUND)
+    message(STATUS "TLS support enabled (OpenSSL ${OPENSSL_VERSION})")
+    add_compile_definitions(SOCKET_HAS_TLS=1)
+else()
+    message(STATUS "TLS support disabled (OpenSSL not found)")
+    add_compile_definitions(SOCKET_HAS_TLS=0)
+endif()
+
+# Find zlib for compression
+find_package(ZLIB QUIET)
+if(ZLIB_FOUND)
+    message(STATUS "Compression support enabled (zlib)")
+    add_compile_definitions(SOCKETHTTP1_HAS_ZLIB=1)
+else()
+    add_compile_definitions(SOCKETHTTP1_HAS_ZLIB=0)
+endif()
+
+#==============================================================================
+# tcurl executable
+#==============================================================================
+
+set(TCURL_SOURCES
+    src/curl_main.c
+    src/curl_args.c
+    src/StreamingCurl.c
+    src/StreamingCurl_auth.c
+    src/StreamingCurl_connect.c
+    src/StreamingCurl_cookie.c
+    src/StreamingCurl_decomp.c
+    src/StreamingCurl_h1.c
+    src/StreamingCurl_h2.c
+    src/StreamingCurl_redirect.c
+    src/StreamingCurl_request.c
+    src/StreamingCurl_url.c
+)
+
+add_executable(tcurl ${TCURL_SOURCES})
+
+# Include directories:
+# - Local headers: include/ contains curl/ subdirectory
+#   So "curl/StreamingCurl.h" resolves to include/curl/StreamingCurl.h
+# - tetsuo-socket library headers (core/, http/, socket/, tls/, etc.)
+target_include_directories(tcurl PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${SOCKET_INCLUDE_DIRS}
+)
+
+# Link against tetsuo-socket and system libraries
+target_link_libraries(tcurl PRIVATE
+    ${SOCKET_LIBRARIES}
+    pthread
+    m
+)
+
+# Platform-specific libraries
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    target_link_libraries(tcurl PRIVATE dl)
+endif()
+
+# Optional dependencies
+if(OpenSSL_FOUND)
+    target_link_libraries(tcurl PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+endif()
+
+if(ZLIB_FOUND)
+    target_link_libraries(tcurl PRIVATE ZLIB::ZLIB)
+endif()
+
+#==============================================================================
+# Installation
+#==============================================================================
+
+install(TARGETS tcurl DESTINATION bin)
+
+#==============================================================================
+# Summary
+#==============================================================================
+
+message(STATUS "")
+message(STATUS "tcurl configuration:")
+message(STATUS "  Build type:     ${CMAKE_BUILD_TYPE}")
+message(STATUS "  TLS support:    ${OpenSSL_FOUND}")
+message(STATUS "  Compression:    ${ZLIB_FOUND}")
+message(STATUS "  Sanitizers:     ${ENABLE_SANITIZERS}")
+message(STATUS "")
+message(STATUS "Build with: cmake --build build -j$(nproc)")
+message(STATUS "")

--- a/examples/curl/README.md
+++ b/examples/curl/README.md
@@ -1,0 +1,120 @@
+# tcurl
+
+A custom curl implementation built on my socket library with help from Grok.
+
+Zero dependencies except OpenSSL for crypto primitives. Everything else is hand-rolled.
+
+```
+10.0.0.167.48458 > 54.158.135.159.443: Flags [S]
+  54.158.135.159.443 > 10.0.0.167.48458: Flags [S.], ack
+```
+
+DNS resolution → TCP handshake → TLS negotiation → HTTP request → encrypted response.
+
+All custom. No libcurl. No libuv.
+
+---
+
+## What's in the box
+
+- Full TLS 1.3 handshake + certificate chain validation
+- HTTP/1.1 & HTTP/2 with HPACK compression
+- Complete DNS resolver with DoT, DoH, DNSSEC
+- io_uring async backend with SQPOLL + registered buffers
+- WebSocket + WebSocket-over-HTTP/2
+- SOCKS4/5 + HTTP CONNECT proxy support
+- Connection pooling with health monitoring + rate limiting
+- Happy Eyeballs v2 dual-stack connection racing
+- Arena-based memory management
+- Custom exception handling (TRY/EXCEPT/FINALLY)
+
+## Build
+
+### Option 1: Build from tetsuo-socket repo (recommended)
+
+If you're in the `examples/curl/` directory of the tetsuo-socket repo:
+
+```bash
+# First, build the main library (from repo root)
+cd ../..
+cmake -S . -B build -DENABLE_TLS=ON -DENABLE_HTTP_COMPRESSION=ON
+cmake --build build -j$(nproc)
+
+# Then build tcurl (from examples/curl/)
+cd examples/curl
+cmake -S . -B build
+cmake --build build -j$(nproc)
+
+# Run it
+./build/tcurl --help
+./build/tcurl https://example.com
+```
+
+### Option 2: Standalone build (auto-fetches library)
+
+If you just have the curl example folder:
+
+```bash
+cmake -S . -B build
+cmake --build build -j$(nproc)
+```
+
+CMake will automatically fetch and build tetsuo-socket from GitHub.
+
+### Option 3: Use installed library
+
+If tetsuo-socket is installed system-wide:
+
+```bash
+cmake -S . -B build -DUSE_SYSTEM_SOCKET=ON
+cmake --build build -j$(nproc)
+```
+
+### Build Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `ENABLE_SANITIZERS` | OFF | Enable ASan + UBSan |
+| `CMAKE_BUILD_TYPE` | Release | Debug or Release |
+
+## What's redacted
+
+- HTTP/3 + QUIC (in progress)
+- Simple API layer
+- Fuzz harnesses
+- Unit/integration test suite
+- Examples folder (30+ demo programs)
+
+## About the API
+
+The Simple API from previous demos encapsulated much of the underlying functionality—exception handling, connection management, etc. This demo uses the lower layer of the socket library directly. The Simple API isn't public yet because I haven't had time to fully fuzz it.
+
+The exception-based API shown here has been fuzzed (not full coverage) and hammered with ASan/UBSan. It passes the full test suite. There are still some issues.
+
+For everyone crashing out about "seeing source code"—yes, it's a library. There will be some issues. That's how libraries work.
+
+Still under active development. The code shown is battle-tested, not final.
+
+---
+
+## FAQ
+
+**Q: Why did you add a Q/A to a lame ass project like this?**
+A: To drive you insane.
+
+**Q: Can I use this for a production server?**
+A: It's designed for learning and experimentation. Run it locally or in controlled environments.
+
+**Q: Why implement curl when curl already exists?**
+A: Picked it as a challenge. Building something that already exists is one of the best ways to learn how it actually works.
+
+**Q: Why are you vibe coding bad software?**
+A: I build things. That's what I do.
+
+**Q: Did you even read any of the code?**
+A: There's no magic button that writes code like this. If you think there is, I'd encourage you to try a similar project yourself.
+
+**Q: Do you even know how to code?**
+A: CS and math degrees. 4.0 GPA. Solo-raised my daughter through it. I code every waking moment.
+
+---

--- a/examples/curl/demo_tcurl.sh
+++ b/examples/curl/demo_tcurl.sh
@@ -1,0 +1,523 @@
+#!/bin/bash
+# Comprehensive tcurl demo - shows ALL features
+
+set -e
+
+# Get script directory for absolute paths
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TCURL="${1:-$SCRIPT_DIR/build/tcurl}"
+
+# Find an available port
+PORT=18080
+while netstat -tuln 2>/dev/null | grep -q ":$PORT " || ss -tuln 2>/dev/null | grep -q ":$PORT "; do
+    PORT=$((PORT + 1))
+done
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+demo() {
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${YELLOW}$1${NC}"
+    echo -e "${BLUE}$ $2${NC}"
+    echo -e "${CYAN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    eval "$2" 2>&1 || true
+    echo
+    sleep 0.5
+}
+
+echo -e "${GREEN}"
+echo "╔═══════════════════════════════════════════════════════════════╗"
+echo "║                    tcurl FEATURE DEMO                         ║"
+echo "║         Streaming HTTP Client - Full Capabilities             ║"
+echo "╚═══════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"
+
+# Check tcurl exists
+if [[ ! -x "$TCURL" ]]; then
+    echo -e "${RED}Error: tcurl not found at $TCURL${NC}"
+    echo "Build it first: cmake --build build"
+    exit 1
+fi
+
+echo -e "${CYAN}Using: $TCURL${NC}"
+echo -e "${CYAN}Server port: $PORT${NC}"
+echo
+
+# Create temp directory
+DEMO_DIR=$(mktemp -d)
+trap "rm -rf $DEMO_DIR; kill $SERVER_PID 2>/dev/null; kill $REDIRECT_PID 2>/dev/null" EXIT
+
+# Create test files
+echo '{"status":"ok","user":"demo","items":[1,2,3]}' > "$DEMO_DIR/api.json"
+echo '<html><body><h1>tcurl Demo</h1><p>Hello World!</p></body></html>' > "$DEMO_DIR/index.html"
+dd if=/dev/urandom of="$DEMO_DIR/binary.bin" bs=1024 count=10 2>/dev/null
+echo "Line 1 of text file" > "$DEMO_DIR/file.txt"
+echo "Line 2 of text file" >> "$DEMO_DIR/file.txt"
+gzip -k "$DEMO_DIR/file.txt" 2>/dev/null || true
+
+# Create Python test server with more features
+cat > "$DEMO_DIR/server.py" << 'PYEOF'
+from http.server import HTTPServer, BaseHTTPRequestHandler
+import json
+import base64
+import gzip
+import sys
+import urllib.parse
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        pass  # Suppress logging
+
+    def send_cors(self):
+        self.send_header('Access-Control-Allow-Origin', '*')
+
+    def do_GET(self):
+        parsed = urllib.parse.urlparse(self.path)
+        path = parsed.path
+
+        # Redirect endpoint
+        if path == '/redirect':
+            self.send_response(302)
+            self.send_header('Location', '/final')
+            self.end_headers()
+            return
+
+        if path == '/redirect-chain':
+            self.send_response(301)
+            self.send_header('Location', '/redirect')
+            self.end_headers()
+            return
+
+        if path == '/final':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'You followed the redirect!')
+            return
+
+        # Auth endpoint
+        if path == '/auth':
+            auth = self.headers.get('Authorization', '')
+            if auth.startswith('Basic '):
+                creds = base64.b64decode(auth[6:]).decode()
+                if creds == 'admin:secret':
+                    self.send_response(200)
+                    self.send_header('Content-Type', 'application/json')
+                    self.end_headers()
+                    self.wfile.write(json.dumps({'auth': 'success', 'user': 'admin'}).encode())
+                    return
+            self.send_response(401)
+            self.send_header('WWW-Authenticate', 'Basic realm="Demo"')
+            self.end_headers()
+            self.wfile.write(b'Unauthorized')
+            return
+
+        # Headers echo
+        if path == '/headers':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            headers = {k: v for k, v in self.headers.items()}
+            self.wfile.write(json.dumps(headers, indent=2).encode())
+            return
+
+        # Cookie endpoint
+        if path == '/setcookie':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.send_header('Set-Cookie', 'session=abc123; Path=/')
+            self.send_header('Set-Cookie', 'user=demo; Path=/')
+            self.end_headers()
+            self.wfile.write(b'Cookies set!')
+            return
+
+        if path == '/checkcookie':
+            cookies = self.headers.get('Cookie', 'none')
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(f'Received cookies: {cookies}'.encode())
+            return
+
+        # Compressed response
+        if path == '/compressed':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.send_header('Content-Encoding', 'gzip')
+            self.end_headers()
+            data = b'This response was compressed with gzip!' * 10
+            self.wfile.write(gzip.compress(data))
+            return
+
+        # Large response for download demo
+        if path == '/download':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/octet-stream')
+            self.send_header('Content-Disposition', 'attachment; filename="data.bin"')
+            self.send_header('Content-Length', '10240')
+            self.end_headers()
+            self.wfile.write(b'X' * 10240)
+            return
+
+        # Slow response
+        if path == '/slow':
+            import time
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            for i in range(3):
+                self.wfile.write(f'Chunk {i+1}...\n'.encode())
+                self.wfile.flush()
+                time.sleep(0.3)
+            self.wfile.write(b'Done!')
+            return
+
+        # Status codes
+        if path.startswith('/status/'):
+            code = int(path.split('/')[-1])
+            self.send_response(code)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(f'Status {code}'.encode())
+            return
+
+        # Default: serve files
+        try:
+            filepath = '.' + path
+            if path == '/':
+                filepath = './index.html'
+            with open(filepath, 'rb') as f:
+                content = f.read()
+            self.send_response(200)
+            if filepath.endswith('.json'):
+                self.send_header('Content-Type', 'application/json')
+            elif filepath.endswith('.html'):
+                self.send_header('Content-Type', 'text/html')
+            else:
+                self.send_header('Content-Type', 'application/octet-stream')
+            self.send_header('Content-Length', len(content))
+            self.end_headers()
+            self.wfile.write(content)
+        except FileNotFoundError:
+            self.send_response(404)
+            self.end_headers()
+            self.wfile.write(b'Not Found')
+
+    def do_HEAD(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'text/html')
+        self.send_header('Content-Length', '1234')
+        self.send_header('X-Custom-Header', 'demo-value')
+        self.end_headers()
+
+    def do_POST(self):
+        length = int(self.headers.get('Content-Length', 0))
+        body = self.rfile.read(length) if length else b''
+
+        if self.path == '/echo':
+            self.send_response(200)
+            self.send_header('Content-Type', self.headers.get('Content-Type', 'text/plain'))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+
+        if self.path == '/form':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            response = {
+                'received': body.decode('utf-8', errors='replace'),
+                'content_type': self.headers.get('Content-Type'),
+                'length': length
+            }
+            self.wfile.write(json.dumps(response, indent=2).encode())
+            return
+
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'method': 'POST', 'path': self.path, 'body_len': length}).encode())
+
+    def do_PUT(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'method': 'PUT', 'path': self.path, 'body_len': length}).encode())
+
+    def do_DELETE(self):
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'method': 'DELETE', 'path': self.path}).encode())
+
+    def do_PATCH(self):
+        length = int(self.headers.get('Content-Length', 0))
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(json.dumps({'method': 'PATCH', 'path': self.path, 'body_len': length}).encode())
+
+port = int(sys.argv[1]) if len(sys.argv) > 1 else 18080
+server = HTTPServer(('127.0.0.1', port), Handler)
+print(f'Server running on port {port}', file=sys.stderr)
+server.serve_forever()
+PYEOF
+
+# Start server
+cd "$DEMO_DIR"
+python3 server.py $PORT &
+SERVER_PID=$!
+cd - >/dev/null
+
+# Wait for server to be ready
+for i in {1..10}; do
+    if curl -s "http://127.0.0.1:$PORT/" >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.2
+done
+
+echo -e "${GREEN}Test server started (PID $SERVER_PID)${NC}"
+echo
+
+BASE="http://127.0.0.1:$PORT"
+
+# ============================================================================
+# BASIC REQUESTS
+# ============================================================================
+echo -e "${GREEN}[ BASIC REQUESTS ]${NC}"
+
+demo "1. Simple GET request" \
+    "$TCURL $BASE/index.html"
+
+demo "2. GET JSON API" \
+    "$TCURL $BASE/api.json"
+
+demo "3. HEAD request (headers only)" \
+    "$TCURL -I $BASE/index.html"
+
+demo "4. Include response headers with body" \
+    "$TCURL -i $BASE/api.json"
+
+demo "5. Verbose mode (show request + response headers)" \
+    "$TCURL -v $BASE/api.json"
+
+# ============================================================================
+# HTTP METHODS
+# ============================================================================
+echo -e "${GREEN}[ HTTP METHODS ]${NC}"
+
+demo "6. POST with data" \
+    "$TCURL -X POST -d 'username=demo&password=test' $BASE/form"
+
+demo "7. POST JSON" \
+    "$TCURL -X POST -H 'Content-Type: application/json' -d '{\"name\":\"tcurl\",\"version\":1}' $BASE/echo"
+
+demo "8. PUT request" \
+    "$TCURL -X PUT -d 'updated data' $BASE/resource"
+
+demo "9. DELETE request" \
+    "$TCURL -X DELETE $BASE/resource/123"
+
+demo "10. PATCH request" \
+    "$TCURL -X PATCH -d '{\"field\":\"new_value\"}' $BASE/resource"
+
+# ============================================================================
+# HEADERS & USER-AGENT
+# ============================================================================
+echo -e "${GREEN}[ CUSTOM HEADERS ]${NC}"
+
+demo "11. Custom headers" \
+    "$TCURL -H 'X-Custom: my-value' -H 'X-Request-ID: 12345' $BASE/headers"
+
+demo "12. Custom User-Agent" \
+    "$TCURL -A 'MyApp/2.0 (Linux)' $BASE/headers"
+
+demo "13. Set Referer" \
+    "$TCURL -e 'https://google.com' $BASE/headers"
+
+# ============================================================================
+# AUTHENTICATION
+# ============================================================================
+echo -e "${GREEN}[ AUTHENTICATION ]${NC}"
+
+demo "14. Basic auth (wrong credentials)" \
+    "$TCURL -u wrong:creds $BASE/auth"
+
+demo "15. Basic auth (correct credentials)" \
+    "$TCURL -u admin:secret $BASE/auth"
+
+# ============================================================================
+# REDIRECTS
+# ============================================================================
+echo -e "${GREEN}[ REDIRECTS ]${NC}"
+
+demo "16. Without following redirects" \
+    "$TCURL -i $BASE/redirect"
+
+demo "17. Follow redirects (-L)" \
+    "$TCURL -L $BASE/redirect"
+
+demo "18. Follow redirect chain" \
+    "$TCURL -L -v $BASE/redirect-chain"
+
+# ============================================================================
+# COOKIES
+# ============================================================================
+echo -e "${GREEN}[ COOKIES ]${NC}"
+
+COOKIE_JAR="$DEMO_DIR/cookies.txt"
+
+demo "19. Get cookies from server (save to jar)" \
+    "$TCURL -c $COOKIE_JAR $BASE/setcookie && echo 'Cookie jar:' && cat $COOKIE_JAR"
+
+demo "20. Send cookies from jar" \
+    "$TCURL -b $COOKIE_JAR $BASE/checkcookie"
+
+# ============================================================================
+# FILE OPERATIONS
+# ============================================================================
+echo -e "${GREEN}[ FILE OPERATIONS ]${NC}"
+
+demo "21. Download to file (-o)" \
+    "$TCURL -o $DEMO_DIR/downloaded.bin $BASE/download && ls -la $DEMO_DIR/downloaded.bin"
+
+demo "22. Download with remote name (-O)" \
+    "(cd $DEMO_DIR && $TCURL -O $BASE/api.json && ls -la api.json* | tail -1)"
+
+# ============================================================================
+# COMPRESSION
+# ============================================================================
+echo -e "${GREEN}[ COMPRESSION ]${NC}"
+
+demo "23. Request compressed response" \
+    "$TCURL --compressed $BASE/compressed"
+
+# ============================================================================
+# TIMEOUTS & ERROR HANDLING
+# ============================================================================
+echo -e "${GREEN}[ TIMEOUTS & ERRORS ]${NC}"
+
+demo "24. Connection timeout" \
+    "$TCURL --connect-timeout 2 $BASE/api.json"
+
+demo "25. HTTP 404 response" \
+    "$TCURL $BASE/nonexistent"
+
+demo "26. HTTP 500 response" \
+    "$TCURL $BASE/status/500"
+
+demo "27. Fail silently on error (-f)" \
+    "$TCURL -f $BASE/status/404 && echo 'Success' || echo 'Failed (exit code: \$?)'"
+
+# ============================================================================
+# SILENT & OUTPUT MODES
+# ============================================================================
+echo -e "${GREEN}[ OUTPUT MODES ]${NC}"
+
+demo "28. Silent mode (-s)" \
+    "$TCURL -s $BASE/api.json"
+
+demo "29. Silent + show errors (-sS)" \
+    "$TCURL -sS $BASE/status/500"
+
+# ============================================================================
+# REAL-WORLD APIs (requires internet)
+# ============================================================================
+echo -e "${GREEN}[ REAL-WORLD APIs ]${NC}"
+
+demo "30. httpbin.org - Echo GET request" \
+    "$TCURL https://httpbin.org/get"
+
+demo "31. httpbin.org - See your headers" \
+    "$TCURL https://httpbin.org/headers"
+
+demo "32. httpbin.org - Get your IP address" \
+    "$TCURL https://httpbin.org/ip"
+
+demo "33. httpbin.org - User-Agent echo" \
+    "$TCURL https://httpbin.org/user-agent"
+
+demo "34. httpbin.org - POST with JSON" \
+    "$TCURL -X POST -H 'Content-Type: application/json' -d '{\"test\":\"data\",\"num\":42}' https://httpbin.org/post"
+
+demo "35. httpbin.org - Basic auth test" \
+    "$TCURL -u testuser:testpass https://httpbin.org/basic-auth/testuser/testpass"
+
+demo "36. httpbin.org - Response headers" \
+    "$TCURL -i 'https://httpbin.org/response-headers?X-Custom=hello&X-Demo=tcurl'"
+
+demo "37. httpbin.org - Delayed response (2 sec)" \
+    "$TCURL https://httpbin.org/delay/2"
+
+demo "38. httpbin.org - Redirect test" \
+    "$TCURL -L https://httpbin.org/redirect/3"
+
+demo "39. httpbin.org - UUID generator" \
+    "$TCURL https://httpbin.org/uuid"
+
+demo "40. httpbin.org - Gzip compressed" \
+    "$TCURL --compressed https://httpbin.org/gzip"
+
+demo "41. httpbin.org - Brotli compressed" \
+    "$TCURL --compressed https://httpbin.org/brotli"
+
+demo "42. JSONPlaceholder - Get a post" \
+    "$TCURL https://jsonplaceholder.typicode.com/posts/1"
+
+demo "43. JSONPlaceholder - Get comments for post" \
+    "$TCURL https://jsonplaceholder.typicode.com/posts/1/comments"
+
+demo "44. JSONPlaceholder - Create a post (POST)" \
+    "$TCURL -X POST -H 'Content-Type: application/json' -d '{\"title\":\"tcurl test\",\"body\":\"Hello from tcurl!\",\"userId\":1}' https://jsonplaceholder.typicode.com/posts"
+
+demo "45. JSONPlaceholder - Update a post (PUT)" \
+    "$TCURL -X PUT -H 'Content-Type: application/json' -d '{\"id\":1,\"title\":\"updated\",\"body\":\"modified\",\"userId\":1}' https://jsonplaceholder.typicode.com/posts/1"
+
+demo "46. JSONPlaceholder - Get users list" \
+    "$TCURL https://jsonplaceholder.typicode.com/users"
+
+demo "47. GitHub API - Public endpoint" \
+    "$TCURL -H 'Accept: application/vnd.github.v3+json' https://api.github.com"
+
+demo "48. GitHub API - Get a repo" \
+    "$TCURL https://api.github.com/repos/curl/curl"
+
+demo "49. icanhazip.com - Simple IP check" \
+    "$TCURL https://icanhazip.com"
+
+demo "50. wttr.in - Weather (text mode)" \
+    "$TCURL 'https://wttr.in/?format=3'"
+
+# ============================================================================
+# SUMMARY
+# ============================================================================
+echo -e "${GREEN}"
+echo "╔═══════════════════════════════════════════════════════════════╗"
+echo "║                     DEMO COMPLETE                             ║"
+echo "║                                                               ║"
+echo "║  Local server tests (1-29):                                   ║"
+echo "║  - HTTP methods: GET, POST, PUT, DELETE, PATCH, HEAD          ║"
+echo "║  - Custom headers, User-Agent, Referer                        ║"
+echo "║  - Basic authentication                                       ║"
+echo "║  - Redirect following                                         ║"
+echo "║  - Cookie handling (jar read/write)                           ║"
+echo "║  - File downloads                                             ║"
+echo "║  - Compressed responses                                       ║"
+echo "║  - Timeouts and error handling                                ║"
+echo "║  - Verbose and silent modes                                   ║"
+echo "║                                                               ║"
+echo "║  Real-world API tests (30-50):                                ║"
+echo "║  - httpbin.org: headers, auth, redirects, compression         ║"
+echo "║  - JSONPlaceholder: REST CRUD operations                      ║"
+echo "║  - GitHub API: public endpoints                               ║"
+echo "║  - icanhazip.com, wttr.in: simple utilities                   ║"
+echo "╚═══════════════════════════════════════════════════════════════╝"
+echo -e "${NC}"

--- a/examples/curl/include/curl/StreamingCurl-private.h
+++ b/examples/curl/include/curl/StreamingCurl-private.h
@@ -1,0 +1,1107 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl-private.h
+ * @brief Internal structures for streaming curl module.
+ *
+ * This file is not part of the public API. Do not include directly.
+ */
+
+#ifndef STREAMINGCURL_PRIVATE_INCLUDED
+#define STREAMINGCURL_PRIVATE_INCLUDED
+
+#include "curl/StreamingCurl.h"
+#include "socket/Socket.h"
+#include "socket/SocketBuf.h"
+
+/* Forward declarations */
+struct SocketProxy_Config;
+struct SocketHTTP2_Conn;
+struct SocketHTTP2_Stream;
+struct SocketHTTP1_Parser;
+
+/* Optional TLS support */
+#if SOCKET_HAS_TLS
+#include "tls/SocketTLSContext.h"
+#endif
+
+/* Buffer size constants */
+#define CURL_MAX_FILENAME_LEN 256
+#define CURL_MAX_COOKIE_NAME_LEN 256
+#define CURL_MAX_DOMAIN_LEN 256
+#define CURL_MAX_REALM_LEN 256
+#define CURL_MAX_NONCE_LEN 256
+#define CURL_MAX_OPAQUE_LEN 256
+#define CURL_MAX_PATH_LEN 1024
+#define CURL_MAX_COOKIE_VALUE_LEN 4096
+#define CURL_MAX_COOKIE_LINE_LEN 4096
+#define CURL_MAX_CREDENTIAL_LEN 512
+#define CURL_MAX_AUTH_BUFFER_LEN 1024
+#define CURL_MAX_QOP_LEN 64
+#define CURL_MAX_URL_BUFFER_LEN 8192
+#define CURL_REQUEST_BUFFER_SIZE 8192
+#define CURL_CHUNK_BUFFER_SIZE 16384
+
+/* HTTP/1.1 buffer sizes */
+#define CURL_H1_RECV_BUFFER_SIZE 16384
+#define CURL_H1_BODY_BUFFER_SIZE 16384
+
+/* HTTP/2 buffer sizes */
+#define CURL_H2_DATA_BUFFER_SIZE 16384
+#define CURL_H2_DECOMP_BUFFER_SIZE 32768
+#define CURL_H2_MAX_HEADERS 128
+
+/* Decompression buffer size */
+#define CURL_DECOMP_BUFFER_SIZE 32768
+
+/* Header count limits */
+#define CURL_MAX_HEADER_COUNT_SMALL 64
+
+/* ============================================================================
+ * Shared Constants (consolidated from multiple .c files)
+ * ============================================================================ */
+
+/* HTTP default ports */
+#define CURL_HTTP_DEFAULT_PORT 80
+#define CURL_HTTPS_DEFAULT_PORT 443
+
+/* HTTP status codes - no body responses */
+#define CURL_HTTP_STATUS_NO_CONTENT 204
+#define CURL_HTTP_STATUS_NOT_MODIFIED 304
+
+/* HTTP status codes - informational range */
+#define CURL_HTTP_STATUS_INFORMATIONAL_MIN 100
+#define CURL_HTTP_STATUS_INFORMATIONAL_MAX 200
+
+/* HTTP status codes - redirects */
+#define CURL_HTTP_STATUS_MOVED_PERMANENTLY 301
+#define CURL_HTTP_STATUS_FOUND 302
+#define CURL_HTTP_STATUS_SEE_OTHER 303
+#define CURL_HTTP_STATUS_TEMPORARY_REDIRECT 307
+#define CURL_HTTP_STATUS_PERMANENT_REDIRECT 308
+
+/* HTTP status codes - client error boundary */
+#define CURL_HTTP_STATUS_CLIENT_ERROR_MIN 400
+
+/* Default configuration values */
+#define CURL_DEFAULT_CONNECT_TIMEOUT_MS 30000
+#define CURL_DEFAULT_DNS_TIMEOUT_MS 5000
+#define CURL_DEFAULT_REQUEST_TIMEOUT_MS 0  /* No limit */
+#define CURL_DEFAULT_MAX_REDIRECTS 50
+#define CURL_DEFAULT_MAX_RETRIES 3
+
+/* Numeric parsing */
+#define CURL_DECIMAL_BASE 10
+
+/**
+ * @brief Internal connection state.
+ */
+typedef struct CurlConnection
+{
+  Socket_T socket;                 /**< Underlying socket */
+  SocketBuf_T buffer;              /**< Buffered I/O wrapper */
+  int is_tls;                      /**< TLS connection flag */
+  SocketHTTP_Version http_version; /**< Negotiated HTTP version */
+
+#if SOCKET_HAS_TLS
+  SocketTLSContext_T tls_context;  /**< TLS context (owned if auto-created) */
+  int owns_tls_context;            /**< 1 if we created the context */
+#endif
+
+  /* HTTP/2 state (if applicable) */
+  struct SocketHTTP2_Conn *h2_conn;    /**< HTTP/2 connection */
+  struct SocketHTTP2_Stream *h2_stream;/**< Current HTTP/2 stream */
+
+  /* HTTP/1.1 state */
+  struct SocketHTTP1_Parser *h1_parser; /**< HTTP/1.1 response parser */
+
+  /* Connection tracking */
+  char *host;                      /**< Connected host (for reuse) */
+  int port;                        /**< Connected port */
+  int reusable;                    /**< Can be reused for next request */
+  int connected;                   /**< Connection is established */
+} CurlConnection;
+
+/**
+ * @brief Cookie entry.
+ */
+typedef struct CurlCookie
+{
+  char *domain;                    /**< Cookie domain */
+  char *path;                      /**< Cookie path */
+  char *name;                      /**< Cookie name */
+  char *value;                     /**< Cookie value */
+  time_t expires;                  /**< Expiration time (0 = session) */
+  int secure;                      /**< Secure flag */
+  int http_only;                   /**< HttpOnly flag */
+  struct CurlCookie *next;         /**< Next cookie in list */
+} CurlCookie;
+
+/**
+ * @brief Cookie jar.
+ */
+typedef struct CurlCookieJar
+{
+  CurlCookie *cookies;             /**< Linked list of cookies */
+  char *filename;                  /**< Persistence file */
+  int dirty;                       /**< Needs saving */
+  Arena_T arena;                   /**< Memory arena */
+} CurlCookieJar;
+
+/**
+ * @brief Custom headers list.
+ */
+typedef struct CurlCustomHeader
+{
+  char *name;                      /**< Header name */
+  char *value;                     /**< Header value */
+  struct CurlCustomHeader *next;   /**< Next header */
+} CurlCustomHeader;
+
+/**
+ * @brief Internal session structure.
+ */
+struct CurlSession
+{
+  /* Configuration (copied from options) */
+  CurlOptions options;
+
+  /* Memory management */
+  Arena_T arena;                   /**< Session arena */
+  Arena_T request_arena;           /**< Per-request arena (reset each request) */
+
+  /* State machine */
+  CurlState state;
+  CurlError last_error;
+
+  /* Current request */
+  CurlParsedURL current_url;       /**< Parsed URL of current request */
+  SocketHTTP_Method request_method;/**< Current request method */
+  SocketHTTP_Headers_T request_headers; /**< Current request headers */
+
+  /* Response */
+  CurlResponse response;
+
+  /* Connection (may be reused) */
+  CurlConnection *conn;
+
+  /* Custom headers (persist across requests) */
+  CurlCustomHeader *custom_headers;
+
+  /* Cookie handling */
+  CurlCookieJar *cookie_jar;
+
+  /* Authentication state */
+  CurlAuth auth;
+  char *auth_header;               /**< Pre-computed auth header */
+
+  /* Transfer state */
+  int64_t upload_total;            /**< Total bytes to upload */
+  int64_t upload_sent;             /**< Bytes uploaded so far */
+  int64_t download_total;          /**< Total bytes to download */
+  int64_t download_received;       /**< Bytes downloaded so far */
+
+  /* Retry state */
+  int retry_count;                 /**< Current retry attempt */
+};
+
+/**
+ * @brief Duplicate a string into an arena.
+ *
+ * Common utility used throughout the curl module.
+ *
+ * @param arena Memory arena
+ * @param str String to duplicate
+ * @param len String length
+ * @return Duplicated string, or NULL if str is NULL or len is 0
+ */
+extern char *curl_arena_strdup (Arena_T arena, const char *str, size_t len);
+
+/**
+ * @brief Wait for socket to become readable with timeout.
+ *
+ * Uses poll() to wait for data to be available on the socket.
+ *
+ * @param conn Connection
+ * @param timeout_ms Timeout in milliseconds (0 = no timeout, -1 = block)
+ * @return 1 if readable, 0 on timeout, -1 on error
+ */
+extern int curl_wait_readable (CurlConnection *conn, int timeout_ms);
+
+/**
+ * @brief Internal URL parsing helper.
+ *
+ * Wraps SocketHTTP_URI_parse() with curl-specific validation.
+ *
+ * @param url URL string
+ * @param len Length (0 for strlen)
+ * @param result Output structure
+ * @param arena Memory arena
+ * @return CURL_OK or CURL_ERROR_INVALID_URL
+ */
+extern CurlError curl_internal_parse_url (const char *url, size_t len,
+                                           CurlParsedURL *result,
+                                           Arena_T arena);
+
+/**
+ * @brief Check if two URLs have the same origin.
+ *
+ * Same origin means same scheme, host, and port.
+ *
+ * @param a First parsed URL
+ * @param b Second parsed URL
+ * @return 1 if same origin, 0 otherwise
+ */
+extern int curl_urls_same_origin (const CurlParsedURL *a,
+                                   const CurlParsedURL *b);
+
+/**
+ * @brief Copy a parsed URL.
+ *
+ * @param dst Destination
+ * @param src Source
+ * @param arena Arena for string allocations
+ */
+extern void curl_url_copy (CurlParsedURL *dst, const CurlParsedURL *src,
+                            Arena_T arena);
+
+
+/**
+ * @brief Establish a connection to a URL target.
+ *
+ * Uses Happy Eyeballs for direct connections, or proxy tunneling if
+ * configured. For HTTPS URLs, performs TLS handshake with ALPN.
+ *
+ * @param url Parsed target URL
+ * @param options Connection options
+ * @param arena Memory arena for allocations
+ * @return New connection, or NULL on failure (sets Curl exception)
+ * @throws Curl_DNSFailed on DNS resolution failure
+ * @throws Curl_ConnectFailed on connection failure
+ * @throws Curl_TLSFailed on TLS handshake failure
+ * @throws Curl_Timeout on connection timeout
+ */
+extern CurlConnection *curl_connect (const CurlParsedURL *url,
+                                      const CurlOptions *options,
+                                      Arena_T arena);
+
+/**
+ * @brief Close a connection and release resources.
+ *
+ * @param conn Connection to close (may be NULL)
+ */
+extern void curl_connection_close (CurlConnection *conn);
+
+/**
+ * @brief Check if a connection can be reused for a URL.
+ *
+ * Checks if the connection is still open and matches the URL's
+ * host, port, and TLS requirements.
+ *
+ * @param conn Existing connection (may be NULL)
+ * @param url Target URL
+ * @return 1 if reusable, 0 otherwise
+ */
+extern int curl_connection_reusable (const CurlConnection *conn,
+                                      const CurlParsedURL *url);
+
+/**
+ * @brief Get the negotiated ALPN protocol.
+ *
+ * @param conn Connection
+ * @return Protocol string ("h2", "http/1.1") or NULL if not TLS
+ */
+extern const char *curl_connection_alpn (const CurlConnection *conn);
+
+/**
+ * @brief Check if connection uses HTTP/2.
+ *
+ * @param conn Connection
+ * @return 1 if HTTP/2, 0 otherwise
+ */
+extern int curl_connection_is_http2 (const CurlConnection *conn);
+
+
+/**
+ * @brief Build HTTP/1.1 request headers.
+ *
+ * @param session Session with request info
+ * @param method HTTP method
+ * @param body Request body (may be NULL)
+ * @param body_len Body length
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t curl_build_http1_request (CurlSession_T session,
+                                          SocketHTTP_Method method,
+                                          const void *body, size_t body_len,
+                                          char *output, size_t output_size);
+
+/**
+ * @brief Send HTTP/1.1 request with optional body.
+ *
+ * @param session Session
+ * @param method HTTP method
+ * @param body Static body (NULL for streaming)
+ * @param body_len Body length
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_send_http1_request (CurlSession_T session,
+                                           SocketHTTP_Method method,
+                                           const void *body, size_t body_len);
+
+/**
+ * @brief Send chunked body using read callback.
+ *
+ * @param session Session with read callback
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_send_chunked_body (CurlSession_T session);
+
+/**
+ * @brief Send HTTP/2 request with optional body.
+ *
+ * @param session Session
+ * @param method HTTP method
+ * @param body Static body (NULL for streaming)
+ * @param body_len Body length
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_send_http2_request (CurlSession_T session,
+                                           SocketHTTP_Method method,
+                                           const void *body, size_t body_len);
+
+/**
+ * @brief Send DATA frame(s) for HTTP/2.
+ *
+ * @param session Session
+ * @param data Data to send
+ * @param len Data length
+ * @param end_stream End stream flag
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_send_h2_data (CurlSession_T session, const void *data,
+                                     size_t len, int end_stream);
+
+/**
+ * @brief Send streaming body for HTTP/2 using read callback.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_send_h2_streaming_body (CurlSession_T session);
+
+/**
+ * @brief Send request using appropriate protocol.
+ *
+ * Automatically selects HTTP/1.1 or HTTP/2 based on connection.
+ *
+ * @param session Session
+ * @param method HTTP method
+ * @param body Request body (NULL for none)
+ * @param body_len Body length
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_send_request (CurlSession_T session,
+                                     SocketHTTP_Method method, const void *body,
+                                     size_t body_len);
+
+/**
+ * @brief Build request headers for a session.
+ *
+ * @param session Session
+ * @param method HTTP method
+ * @param content_type Content-Type for body (may be NULL)
+ * @param body_len Body length (0 for none or streaming)
+ * @return 0 on success, -1 on error
+ */
+extern int curl_build_request_headers (CurlSession_T session,
+                                        SocketHTTP_Method method,
+                                        const char *content_type,
+                                        size_t body_len);
+
+
+/**
+ * @brief Build Basic authentication header value.
+ *
+ * @param username Username
+ * @param password Password
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Header value length, or -1 on error
+ */
+extern ssize_t curl_auth_basic (const char *username, const char *password,
+                                 char *output, size_t output_size);
+
+/**
+ * @brief Build Bearer token authentication header value.
+ *
+ * @param token Bearer token
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Header value length, or -1 on error
+ */
+extern ssize_t curl_auth_bearer (const char *token, char *output,
+                                  size_t output_size);
+
+/**
+ * @brief Parse WWW-Authenticate header for Digest parameters.
+ *
+ * @param header WWW-Authenticate header value
+ * @param realm Output realm
+ * @param realm_size Realm buffer size
+ * @param nonce Output nonce
+ * @param nonce_size Nonce buffer size
+ * @param opaque Output opaque (may be NULL)
+ * @param opaque_size Opaque buffer size
+ * @param qop Output qop (may be NULL)
+ * @param qop_size Qop buffer size
+ * @return 0 on success, -1 on error
+ */
+extern int curl_auth_parse_digest_challenge (const char *header, char *realm,
+                                              size_t realm_size, char *nonce,
+                                              size_t nonce_size, char *opaque,
+                                              size_t opaque_size, char *qop,
+                                              size_t qop_size);
+
+/**
+ * @brief Digest authentication parameters.
+ *
+ * Groups all parameters needed for RFC 7616 Digest authentication.
+ */
+typedef struct CurlDigestParams
+{
+  /* Credentials */
+  const char *username;            /**< Username */
+  const char *password;            /**< Password */
+
+  /* Challenge parameters */
+  const char *realm;               /**< Realm from server challenge */
+  const char *nonce;               /**< Nonce from server challenge */
+  const char *opaque;              /**< Opaque from challenge (may be NULL) */
+  const char *qop;                 /**< Quality of Protection (may be NULL) */
+
+  /* Request parameters */
+  const char *uri;                 /**< Request URI */
+  const char *method;              /**< HTTP method */
+
+  /* Client parameters */
+  const char *nc;                  /**< Nonce count (hex string) */
+  const char *cnonce;              /**< Client nonce */
+
+  /* Output buffer */
+  char *output;                    /**< Output buffer */
+  size_t output_size;              /**< Output buffer size */
+} CurlDigestParams;
+
+/**
+ * @brief Build Digest authentication header value.
+ *
+ * @param params Digest authentication parameters
+ * @return Header value length, or -1 on error
+ */
+extern ssize_t
+curl_auth_digest (const CurlDigestParams *params);
+
+/**
+ * @brief Set up authentication header for session.
+ *
+ * @param session Session
+ * @return 0 on success, -1 on error
+ */
+extern int curl_auth_setup (CurlSession_T session);
+
+/**
+ * @brief Handle 401 Unauthorized response for Digest auth.
+ *
+ * @param session Session
+ * @param www_auth WWW-Authenticate header value
+ * @param method HTTP method
+ * @param uri Request URI
+ * @return 0 on success, -1 on error
+ */
+extern int curl_auth_handle_challenge (CurlSession_T session,
+                                        const char *www_auth,
+                                        const char *method, const char *uri);
+
+
+/**
+ * @brief Receive and parse HTTP/1.1 response headers.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_receive_h1_headers (CurlSession_T session);
+
+/**
+ * @brief Stream HTTP/1.1 response body through callback.
+ *
+ * Handles Content-Length and chunked transfer encoding transparently.
+ * Invokes write callback with body data without buffering.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_receive_h1_body (CurlSession_T session);
+
+/**
+ * @brief Receive complete HTTP/1.1 response (headers + body).
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_receive_h1_response (CurlSession_T session);
+
+/**
+ * @brief Check if HTTP/1.1 connection should be kept alive.
+ *
+ * @param session Session after response
+ * @return 1 if keep-alive, 0 otherwise
+ */
+extern int curl_h1_should_keepalive (CurlSession_T session);
+
+/**
+ * @brief Get trailer headers (for chunked responses).
+ *
+ * @param session Session after body complete
+ * @return Trailer headers or NULL
+ */
+extern SocketHTTP_Headers_T curl_h1_get_trailers (CurlSession_T session);
+
+
+/**
+ * @brief Receive and parse HTTP/2 response headers.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_receive_h2_headers (CurlSession_T session);
+
+/**
+ * @brief Stream HTTP/2 response body through callback.
+ *
+ * Handles DATA frames with flow control (WINDOW_UPDATE).
+ * Invokes write callback with body data without buffering.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_receive_h2_body (CurlSession_T session);
+
+/**
+ * @brief Receive complete HTTP/2 response (headers + body).
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_receive_h2_response (CurlSession_T session);
+
+/**
+ * @brief Get HTTP/2 stream state.
+ *
+ * @param session Session
+ * @return Stream state, or -1 on error
+ */
+extern int curl_h2_stream_state (CurlSession_T session);
+
+/**
+ * @brief Close HTTP/2 stream.
+ *
+ * @param session Session
+ * @param error_code HTTP/2 error code (0 for no error)
+ */
+extern void curl_h2_stream_close (CurlSession_T session, int error_code);
+
+/**
+ * @brief Get current send window for HTTP/2 stream.
+ *
+ * @param session Session
+ * @return Send window size, or 0 on error
+ */
+extern int32_t curl_h2_send_window (CurlSession_T session);
+
+/**
+ * @brief Get current receive window for HTTP/2 stream.
+ *
+ * @param session Session
+ * @return Receive window size, or 0 on error
+ */
+extern int32_t curl_h2_recv_window (CurlSession_T session);
+
+
+/**
+ * @brief Decompression context for streaming decompression.
+ */
+typedef struct CurlDecompressor CurlDecompressor;
+
+/**
+ * @brief Create a new decompressor.
+ *
+ * @param encoding Content-Encoding header value
+ * @param arena Memory arena
+ * @return New decompressor, or NULL on error
+ */
+extern CurlDecompressor *curl_decompressor_new (const char *encoding,
+                                                  Arena_T arena);
+
+/**
+ * @brief Decompress data.
+ *
+ * @param decomp Decompressor
+ * @param input Compressed input
+ * @param input_len Input length
+ * @param output Output buffer
+ * @param output_len Output buffer size
+ * @param bytes_written Output bytes written
+ * @return 0 on success, -1 on error
+ */
+extern int curl_decompressor_decompress (CurlDecompressor *decomp,
+                                           const unsigned char *input,
+                                           size_t input_len,
+                                           unsigned char *output,
+                                           size_t output_len,
+                                           size_t *bytes_written);
+
+/**
+ * @brief Finish decompression and get remaining data.
+ *
+ * @param decomp Decompressor
+ * @param output Output buffer
+ * @param output_len Output buffer size
+ * @param bytes_written Output bytes written
+ * @return 0 on success, -1 on error
+ */
+extern int curl_decompressor_finish (CurlDecompressor *decomp,
+                                       unsigned char *output,
+                                       size_t output_len,
+                                       size_t *bytes_written);
+
+/**
+ * @brief Free decompressor resources.
+ *
+ * @param decomp Pointer to decompressor (set to NULL)
+ */
+extern void curl_decompressor_free (CurlDecompressor **decomp);
+
+/**
+ * @brief Check if decompressor is for identity encoding.
+ *
+ * @param decomp Decompressor
+ * @return 1 if identity, 0 otherwise
+ */
+extern int curl_decompressor_is_identity (CurlDecompressor *decomp);
+
+/**
+ * @brief Get coding type name.
+ *
+ * @param decomp Decompressor
+ * @return Static string name
+ */
+extern const char *curl_decompressor_coding_name (CurlDecompressor *decomp);
+
+/**
+ * @brief Create decompressor for session based on Content-Encoding.
+ *
+ * @param session Session
+ * @return New decompressor, or NULL if not needed/error
+ */
+extern CurlDecompressor *curl_session_create_decompressor (
+    CurlSession_T session);
+
+/**
+ * @brief Decompress body data with session's decompressor.
+ *
+ * @param session Session
+ * @param decomp Decompressor (may be NULL)
+ * @param input Input data
+ * @param input_len Input length
+ * @param output Output buffer
+ * @param output_len Output buffer size
+ * @param bytes_written Bytes written to output
+ * @return 0 on success, -1 on error
+ */
+extern int curl_session_decompress (CurlSession_T session,
+                                      CurlDecompressor *decomp,
+                                      const unsigned char *input,
+                                      size_t input_len, unsigned char *output,
+                                      size_t output_len, size_t *bytes_written);
+
+/**
+ * @brief Check if Content-Encoding indicates compression.
+ *
+ * @param headers Response headers
+ * @return 1 if compressed, 0 otherwise
+ */
+extern int curl_is_content_compressed (SocketHTTP_Headers_T headers);
+
+/**
+ * @brief Parse Content-Encoding to coding type.
+ *
+ * @param encoding Content-Encoding header value
+ * @return Coding type
+ */
+extern SocketHTTP_Coding curl_parse_content_encoding (const char *encoding);
+
+
+/**
+ * @brief Check if current response is a redirect.
+ *
+ * @param session Session
+ * @return 1 if redirect (301/302/303/307/308), 0 otherwise
+ */
+extern int curl_is_redirect (CurlSession_T session);
+
+/**
+ * @brief Get redirect status code.
+ *
+ * @param session Session
+ * @return Status code or 0 if not a redirect
+ */
+extern int curl_redirect_status (CurlSession_T session);
+
+/**
+ * @brief Get Location header from redirect response.
+ *
+ * @param session Session
+ * @return Location URL or NULL
+ */
+extern const char *curl_redirect_location (CurlSession_T session);
+
+/**
+ * @brief Check if redirect changes the HTTP method.
+ *
+ * 303 always changes to GET. 301/302 with POST changes to GET.
+ * 307/308 preserve the original method.
+ *
+ * @param session Session
+ * @return 1 if method changes to GET, 0 otherwise
+ */
+extern int curl_redirect_changes_method (CurlSession_T session);
+
+/**
+ * @brief Get the HTTP method for redirect request.
+ *
+ * @param session Session
+ * @return Method to use for redirect
+ */
+extern SocketHTTP_Method curl_redirect_method (CurlSession_T session);
+
+/**
+ * @brief Check if redirect preserves request body.
+ *
+ * Only 307 and 308 preserve the body.
+ *
+ * @param session Session
+ * @return 1 if body should be preserved, 0 otherwise
+ */
+extern int curl_redirect_preserves_body (CurlSession_T session);
+
+/**
+ * @brief Check if redirect is to a different origin.
+ *
+ * @param session Session
+ * @param location Location URL
+ * @return 1 if cross-origin, 0 if same origin
+ */
+extern int curl_redirect_is_cross_origin (CurlSession_T session,
+                                           const char *location);
+
+/**
+ * @brief Resolve redirect URL relative to current URL.
+ *
+ * @param session Session
+ * @param location Location header value
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t curl_resolve_redirect_url (CurlSession_T session,
+                                           const char *location,
+                                           char *output, size_t output_size);
+
+/**
+ * @brief Parse redirect URL into CurlParsedURL.
+ *
+ * @param session Session
+ * @param location Location header value
+ * @param result Output parsed URL
+ * @return 0 on success, -1 on error
+ */
+extern int curl_parse_redirect_url (CurlSession_T session,
+                                     const char *location,
+                                     CurlParsedURL *result);
+
+/**
+ * @brief Check if redirect should be followed.
+ *
+ * Considers: follow_redirects option, max_redirects limit, Location header.
+ *
+ * @param session Session
+ * @return 1 if should follow, 0 otherwise
+ */
+extern int curl_should_follow_redirect (CurlSession_T session);
+
+/**
+ * @brief Prepare session for redirect.
+ *
+ * Updates current_url, request_method, redirect_count.
+ * Closes connection if cross-origin.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_prepare_redirect (CurlSession_T session);
+
+/**
+ * @brief Handle redirect response.
+ *
+ * If redirect should be followed, prepares session for next request.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError curl_handle_redirect (CurlSession_T session);
+
+/**
+ * @brief Get current redirect count.
+ *
+ * @param session Session
+ * @return Number of redirects followed
+ */
+extern int curl_get_redirect_count (CurlSession_T session);
+
+/**
+ * @brief Check if redirect is a security downgrade (HTTPS to HTTP).
+ *
+ * @param session Session
+ * @param location Location URL
+ * @return 1 if downgrade, 0 otherwise
+ */
+extern int curl_redirect_is_secure_downgrade (CurlSession_T session,
+                                               const char *location);
+
+/**
+ * @brief Check if redirect is to the same host.
+ *
+ * @param session Session
+ * @param location Location URL
+ * @return 1 if same host, 0 otherwise
+ */
+extern int curl_redirect_is_same_host (CurlSession_T session,
+                                        const char *location);
+
+/**
+ * @brief Reset redirect count.
+ *
+ * @param session Session
+ */
+extern void curl_reset_redirect_count (CurlSession_T session);
+
+
+/**
+ * @brief Create a new cookie jar.
+ *
+ * @param arena Memory arena
+ * @return New cookie jar, or NULL on error
+ */
+extern CurlCookieJar *curl_cookiejar_new (Arena_T arena);
+
+/**
+ * @brief Free cookie jar.
+ *
+ * @param jar Pointer to cookie jar (set to NULL)
+ */
+extern void curl_cookiejar_free (CurlCookieJar **jar);
+
+/**
+ * @brief Parse a Set-Cookie header value.
+ *
+ * @param set_cookie Set-Cookie header value
+ * @param request_host Request host (for default domain)
+ * @param request_path Request path (for default path)
+ * @param request_secure 1 if HTTPS, 0 if HTTP
+ * @param arena Memory arena
+ * @return Parsed cookie, or NULL on error
+ */
+extern CurlCookie *curl_cookie_parse (const char *set_cookie,
+                                       const char *request_host,
+                                       const char *request_path,
+                                       int request_secure, Arena_T arena);
+
+/**
+ * @brief Check if cookie domain matches request host.
+ *
+ * @param cookie_domain Cookie domain
+ * @param request_host Request host
+ * @return 1 if matches, 0 otherwise
+ */
+extern int curl_cookie_domain_match (const char *cookie_domain,
+                                      const char *request_host);
+
+/**
+ * @brief Check if cookie path matches request path.
+ *
+ * @param cookie_path Cookie path
+ * @param request_path Request path
+ * @return 1 if matches, 0 otherwise
+ */
+extern int curl_cookie_path_match (const char *cookie_path,
+                                    const char *request_path);
+
+/**
+ * @brief Check if cookie matches request.
+ *
+ * Checks domain, path, secure flag, and expiration.
+ *
+ * @param cookie Cookie to check
+ * @param host Request host
+ * @param path Request path
+ * @param is_secure 1 if HTTPS, 0 if HTTP
+ * @return 1 if matches, 0 otherwise
+ */
+extern int curl_cookie_matches (const CurlCookie *cookie, const char *host,
+                                 const char *path, int is_secure);
+
+/**
+ * @brief Check if cookie has expired.
+ *
+ * @param cookie Cookie to check
+ * @return 1 if expired, 0 otherwise
+ */
+extern int curl_cookie_is_expired (const CurlCookie *cookie);
+
+/**
+ * @brief Add cookie to jar.
+ *
+ * Replaces existing cookie with same name/domain/path.
+ *
+ * @param jar Cookie jar
+ * @param cookie Cookie to add
+ * @return 0 on success, -1 on error
+ */
+extern int curl_cookiejar_add (CurlCookieJar *jar, CurlCookie *cookie);
+
+/**
+ * @brief Remove cookie from jar.
+ *
+ * @param jar Cookie jar
+ * @param name Cookie name
+ * @param domain Cookie domain (NULL for any)
+ * @param path Cookie path (NULL for any)
+ * @return 1 if removed, 0 if not found, -1 on error
+ */
+extern int curl_cookiejar_remove (CurlCookieJar *jar, const char *name,
+                                   const char *domain, const char *path);
+
+/**
+ * @brief Clear all cookies from jar.
+ *
+ * @param jar Cookie jar
+ */
+extern void curl_cookiejar_clear (CurlCookieJar *jar);
+
+/**
+ * @brief Clear expired cookies from jar.
+ *
+ * @param jar Cookie jar
+ */
+extern void curl_cookiejar_clear_expired (CurlCookieJar *jar);
+
+/**
+ * @brief Get number of cookies in jar.
+ *
+ * @param jar Cookie jar
+ * @return Cookie count
+ */
+extern int curl_cookiejar_count (const CurlCookieJar *jar);
+
+/**
+ * @brief Build Cookie header value for request.
+ *
+ * @param jar Cookie jar
+ * @param host Request host
+ * @param path Request path
+ * @param is_secure 1 if HTTPS, 0 if HTTP
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t curl_cookiejar_get_header (const CurlCookieJar *jar,
+                                           const char *host, const char *path,
+                                           int is_secure, char *output,
+                                           size_t output_size);
+
+/**
+ * @brief Process Set-Cookie headers from response.
+ *
+ * @param jar Cookie jar
+ * @param headers Response headers
+ * @param host Request host
+ * @param path Request path
+ * @param is_secure 1 if HTTPS, 0 if HTTP
+ * @param arena Memory arena for new cookies
+ * @return Number of cookies processed
+ */
+extern int curl_cookiejar_process_response (CurlCookieJar *jar,
+                                             SocketHTTP_Headers_T headers,
+                                             const char *host, const char *path,
+                                             int is_secure, Arena_T arena);
+
+/**
+ * @brief Load cookies from Netscape format file.
+ *
+ * @param jar Cookie jar
+ * @param filename Cookie file path
+ * @return Number of cookies loaded, or -1 on error
+ */
+extern int curl_cookiejar_load (CurlCookieJar *jar, const char *filename);
+
+/**
+ * @brief Save cookies to Netscape format file.
+ *
+ * @param jar Cookie jar
+ * @param filename Cookie file path (NULL to use jar's filename)
+ * @return 0 on success, -1 on error
+ */
+extern int curl_cookiejar_save (const CurlCookieJar *jar, const char *filename);
+
+/**
+ * @brief Add cookies to request headers.
+ *
+ * @param session Session
+ * @return 1 if cookies added, 0 if no cookies
+ */
+extern int curl_session_add_cookies (CurlSession_T session);
+
+/**
+ * @brief Process cookies from response.
+ *
+ * @param session Session
+ * @return Number of cookies processed
+ */
+extern int curl_session_process_cookies (CurlSession_T session);
+
+/**
+ * @brief Initialize cookie handling for session.
+ *
+ * @param session Session
+ * @param cookie_file Cookie file path (NULL for no persistence)
+ * @return 0 on success, -1 on error
+ */
+extern int curl_session_init_cookies (CurlSession_T session,
+                                       const char *cookie_file);
+
+/**
+ * @brief Save session cookies if dirty.
+ *
+ * @param session Session
+ * @return 0 on success, -1 on error
+ */
+extern int curl_session_save_cookies (CurlSession_T session);
+
+#endif /* STREAMINGCURL_PRIVATE_INCLUDED */

--- a/examples/curl/include/curl/StreamingCurl.h
+++ b/examples/curl/include/curl/StreamingCurl.h
@@ -1,0 +1,656 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @defgroup curl Streaming Curl Module
+ * @ingroup http
+ * @brief Memory-efficient streaming HTTP client with curl-like API.
+ *
+ * Features: Streaming body read/write via callbacks, HTTP/1.1 and HTTP/2
+ * support (via ALPN), redirect following, cookie handling, Basic/Digest/Bearer
+ * authentication, connection pooling, proxy support (SOCKS4/5, HTTP CONNECT),
+ * configurable timeouts and retries.
+ *
+ * Memory: Bodies are streamed through callbacks, never buffered in memory.
+ * Suitable for large file downloads/uploads.
+ *
+ * Thread safety: Session instances are NOT thread-safe. Use one session per
+ * thread.
+ * @{
+ */
+
+/**
+ * @file StreamingCurl.h
+ * @ingroup curl
+ * @brief Public API for streaming curl module.
+ */
+
+#ifndef STREAMINGCURL_INCLUDED
+#define STREAMINGCURL_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/SocketHTTP.h"
+
+/* Forward declarations for optional TLS */
+#if SOCKET_HAS_TLS
+#include "tls/SocketTLSContext.h"
+#else
+typedef struct SocketTLSContext_T *SocketTLSContext_T;
+#endif
+
+/**
+ * @name Exception Types
+ * @{
+ */
+
+/** @brief Generic curl operation failure. */
+extern const Except_T Curl_Failed;
+
+/** @brief DNS resolution failure. */
+extern const Except_T Curl_DNSFailed;
+
+/** @brief Connection failure. */
+extern const Except_T Curl_ConnectFailed;
+
+/** @brief TLS handshake failure. */
+extern const Except_T Curl_TLSFailed;
+
+/** @brief Operation timed out. */
+extern const Except_T Curl_Timeout;
+
+/** @brief HTTP protocol error. */
+extern const Except_T Curl_ProtocolError;
+
+/** @brief Too many redirects. */
+extern const Except_T Curl_TooManyRedirects;
+
+/** @brief Invalid URL syntax. */
+extern const Except_T Curl_InvalidURL;
+
+/** @} */
+
+/**
+ * @name Error Codes
+ * @{
+ */
+
+/** @brief Error codes for non-exception error handling. */
+typedef enum
+{
+  CURL_OK = 0,                     /**< Success */
+  CURL_ERROR_DNS,                  /**< DNS resolution failed */
+  CURL_ERROR_CONNECT,              /**< Connection failed */
+  CURL_ERROR_TLS,                  /**< TLS handshake failed */
+  CURL_ERROR_TIMEOUT,              /**< Operation timed out */
+  CURL_ERROR_PROTOCOL,             /**< HTTP protocol error */
+  CURL_ERROR_TOO_MANY_REDIRECTS,   /**< Exceeded redirect limit */
+  CURL_ERROR_INVALID_URL,          /**< Malformed URL */
+  CURL_ERROR_WRITE_CALLBACK,       /**< Write callback returned error */
+  CURL_ERROR_READ_CALLBACK,        /**< Read callback returned error */
+  CURL_ERROR_OUT_OF_MEMORY,        /**< Memory allocation failed */
+  CURL_ERROR_ABORTED               /**< Operation aborted by callback */
+} CurlError;
+
+/**
+ * @brief Get human-readable error string.
+ * @param error Error code
+ * @return Static error description string
+ */
+extern const char *Curl_error_string (CurlError error);
+
+/** @} */
+
+/**
+ * @name Callback Types
+ * @{
+ */
+
+/**
+ * @brief Callback for writing received data (response body).
+ *
+ * Called as response body data arrives. Return the number of bytes handled.
+ * Return a value different from size*nmemb to abort the transfer.
+ *
+ * @param data Pointer to received data
+ * @param size Always 1
+ * @param nmemb Number of bytes
+ * @param userdata User-provided pointer from CurlOptions
+ * @return Number of bytes handled (return != size*nmemb to abort)
+ *
+ * Example:
+ * @code
+ * size_t write_to_file(void *data, size_t size, size_t nmemb, void *userdata) {
+ *     FILE *fp = (FILE *)userdata;
+ *     return fwrite(data, size, nmemb, fp);
+ * }
+ * @endcode
+ */
+typedef size_t (*CurlWriteCallback) (void *data, size_t size, size_t nmemb,
+                                      void *userdata);
+
+/**
+ * @brief Callback for reading data to send (request body).
+ *
+ * Called to read request body data. Fill buffer with up to size*nmemb bytes.
+ * Return 0 to signal end of data, or CURL_READFUNC_ABORT to abort.
+ *
+ * @param buffer Buffer to fill with data
+ * @param size Always 1
+ * @param nmemb Maximum bytes to read
+ * @param userdata User-provided pointer from CurlOptions
+ * @return Number of bytes read, 0 for EOF, CURL_READFUNC_ABORT to abort
+ */
+typedef size_t (*CurlReadCallback) (void *buffer, size_t size, size_t nmemb,
+                                     void *userdata);
+
+/** @brief Return value to abort read callback. */
+#define CURL_READFUNC_ABORT ((size_t)-1)
+
+/**
+ * @brief Callback for progress reporting.
+ *
+ * Called periodically during transfer. Return non-zero to abort.
+ *
+ * @param userdata User-provided pointer from CurlOptions
+ * @param dltotal Total bytes to download (0 if unknown)
+ * @param dlnow Bytes downloaded so far
+ * @param ultotal Total bytes to upload (0 if unknown)
+ * @param ulnow Bytes uploaded so far
+ * @return 0 to continue, non-zero to abort
+ */
+typedef int (*CurlProgressCallback) (void *userdata, int64_t dltotal,
+                                      int64_t dlnow, int64_t ultotal,
+                                      int64_t ulnow);
+
+/**
+ * @brief Callback for receiving headers.
+ *
+ * Called for each header line received. Called after status line.
+ *
+ * @param data Header line data (includes trailing CRLF for HTTP/1.1)
+ * @param size Always 1
+ * @param nmemb Number of bytes in header line
+ * @param userdata User-provided pointer from CurlOptions
+ * @return Number of bytes handled (return != size*nmemb to abort)
+ */
+typedef size_t (*CurlHeaderCallback) (void *data, size_t size, size_t nmemb,
+                                       void *userdata);
+
+/** @} */
+
+/**
+ * @name Session State
+ * @{
+ */
+
+/**
+ * @brief Session state machine states.
+ *
+ * Tracks the current phase of an HTTP request/response cycle.
+ */
+typedef enum
+{
+  CURL_STATE_IDLE,             /**< No active request */
+  CURL_STATE_CONNECTING,       /**< Establishing TCP connection */
+  CURL_STATE_TLS_HANDSHAKE,    /**< Performing TLS handshake */
+  CURL_STATE_SENDING_REQUEST,  /**< Sending request headers/body */
+  CURL_STATE_READING_HEADERS,  /**< Reading response headers */
+  CURL_STATE_READING_BODY,     /**< Reading response body */
+  CURL_STATE_COMPLETE,         /**< Request completed successfully */
+  CURL_STATE_ERROR             /**< Request failed with error */
+} CurlState;
+
+/** @} */
+
+/**
+ * @name Authentication
+ * @{
+ */
+
+/**
+ * @brief Authentication types.
+ */
+typedef enum
+{
+  CURL_AUTH_NONE = 0,  /**< No authentication */
+  CURL_AUTH_BASIC,     /**< HTTP Basic authentication */
+  CURL_AUTH_DIGEST,    /**< HTTP Digest authentication */
+  CURL_AUTH_BEARER     /**< Bearer token authentication */
+} CurlAuthType;
+
+/**
+ * @brief Authentication credentials.
+ */
+typedef struct
+{
+  CurlAuthType type;       /**< Authentication type */
+  const char *username;    /**< Username (for Basic/Digest) */
+  const char *password;    /**< Password (for Basic/Digest) */
+  const char *token;       /**< Token (for Bearer) */
+} CurlAuth;
+
+/** @} */
+
+/**
+ * @name Parsed URL
+ * @{
+ */
+
+/**
+ * @brief Parsed URL components.
+ *
+ * Holds the components of a parsed URL. All strings are arena-allocated
+ * and remain valid until the arena is freed.
+ */
+typedef struct
+{
+  char *scheme;       /**< "http" or "https" */
+  size_t scheme_len;  /**< Length of scheme */
+  char *userinfo;     /**< "user:pass" or NULL */
+  size_t userinfo_len;/**< Length of userinfo */
+  char *host;         /**< Hostname or IP address */
+  size_t host_len;    /**< Length of host */
+  int port;           /**< Port number (80, 443, or explicit) */
+  char *path;         /**< Path starting with "/" */
+  size_t path_len;    /**< Length of path */
+  char *query;        /**< Query string (after ?) or NULL */
+  size_t query_len;   /**< Length of query */
+  char *fragment;     /**< Fragment (after #) or NULL */
+  size_t fragment_len;/**< Length of fragment */
+  int is_secure;      /**< 1 for https, 0 for http */
+} CurlParsedURL;
+
+/**
+ * @brief Parse a URL string into components.
+ *
+ * Parses an absolute HTTP/HTTPS URL. Validates scheme, host, and port.
+ * Returns error code for malformed URLs.
+ *
+ * @param url URL string to parse
+ * @param len Length of URL (0 to use strlen)
+ * @param result Output parsed URL structure
+ * @param arena Arena for string allocations
+ * @return CURL_OK on success, CURL_ERROR_INVALID_URL on failure
+ */
+extern CurlError Curl_parse_url (const char *url, size_t len,
+                                  CurlParsedURL *result, Arena_T arena);
+
+/**
+ * @brief Get effective port from parsed URL.
+ *
+ * Returns the explicit port if present, otherwise the default port
+ * for the scheme (80 for http, 443 for https).
+ *
+ * @param url Parsed URL
+ * @return Port number
+ */
+extern int Curl_url_get_port (const CurlParsedURL *url);
+
+/**
+ * @brief Resolve a relative URL against a base URL.
+ *
+ * Handles relative paths, absolute paths, and full URLs.
+ *
+ * @param base Base URL (absolute)
+ * @param relative Relative URL or absolute URL
+ * @param result Output buffer for resolved URL
+ * @param result_size Size of output buffer
+ * @return Length written, or -1 on error
+ */
+extern ssize_t Curl_resolve_url (const CurlParsedURL *base,
+                                  const char *relative,
+                                  char *result, size_t result_size);
+
+/** @} */
+
+/**
+ * @name Configuration Options
+ * @{
+ */
+
+/**
+ * @brief Configuration options for curl sessions.
+ *
+ * Initialize with Curl_options_defaults() before modifying.
+ */
+typedef struct
+{
+  /* Protocol settings */
+  SocketHTTP_Version max_version;  /**< Maximum HTTP version (default: HTTP/2) */
+  int allow_http2_cleartext;       /**< Allow HTTP/2 without TLS (default: 0) */
+
+  /* Timeouts (milliseconds) */
+  int connect_timeout_ms;          /**< Connection timeout (default: 30000) */
+  int request_timeout_ms;          /**< Total request timeout (default: 0 = no limit) */
+  int dns_timeout_ms;              /**< DNS resolution timeout (default: 5000) */
+
+  /* Redirects */
+  int follow_redirects;            /**< Follow redirects (default: 1) */
+  int max_redirects;               /**< Maximum redirects (default: 50) */
+
+  /* TLS settings */
+  SocketTLSContext_T tls_context;  /**< Custom TLS context (NULL for default) */
+  int verify_ssl;                  /**< Verify TLS certificates (default: 1) */
+
+  /* Proxy settings */
+  const char *proxy_url;           /**< Proxy URL (NULL for direct) */
+
+  /* Request settings */
+  const char *user_agent;          /**< User-Agent header (NULL for default) */
+  int accept_encoding;             /**< Send Accept-Encoding (default: 1) */
+  int auto_decompress;             /**< Auto-decompress responses (default: 1) */
+
+  /* Callbacks */
+  CurlWriteCallback write_callback;     /**< Body write callback */
+  void *write_userdata;                 /**< User data for write callback */
+  CurlReadCallback read_callback;       /**< Body read callback */
+  void *read_userdata;                  /**< User data for read callback */
+  CurlProgressCallback progress_callback; /**< Progress callback */
+  void *progress_userdata;              /**< User data for progress callback */
+  CurlHeaderCallback header_callback;   /**< Header callback */
+  void *header_userdata;                /**< User data for header callback */
+
+  /* Authentication */
+  CurlAuth auth;                   /**< Authentication credentials */
+
+  /* Cookie handling */
+  const char *cookie_file;         /**< Cookie jar file (NULL for no cookies) */
+
+  /* Retry settings */
+  int enable_retry;                /**< Enable automatic retry (default: 0) */
+  int max_retries;                 /**< Maximum retry attempts (default: 3) */
+  int retry_on_connection_error;   /**< Retry on connection failure (default: 1) */
+  int retry_on_timeout;            /**< Retry on timeout (default: 1) */
+  int retry_on_5xx;                /**< Retry on 5xx responses (default: 0) */
+
+  /* Verbose/debug */
+  int verbose;                     /**< Enable verbose output (default: 0) */
+} CurlOptions;
+
+/**
+ * @brief Initialize options with sensible defaults.
+ *
+ * Must be called before using a CurlOptions structure.
+ *
+ * @param options Options structure to initialize
+ */
+extern void Curl_options_defaults (CurlOptions *options);
+
+/** @} */
+
+/**
+ * @name Response Information
+ * @{
+ */
+
+/**
+ * @brief Response information from a completed request.
+ *
+ * Contains status code and headers. Body is delivered via write callback.
+ */
+typedef struct
+{
+  int status_code;                 /**< HTTP status code (e.g., 200, 404) */
+  SocketHTTP_Version version;      /**< HTTP version used */
+  SocketHTTP_Headers_T headers;    /**< Response headers */
+  int64_t content_length;          /**< Content-Length or -1 if chunked/unknown */
+  size_t redirect_count;           /**< Number of redirects followed */
+  CurlError error;                 /**< Error code if request failed */
+} CurlResponse;
+
+/** @} */
+
+/**
+ * @name Session Handle
+ * @{
+ */
+
+/**
+ * @brief Opaque session handle.
+ *
+ * Manages connection state, cookies, and can be reused for multiple requests.
+ * Connection reuse is automatic for same-host requests.
+ */
+typedef struct CurlSession *CurlSession_T;
+
+/**
+ * @brief Create a new curl session.
+ *
+ * @param options Configuration options (NULL for defaults)
+ * @return New session handle
+ * @throws Curl_Failed if session creation fails
+ */
+extern CurlSession_T Curl_session_new (const CurlOptions *options);
+
+/**
+ * @brief Free a curl session.
+ *
+ * Closes any open connections and frees resources.
+ *
+ * @param session Pointer to session handle (set to NULL after free)
+ */
+extern void Curl_session_free (CurlSession_T *session);
+
+/**
+ * @brief Reset session state for a new request.
+ *
+ * Clears response data but keeps connections and cookies.
+ *
+ * @param session Session handle
+ */
+extern void Curl_session_reset (CurlSession_T session);
+
+/**
+ * @brief Get current session state.
+ *
+ * @param session Session handle
+ * @return Current state
+ */
+extern CurlState Curl_session_state (CurlSession_T session);
+
+/**
+ * @brief Get last error from session.
+ *
+ * @param session Session handle
+ * @return Last error code
+ */
+extern CurlError Curl_session_error (CurlSession_T session);
+
+/**
+ * @brief Get response information.
+ *
+ * Valid after request completion. Data is valid until next request or
+ * session free.
+ *
+ * @param session Session handle
+ * @return Pointer to response info (do not free)
+ */
+extern const CurlResponse *Curl_session_response (CurlSession_T session);
+
+/** @} */
+
+/**
+ * @name Request Methods
+ * @{
+ */
+
+/**
+ * @brief Perform a GET request.
+ *
+ * Response body is delivered via write callback.
+ *
+ * @param session Session handle
+ * @param url URL to fetch
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_get (CurlSession_T session, const char *url);
+
+/**
+ * @brief Perform a HEAD request.
+ *
+ * @param session Session handle
+ * @param url URL to fetch
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_head (CurlSession_T session, const char *url);
+
+/**
+ * @brief Perform a POST request.
+ *
+ * Request body is read via read callback (if set) or from the provided data.
+ *
+ * @param session Session handle
+ * @param url URL to post to
+ * @param content_type Content-Type header value
+ * @param body Request body data (NULL to use read callback)
+ * @param body_len Length of body data
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_post (CurlSession_T session, const char *url,
+                             const char *content_type, const void *body,
+                             size_t body_len);
+
+/**
+ * @brief Perform a PUT request.
+ *
+ * @param session Session handle
+ * @param url URL to put to
+ * @param content_type Content-Type header value
+ * @param body Request body data (NULL to use read callback)
+ * @param body_len Length of body data
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_put (CurlSession_T session, const char *url,
+                            const char *content_type, const void *body,
+                            size_t body_len);
+
+/**
+ * @brief Perform a DELETE request.
+ *
+ * @param session Session handle
+ * @param url URL to delete
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_delete (CurlSession_T session, const char *url);
+
+/**
+ * @brief Perform a request with custom method.
+ *
+ * @param session Session handle
+ * @param method HTTP method
+ * @param url URL
+ * @param headers Additional headers (NULL for none)
+ * @param body Request body (NULL for none)
+ * @param body_len Length of body
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_request (CurlSession_T session, SocketHTTP_Method method,
+                                const char *url, SocketHTTP_Headers_T headers,
+                                const void *body, size_t body_len);
+
+/** @} */
+
+/**
+ * @name Convenience Functions
+ * @{
+ */
+
+/**
+ * @brief One-shot GET request with write callback.
+ *
+ * Creates a temporary session, performs the request, and frees the session.
+ *
+ * @param url URL to fetch
+ * @param write_cb Callback to receive response body
+ * @param userdata User data for callback
+ * @param options Options (NULL for defaults)
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_fetch (const char *url, CurlWriteCallback write_cb,
+                              void *userdata, const CurlOptions *options);
+
+/**
+ * @brief Download a file.
+ *
+ * @param url URL to download
+ * @param filepath Local file path to save to
+ * @param options Options (NULL for defaults)
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_download (const char *url, const char *filepath,
+                                 const CurlOptions *options);
+
+/**
+ * @brief Upload a file.
+ *
+ * @param url URL to upload to
+ * @param filepath Local file path to upload
+ * @param content_type Content-Type header value
+ * @param options Options (NULL for defaults)
+ * @return CURL_OK on success, error code on failure
+ */
+extern CurlError Curl_upload (const char *url, const char *filepath,
+                               const char *content_type,
+                               const CurlOptions *options);
+
+/** @} */
+
+/**
+ * @name Session Configuration
+ * @{
+ */
+
+/**
+ * @brief Set custom header for all requests.
+ *
+ * @param session Session handle
+ * @param name Header name
+ * @param value Header value
+ * @return 0 on success, -1 on error
+ */
+extern int Curl_session_set_header (CurlSession_T session, const char *name,
+                                     const char *value);
+
+/**
+ * @brief Set authentication credentials.
+ *
+ * @param session Session handle
+ * @param auth Authentication credentials
+ */
+extern void Curl_session_set_auth (CurlSession_T session, const CurlAuth *auth);
+
+/**
+ * @brief Update callbacks.
+ *
+ * @param session Session handle
+ * @param write_cb Write callback (NULL to keep current)
+ * @param write_userdata Write callback user data
+ */
+extern void Curl_session_set_write_callback (CurlSession_T session,
+                                              CurlWriteCallback write_cb,
+                                              void *write_userdata);
+
+/**
+ * @brief Update read callback.
+ *
+ * @param session Session handle
+ * @param read_cb Read callback (NULL to keep current)
+ * @param read_userdata Read callback user data
+ */
+extern void Curl_session_set_read_callback (CurlSession_T session,
+                                             CurlReadCallback read_cb,
+                                             void *read_userdata);
+
+/** @} */
+
+/** @} */
+
+#endif /* STREAMINGCURL_INCLUDED */

--- a/examples/curl/include/curl/curl_args.h
+++ b/examples/curl/include/curl/curl_args.h
@@ -1,0 +1,147 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file curl_args.h
+ * @ingroup curl
+ * @brief Command-line argument parsing for tcurl CLI tool.
+ */
+
+#ifndef CURL_ARGS_INCLUDED
+#define CURL_ARGS_INCLUDED
+
+#include "http/SocketHTTP.h"
+
+/**
+ * @brief HTTP version preference.
+ */
+typedef enum
+{
+  TCURL_HTTP_DEFAULT = 0,  /**< Auto-negotiate (prefer HTTP/2) */
+  TCURL_HTTP_1_0,          /**< Force HTTP/1.0 */
+  TCURL_HTTP_1_1,          /**< Force HTTP/1.1 */
+  TCURL_HTTP_2             /**< Prefer HTTP/2 */
+} TcurlHttpVersion;
+
+/**
+ * @brief Parsed command-line options.
+ */
+typedef struct
+{
+  /* URL and method */
+  const char *url;           /**< Target URL */
+  const char *method;        /**< HTTP method (NULL for GET) */
+
+  /* Request data */
+  const char *data;          /**< POST/PUT data */
+  size_t data_len;           /**< Length of data */
+  int data_allocated;        /**< Whether data was dynamically allocated */
+  const char *form_data;     /**< Multipart form data */
+
+  /* Headers */
+  char **headers;            /**< Array of custom headers */
+  int header_count;          /**< Number of headers */
+
+  /* Output */
+  const char *output_file;   /**< Output file path */
+  int remote_name;           /**< Use remote filename (-O) */
+  const char *write_out;     /**< Write-out format string */
+
+  /* Behavior */
+  int follow_redirects;      /**< Follow redirects (-L) */
+  int max_redirects;         /**< Maximum redirects */
+  int insecure;              /**< Skip TLS verification (-k) */
+  int verbose;               /**< Verbose output (-v) */
+  int silent;                /**< Silent mode (-s) */
+  int show_error;            /**< Show errors in silent mode (-S) */
+  int include_headers;       /**< Include headers in output (-i) */
+  int head_only;             /**< HEAD request only (-I) */
+  int compressed;            /**< Request compressed response */
+  int fail_on_error;         /**< Fail on HTTP errors (-f) */
+  int fail_with_body;        /**< Fail with body on HTTP errors */
+
+  /* Timeouts */
+  int connect_timeout;       /**< Connection timeout (seconds) */
+  int max_time;              /**< Total timeout (seconds) */
+
+  /* Protocol */
+  TcurlHttpVersion http_version;  /**< HTTP version preference */
+
+  /* Authentication */
+  const char *user;          /**< user:password */
+
+  /* Proxy */
+  const char *proxy;         /**< Proxy URL */
+
+  /* Cookies */
+  const char *cookie_file;   /**< Cookie file to read */
+  const char *cookie_jar;    /**< Cookie file to write */
+
+  /* Other */
+  const char *user_agent;    /**< User-Agent header */
+  const char *referer;       /**< Referer header */
+  int retry_count;           /**< Number of retries */
+
+  /* Control flags */
+  int show_help;             /**< Show help and exit */
+  int show_version;          /**< Show version and exit */
+} TcurlOptions;
+
+/**
+ * @brief Initialize options with defaults.
+ * @param opts Options structure to initialize
+ */
+extern void Tcurl_options_init (TcurlOptions *opts);
+
+/**
+ * @brief Free resources in options structure.
+ * @param opts Options structure to free
+ */
+extern void Tcurl_options_free (TcurlOptions *opts);
+
+/**
+ * @brief Add a header to the options.
+ * @param opts Options structure
+ * @param header Header string (will be copied)
+ * @return 0 on success, -1 on failure
+ */
+extern int Tcurl_add_header (TcurlOptions *opts, const char *header);
+
+/**
+ * @brief Parse command-line arguments.
+ * @param argc Argument count
+ * @param argv Argument vector
+ * @param opts Output options structure
+ * @return 0 on success, -1 on failure
+ */
+extern int Tcurl_parse_args (int argc, char **argv, TcurlOptions *opts);
+
+/**
+ * @brief Validate parsed options.
+ * @param opts Options to validate
+ * @return 0 if valid, -1 if invalid
+ */
+extern int Tcurl_validate_args (const TcurlOptions *opts);
+
+/**
+ * @brief Print usage information.
+ * @param progname Program name (argv[0])
+ */
+extern void Tcurl_print_usage (const char *progname);
+
+/**
+ * @brief Print version information.
+ */
+extern void Tcurl_print_version (void);
+
+/**
+ * @brief Convert method string to SocketHTTP_Method.
+ * @param opts Options containing method string
+ * @return HTTP method enum value
+ */
+extern SocketHTTP_Method Tcurl_get_http_method (const TcurlOptions *opts);
+
+#endif /* CURL_ARGS_INCLUDED */

--- a/examples/curl/src/StreamingCurl.c
+++ b/examples/curl/src/StreamingCurl.c
@@ -1,0 +1,844 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl.c
+ * @brief Main implementation of streaming curl module.
+ *
+ * Implements the public API for the streaming HTTP client:
+ * - Session lifecycle (new, reset, free)
+ * - Request methods (GET, POST, PUT, DELETE, HEAD)
+ * - Convenience functions (fetch, download, upload)
+ * - Exception-safe resource management
+ * - Connection reuse for same-host requests
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* Curl_options_defaults is defined in StreamingCurl_url.c */
+
+/* Constants */
+#define URL_PARSE_FLAGS_NONE 0     /* No special flags for URL parsing */
+#define FILE_MODE_WRITE_BINARY "wb" /* File mode for binary write */
+#define FILE_MODE_READ_BINARY "rb"  /* File mode for binary read */
+#define FREAD_ELEMENT_SIZE 1        /* Read 1-byte elements with fread */
+#define NULL_TERMINATOR_SIZE 1      /* Extra byte for null terminator */
+
+CurlSession_T
+Curl_session_new (const CurlOptions *options)
+{
+  /* Create session arena */
+  Arena_T arena = Arena_new ();
+  if (!arena)
+    {
+      RAISE (Curl_Failed);
+    }
+
+  /* Allocate session structure */
+  CurlSession_T session = CALLOC (arena, 1, sizeof (*session));
+  session->arena = arena;
+
+  /* Create per-request arena */
+  session->request_arena = Arena_new ();
+  if (!session->request_arena)
+    {
+      Arena_dispose (&arena);
+      RAISE (Curl_Failed);
+    }
+
+  /* Copy options or use defaults */
+  if (options)
+    {
+      session->options = *options;
+    }
+  else
+    {
+      Curl_options_defaults (&session->options);
+    }
+
+  /* Copy authentication credentials to session */
+  session->auth = session->options.auth;
+
+  /* Initialize state */
+  session->state = CURL_STATE_IDLE;
+  session->last_error = CURL_OK;
+
+  /* Initialize cookie handling if enabled */
+  if (session->options.cookie_file)
+    {
+      curl_session_init_cookies (session, session->options.cookie_file);
+    }
+
+  return session;
+}
+
+void
+Curl_session_free (CurlSession_T *session_p)
+{
+  if (!session_p || !*session_p)
+    return;
+
+  CurlSession_T session = *session_p;
+
+  /* Save cookies if needed */
+  if (session->cookie_jar && session->cookie_jar->dirty)
+    {
+      curl_session_save_cookies (session);
+    }
+
+  /* Close connection if open */
+  if (session->conn)
+    {
+      curl_connection_close (session->conn);
+      session->conn = NULL;
+    }
+
+  /* Free per-request arena */
+  if (session->request_arena)
+    {
+      Arena_dispose (&session->request_arena);
+    }
+
+  /* Free session arena (frees everything including session struct).
+   * Save arena to local variable first because session itself is allocated
+   * from this arena - after Arena_clear, session memory is freed. */
+  Arena_T arena = session->arena;
+  Arena_dispose (&arena);
+  *session_p = NULL;
+}
+
+void
+Curl_session_reset (CurlSession_T session)
+{
+  if (!session)
+    return;
+
+  /* Reset per-request arena */
+  if (session->request_arena)
+    {
+      Arena_dispose (&session->request_arena);
+      session->request_arena = Arena_new ();
+      if (!session->request_arena)
+        {
+          RAISE (Curl_Failed);
+        }
+    }
+
+  /* Reset state */
+  session->state = CURL_STATE_IDLE;
+  session->last_error = CURL_OK;
+
+  /* Reset response (but keep headers from session arena) */
+  memset (&session->response, 0, sizeof (session->response));
+
+  /* Reset URL */
+  memset (&session->current_url, 0, sizeof (session->current_url));
+
+  /* Keep connection for reuse (if compatible with next request) */
+  /* Keep cookie jar */
+  /* Keep custom headers */
+
+  /* Reset transfer state */
+  session->upload_total = 0;
+  session->upload_sent = 0;
+  session->download_total = 0;
+  session->download_received = 0;
+
+  /* Reset retry count */
+  session->retry_count = 0;
+}
+
+CurlState
+Curl_session_state (CurlSession_T session)
+{
+  if (!session)
+    return CURL_STATE_ERROR;
+
+  return session->state;
+}
+
+CurlError
+Curl_session_error (CurlSession_T session)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  return session->last_error;
+}
+
+const CurlResponse *
+Curl_session_response (CurlSession_T session)
+{
+  if (!session)
+    return NULL;
+
+  return &session->response;
+}
+
+int
+Curl_session_set_header (CurlSession_T session, const char *name,
+                         const char *value)
+{
+  if (!session || !name)
+    return -1;
+
+  /* Allocate new custom header */
+  CurlCustomHeader *header = ALLOC (session->arena, sizeof (*header));
+  header->name = curl_arena_strdup (session->arena, name, strlen (name));
+  header->value
+      = value ? curl_arena_strdup (session->arena, value, strlen (value))
+              : NULL;
+
+  /* Prepend to list */
+  header->next = session->custom_headers;
+  session->custom_headers = header;
+
+  return 0;
+}
+
+void
+Curl_session_set_auth (CurlSession_T session, const CurlAuth *auth)
+{
+  if (!session)
+    return;
+
+  if (auth)
+    {
+      session->auth = *auth;
+    }
+  else
+    {
+      session->auth.type = CURL_AUTH_NONE;
+      session->auth.username = NULL;
+      session->auth.password = NULL;
+      session->auth.token = NULL;
+    }
+}
+
+void
+Curl_session_set_write_callback (CurlSession_T session,
+                                 CurlWriteCallback write_cb,
+                                 void *write_userdata)
+{
+  if (!session)
+    return;
+
+  session->options.write_callback = write_cb;
+  session->options.write_userdata = write_userdata;
+}
+
+void
+Curl_session_set_read_callback (CurlSession_T session,
+                                CurlReadCallback read_cb, void *read_userdata)
+{
+  if (!session)
+    return;
+
+  session->options.read_callback = read_cb;
+  session->options.read_userdata = read_userdata;
+}
+
+/**
+ * @brief Raise an exception based on CurlError code.
+ */
+static void
+curl_raise_for_error (CurlError error)
+{
+  switch (error)
+    {
+    case CURL_ERROR_DNS:
+      RAISE (Curl_DNSFailed);
+    case CURL_ERROR_CONNECT:
+      RAISE (Curl_ConnectFailed);
+    case CURL_ERROR_TLS:
+      RAISE (Curl_TLSFailed);
+    case CURL_ERROR_TIMEOUT:
+      RAISE (Curl_Timeout);
+    case CURL_ERROR_TOO_MANY_REDIRECTS:
+      RAISE (Curl_TooManyRedirects);
+    case CURL_ERROR_INVALID_URL:
+      RAISE (Curl_InvalidURL);
+    case CURL_ERROR_PROTOCOL:
+      RAISE (Curl_ProtocolError);
+    case CURL_OK:
+    case CURL_ERROR_WRITE_CALLBACK:
+    case CURL_ERROR_READ_CALLBACK:
+    case CURL_ERROR_OUT_OF_MEMORY:
+    case CURL_ERROR_ABORTED:
+    default:
+      RAISE (Curl_Failed);
+    }
+}
+
+/**
+ * @brief Prepare session for a new request.
+ *
+ * Validates inputs, resets session state, and parses the URL.
+ *
+ * @param session Session handle
+ * @param url URL string to parse
+ * @return CURL_OK on success, error code on failure (also sets session error state)
+ */
+static CurlError
+curl_prepare_request (CurlSession_T session, const char *url)
+{
+  if (!session || !url)
+    return CURL_ERROR_CONNECT;
+
+  Curl_session_reset (session);
+
+  CurlError err = curl_internal_parse_url (url, URL_PARSE_FLAGS_NONE,
+                                           &session->current_url,
+                                           session->request_arena);
+  if (err != CURL_OK)
+    {
+      session->state = CURL_STATE_ERROR;
+      session->last_error = err;
+    }
+
+  return err;
+}
+
+/**
+ * @brief Initialize options from provided or defaults.
+ */
+static void
+curl_init_options (CurlOptions *opts, const CurlOptions *provided)
+{
+  if (provided)
+    *opts = *provided;
+  else
+    Curl_options_defaults (opts);
+}
+
+/**
+ * @brief Set session error state.
+ */
+static void
+curl_set_error (CurlSession_T session, CurlError error)
+{
+  session->state = CURL_STATE_ERROR;
+  session->last_error = error;
+}
+
+/**
+ * @brief Setup connection for the request.
+ *
+ * Checks if existing connection can be reused, otherwise establishes
+ * a new connection to the target URL.
+ *
+ * @param session Session handle
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+setup_connection (CurlSession_T session)
+{
+  /* Check if existing connection can be reused */
+  if (session->conn
+      && !curl_connection_reusable (session->conn, &session->current_url))
+    {
+      curl_connection_close (session->conn);
+      session->conn = NULL;
+    }
+
+  /* Establish connection if needed */
+  if (!session->conn)
+    {
+      session->state = CURL_STATE_CONNECTING;
+      session->conn = curl_connect (&session->current_url, &session->options,
+                                     session->request_arena);
+      if (!session->conn)
+        {
+          return CURL_ERROR_CONNECT;
+        }
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Build and send HTTP request.
+ *
+ * Builds request headers (including auth and cookies), then sends
+ * the request using the appropriate protocol (HTTP/1.1 or HTTP/2).
+ *
+ * @param session Session handle
+ * @param method HTTP method
+ * @param body Request body (NULL for none)
+ * @param body_len Body length
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+send_request (CurlSession_T session, SocketHTTP_Method method,
+              const void *body, size_t body_len)
+{
+  /* Build request headers */
+  if (curl_build_request_headers (session, method, NULL, body_len) != 0)
+    {
+      return CURL_ERROR_OUT_OF_MEMORY;
+    }
+
+  /* Add authentication header */
+  curl_auth_setup (session);
+
+  /* Add cookies to request */
+  if (session->cookie_jar)
+    {
+      curl_session_add_cookies (session);
+    }
+
+  /* Send request */
+  session->state = CURL_STATE_SENDING_REQUEST;
+  return curl_send_request (session, method, body, body_len);
+}
+
+/**
+ * @brief Receive HTTP response.
+ *
+ * Receives response headers and body using the appropriate protocol
+ * (HTTP/1.1 or HTTP/2).
+ *
+ * @param session Session handle
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+receive_response (CurlSession_T session)
+{
+  if (curl_connection_is_http2 (session->conn))
+    {
+      return curl_receive_h2_response (session);
+    }
+  else
+    {
+      return curl_receive_h1_response (session);
+    }
+}
+
+/**
+ * @brief Process cookies from response headers.
+ *
+ * Parses Set-Cookie headers from the response and adds them to
+ * the session's cookie jar.
+ *
+ * @param session Session handle
+ * @return CURL_OK (always succeeds)
+ */
+static CurlError
+handle_cookies (CurlSession_T session)
+{
+  if (session->cookie_jar)
+    {
+      curl_session_process_cookies (session);
+    }
+  return CURL_OK;
+}
+
+/**
+ * @brief Check and handle redirect response.
+ *
+ * Determines if the response is a redirect that should be followed,
+ * updates the session URL and state for the next request.
+ *
+ * @param session Session handle
+ * @param should_retry Output flag: 1 if redirect should be followed
+ * @param body_ptr Pointer to body pointer (may be reset for GET redirects)
+ * @param body_len_ptr Pointer to body length (may be reset for GET redirects)
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+check_redirect (CurlSession_T session, int *should_retry,
+                const void **body_ptr, size_t *body_len_ptr)
+{
+  *should_retry = 0;
+
+  if (!curl_should_follow_redirect (session))
+    {
+      return CURL_OK;
+    }
+
+  CurlError result = curl_handle_redirect (session);
+  if (result != CURL_OK)
+    {
+      return result;
+    }
+
+  if (curl_is_redirect (session))
+    {
+      /* Continue loop for redirect */
+      *should_retry = 1;
+
+      /* Reset for next request - but keep connection if reusable */
+      session->state = CURL_STATE_IDLE;
+
+      /* Reset upload state - body may not be sent for GET redirect */
+      if (session->request_method == HTTP_METHOD_GET)
+        {
+          *body_ptr = NULL;
+          *body_len_ptr = 0;
+          session->upload_total = 0;
+        }
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Execute a request with the session's current configuration.
+ *
+ * Handles connection establishment, request sending, response receiving,
+ * redirect following, and cookie processing.
+ *
+ * @param session Session handle
+ * @param method HTTP method
+ * @param body Request body (NULL for none)
+ * @param body_len Body length
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError curl_perform_internal (CurlSession_T session,
+                                        SocketHTTP_Method method,
+                                        const void *body, size_t body_len);
+
+static CurlError
+curl_perform (CurlSession_T session, SocketHTTP_Method method,
+              const void *body, size_t body_len)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  return curl_perform_internal (session, method, body, body_len);
+}
+
+/**
+ * @brief Check result and raise exception on error.
+ */
+static void
+curl_check_result (CurlError result)
+{
+  if (result != CURL_OK)
+    curl_raise_for_error (result);
+}
+
+static CurlError
+curl_perform_internal (CurlSession_T session, SocketHTTP_Method method,
+                       const void *body_init, size_t body_len_init)
+{
+  volatile CurlError result = CURL_OK;
+  volatile int should_retry = 0;
+  const void *volatile body = body_init;
+  volatile size_t body_len = body_len_init;
+
+  session->state = CURL_STATE_CONNECTING;
+  session->request_method = method;
+  session->upload_total = (int64_t)body_len_init;
+  session->upload_sent = 0;
+  session->download_received = 0;
+
+  TRY
+  {
+    do
+      {
+        should_retry = 0;
+        curl_check_result (setup_connection (session));
+        curl_check_result (send_request (session, method, body, (size_t)body_len));
+        curl_check_result (receive_response (session));
+        curl_check_result (handle_cookies (session));
+        curl_check_result (check_redirect (session, (int *)&should_retry,
+                                           (const void **)&body,
+                                           (size_t *)&body_len));
+      }
+    while (should_retry);
+    session->state = CURL_STATE_COMPLETE;
+  }
+  EXCEPT (Curl_DNSFailed) { curl_set_error (session, result = CURL_ERROR_DNS); }
+  EXCEPT (Curl_ConnectFailed) { curl_set_error (session, result = CURL_ERROR_CONNECT); }
+  EXCEPT (Curl_TLSFailed) { curl_set_error (session, result = CURL_ERROR_TLS); }
+  EXCEPT (Curl_Timeout) { curl_set_error (session, result = CURL_ERROR_TIMEOUT); }
+  EXCEPT (Curl_TooManyRedirects) { curl_set_error (session, result = CURL_ERROR_TOO_MANY_REDIRECTS); }
+  EXCEPT (Curl_ProtocolError) { curl_set_error (session, result = CURL_ERROR_PROTOCOL); }
+  FINALLY
+  {
+    if (session->cookie_jar && session->cookie_jar->dirty
+        && session->options.cookie_file)
+      curl_session_save_cookies (session);
+  }
+  END_TRY;
+
+  return result;
+}
+
+CurlError
+Curl_get (CurlSession_T session, const char *url)
+{
+  CurlError err = curl_prepare_request (session, url);
+  if (err != CURL_OK)
+    return err;
+
+  return curl_perform (session, HTTP_METHOD_GET, NULL, 0);
+}
+
+CurlError
+Curl_head (CurlSession_T session, const char *url)
+{
+  CurlError err = curl_prepare_request (session, url);
+  if (err != CURL_OK)
+    return err;
+
+  return curl_perform (session, HTTP_METHOD_HEAD, NULL, 0);
+}
+
+CurlError
+Curl_post (CurlSession_T session, const char *url, const char *content_type,
+           const void *body, size_t body_len)
+{
+  CurlError err = curl_prepare_request (session, url);
+  if (err != CURL_OK)
+    return err;
+
+  if (content_type)
+    Curl_session_set_header (session, "Content-Type", content_type);
+
+  return curl_perform (session, HTTP_METHOD_POST, body, body_len);
+}
+
+CurlError
+Curl_put (CurlSession_T session, const char *url, const char *content_type,
+          const void *body, size_t body_len)
+{
+  CurlError err = curl_prepare_request (session, url);
+  if (err != CURL_OK)
+    return err;
+
+  if (content_type)
+    Curl_session_set_header (session, "Content-Type", content_type);
+
+  return curl_perform (session, HTTP_METHOD_PUT, body, body_len);
+}
+
+CurlError
+Curl_delete (CurlSession_T session, const char *url)
+{
+  CurlError err = curl_prepare_request (session, url);
+  if (err != CURL_OK)
+    return err;
+
+  return curl_perform (session, HTTP_METHOD_DELETE, NULL, 0);
+}
+
+/**
+ * @brief Copy headers from SocketHTTP_Headers_T to session.
+ */
+static void
+curl_copy_headers (CurlSession_T session, SocketHTTP_Headers_T headers)
+{
+  size_t count = SocketHTTP_Headers_count (headers);
+  for (size_t i = 0; i < count; i++)
+    {
+      const SocketHTTP_Header *h = SocketHTTP_Headers_at (headers, i);
+      if (!h || !h->name || !h->value)
+        continue;
+
+      char *name = ALLOC (session->request_arena, h->name_len + NULL_TERMINATOR_SIZE);
+      if (!name)
+        continue;
+      memcpy (name, h->name, h->name_len);
+      name[h->name_len] = '\0';
+
+      char *value = ALLOC (session->request_arena, h->value_len + NULL_TERMINATOR_SIZE);
+      if (!value)
+        continue;
+      memcpy (value, h->value, h->value_len);
+      value[h->value_len] = '\0';
+
+      Curl_session_set_header (session, name, value);
+    }
+}
+
+CurlError
+Curl_request (CurlSession_T session, SocketHTTP_Method method, const char *url,
+              SocketHTTP_Headers_T headers, const void *body, size_t body_len)
+{
+  CurlError err = curl_prepare_request (session, url);
+  if (err != CURL_OK)
+    return err;
+
+  if (headers)
+    curl_copy_headers (session, headers);
+
+  return curl_perform (session, method, body, body_len);
+}
+
+CurlError
+Curl_fetch (const char *url, CurlWriteCallback write_cb, void *userdata,
+            const CurlOptions *options)
+{
+  if (!url)
+    return CURL_ERROR_INVALID_URL;
+
+  CurlOptions opts;
+  curl_init_options (&opts, options);
+  opts.write_callback = write_cb;
+  opts.write_userdata = userdata;
+
+  CurlSession_T session = Curl_session_new (&opts);
+  if (!session)
+    return CURL_ERROR_OUT_OF_MEMORY;
+
+  CurlError result = Curl_get (session, url);
+  Curl_session_free (&session);
+
+  return result;
+}
+
+/**
+ * @brief Write callback for file download.
+ */
+static size_t
+file_write_callback (void *data, size_t size, size_t nmemb, void *userdata)
+{
+  FILE *fp = (FILE *)userdata;
+  if (!fp)
+    return 0;
+
+  return fwrite (data, size, nmemb, fp);
+}
+
+CurlError
+Curl_download (const char *url, const char *filepath,
+               const CurlOptions *options)
+{
+  if (!url || !filepath)
+    return CURL_ERROR_INVALID_URL;
+
+  FILE *fp = fopen (filepath, FILE_MODE_WRITE_BINARY);
+  if (!fp)
+    return CURL_ERROR_WRITE_CALLBACK;
+
+  CurlOptions opts;
+  curl_init_options (&opts, options);
+  opts.write_callback = file_write_callback;
+  opts.write_userdata = fp;
+
+  CurlSession_T session = Curl_session_new (&opts);
+  if (!session)
+    {
+      fclose (fp);
+      return CURL_ERROR_OUT_OF_MEMORY;
+    }
+
+  volatile CurlError result = CURL_OK;
+  TRY { result = Curl_get (session, url); }
+  FINALLY
+  {
+    Curl_session_free (&session);
+    fclose (fp);
+  }
+  END_TRY;
+
+  return result;
+}
+
+/**
+ * @brief File upload state.
+ */
+typedef struct
+{
+  FILE *fp;
+  size_t size;
+  size_t sent;
+} FileUploadState;
+
+/**
+ * @brief Read callback for file upload.
+ */
+static size_t
+file_read_callback (void *buffer, size_t size, size_t nmemb, void *userdata)
+{
+  FileUploadState *state = (FileUploadState *)userdata;
+  if (!state || !state->fp)
+    return 0;
+
+  size_t remaining = state->size - state->sent;
+  size_t to_read = size * nmemb;
+  if (to_read > remaining)
+    to_read = remaining;
+
+  size_t nread = fread (buffer, FREAD_ELEMENT_SIZE, to_read, state->fp);
+  state->sent += nread;
+
+  return nread;
+}
+
+/**
+ * @brief Get file size, returning -1 on error.
+ */
+static long
+curl_get_file_size (FILE *fp)
+{
+  fseek (fp, 0, SEEK_END);
+  long size = ftell (fp);
+  fseek (fp, 0, SEEK_SET);
+  return size;
+}
+
+/**
+ * @brief Internal upload implementation to avoid clobbered parameter warnings.
+ */
+static CurlError
+curl_upload_internal (const char *url, FILE *fp, long size, const char *ct,
+                      const CurlOptions *options)
+{
+  FileUploadState state = { .fp = fp, .size = (size_t)size, .sent = 0 };
+
+  CurlOptions opts;
+  curl_init_options (&opts, options);
+  opts.read_callback = file_read_callback;
+  opts.read_userdata = &state;
+
+  CurlSession_T session = Curl_session_new (&opts);
+  if (!session)
+    return CURL_ERROR_OUT_OF_MEMORY;
+
+  volatile CurlError result = CURL_OK;
+  TRY { result = Curl_put (session, url, ct, NULL, (size_t)size); }
+  FINALLY { Curl_session_free (&session); }
+  END_TRY;
+
+  return result;
+}
+
+CurlError
+Curl_upload (const char *url, const char *filepath, const char *content_type,
+             const CurlOptions *options)
+{
+  if (!url || !filepath)
+    return CURL_ERROR_INVALID_URL;
+
+  FILE *fp = fopen (filepath, FILE_MODE_READ_BINARY);
+  if (!fp)
+    return CURL_ERROR_READ_CALLBACK;
+
+  long size = curl_get_file_size (fp);
+  if (size < 0)
+    {
+      fclose (fp);
+      return CURL_ERROR_READ_CALLBACK;
+    }
+
+  const char *ct = content_type ? content_type : "application/octet-stream";
+  CurlError result = curl_upload_internal (url, fp, size, ct, options);
+  fclose (fp);
+
+  return result;
+}

--- a/examples/curl/src/StreamingCurl_auth.c
+++ b/examples/curl/src/StreamingCurl_auth.c
@@ -1,0 +1,587 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_auth.c
+ * @brief Authentication support for streaming curl module.
+ *
+ * Implements HTTP authentication methods:
+ * - Basic authentication (RFC 7617)
+ * - Bearer token authentication (RFC 6750)
+ * - Digest authentication (RFC 7616) - basic support
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+
+#include "core/SocketCrypto.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Authentication header prefixes */
+#define BASIC_PREFIX "Basic "
+#define BASIC_PREFIX_LEN 6
+#define BEARER_PREFIX "Bearer "
+#define BEARER_PREFIX_LEN 7
+
+/* Base64 encoding constants */
+#define BASE64_BYTES_PER_GROUP 3
+#define BASE64_CHARS_PER_GROUP 4
+#define BASE64_OCTET_SHIFT_HIGH 16
+#define BASE64_OCTET_SHIFT_MID 8
+#define BASE64_SEXTET_SHIFT_1 18
+#define BASE64_SEXTET_SHIFT_2 12
+#define BASE64_SEXTET_SHIFT_3 6
+#define BASE64_SEXTET_MASK 0x3F
+#define BASE64_PADDING_CHAR '='
+#define BASE64_MODULO_1_REMAINING 1
+#define BASE64_MODULO_2_REMAINING 2
+
+/* MD5 hash constants */
+#define MD5_HEX_STRING_SIZE 33
+
+/* Digest authentication constants */
+#define DIGEST_PREFIX "Digest "
+#define DIGEST_PREFIX_LEN 7
+#define DIGEST_REALM_KEY_LEN 5
+#define DIGEST_NONCE_KEY_LEN 5
+#define DIGEST_OPAQUE_KEY_LEN 6
+#define DIGEST_QOP_KEY_LEN 3
+#define DIGEST_CNONCE_SIZE 17
+#define DIGEST_CNONCE_FORMAT "%08x%08x"
+#define DIGEST_NC_INITIAL "00000001"
+
+/* String length constants */
+#define COLON_SEPARATOR_LEN 1
+#define NULL_TERMINATOR_LEN 1
+
+/* Base64 encoding table */
+static const char base64_table[]
+    = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/**
+ * @brief Calculate base64 encoded length.
+ *
+ * @param input_len Input data length
+ * @return Required output buffer size (including null terminator)
+ */
+static size_t
+base64_encoded_len (size_t input_len)
+{
+  return ((input_len + BASE64_MODULO_2_REMAINING) / BASE64_BYTES_PER_GROUP) * BASE64_CHARS_PER_GROUP + NULL_TERMINATOR_LEN;
+}
+
+/**
+ * @brief Encode data to base64.
+ *
+ * @param input Input data
+ * @param input_len Input length
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Encoded length (excluding null), or -1 on error
+ */
+static ssize_t
+base64_encode (const unsigned char *input, size_t input_len, char *output,
+               size_t output_size)
+{
+  if (!input || !output)
+    return -1;
+
+  size_t needed = base64_encoded_len (input_len);
+  if (output_size < needed)
+    return -1;
+
+  size_t i, j;
+  /* Process complete 3-byte groups */
+  for (i = 0, j = 0; i + BASE64_MODULO_2_REMAINING < input_len; i += BASE64_BYTES_PER_GROUP)
+    {
+      uint32_t octet_a = input[i];
+      uint32_t octet_b = input[i + 1];
+      uint32_t octet_c = input[i + 2];
+
+      uint32_t triple = (octet_a << BASE64_OCTET_SHIFT_HIGH) | (octet_b << BASE64_OCTET_SHIFT_MID) | octet_c;
+
+      output[j++] = base64_table[(triple >> BASE64_SEXTET_SHIFT_1) & BASE64_SEXTET_MASK];
+      output[j++] = base64_table[(triple >> BASE64_SEXTET_SHIFT_2) & BASE64_SEXTET_MASK];
+      output[j++] = base64_table[(triple >> BASE64_SEXTET_SHIFT_3) & BASE64_SEXTET_MASK];
+      output[j++] = base64_table[triple & BASE64_SEXTET_MASK];
+    }
+
+  /* Handle remaining 1 or 2 bytes */
+  if (i < input_len)
+    {
+      uint32_t octet_a = input[i];
+      uint32_t octet_b = (i + BASE64_MODULO_1_REMAINING < input_len) ? input[i + 1] : 0;
+      uint32_t octet_c = 0;
+
+      uint32_t triple = (octet_a << BASE64_OCTET_SHIFT_HIGH) | (octet_b << BASE64_OCTET_SHIFT_MID) | octet_c;
+
+      output[j++] = base64_table[(triple >> BASE64_SEXTET_SHIFT_1) & BASE64_SEXTET_MASK];
+      output[j++] = base64_table[(triple >> BASE64_SEXTET_SHIFT_2) & BASE64_SEXTET_MASK];
+      output[j++] = base64_table[(triple >> BASE64_SEXTET_SHIFT_3) & BASE64_SEXTET_MASK];
+      output[j++] = base64_table[triple & BASE64_SEXTET_MASK];
+    }
+
+  /* Add padding */
+  size_t mod = input_len % BASE64_BYTES_PER_GROUP;
+  if (mod == BASE64_MODULO_1_REMAINING)
+    {
+      output[j - 2] = BASE64_PADDING_CHAR;
+      output[j - 1] = BASE64_PADDING_CHAR;
+    }
+  else if (mod == BASE64_MODULO_2_REMAINING)
+    {
+      output[j - 1] = BASE64_PADDING_CHAR;
+    }
+
+  output[j] = '\0';
+  return (ssize_t)j;
+}
+
+/**
+ * @brief Build Basic authentication header value.
+ *
+ * Format: "Basic base64(username:password)"
+ *
+ * @param username Username
+ * @param password Password
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Header value length, or -1 on error
+ */
+ssize_t
+curl_auth_basic (const char *username, const char *password, char *output,
+                 size_t output_size)
+{
+  if (!username || !password || !output || output_size == 0)
+    return -1;
+
+  /* Build "username:password" string */
+  size_t user_len = strlen (username);
+  size_t pass_len = strlen (password);
+  size_t cred_len = user_len + COLON_SEPARATOR_LEN + pass_len;
+
+  /* Allocate on stack for small credentials */
+  char credentials[CURL_MAX_CREDENTIAL_LEN];
+  if (cred_len >= sizeof (credentials))
+    return -1;
+
+  snprintf (credentials, sizeof (credentials), "%s:%s", username, password);
+
+  /* Calculate output size needed */
+  size_t b64_len = base64_encoded_len (cred_len);
+  size_t total_len = BASIC_PREFIX_LEN + b64_len; /* "Basic " + base64 */
+
+  if (output_size < total_len)
+    return -1;
+
+  /* Build header value */
+  memcpy (output, BASIC_PREFIX, BASIC_PREFIX_LEN);
+
+  ssize_t encoded = base64_encode ((const unsigned char *)credentials,
+                                   cred_len, output + BASIC_PREFIX_LEN, output_size - BASIC_PREFIX_LEN);
+  if (encoded < 0)
+    return -1;
+
+  return BASIC_PREFIX_LEN + encoded;
+}
+
+/**
+ * @brief Build Bearer token authentication header value.
+ *
+ * Format: "Bearer <token>"
+ *
+ * @param token Bearer token
+ * @param output Output buffer
+ * @param output_size Output buffer size
+ * @return Header value length, or -1 on error
+ */
+ssize_t
+curl_auth_bearer (const char *token, char *output, size_t output_size)
+{
+  if (!token || !output || output_size == 0)
+    return -1;
+
+  size_t token_len = strlen (token);
+  size_t total_len = BEARER_PREFIX_LEN + token_len; /* "Bearer " + token */
+
+  if (output_size < total_len + NULL_TERMINATOR_LEN)
+    return -1;
+
+  int len = snprintf (output, output_size, BEARER_PREFIX "%s", token);
+  if (len < 0 || (size_t)len >= output_size)
+    return -1;
+
+  return (ssize_t)len;
+}
+
+/**
+ * @brief Compute MD5 hash and return as hex string.
+ *
+ * Uses SocketCrypto_md5 for proper RFC 1321 implementation.
+ *
+ * @param input Input data to hash
+ * @param input_len Length of input data
+ * @param output Output buffer (must be at least 33 bytes for hex + null)
+ * @return 0 on success
+ */
+static int
+md5_hex (const char *input, size_t input_len, char *output)
+{
+  unsigned char digest[SOCKET_CRYPTO_MD5_SIZE];
+
+  SocketCrypto_md5 (input, input_len, digest);
+  SocketCrypto_hex_encode (digest, SOCKET_CRYPTO_MD5_SIZE, output, 1);
+
+  return 0;
+}
+
+/**
+ * @brief Parse WWW-Authenticate header for Digest parameters.
+ *
+ * @param header WWW-Authenticate header value
+ * @param realm Output realm
+ * @param nonce Output nonce
+ * @param opaque Output opaque (may be NULL)
+ * @param qop Output qop (may be NULL)
+ * @return 0 on success, -1 on error
+ */
+int
+curl_auth_parse_digest_challenge (const char *header, char *realm,
+                                  size_t realm_size, char *nonce,
+                                  size_t nonce_size, char *opaque,
+                                  size_t opaque_size, char *qop,
+                                  size_t qop_size)
+{
+  if (!header || !realm || !nonce)
+    return -1;
+
+  /* Skip "Digest " prefix */
+  if (strncasecmp (header, DIGEST_PREFIX, DIGEST_PREFIX_LEN) != 0)
+    return -1;
+
+  const char *ptr = header + DIGEST_PREFIX_LEN;
+
+  realm[0] = '\0';
+  nonce[0] = '\0';
+  if (opaque)
+    opaque[0] = '\0';
+  if (qop)
+    qop[0] = '\0';
+
+  /* Simple parser for key="value" pairs */
+  while (*ptr)
+    {
+      /* Skip whitespace and commas */
+      while (*ptr == ' ' || *ptr == ',' || *ptr == '\t')
+        ptr++;
+
+      if (*ptr == '\0')
+        break;
+
+      /* Find key */
+      const char *key_start = ptr;
+      while (*ptr && *ptr != '=' && *ptr != ' ')
+        ptr++;
+
+      size_t key_len = (size_t)(ptr - key_start);
+
+      if (*ptr != '=')
+        continue;
+      ptr++; /* Skip '=' */
+
+      /* Find value */
+      const char *value_start;
+      const char *value_end;
+
+      if (*ptr == '"')
+        {
+          ptr++;
+          value_start = ptr;
+          while (*ptr && *ptr != '"')
+            ptr++;
+          value_end = ptr;
+          if (*ptr == '"')
+            ptr++;
+        }
+      else
+        {
+          value_start = ptr;
+          while (*ptr && *ptr != ',' && *ptr != ' ')
+            ptr++;
+          value_end = ptr;
+        }
+
+      size_t value_len = (size_t)(value_end - value_start);
+
+      /* Match key */
+      if (key_len == DIGEST_REALM_KEY_LEN && strncasecmp (key_start, "realm", DIGEST_REALM_KEY_LEN) == 0)
+        {
+          if (value_len < realm_size)
+            {
+              memcpy (realm, value_start, value_len);
+              realm[value_len] = '\0';
+            }
+        }
+      else if (key_len == DIGEST_NONCE_KEY_LEN && strncasecmp (key_start, "nonce", DIGEST_NONCE_KEY_LEN) == 0)
+        {
+          if (value_len < nonce_size)
+            {
+              memcpy (nonce, value_start, value_len);
+              nonce[value_len] = '\0';
+            }
+        }
+      else if (key_len == DIGEST_OPAQUE_KEY_LEN && strncasecmp (key_start, "opaque", DIGEST_OPAQUE_KEY_LEN) == 0
+               && opaque)
+        {
+          if (value_len < opaque_size)
+            {
+              memcpy (opaque, value_start, value_len);
+              opaque[value_len] = '\0';
+            }
+        }
+      else if (key_len == DIGEST_QOP_KEY_LEN && strncasecmp (key_start, "qop", DIGEST_QOP_KEY_LEN) == 0 && qop)
+        {
+          if (value_len < qop_size)
+            {
+              memcpy (qop, value_start, value_len);
+              qop[value_len] = '\0';
+            }
+        }
+    }
+
+  /* Validate required fields */
+  if (realm[0] == '\0' || nonce[0] == '\0')
+    return -1;
+
+  return 0;
+}
+
+/**
+ * @brief Build Digest authentication header value.
+ *
+ * @param params Digest authentication parameters
+ * @return Header value length, or -1 on error
+ */
+ssize_t
+curl_auth_digest (const CurlDigestParams *params)
+{
+  if (!params || !params->username || !params->password || !params->realm
+      || !params->nonce || !params->uri || !params->method || !params->output)
+    return -1;
+
+  char ha1[MD5_HEX_STRING_SIZE], ha2[MD5_HEX_STRING_SIZE], response[MD5_HEX_STRING_SIZE];
+  char buf[CURL_MAX_AUTH_BUFFER_LEN];
+  int len;
+  ssize_t result = -1;
+
+  /* HA1 = MD5(username:realm:password) */
+  len = snprintf (buf, sizeof (buf), "%s:%s:%s", params->username, params->realm, params->password);
+  if (len < 0 || (size_t)len >= sizeof (buf))
+    goto cleanup;
+  md5_hex (buf, (size_t)len, ha1);
+
+  /* HA2 = MD5(method:uri) */
+  len = snprintf (buf, sizeof (buf), "%s:%s", params->method, params->uri);
+  if (len < 0 || (size_t)len >= sizeof (buf))
+    goto cleanup;
+  md5_hex (buf, (size_t)len, ha2);
+
+  /* Response calculation depends on qop */
+  if (params->qop && (strcmp (params->qop, "auth") == 0 || strcmp (params->qop, "auth-int") == 0))
+    {
+      /* response = MD5(HA1:nonce:nc:cnonce:qop:HA2) */
+      if (!params->nc || !params->cnonce)
+        goto cleanup;
+
+      len = snprintf (buf, sizeof (buf), "%s:%s:%s:%s:%s:%s", ha1, params->nonce, params->nc,
+                      params->cnonce, params->qop, ha2);
+      if (len < 0 || (size_t)len >= sizeof (buf))
+        goto cleanup;
+      md5_hex (buf, (size_t)len, response);
+
+      /* Build header with qop */
+      len = snprintf (
+          params->output, params->output_size,
+          "Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", uri=\"%s\", "
+          "qop=%s, nc=%s, cnonce=\"%s\", response=\"%s\"",
+          params->username, params->realm, params->nonce, params->uri, params->qop, params->nc, params->cnonce, response);
+    }
+  else
+    {
+      /* response = MD5(HA1:nonce:HA2) */
+      len = snprintf (buf, sizeof (buf), "%s:%s:%s", ha1, params->nonce, ha2);
+      if (len < 0 || (size_t)len >= sizeof (buf))
+        goto cleanup;
+      md5_hex (buf, (size_t)len, response);
+
+      /* Build header without qop */
+      len = snprintf (params->output, params->output_size,
+                      "Digest username=\"%s\", realm=\"%s\", nonce=\"%s\", "
+                      "uri=\"%s\", response=\"%s\"",
+                      params->username, params->realm, params->nonce, params->uri, response);
+    }
+
+  if (len < 0 || (size_t)len >= params->output_size)
+    goto cleanup;
+
+  /* Add opaque if present */
+  if (params->opaque && params->opaque[0] != '\0')
+    {
+      size_t current_len = (size_t)len;
+      int added = snprintf (params->output + current_len, params->output_size - current_len,
+                            ", opaque=\"%s\"", params->opaque);
+      if (added > 0 && current_len + (size_t)added < params->output_size)
+        len += added;
+    }
+
+  result = (ssize_t)len;
+
+cleanup:
+  /* Clear sensitive data before returning */
+  explicit_bzero (ha1, sizeof (ha1));
+  explicit_bzero (ha2, sizeof (ha2));
+  explicit_bzero (response, sizeof (response));
+  explicit_bzero (buf, sizeof (buf));
+
+  return result;
+}
+
+/**
+ * @brief Set up authentication header for session.
+ *
+ * Pre-computes the authentication header based on session auth settings.
+ *
+ * @param session Session
+ * @return 0 on success, -1 on error
+ */
+int
+curl_auth_setup (CurlSession_T session)
+{
+  if (!session)
+    return -1;
+
+  /* Clear existing auth header */
+  session->auth_header = NULL;
+
+  const CurlAuth *auth = &session->auth;
+
+  if (auth->type == CURL_AUTH_NONE)
+    return 0;
+
+  Arena_T arena = session->arena;
+  char buf[CURL_MAX_AUTH_BUFFER_LEN];
+  ssize_t len;
+
+  switch (auth->type)
+    {
+    case CURL_AUTH_BASIC:
+      if (!auth->username || !auth->password)
+        return -1;
+
+      len = curl_auth_basic (auth->username, auth->password, buf,
+                             sizeof (buf));
+      if (len < 0)
+        return -1;
+
+      session->auth_header = ALLOC (arena, (size_t)len + 1);
+      memcpy (session->auth_header, buf, (size_t)len);
+      session->auth_header[len] = '\0';
+      break;
+
+    case CURL_AUTH_BEARER:
+      if (!auth->token)
+        return -1;
+
+      len = curl_auth_bearer (auth->token, buf, sizeof (buf));
+      if (len < 0)
+        return -1;
+
+      session->auth_header = ALLOC (arena, (size_t)len + 1);
+      memcpy (session->auth_header, buf, (size_t)len);
+      session->auth_header[len] = '\0';
+      break;
+
+    case CURL_AUTH_DIGEST:
+      /* Digest auth requires a challenge from server first */
+      /* Set up will be done after receiving 401 response */
+      break;
+
+    default:
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Handle 401 Unauthorized response for Digest auth.
+ *
+ * Parses WWW-Authenticate header and generates Digest response.
+ *
+ * @param session Session
+ * @param www_auth WWW-Authenticate header value
+ * @param method HTTP method
+ * @param uri Request URI
+ * @return 0 on success (auth_header updated), -1 on error
+ */
+int
+curl_auth_handle_challenge (CurlSession_T session, const char *www_auth,
+                            const char *method, const char *uri)
+{
+  if (!session || !www_auth || !method || !uri)
+    return -1;
+
+  const CurlAuth *auth = &session->auth;
+  if (auth->type != CURL_AUTH_DIGEST)
+    return -1;
+
+  if (!auth->username || !auth->password)
+    return -1;
+
+  /* Parse challenge */
+  char realm[CURL_MAX_REALM_LEN], nonce[CURL_MAX_NONCE_LEN],
+      opaque[CURL_MAX_OPAQUE_LEN], qop[CURL_MAX_QOP_LEN];
+  if (curl_auth_parse_digest_challenge (www_auth, realm, sizeof (realm), nonce,
+                                        sizeof (nonce), opaque,
+                                        sizeof (opaque), qop, sizeof (qop))
+      != 0)
+    return -1;
+
+  /* Generate client nonce using cryptographically secure random */
+  char cnonce[DIGEST_CNONCE_SIZE];
+  snprintf (cnonce, sizeof (cnonce), DIGEST_CNONCE_FORMAT, SocketCrypto_random_uint32 (),
+            SocketCrypto_random_uint32 ());
+
+  /* Build response */
+  char buf[CURL_MAX_AUTH_BUFFER_LEN];
+  CurlDigestParams digest_params = {
+      .username = auth->username,
+      .password = auth->password,
+      .realm = realm,
+      .nonce = nonce,
+      .opaque = opaque[0] ? opaque : NULL,
+      .qop = qop[0] ? qop : NULL,
+      .uri = uri,
+      .method = method,
+      .nc = DIGEST_NC_INITIAL,
+      .cnonce = cnonce,
+      .output = buf,
+      .output_size = sizeof (buf)};
+  ssize_t len = curl_auth_digest (&digest_params);
+  if (len < 0)
+    return -1;
+
+  /* Store in session */
+  Arena_T arena = session->arena;
+  session->auth_header = ALLOC (arena, (size_t)len + 1);
+  memcpy (session->auth_header, buf, (size_t)len);
+  session->auth_header[len] = '\0';
+
+  return 0;
+}

--- a/examples/curl/src/StreamingCurl_connect.c
+++ b/examples/curl/src/StreamingCurl_connect.c
@@ -1,0 +1,383 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_connect.c
+ * @brief Connection establishment layer for streaming curl module.
+ *
+ * Implements connection establishment with:
+ * - Happy Eyeballs for dual-stack racing (RFC 8305)
+ * - Proxy tunneling (SOCKS4/5, HTTP CONNECT)
+ * - TLS handshake with ALPN for HTTP/2 negotiation
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "socket/Socket.h"
+#include "socket/SocketBuf.h"
+#include "socket/SocketHappyEyeballs.h"
+#include "socket/SocketProxy.h"
+
+#if SOCKET_HAS_TLS
+#include "tls/SocketTLS.h"
+#include "tls/SocketTLSContext.h"
+#endif
+
+#include <stdlib.h>
+#include <string.h>
+
+/* Connection timeout and protocol constants */
+#define ATTEMPT_TIMEOUT_DIVISOR 2
+#define DEFAULT_TLS_HANDSHAKE_TIMEOUT_MS 30000
+#define ALPN_PROTOCOL_COUNT_HTTP2 2
+#define ALPN_PROTOCOL_COUNT_HTTP1 1
+
+/**
+ * @brief Allocate a connection structure from arena.
+ */
+static CurlConnection *
+alloc_connection (Arena_T arena)
+{
+  CurlConnection *conn = ALLOC (arena, sizeof (CurlConnection));
+  memset (conn, 0, sizeof (*conn));
+  return conn;
+}
+
+/**
+ * @brief Establish TCP connection using Happy Eyeballs.
+ */
+static Socket_T
+connect_direct (const char *host, int port, const CurlOptions *options)
+{
+  SocketHE_Config_T he_config;
+  SocketHappyEyeballs_config_defaults (&he_config);
+
+  /* Apply curl options to Happy Eyeballs config */
+  if (options->connect_timeout_ms > 0)
+    {
+      he_config.total_timeout_ms = options->connect_timeout_ms;
+      he_config.attempt_timeout_ms = options->connect_timeout_ms / ATTEMPT_TIMEOUT_DIVISOR;
+    }
+
+  if (options->dns_timeout_ms > 0)
+    {
+      he_config.dns_timeout_ms = options->dns_timeout_ms;
+    }
+
+  /* Perform Happy Eyeballs connection */
+  return SocketHappyEyeballs_connect (host, port, &he_config);
+}
+
+/**
+ * @brief Establish TCP connection through proxy.
+ */
+static Socket_T
+connect_via_proxy (const char *host, int port, const CurlOptions *options,
+                   Arena_T arena)
+{
+  if (!options->proxy_url)
+    return NULL;
+
+  SocketProxy_Config proxy_config;
+  SocketProxy_config_defaults (&proxy_config);
+
+  /* Parse proxy URL */
+  if (SocketProxy_parse_url (options->proxy_url, &proxy_config, arena) != 0)
+    {
+      return NULL;
+    }
+
+  /* Apply timeouts */
+  if (options->connect_timeout_ms > 0)
+    {
+      proxy_config.connect_timeout_ms = options->connect_timeout_ms;
+      proxy_config.handshake_timeout_ms = options->connect_timeout_ms;
+    }
+
+  /* Connect through proxy */
+  return SocketProxy_connect (&proxy_config, host, port);
+}
+
+#if SOCKET_HAS_TLS
+/**
+ * @brief Create TLS context for client connection.
+ */
+static SocketTLSContext_T
+create_tls_context (const CurlOptions *options)
+{
+  SocketTLSContext_T ctx;
+
+  /* Use provided context if available */
+  if (options->tls_context)
+    {
+      return options->tls_context;
+    }
+
+  /* Create new client context */
+  ctx = SocketTLSContext_new_client (NULL);
+
+  /* Configure verification */
+  if (!options->verify_ssl)
+    {
+      SocketTLSContext_set_verify_mode (ctx, TLS_VERIFY_NONE);
+    }
+
+  /* Set ALPN protocols for HTTP/2 negotiation */
+  if (options->max_version >= HTTP_VERSION_2)
+    {
+      const char *protos[] = { "h2", "http/1.1" };
+      SocketTLSContext_set_alpn_protos (ctx, protos, ALPN_PROTOCOL_COUNT_HTTP2);
+    }
+  else
+    {
+      const char *protos[] = { "http/1.1" };
+      SocketTLSContext_set_alpn_protos (ctx, protos, ALPN_PROTOCOL_COUNT_HTTP1);
+    }
+
+  return ctx;
+}
+
+/**
+ * @brief Perform TLS handshake on socket.
+ */
+static int
+perform_tls_handshake (Socket_T socket, const char *hostname,
+                       SocketTLSContext_T ctx, const CurlOptions *options)
+{
+  /* Enable TLS on socket */
+  SocketTLS_enable (socket, ctx);
+
+  /* Set SNI hostname */
+  SocketTLS_set_hostname (socket, hostname);
+
+  /* Perform handshake with timeout */
+  int timeout_ms
+      = options->connect_timeout_ms > 0 ? options->connect_timeout_ms : DEFAULT_TLS_HANDSHAKE_TIMEOUT_MS;
+  TLSHandshakeState state = SocketTLS_handshake_loop (socket, timeout_ms);
+
+  if (state != TLS_HANDSHAKE_COMPLETE)
+    {
+      return -1;
+    }
+
+  /* Verify certificate if required */
+  if (options->verify_ssl)
+    {
+      long verify_result = SocketTLS_get_verify_result (socket);
+      if (verify_result != 0)
+        {
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+#endif /* SOCKET_HAS_TLS */
+
+CurlConnection *
+curl_connect (const CurlParsedURL *url, const CurlOptions *options,
+              Arena_T arena)
+{
+  if (!url || !options || !arena)
+    return NULL;
+
+  CurlConnection *conn = alloc_connection (arena);
+  volatile Socket_T sock = NULL;
+
+  TRY
+  {
+    /* Get host and port */
+    int port = url->port > 0 ? url->port : (url->is_secure ? CURL_HTTPS_DEFAULT_PORT : CURL_HTTP_DEFAULT_PORT);
+
+    /* Step 1: Establish TCP connection */
+    if (options->proxy_url)
+      {
+        /* Connect through proxy */
+        sock = connect_via_proxy (url->host, port, options, arena);
+        if (!sock)
+          {
+            RAISE (Curl_ConnectFailed);
+          }
+      }
+    else
+      {
+        /* Direct connection with Happy Eyeballs */
+        sock = connect_direct (url->host, port, options);
+      }
+
+    conn->socket = sock;
+    sock = NULL; /* Transfer ownership - don't close in FINALLY */
+    conn->connected = 1;
+
+    /* Step 2: TLS handshake if HTTPS */
+    if (url->is_secure)
+      {
+#if SOCKET_HAS_TLS
+        /* Create or use provided TLS context */
+        volatile SocketTLSContext_T tls_ctx = create_tls_context (options);
+        if (!tls_ctx)
+          {
+            RAISE (Curl_TLSFailed);
+          }
+
+        /* Track if we own the context */
+        conn->owns_tls_context = (options->tls_context == NULL);
+        conn->tls_context = tls_ctx;
+
+        /* Perform TLS handshake */
+        if (perform_tls_handshake (conn->socket, url->host, tls_ctx, options) != 0)
+          {
+            RAISE (Curl_TLSFailed);
+          }
+
+        conn->is_tls = 1;
+
+        /* Step 3: Check ALPN result for HTTP/2 */
+        const char *alpn = SocketTLS_get_alpn_selected (conn->socket);
+        if (alpn && strcmp (alpn, "h2") == 0)
+          {
+            conn->http_version = HTTP_VERSION_2;
+          }
+        else
+          {
+            conn->http_version = HTTP_VERSION_1_1;
+          }
+#else
+        /* TLS not available */
+        RAISE (Curl_TLSFailed);
+#endif
+      }
+    else
+      {
+        /* Plain HTTP */
+        conn->is_tls = 0;
+        conn->http_version = HTTP_VERSION_1_1;
+
+        /* HTTP/2 cleartext (h2c) not supported by default */
+        if (options->max_version >= HTTP_VERSION_2
+            && options->allow_http2_cleartext)
+          {
+            /* Would require h2c upgrade, not implemented yet */
+            conn->http_version = HTTP_VERSION_1_1;
+          }
+      }
+
+    /* Store connection info for reuse checking */
+    conn->host = curl_arena_strdup (arena, url->host, url->host_len);
+    conn->port = port;
+    conn->reusable = 1;
+  }
+  EXCEPT (SocketHE_Failed) { RAISE (Curl_DNSFailed); }
+  EXCEPT (SocketProxy_Failed) { RAISE (Curl_ConnectFailed); }
+#if SOCKET_HAS_TLS
+  EXCEPT (SocketTLS_Failed) { RAISE (Curl_TLSFailed); }
+  EXCEPT (SocketTLS_HandshakeFailed) { RAISE (Curl_TLSFailed); }
+  EXCEPT (SocketTLS_VerifyFailed) { RAISE (Curl_TLSFailed); }
+#endif
+  FINALLY
+  {
+    /* Clean up socket if we still own it (exception occurred before transfer)
+     */
+    if (sock)
+      {
+        Socket_T s = (Socket_T)sock;
+        Socket_free (&s);
+      }
+  }
+  END_TRY;
+
+  return conn;
+}
+
+void
+curl_connection_close (CurlConnection *conn)
+{
+  if (!conn)
+    return;
+
+  if (conn->socket)
+    {
+#if SOCKET_HAS_TLS
+      if (conn->is_tls)
+        {
+          /* Best-effort TLS shutdown */
+          SocketTLS_disable (conn->socket);
+        }
+
+      /* Free TLS context if we own it */
+      if (conn->owns_tls_context && conn->tls_context)
+        {
+          SocketTLSContext_free (&conn->tls_context);
+        }
+#endif
+
+      /* Close and free socket */
+      Socket_free (&conn->socket);
+    }
+
+  conn->connected = 0;
+  conn->reusable = 0;
+}
+
+int
+curl_connection_reusable (const CurlConnection *conn, const CurlParsedURL *url)
+{
+  if (!conn || !url)
+    return 0;
+
+  /* Must be connected and marked reusable */
+  if (!conn->connected || !conn->reusable)
+    return 0;
+
+  /* Check TLS requirement match */
+  if (url->is_secure != conn->is_tls)
+    return 0;
+
+  /* Check host match */
+  if (!conn->host || !url->host)
+    return 0;
+
+  if (conn->host && url->host)
+    {
+      if (url->host_len != strlen (conn->host))
+        return 0;
+      if (strncasecmp (conn->host, url->host, url->host_len) != 0)
+        return 0;
+    }
+
+  /* Check port match */
+  int target_port = url->port > 0 ? url->port : (url->is_secure ? CURL_HTTPS_DEFAULT_PORT : CURL_HTTP_DEFAULT_PORT);
+  if (conn->port != target_port)
+    return 0;
+
+  return 1;
+}
+
+const char *
+curl_connection_alpn (const CurlConnection *conn)
+{
+  if (!conn)
+    return NULL;
+
+#if SOCKET_HAS_TLS
+  if (conn->is_tls && conn->socket)
+    {
+      return SocketTLS_get_alpn_selected (conn->socket);
+    }
+#endif
+
+  return NULL;
+}
+
+int
+curl_connection_is_http2 (const CurlConnection *conn)
+{
+  if (!conn)
+    return 0;
+
+  return conn->http_version == HTTP_VERSION_2;
+}

--- a/examples/curl/src/StreamingCurl_cookie.c
+++ b/examples/curl/src/StreamingCurl_cookie.c
@@ -1,0 +1,893 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_cookie.c
+ * @brief Cookie jar implementation for curl module.
+ *
+ * Implements RFC 6265 cookie handling with:
+ * - Netscape cookie file format for persistence
+ * - Domain matching
+ * - Path matching
+ * - Secure/HttpOnly flags
+ * - Expiration handling
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Cookie parsing and formatting constants */
+#define COOKIE_EXPIRED_IMMEDIATELY 1
+#define COOKIE_DEFAULT_PATH_LEN 1
+#define COOKIE_ROOT_PATH_ALLOC_SIZE 2
+#define COOKIE_SEPARATOR_LEN 2         /* "; " */
+#define COOKIE_NAME_VALUE_SEP_LEN 1    /* "=" */
+#define SET_COOKIE_HEADER_LEN 10       /* "Set-Cookie" */
+
+/* Netscape cookie file format field widths */
+#define NETSCAPE_DOMAIN_FIELD_WIDTH 255
+#define NETSCAPE_TAILMATCH_FIELD_WIDTH 15
+#define NETSCAPE_PATH_FIELD_WIDTH 1023
+#define NETSCAPE_SECURE_FIELD_WIDTH 15
+#define NETSCAPE_NAME_FIELD_WIDTH 255
+#define NETSCAPE_VALUE_FIELD_WIDTH 4094
+#define NETSCAPE_MIN_FIELDS 6
+#define NETSCAPE_FULL_FIELDS 7
+
+/* Helper macros for sscanf format strings */
+#define XSTR(s) STR(s)
+#define STR(s) #s
+
+CurlCookieJar *
+curl_cookiejar_new (Arena_T arena)
+{
+  if (!arena)
+    return NULL;
+
+  CurlCookieJar *jar = CALLOC (arena, 1, sizeof (CurlCookieJar));
+  jar->arena = arena;
+  jar->cookies = NULL;
+  jar->filename = NULL;
+  jar->dirty = 0;
+
+  return jar;
+}
+
+void
+curl_cookiejar_free (CurlCookieJar **jar)
+{
+  if (!jar || !*jar)
+    return;
+
+  /* Cookies are arena-allocated, no need to free individually */
+  *jar = NULL;
+}
+
+/**
+ * @brief Skip whitespace.
+ */
+static const char *
+skip_ws (const char *s)
+{
+  while (*s && (*s == ' ' || *s == '\t'))
+    s++;
+  return s;
+}
+
+/**
+ * @brief Parse a quoted or unquoted value.
+ */
+static const char *
+parse_value (const char *s, char *out, size_t out_size, size_t *out_len)
+{
+  s = skip_ws (s);
+
+  if (*s == '"')
+    {
+      /* Quoted value */
+      s++;
+      size_t i = 0;
+      while (*s && *s != '"' && i < out_size - 1)
+        out[i++] = *s++;
+      out[i] = '\0';
+      *out_len = i;
+      if (*s == '"')
+        s++;
+    }
+  else
+    {
+      /* Unquoted value until ; or end */
+      size_t i = 0;
+      while (*s && *s != ';' && *s != ',' && i < out_size - 1)
+        out[i++] = *s++;
+      /* Trim trailing whitespace */
+      while (i > 0 && (out[i - 1] == ' ' || out[i - 1] == '\t'))
+        i--;
+      out[i] = '\0';
+      *out_len = i;
+    }
+
+  return s;
+}
+
+/**
+ * @brief Parse a Set-Cookie attribute name.
+ */
+static const char *
+parse_attr_name (const char *s, char *out, size_t out_size)
+{
+  s = skip_ws (s);
+  size_t i = 0;
+  while (*s && *s != '=' && *s != ';' && i < out_size - 1)
+    out[i++] = *s++;
+  /* Trim trailing whitespace */
+  while (i > 0 && (out[i - 1] == ' ' || out[i - 1] == '\t'))
+    i--;
+  out[i] = '\0';
+
+  if (*s == '=')
+    s++;
+
+  return s;
+}
+
+/**
+ * @brief Parse cookie name=value pair.
+ * @return 0 on success, -1 on failure.
+ */
+static int
+parse_cookie_name_value (const char **p, CurlCookie *cookie, Arena_T arena)
+{
+  char name[CURL_MAX_COOKIE_NAME_LEN], value[CURL_MAX_COOKIE_VALUE_LEN];
+  size_t name_len = 0, value_len = 0;
+
+  /* Get cookie name */
+  *p = skip_ws (*p);
+  size_t i = 0;
+  while (**p && **p != '=' && **p != ';' && i < sizeof (name) - 1)
+    name[i++] = *(*p)++;
+  /* Trim trailing whitespace from name */
+  while (i > 0 && (name[i - 1] == ' ' || name[i - 1] == '\t'))
+    i--;
+  name[i] = '\0';
+  name_len = i;
+
+  if (**p != '=')
+    return -1; /* No value - invalid cookie */
+
+  (*p)++; /* Skip '=' */
+
+  /* Get cookie value */
+  *p = parse_value (*p, value, sizeof (value), &value_len);
+
+  /* Store name and value */
+  cookie->name = ALLOC (arena, name_len + 1);
+  if (!cookie->name)
+    return -1;
+  memcpy (cookie->name, name, name_len);
+  cookie->name[name_len] = '\0';
+
+  cookie->value = ALLOC (arena, value_len + 1);
+  if (!cookie->value)
+    return -1;
+  memcpy (cookie->value, value, value_len);
+  cookie->value[value_len] = '\0';
+
+  return 0;
+}
+
+/**
+ * @brief Parse cookie Domain attribute.
+ */
+static void
+parse_cookie_domain (const char *attr_value, size_t attr_val_len,
+                     CurlCookie *cookie, Arena_T arena)
+{
+  if (attr_val_len == 0)
+    return;
+
+  /* Remove leading dot if present */
+  const char *domain = attr_value;
+  if (*domain == '.')
+    domain++;
+  size_t dlen = strlen (domain);
+  cookie->domain = ALLOC (arena, dlen + 1);
+  memcpy (cookie->domain, domain, dlen);
+  cookie->domain[dlen] = '\0';
+}
+
+/**
+ * @brief Parse cookie Path attribute.
+ */
+static void
+parse_cookie_path (const char *attr_value, size_t attr_val_len,
+                   CurlCookie *cookie, Arena_T arena)
+{
+  if (attr_val_len == 0)
+    return;
+
+  size_t plen = strlen (attr_value);
+  cookie->path = ALLOC (arena, plen + 1);
+  memcpy (cookie->path, attr_value, plen);
+  cookie->path[plen] = '\0';
+}
+
+/**
+ * @brief Parse cookie Expires and Max-Age attributes.
+ */
+static void
+parse_cookie_expires (const char *attr_name, const char *attr_value,
+                      size_t attr_val_len, CurlCookie *cookie)
+{
+  if (attr_val_len == 0)
+    return;
+
+  if (strcasecmp (attr_name, "Expires") == 0)
+    {
+      /* Parse HTTP date format */
+      struct tm tm;
+      memset (&tm, 0, sizeof (tm));
+      if (strptime (attr_value, "%a, %d %b %Y %H:%M:%S", &tm) != NULL)
+        {
+          cookie->expires = timegm (&tm);
+        }
+    }
+  else if (strcasecmp (attr_name, "Max-Age") == 0)
+    {
+      long max_age = strtol (attr_value, NULL, 10);
+      if (max_age > 0)
+        cookie->expires = time (NULL) + max_age;
+      else if (max_age <= 0)
+        cookie->expires = COOKIE_EXPIRED_IMMEDIATELY; /* Delete immediately */
+    }
+}
+
+/**
+ * @brief Parse cookie flags (Secure, HttpOnly, SameSite).
+ */
+static void
+parse_cookie_flags (const char *attr_name, CurlCookie *cookie)
+{
+  if (strcasecmp (attr_name, "Secure") == 0)
+    {
+      cookie->secure = 1;
+    }
+  else if (strcasecmp (attr_name, "HttpOnly") == 0)
+    {
+      cookie->http_only = 1;
+    }
+  /* SameSite is parsed but not enforced in this implementation */
+}
+
+CurlCookie *
+curl_cookie_parse (const char *set_cookie, const char *request_host,
+                   const char *request_path, int request_secure, Arena_T arena)
+{
+  if (!set_cookie || !arena)
+    return NULL;
+
+  CurlCookie *cookie = CALLOC (arena, 1, sizeof (CurlCookie));
+
+  /* Parse name=value pair first */
+  const char *p = set_cookie;
+  if (parse_cookie_name_value (&p, cookie, arena) != 0)
+    return NULL;
+
+  /* Set defaults */
+  cookie->secure = 0;
+  cookie->http_only = 0;
+  cookie->expires = 0; /* Session cookie */
+
+  /* Default domain to request host */
+  if (request_host)
+    {
+      size_t host_len = strlen (request_host);
+      cookie->domain = ALLOC (arena, host_len + 1);
+      memcpy (cookie->domain, request_host, host_len);
+      cookie->domain[host_len] = '\0';
+    }
+
+  /* Default path to request path */
+  if (request_path)
+    {
+      /* Use directory part of path */
+      const char *last_slash = strrchr (request_path, '/');
+      size_t path_len
+          = last_slash ? (size_t)(last_slash - request_path + 1) : COOKIE_DEFAULT_PATH_LEN;
+      if (path_len == 0)
+        path_len = COOKIE_DEFAULT_PATH_LEN;
+      cookie->path = ALLOC (arena, path_len + 1);
+      if (last_slash)
+        memcpy (cookie->path, request_path, path_len);
+      else
+        cookie->path[0] = '/';
+      cookie->path[path_len] = '\0';
+    }
+  else
+    {
+      cookie->path = ALLOC (arena, COOKIE_ROOT_PATH_ALLOC_SIZE);
+      cookie->path[0] = '/';
+      cookie->path[1] = '\0';
+    }
+
+  /* Parse attributes */
+  char attr_name[CURL_MAX_QOP_LEN], attr_value[CURL_MAX_DOMAIN_LEN];
+
+  while (*p)
+    {
+      /* Skip semicolon and whitespace */
+      if (*p == ';')
+        p++;
+      p = skip_ws (p);
+
+      if (*p == '\0')
+        break;
+
+      /* Parse attribute */
+      p = parse_attr_name (p, attr_name, sizeof (attr_name));
+      p = skip_ws (p);
+
+      /* Get value if present */
+      attr_value[0] = '\0';
+      size_t attr_val_len = 0;
+      if (*p && *p != ';')
+        {
+          p = parse_value (p, attr_value, sizeof (attr_value), &attr_val_len);
+        }
+
+      /* Process attribute */
+      if (strcasecmp (attr_name, "Domain") == 0)
+        {
+          parse_cookie_domain (attr_value, attr_val_len, cookie, arena);
+        }
+      else if (strcasecmp (attr_name, "Path") == 0)
+        {
+          parse_cookie_path (attr_value, attr_val_len, cookie, arena);
+        }
+      else if (strcasecmp (attr_name, "Expires") == 0
+               || strcasecmp (attr_name, "Max-Age") == 0)
+        {
+          parse_cookie_expires (attr_name, attr_value, attr_val_len, cookie);
+        }
+      else
+        {
+          parse_cookie_flags (attr_name, cookie);
+        }
+    }
+
+  /* Validate secure cookie on secure request */
+  (void)request_secure; /* May be used for validation in future */
+
+  return cookie;
+}
+
+int
+curl_cookie_domain_match (const char *cookie_domain, const char *request_host)
+{
+  if (!cookie_domain || !request_host)
+    return 0;
+
+  size_t cookie_len = strlen (cookie_domain);
+  size_t host_len = strlen (request_host);
+
+  /* Exact match */
+  if (cookie_len == host_len && strcasecmp (cookie_domain, request_host) == 0)
+    return 1;
+
+  /* Domain suffix match */
+  if (cookie_len < host_len)
+    {
+      const char *suffix = request_host + host_len - cookie_len;
+      /* Check suffix match and that preceding char is a dot */
+      if (strcasecmp (suffix, cookie_domain) == 0 && suffix[-1] == '.')
+        return 1;
+    }
+
+  return 0;
+}
+
+int
+curl_cookie_path_match (const char *cookie_path, const char *request_path)
+{
+  if (!cookie_path || !request_path)
+    return 0;
+
+  size_t cookie_len = strlen (cookie_path);
+  size_t path_len = strlen (request_path);
+
+  /* Cookie path must be prefix of request path */
+  if (cookie_len > path_len)
+    return 0;
+
+  if (strncmp (cookie_path, request_path, cookie_len) != 0)
+    return 0;
+
+  /* Must be exact match or next char in request is '/' */
+  if (cookie_len == path_len)
+    return 1;
+
+  if (cookie_path[cookie_len - 1] == '/')
+    return 1;
+
+  if (request_path[cookie_len] == '/')
+    return 1;
+
+  return 0;
+}
+
+int
+curl_cookie_matches (const CurlCookie *cookie, const char *host,
+                     const char *path, int is_secure)
+{
+  if (!cookie || !host || !path)
+    return 0;
+
+  /* Check domain */
+  if (!curl_cookie_domain_match (cookie->domain, host))
+    return 0;
+
+  /* Check path */
+  if (!curl_cookie_path_match (cookie->path, path))
+    return 0;
+
+  /* Check secure flag */
+  if (cookie->secure && !is_secure)
+    return 0;
+
+  /* Check expiration */
+  if (cookie->expires > 0 && cookie->expires <= time (NULL))
+    return 0;
+
+  return 1;
+}
+
+int
+curl_cookie_is_expired (const CurlCookie *cookie)
+{
+  if (!cookie)
+    return 1;
+
+  /* Session cookie (expires == 0) never expires during session */
+  if (cookie->expires == 0)
+    return 0;
+
+  return cookie->expires <= time (NULL);
+}
+
+int
+curl_cookiejar_add (CurlCookieJar *jar, CurlCookie *cookie)
+{
+  if (!jar || !cookie)
+    return -1;
+
+  /* Remove existing cookie with same name, domain, path */
+  curl_cookiejar_remove (jar, cookie->name, cookie->domain, cookie->path);
+
+  /* Check if cookie has already expired (delete cookie) */
+  if (cookie->expires > 0 && cookie->expires <= time (NULL))
+    return 0; /* Don't add expired cookie */
+
+  /* Add to front of list */
+  cookie->next = jar->cookies;
+  jar->cookies = cookie;
+  jar->dirty = 1;
+
+  return 0;
+}
+
+int
+curl_cookiejar_remove (CurlCookieJar *jar, const char *name,
+                       const char *domain, const char *path)
+{
+  if (!jar || !name)
+    return -1;
+
+  CurlCookie **pp = &jar->cookies;
+  while (*pp)
+    {
+      CurlCookie *c = *pp;
+      int match = (strcmp (c->name, name) == 0);
+
+      if (match && domain)
+        match = (strcasecmp (c->domain, domain) == 0);
+
+      if (match && path)
+        match = (strcmp (c->path, path) == 0);
+
+      if (match)
+        {
+          *pp = c->next;
+          jar->dirty = 1;
+          /* Cookie memory is arena-managed */
+          return 1; /* Removed */
+        }
+
+      pp = &c->next;
+    }
+
+  return 0; /* Not found */
+}
+
+void
+curl_cookiejar_clear (CurlCookieJar *jar)
+{
+  if (!jar)
+    return;
+
+  jar->cookies = NULL;
+  jar->dirty = 1;
+}
+
+void
+curl_cookiejar_clear_expired (CurlCookieJar *jar)
+{
+  if (!jar)
+    return;
+
+  time_t now = time (NULL);
+  CurlCookie **pp = &jar->cookies;
+
+  while (*pp)
+    {
+      CurlCookie *c = *pp;
+      if (c->expires > 0 && c->expires <= now)
+        {
+          *pp = c->next;
+          jar->dirty = 1;
+        }
+      else
+        {
+          pp = &c->next;
+        }
+    }
+}
+
+int
+curl_cookiejar_count (const CurlCookieJar *jar)
+{
+  if (!jar)
+    return 0;
+
+  int count = 0;
+  for (const CurlCookie *c = jar->cookies; c; c = c->next)
+    count++;
+
+  return count;
+}
+
+ssize_t
+curl_cookiejar_get_header (const CurlCookieJar *jar, const char *host,
+                           const char *path, int is_secure, char *output,
+                           size_t output_size)
+{
+  if (!jar || !host || !path || !output || output_size == 0)
+    return -1;
+
+  size_t written = 0;
+  int first = 1;
+
+  for (const CurlCookie *c = jar->cookies; c; c = c->next)
+    {
+      if (!curl_cookie_matches (c, host, path, is_secure))
+        continue;
+
+      /* Format: name=value; name2=value2 */
+      size_t needed = strlen (c->name) + COOKIE_NAME_VALUE_SEP_LEN + strlen (c->value);
+      if (!first)
+        needed += COOKIE_SEPARATOR_LEN; /* "; " */
+
+      if (written + needed >= output_size)
+        break; /* Buffer full */
+
+      if (!first)
+        {
+          output[written++] = ';';
+          output[written++] = ' ';
+        }
+
+      size_t name_len = strlen (c->name);
+      memcpy (output + written, c->name, name_len);
+      written += name_len;
+
+      output[written++] = '=';
+
+      size_t value_len = strlen (c->value);
+      memcpy (output + written, c->value, value_len);
+      written += value_len;
+
+      first = 0;
+    }
+
+  output[written] = '\0';
+  return (ssize_t)written;
+}
+
+int
+curl_cookiejar_process_response (CurlCookieJar *jar,
+                                 SocketHTTP_Headers_T headers,
+                                 const char *host, const char *path,
+                                 int is_secure, Arena_T arena)
+{
+  if (!jar || !headers)
+    return -1;
+
+  int count = 0;
+  size_t header_count = SocketHTTP_Headers_count (headers);
+
+  for (size_t i = 0; i < header_count; i++)
+    {
+      const SocketHTTP_Header *h = SocketHTTP_Headers_at (headers, i);
+      if (!h)
+        continue;
+
+      /* Check for Set-Cookie header (case-insensitive) */
+      if (h->name_len == SET_COOKIE_HEADER_LEN && strncasecmp (h->name, "Set-Cookie", SET_COOKIE_HEADER_LEN) == 0)
+        {
+          /* Create null-terminated copy */
+          char *value = ALLOC (arena, h->value_len + 1);
+          memcpy (value, h->value, h->value_len);
+          value[h->value_len] = '\0';
+
+          CurlCookie *cookie
+              = curl_cookie_parse (value, host, path, is_secure, arena);
+          if (cookie)
+            {
+              curl_cookiejar_add (jar, cookie);
+              count++;
+            }
+        }
+    }
+
+  return count;
+}
+
+int
+curl_cookiejar_load (CurlCookieJar *jar, const char *filename)
+{
+  if (!jar || !filename)
+    return -1;
+
+  /* Use open() with O_NOFOLLOW to prevent symlink attacks */
+  int fd = open (filename, O_RDONLY | O_NOFOLLOW);
+  if (fd < 0)
+    {
+      if (errno == ENOENT)
+        return 0; /* File doesn't exist yet - OK */
+      return -1;
+    }
+
+  FILE *fp = fdopen (fd, "r");
+  if (!fp)
+    {
+      close (fd);
+      return -1;
+    }
+
+  char line[CURL_MAX_COOKIE_LINE_LEN];
+  int count = 0;
+
+  while (fgets (line, sizeof (line), fp))
+    {
+      /* Skip comments and blank lines */
+      if (line[0] == '#' || line[0] == '\n' || line[0] == '\r')
+        continue;
+
+      /* Netscape format: domain TAB tailmatch TAB path TAB secure TAB expires
+       * TAB name TAB value */
+      char domain[CURL_MAX_DOMAIN_LEN], tailmatch[NETSCAPE_TAILMATCH_FIELD_WIDTH + 1], path[CURL_MAX_PATH_LEN],
+          secure_str[NETSCAPE_SECURE_FIELD_WIDTH + 1];
+      char name[CURL_MAX_COOKIE_NAME_LEN], value[CURL_MAX_COOKIE_VALUE_LEN];
+      long expires;
+
+      int n = sscanf (
+          line, "%" XSTR(NETSCAPE_DOMAIN_FIELD_WIDTH) "s\t"
+                "%" XSTR(NETSCAPE_TAILMATCH_FIELD_WIDTH) "s\t"
+                "%" XSTR(NETSCAPE_PATH_FIELD_WIDTH) "s\t"
+                "%" XSTR(NETSCAPE_SECURE_FIELD_WIDTH) "s\t%ld\t"
+                "%" XSTR(NETSCAPE_NAME_FIELD_WIDTH) "s\t"
+                "%" XSTR(NETSCAPE_VALUE_FIELD_WIDTH) "[^\r\n]",
+          domain, tailmatch, path, secure_str, &expires, name, value);
+
+      if (n < NETSCAPE_FULL_FIELDS)
+        {
+          /* Try without value (empty value) */
+          n = sscanf (line, "%" XSTR(NETSCAPE_DOMAIN_FIELD_WIDTH) "s\t"
+                            "%" XSTR(NETSCAPE_TAILMATCH_FIELD_WIDTH) "s\t"
+                            "%" XSTR(NETSCAPE_PATH_FIELD_WIDTH) "s\t"
+                            "%" XSTR(NETSCAPE_SECURE_FIELD_WIDTH) "s\t%ld\t"
+                            "%" XSTR(NETSCAPE_NAME_FIELD_WIDTH) "s",
+                      domain, tailmatch, path, secure_str, &expires, name);
+          if (n >= NETSCAPE_MIN_FIELDS)
+            value[0] = '\0';
+          else
+            continue;
+        }
+
+      /* Validate expires range before casting to time_t */
+      if (expires < 0)
+        continue;
+
+      /* Create cookie */
+      CurlCookie *cookie = CALLOC (jar->arena, 1, sizeof (CurlCookie));
+
+      /* Remove leading dot from domain for storage */
+      const char *d = domain;
+      if (*d == '.')
+        d++;
+      size_t dlen = strlen (d);
+      cookie->domain = ALLOC (jar->arena, dlen + 1);
+      if (!cookie->domain)
+        continue;
+      memcpy (cookie->domain, d, dlen);
+      cookie->domain[dlen] = '\0';
+
+      size_t plen = strlen (path);
+      cookie->path = ALLOC (jar->arena, plen + 1);
+      if (!cookie->path)
+        continue;
+      memcpy (cookie->path, path, plen);
+      cookie->path[plen] = '\0';
+
+      size_t nlen = strlen (name);
+      cookie->name = ALLOC (jar->arena, nlen + 1);
+      if (!cookie->name)
+        continue;
+      memcpy (cookie->name, name, nlen);
+      cookie->name[nlen] = '\0';
+
+      size_t vlen = strlen (value);
+      cookie->value = ALLOC (jar->arena, vlen + 1);
+      if (!cookie->value)
+        continue;
+      memcpy (cookie->value, value, vlen);
+      cookie->value[vlen] = '\0';
+
+      cookie->secure = (strcasecmp (secure_str, "TRUE") == 0);
+      cookie->http_only = 0; /* Not stored in Netscape format */
+      cookie->expires = (time_t)expires;
+
+      /* Add to jar */
+      cookie->next = jar->cookies;
+      jar->cookies = cookie;
+      count++;
+    }
+
+  fclose (fp);
+
+  /* Store filename for later save */
+  size_t fname_len = strlen (filename);
+  jar->filename = ALLOC (jar->arena, fname_len + 1);
+  memcpy (jar->filename, filename, fname_len);
+  jar->filename[fname_len] = '\0';
+  jar->dirty = 0;
+
+  return count;
+}
+
+int
+curl_cookiejar_save (const CurlCookieJar *jar, const char *filename)
+{
+  if (!jar)
+    return -1;
+
+  const char *save_file = filename ? filename : jar->filename;
+  if (!save_file)
+    return -1;
+
+  FILE *fp = fopen (save_file, "w");
+  if (!fp)
+    return -1;
+
+  /* Write Netscape header */
+  fprintf (fp, "# Netscape HTTP Cookie File\n");
+  fprintf (fp, "# https://curl.se/docs/http-cookies.html\n");
+  fprintf (fp, "# This file was generated by tetsuo-curl\n\n");
+
+  time_t now = time (NULL);
+
+  for (const CurlCookie *c = jar->cookies; c; c = c->next)
+    {
+      /* Skip expired cookies */
+      if (c->expires > 0 && c->expires <= now)
+        continue;
+
+      /* Skip session cookies if expires is 0 */
+      /* (We save them anyway, they'll be treated as session cookies on load)
+       */
+
+      /* Format: domain tailmatch path secure expires name value */
+      fprintf (fp, ".%s\tTRUE\t%s\t%s\t%ld\t%s\t%s\n", c->domain, c->path,
+               c->secure ? "TRUE" : "FALSE", (long)c->expires, c->name,
+               c->value);
+    }
+
+  fclose (fp);
+  return 0;
+}
+
+int
+curl_session_add_cookies (CurlSession_T session)
+{
+  if (!session || !session->cookie_jar || !session->request_headers)
+    return 0;
+
+  char cookie_header[CURL_MAX_URL_BUFFER_LEN];
+  ssize_t len = curl_cookiejar_get_header (
+      session->cookie_jar, session->current_url.host,
+      session->current_url.path ? session->current_url.path : "/",
+      session->current_url.is_secure, cookie_header, sizeof (cookie_header));
+
+  if (len <= 0)
+    return 0;
+
+  SocketHTTP_Headers_set (session->request_headers, "Cookie", cookie_header);
+  return 1;
+}
+
+int
+curl_session_process_cookies (CurlSession_T session)
+{
+  if (!session || !session->cookie_jar || !session->response.headers)
+    return 0;
+
+  return curl_cookiejar_process_response (
+      session->cookie_jar, session->response.headers,
+      session->current_url.host,
+      session->current_url.path ? session->current_url.path : "/",
+      session->current_url.is_secure, session->request_arena);
+}
+
+int
+curl_session_init_cookies (CurlSession_T session, const char *cookie_file)
+{
+  if (!session)
+    return -1;
+
+  /* Create cookie jar if needed */
+  if (!session->cookie_jar)
+    {
+      session->cookie_jar = curl_cookiejar_new (session->arena);
+      if (!session->cookie_jar)
+        return -1;
+    }
+
+  /* Load from file if specified */
+  if (cookie_file)
+    {
+      int result = curl_cookiejar_load (session->cookie_jar, cookie_file);
+      if (result < 0)
+        return -1;
+    }
+
+  return 0;
+}
+
+int
+curl_session_save_cookies (CurlSession_T session)
+{
+  if (!session || !session->cookie_jar)
+    return 0;
+
+  if (!session->cookie_jar->dirty)
+    return 0; /* Nothing to save */
+
+  if (!session->cookie_jar->filename && !session->options.cookie_file)
+    return 0; /* No file configured */
+
+  return curl_cookiejar_save (session->cookie_jar,
+                              session->options.cookie_file);
+}

--- a/examples/curl/src/StreamingCurl_decomp.c
+++ b/examples/curl/src/StreamingCurl_decomp.c
@@ -1,0 +1,379 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_decomp.c
+ * @brief Content decompression wrapper for curl module.
+ *
+ * Implements automatic decompression for HTTP responses:
+ * - gzip (deflate with gzip header)
+ * - deflate (raw deflate)
+ * - br (Brotli compression)
+ *
+ * Requires SOCKETHTTP1_HAS_COMPRESSION to be defined for actual
+ * decompression. When not available, passes data through unchanged.
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP1.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/**
+ * @brief Decompression context for streaming decompression.
+ */
+typedef struct CurlDecompressor
+{
+  SocketHTTP_Coding coding; /**< Content encoding type */
+  Arena_T arena;            /**< Memory arena */
+  int initialized;          /**< Decoder initialized */
+#if SOCKETHTTP1_HAS_COMPRESSION
+  SocketHTTP1_Decoder_T decoder; /**< HTTP/1.1 decoder */
+#endif
+} CurlDecompressor;
+
+/**
+ * @brief Create a new decompressor.
+ *
+ * @param encoding Content-Encoding header value
+ * @param arena Memory arena
+ * @return New decompressor, or NULL on error
+ */
+CurlDecompressor *
+curl_decompressor_new (const char *encoding, Arena_T arena)
+{
+  if (!arena)
+    return NULL;
+
+  CurlDecompressor *decomp = CALLOC (arena, 1, sizeof (CurlDecompressor));
+  decomp->arena = arena;
+  decomp->initialized = 0;
+
+  /* Determine coding type */
+  if (!encoding || *encoding == '\0')
+    {
+      decomp->coding = HTTP_CODING_IDENTITY;
+    }
+  else
+    {
+      decomp->coding = SocketHTTP_coding_parse (encoding, strlen (encoding));
+    }
+
+  return decomp;
+}
+
+/**
+ * @brief Initialize decoder on first use.
+ *
+ * @param decomp Decompressor
+ * @return 0 on success, -1 on error
+ */
+static int
+curl_decompressor_init (CurlDecompressor *decomp)
+{
+  if (!decomp || decomp->initialized)
+    return 0;
+
+  /* Identity encoding - no decoder needed */
+  if (decomp->coding == HTTP_CODING_IDENTITY)
+    {
+      decomp->initialized = 1;
+      return 0;
+    }
+
+#if SOCKETHTTP1_HAS_COMPRESSION
+  decomp->decoder
+      = SocketHTTP1_Decoder_new (decomp->coding, NULL, decomp->arena);
+  if (!decomp->decoder)
+    return -1;
+#endif
+
+  decomp->initialized = 1;
+  return 0;
+}
+
+/**
+ * @brief Decompress data.
+ *
+ * @param decomp Decompressor
+ * @param input Compressed input
+ * @param input_len Input length
+ * @param output Output buffer
+ * @param output_len Output buffer size
+ * @param bytes_written Output bytes written
+ * @return 0 on success, -1 on error
+ */
+int
+curl_decompressor_decompress (CurlDecompressor *decomp,
+                              const unsigned char *input, size_t input_len,
+                              unsigned char *output, size_t output_len,
+                              size_t *bytes_written)
+{
+  if (!decomp || !output || !bytes_written)
+    return -1;
+
+  *bytes_written = 0;
+
+  /* Initialize on first use */
+  if (!decomp->initialized)
+    {
+      if (curl_decompressor_init (decomp) != 0)
+        return -1;
+    }
+
+  /* Identity encoding - pass through */
+  if (decomp->coding == HTTP_CODING_IDENTITY)
+    {
+      size_t copy_len = input_len > output_len ? output_len : input_len;
+      if (input && copy_len > 0)
+        {
+          memcpy (output, input, copy_len);
+        }
+      *bytes_written = copy_len;
+      return 0;
+    }
+
+#if SOCKETHTTP1_HAS_COMPRESSION
+  if (!decomp->decoder)
+    return -1;
+
+  size_t consumed;
+  SocketHTTP1_Result res = SocketHTTP1_Decoder_decode (
+      decomp->decoder, input, input_len, &consumed, output, output_len,
+      bytes_written);
+
+  if (res != HTTP1_OK && res != HTTP1_INCOMPLETE)
+    return -1;
+
+  return 0;
+#else
+  /* No compression support - pass through */
+  size_t copy_len = input_len > output_len ? output_len : input_len;
+  if (input && copy_len > 0)
+    {
+      memcpy (output, input, copy_len);
+    }
+  *bytes_written = copy_len;
+  return 0;
+#endif
+}
+
+/**
+ * @brief Finish decompression and get remaining data.
+ *
+ * @param decomp Decompressor
+ * @param output Output buffer
+ * @param output_len Output buffer size
+ * @param bytes_written Output bytes written
+ * @return 0 on success, -1 on error
+ */
+int
+curl_decompressor_finish (CurlDecompressor *decomp, unsigned char *output,
+                          size_t output_len, size_t *bytes_written)
+{
+  if (!decomp || !output || !bytes_written)
+    return -1;
+
+  *bytes_written = 0;
+
+  if (!decomp->initialized || decomp->coding == HTTP_CODING_IDENTITY)
+    {
+      (void)output_len; /* Unused for identity encoding */
+      return 0;
+    }
+
+#if SOCKETHTTP1_HAS_COMPRESSION
+  if (!decomp->decoder)
+    return 0;
+
+  SocketHTTP1_Result res = SocketHTTP1_Decoder_finish (
+      decomp->decoder, output, output_len, bytes_written);
+
+  if (res != HTTP1_OK && res != HTTP1_INCOMPLETE)
+    return -1;
+
+  return 0;
+#else
+  return 0;
+#endif
+}
+
+/**
+ * @brief Free decompressor resources.
+ *
+ * @param decomp Pointer to decompressor (set to NULL)
+ */
+void
+curl_decompressor_free (CurlDecompressor **decomp)
+{
+  if (!decomp || !*decomp)
+    return;
+
+#if SOCKETHTTP1_HAS_COMPRESSION
+  if ((*decomp)->decoder)
+    {
+      SocketHTTP1_Decoder_free (&(*decomp)->decoder);
+    }
+#endif
+
+  *decomp = NULL;
+}
+
+/**
+ * @brief Check if decompressor is for identity encoding.
+ *
+ * @param decomp Decompressor
+ * @return 1 if identity, 0 otherwise
+ */
+int
+curl_decompressor_is_identity (CurlDecompressor *decomp)
+{
+  if (!decomp)
+    return 1;
+
+  return decomp->coding == HTTP_CODING_IDENTITY;
+}
+
+/**
+ * @brief Get coding type name.
+ *
+ * @param decomp Decompressor
+ * @return Static string name
+ */
+const char *
+curl_decompressor_coding_name (CurlDecompressor *decomp)
+{
+  if (!decomp)
+    return "identity";
+
+  switch (decomp->coding)
+    {
+    case HTTP_CODING_IDENTITY:
+      return "identity";
+    case HTTP_CODING_GZIP:
+      return "gzip";
+    case HTTP_CODING_DEFLATE:
+      return "deflate";
+    case HTTP_CODING_BR:
+      return "br";
+    default:
+      return "unknown";
+    }
+}
+
+/**
+ * @brief Create decompressor for session based on Content-Encoding.
+ *
+ * @param session Session
+ * @return New decompressor, or NULL if not needed/error
+ */
+CurlDecompressor *
+curl_session_create_decompressor (CurlSession_T session)
+{
+  if (!session || !session->response.headers)
+    return NULL;
+
+  /* Check if auto-decompress is enabled */
+  if (!session->options.auto_decompress)
+    return NULL;
+
+  /* Get Content-Encoding header */
+  const char *encoding
+      = SocketHTTP_Headers_get (session->response.headers, "Content-Encoding");
+  if (!encoding)
+    return NULL;
+
+  /* Skip if identity encoding */
+  if (strcasecmp (encoding, "identity") == 0)
+    return NULL;
+
+  return curl_decompressor_new (encoding, session->request_arena);
+}
+
+/**
+ * @brief Decompress body data with session's decompressor.
+ *
+ * @param session Session
+ * @param decomp Decompressor (may be NULL)
+ * @param input Input data
+ * @param input_len Input length
+ * @param output Output buffer
+ * @param output_len Output buffer size
+ * @param bytes_written Bytes written to output
+ * @return 0 on success, -1 on error
+ */
+int
+curl_session_decompress (CurlSession_T session, CurlDecompressor *decomp,
+                         const unsigned char *input, size_t input_len,
+                         unsigned char *output, size_t output_len,
+                         size_t *bytes_written)
+{
+  (void)session; /* May be used for error reporting in future */
+
+  if (!bytes_written)
+    return -1;
+
+  /* No decompressor - pass through */
+  if (!decomp)
+    {
+      size_t copy_len = input_len > output_len ? output_len : input_len;
+      if (input && copy_len > 0)
+        {
+          memcpy (output, input, copy_len);
+        }
+      *bytes_written = copy_len;
+      return 0;
+    }
+
+  return curl_decompressor_decompress (decomp, input, input_len, output,
+                                       output_len, bytes_written);
+}
+
+/**
+ * @brief Check if Content-Encoding indicates compression.
+ *
+ * @param headers Response headers
+ * @return 1 if compressed, 0 otherwise
+ */
+int
+curl_is_content_compressed (SocketHTTP_Headers_T headers)
+{
+  if (!headers)
+    return 0;
+
+  const char *encoding = SocketHTTP_Headers_get (headers, "Content-Encoding");
+  if (!encoding)
+    return 0;
+
+  /* Check for known compression types */
+  if (strcasecmp (encoding, "gzip") == 0)
+    return 1;
+  if (strcasecmp (encoding, "deflate") == 0)
+    return 1;
+  if (strcasecmp (encoding, "br") == 0)
+    return 1;
+
+  return 0;
+}
+
+/**
+ * @brief Parse Content-Encoding to coding type.
+ *
+ * @param encoding Content-Encoding header value
+ * @return Coding type
+ */
+SocketHTTP_Coding
+curl_parse_content_encoding (const char *encoding)
+{
+  if (!encoding)
+    return HTTP_CODING_IDENTITY;
+
+  return SocketHTTP_coding_parse (encoding, strlen (encoding));
+}

--- a/examples/curl/src/StreamingCurl_h1.c
+++ b/examples/curl/src/StreamingCurl_h1.c
@@ -1,0 +1,571 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_h1.c
+ * @brief HTTP/1.1 response streaming for curl module.
+ *
+ * Implements streaming response body handling for HTTP/1.1:
+ * - Incremental header parsing
+ * - Transparent chunked encoding decoding
+ * - Content-Length body handling
+ * - Connection-close body handling
+ * - Progress callbacks
+ * - Response size limits
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP1.h"
+#include "socket/Socket.h"
+#include "socket/SocketBuf.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Default timeout if none specified (30 seconds) */
+#define CURL_H1_DEFAULT_TIMEOUT_MS 30000
+
+/* HTTP header formatting constants */
+#define HTTP_HEADER_SEPARATOR_LEN 2  /* ": " */
+#define HTTP_HEADER_CRLF_LEN 2       /* "\r\n" */
+
+/* Content-Length limits */
+#define CURL_MAX_CONTENT_LENGTH (4294967296LL) /* 4GB */
+
+int
+curl_wait_readable (CurlConnection *conn, int timeout_ms)
+{
+  if (!conn || !conn->socket)
+    return -1;
+
+  int fd = Socket_fd (conn->socket);
+  if (fd < 0)
+    return -1;
+
+  struct pollfd pfd;
+  pfd.fd = fd;
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  int ret = poll (&pfd, 1, timeout_ms);
+
+  if (ret < 0)
+    {
+      if (errno == EINTR)
+        return 0; /* Interrupted, treat as timeout for retry */
+      return -1;  /* Error */
+    }
+
+  if (ret == 0)
+    return 0; /* Timeout */
+
+  if (pfd.revents & (POLLERR | POLLHUP | POLLNVAL))
+    return -1; /* Error condition */
+
+  return 1; /* Readable */
+}
+
+/**
+ * @brief Receive data from connection with timeout.
+ *
+ * Handles both TLS and plain sockets with proper timeout handling.
+ *
+ * @param conn Connection
+ * @param buf Buffer to receive into
+ * @param len Buffer size
+ * @param timeout_ms Timeout in milliseconds (0 = use default, -1 = block)
+ * @return Bytes received, 0 on EOF, -1 on error, -2 on timeout
+ */
+static ssize_t
+curl_h1_recv_timeout (CurlConnection *conn, void *buf, size_t len,
+                      int timeout_ms)
+{
+  if (!conn || !conn->socket)
+    return -1;
+
+  /* Use default timeout if none specified */
+  if (timeout_ms == 0)
+    timeout_ms = CURL_H1_DEFAULT_TIMEOUT_MS;
+
+  /* Wait for data with timeout */
+  int wait_result = curl_wait_readable (conn, timeout_ms);
+  if (wait_result < 0)
+    return -1; /* Error */
+  if (wait_result == 0)
+    return -2; /* Timeout */
+
+  volatile ssize_t result = 0;
+
+  TRY { result = Socket_recv (conn->socket, buf, len); }
+  EXCEPT (Socket_Failed) { return -1; }
+  EXCEPT (Socket_Closed) { return 0; }
+  END_TRY;
+
+  return result;
+}
+
+/**
+ * @brief Invoke header callback for each header.
+ *
+ * @param session Session with header callback
+ * @param headers Response headers
+ * @return 0 on success, -1 on abort
+ */
+static int
+curl_h1_invoke_header_callback (CurlSession_T session,
+                                SocketHTTP_Headers_T headers)
+{
+  if (!session || !session->options.header_callback || !headers)
+    return 0;
+
+  size_t count = SocketHTTP_Headers_count (headers);
+
+  for (size_t i = 0; i < count; i++)
+    {
+      const SocketHTTP_Header *h = SocketHTTP_Headers_at (headers, i);
+      if (!h)
+        continue;
+
+      /* Format header line: "Name: Value\r\n" */
+      size_t line_len = h->name_len + HTTP_HEADER_SEPARATOR_LEN + h->value_len + HTTP_HEADER_CRLF_LEN;
+      char *line = ALLOC (session->request_arena, line_len + 1);
+      if (!line)
+        continue; /* Skip this header if allocation fails */
+
+      int len
+          = snprintf (line, line_len + 1, "%.*s: %.*s\r\n", (int)h->name_len,
+                      h->name, (int)h->value_len, h->value);
+      if (len < 0)
+        continue;
+
+      size_t written = session->options.header_callback (
+          line, 1, (size_t)len, session->options.header_userdata);
+
+      if (written != (size_t)len)
+        return -1; /* Callback aborted */
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Get Content-Length header value.
+ *
+ * @param headers Response headers
+ * @return Content-Length or -1 if not set or chunked
+ */
+static int64_t
+curl_h1_get_content_length (SocketHTTP_Headers_T headers)
+{
+  if (!headers)
+    return -1;
+
+  const char *cl = SocketHTTP_Headers_get (headers, "Content-Length");
+  if (!cl)
+    return -1;
+
+  char *endptr;
+  errno = 0;
+  long long val = strtoll (cl, &endptr, CURL_DECIMAL_BASE);
+  if (*endptr != '\0' || val < 0)
+    return -1;
+  if (errno == ERANGE)
+    return -1;
+
+  /* Enforce upper bound to prevent DoS (4GB limit) */
+  if (val > CURL_MAX_CONTENT_LENGTH)
+    return -1;
+
+  return (int64_t)val;
+}
+
+/**
+ * @brief Check if response has Transfer-Encoding: chunked.
+ *
+ * @param headers Response headers
+ * @return 1 if chunked, 0 otherwise
+ */
+static int
+curl_h1_is_chunked (SocketHTTP_Headers_T headers)
+{
+  if (!headers)
+    return 0;
+
+  const char *te = SocketHTTP_Headers_get (headers, "Transfer-Encoding");
+  if (!te)
+    return 0;
+
+  return (strstr (te, "chunked") != NULL);
+}
+
+/**
+ * @brief Ensure HTTP/1.1 parser exists and is ready.
+ *
+ * @param conn Connection
+ * @param arena Arena for allocation
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+curl_h1_ensure_parser (CurlConnection *conn, Arena_T arena)
+{
+  if (!conn->h1_parser)
+    {
+      conn->h1_parser
+          = SocketHTTP1_Parser_new (HTTP1_PARSE_RESPONSE, NULL, arena);
+      if (!conn->h1_parser)
+        return CURL_ERROR_OUT_OF_MEMORY;
+    }
+  else
+    {
+      SocketHTTP1_Parser_reset (conn->h1_parser);
+    }
+  return CURL_OK;
+}
+
+/**
+ * @brief Get effective timeout value.
+ *
+ * @param session Session with options
+ * @return Timeout in milliseconds
+ */
+static int
+curl_h1_get_timeout (CurlSession_T session)
+{
+  int timeout_ms = session->options.request_timeout_ms;
+  return (timeout_ms > 0) ? timeout_ms : CURL_H1_DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * @brief Receive and parse header data until complete.
+ *
+ * @param conn Connection with parser
+ * @param timeout_ms Timeout in milliseconds
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+curl_h1_recv_headers_loop (CurlConnection *conn, int timeout_ms)
+{
+  char buf[CURL_H1_RECV_BUFFER_SIZE];
+  size_t consumed;
+
+  while (1)
+    {
+      ssize_t nread
+          = curl_h1_recv_timeout (conn, buf, sizeof (buf), timeout_ms);
+
+      if (nread == -2)
+        return CURL_ERROR_TIMEOUT;
+      if (nread < 0)
+        return CURL_ERROR_CONNECT;
+      if (nread == 0)
+        return CURL_ERROR_PROTOCOL;
+
+      SocketHTTP1_Result res = SocketHTTP1_Parser_execute (
+          conn->h1_parser, buf, (size_t)nread, &consumed);
+
+      if (res == HTTP1_OK)
+        return CURL_OK;
+      if (res != HTTP1_INCOMPLETE)
+        return CURL_ERROR_PROTOCOL;
+    }
+}
+
+/**
+ * @brief Extract response info from parser into session.
+ *
+ * @param session Session to populate
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+curl_h1_extract_response (CurlSession_T session)
+{
+  const SocketHTTP_Response *resp
+      = SocketHTTP1_Parser_get_response (session->conn->h1_parser);
+  if (!resp)
+    return CURL_ERROR_PROTOCOL;
+
+  session->response.status_code = resp->status_code;
+  session->response.version = resp->version;
+  session->response.headers = resp->headers;
+  session->response.content_length
+      = curl_h1_get_content_length (resp->headers);
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Receive and parse HTTP/1.1 response headers.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+CurlError
+curl_receive_h1_headers (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->socket)
+    return CURL_ERROR_CONNECT;
+
+  CurlError err = curl_h1_ensure_parser (session->conn, session->request_arena);
+  if (err != CURL_OK)
+    return err;
+
+  session->state = CURL_STATE_READING_HEADERS;
+
+  err = curl_h1_recv_headers_loop (session->conn, curl_h1_get_timeout (session));
+  if (err != CURL_OK)
+    return err;
+
+  err = curl_h1_extract_response (session);
+  if (err != CURL_OK)
+    return err;
+
+  if (session->options.header_callback)
+    {
+      if (curl_h1_invoke_header_callback (session, session->response.headers)
+          != 0)
+        return CURL_ERROR_ABORTED;
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Check if response has no body based on status code or method.
+ *
+ * @param session Session with response info
+ * @return 1 if no body expected, 0 otherwise
+ */
+static int
+curl_h1_is_nobody_response (CurlSession_T session)
+{
+  int status = session->response.status_code;
+
+  if (status == CURL_HTTP_STATUS_NO_CONTENT
+      || status == CURL_HTTP_STATUS_NOT_MODIFIED)
+    return 1;
+
+  if (session->request_method == HTTP_METHOD_HEAD)
+    return 1;
+
+  if (status >= CURL_HTTP_STATUS_INFORMATIONAL_MIN
+      && status < CURL_HTTP_STATUS_INFORMATIONAL_MAX)
+    return 1;
+
+  return 0;
+}
+
+/**
+ * @brief Mark session as complete with no body.
+ *
+ * @param session Session to mark complete
+ */
+static void
+curl_h1_complete_nobody (CurlSession_T session)
+{
+  session->state = CURL_STATE_COMPLETE;
+  session->download_received = 0;
+}
+
+/**
+ * @brief Handle EOF during body reception.
+ *
+ * @param body_mode Current body parsing mode
+ * @return CURL_OK if EOF is valid terminator, error otherwise
+ */
+static CurlError
+curl_h1_handle_eof (SocketHTTP1_BodyMode body_mode)
+{
+  return (body_mode == HTTP1_BODY_UNTIL_CLOSE) ? CURL_OK : CURL_ERROR_PROTOCOL;
+}
+
+/**
+ * @brief Stream body chunk to write callback.
+ *
+ * @param session Session with callback
+ * @param data Body data
+ * @param len Data length
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+curl_h1_write_chunk (CurlSession_T session, const void *data, size_t len)
+{
+  if (!session->options.write_callback || len == 0)
+    return CURL_OK;
+
+  size_t written = session->options.write_callback (
+      (void *)data, 1, len, session->options.write_userdata);
+
+  return (written == len) ? CURL_OK : CURL_ERROR_WRITE_CALLBACK;
+}
+
+/**
+ * @brief Invoke progress callback.
+ *
+ * @param session Session with progress state
+ * @return CURL_OK to continue, CURL_ERROR_ABORTED if callback aborts
+ */
+static CurlError
+curl_h1_report_progress (CurlSession_T session)
+{
+  if (!session->options.progress_callback)
+    return CURL_OK;
+
+  int abort = session->options.progress_callback (
+      session->options.progress_userdata, session->download_total,
+      session->download_received, session->upload_total, session->upload_sent);
+
+  return (abort == 0) ? CURL_OK : CURL_ERROR_ABORTED;
+}
+
+/**
+ * @brief Receive and process body data loop.
+ *
+ * @param session Session
+ * @param body_mode Body parsing mode
+ * @param timeout_ms Timeout in milliseconds
+ * @return CURL_OK on success, error code on failure
+ */
+static CurlError
+curl_h1_recv_body_loop (CurlSession_T session, SocketHTTP1_BodyMode body_mode,
+                        int timeout_ms)
+{
+  CurlConnection *conn = session->conn;
+  char recv_buf[CURL_H1_RECV_BUFFER_SIZE];
+  char body_buf[CURL_H1_BODY_BUFFER_SIZE];
+  size_t consumed, written;
+
+  while (!SocketHTTP1_Parser_body_complete (conn->h1_parser))
+    {
+      ssize_t nread = curl_h1_recv_timeout (conn, recv_buf, sizeof (recv_buf),
+                                            timeout_ms);
+      if (nread == -2)
+        return CURL_ERROR_TIMEOUT;
+      if (nread < 0)
+        return CURL_ERROR_CONNECT;
+      if (nread == 0)
+        return curl_h1_handle_eof (body_mode);
+
+      SocketHTTP1_Result res = SocketHTTP1_Parser_read_body (
+          conn->h1_parser, recv_buf, (size_t)nread, &consumed, body_buf,
+          sizeof (body_buf), &written);
+
+      if (res != HTTP1_OK && res != HTTP1_INCOMPLETE)
+        return CURL_ERROR_PROTOCOL;
+
+      CurlError err = curl_h1_write_chunk (session, body_buf, written);
+      if (err != CURL_OK)
+        return err;
+
+      session->download_received += (int64_t)written;
+
+      err = curl_h1_report_progress (session);
+      if (err != CURL_OK)
+        return err;
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Stream HTTP/1.1 response body through callback.
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+CurlError
+curl_receive_h1_body (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->h1_parser)
+    return CURL_ERROR_CONNECT;
+
+  session->state = CURL_STATE_READING_BODY;
+
+  if (curl_h1_is_nobody_response (session))
+    {
+      curl_h1_complete_nobody (session);
+      return CURL_OK;
+    }
+
+  SocketHTTP1_BodyMode body_mode
+      = SocketHTTP1_Parser_body_mode (session->conn->h1_parser);
+
+  if (body_mode == HTTP1_BODY_NONE)
+    {
+      curl_h1_complete_nobody (session);
+      return CURL_OK;
+    }
+
+  session->download_total = session->response.content_length;
+  session->download_received = 0;
+
+  CurlError err
+      = curl_h1_recv_body_loop (session, body_mode, curl_h1_get_timeout (session));
+  if (err != CURL_OK)
+    return err;
+
+  session->state = CURL_STATE_COMPLETE;
+  return CURL_OK;
+}
+
+/**
+ * @brief Receive complete HTTP/1.1 response (headers + body).
+ *
+ * @param session Session
+ * @return CURL_OK on success, error code on failure
+ */
+CurlError
+curl_receive_h1_response (CurlSession_T session)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  /* Receive headers */
+  CurlError err = curl_receive_h1_headers (session);
+  if (err != CURL_OK)
+    return err;
+
+  /* Receive body */
+  err = curl_receive_h1_body (session);
+  if (err != CURL_OK)
+    return err;
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Check if HTTP/1.1 connection should be kept alive.
+ *
+ * @param session Session after response
+ * @return 1 if keep-alive, 0 otherwise
+ */
+int
+curl_h1_should_keepalive (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->h1_parser)
+    return 0;
+
+  return SocketHTTP1_Parser_should_keepalive (session->conn->h1_parser);
+}
+
+/**
+ * @brief Get trailer headers (for chunked responses).
+ *
+ * @param session Session after body complete
+ * @return Trailer headers or NULL
+ */
+SocketHTTP_Headers_T
+curl_h1_get_trailers (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->h1_parser)
+    return NULL;
+
+  return SocketHTTP1_Parser_get_trailers (session->conn->h1_parser);
+}

--- a/examples/curl/src/StreamingCurl_h2.c
+++ b/examples/curl/src/StreamingCurl_h2.c
@@ -1,0 +1,529 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_h2.c
+ * @brief HTTP/2 response streaming for curl module.
+ *
+ * Implements streaming response body handling for HTTP/2:
+ * - HEADERS frame parsing
+ * - DATA frame streaming with flow control
+ * - WINDOW_UPDATE for flow control
+ * - Progress callbacks
+ * - Response size limits
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHPACK.h"
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP2.h"
+#include "socket/Socket.h"
+
+#include <errno.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Default timeout if none specified (30 seconds) */
+#define CURL_H2_DEFAULT_TIMEOUT_MS 30000
+
+/* HTTP/2 constants not in private header */
+#define MAX_HEADER_FIELD_SIZE 8192
+
+/* String lengths for header parsing */
+#define STATUS_PSEUDO_HEADER_LEN 7  /* ":status" */
+#define CONTENT_LENGTH_HEADER_LEN 14 /* "content-length" */
+#define MAX_STATUS_STRING_LEN 15
+
+/* Header formatting constants */
+#define HEADER_SEPARATOR_LEN 2       /* ": " */
+#define HEADER_LINE_TERMINATOR_LEN 2 /* "\r\n" */
+
+/**
+ * @brief Parse status code from :status pseudo-header.
+ */
+static int
+parse_status_code (const SocketHPACK_Header *h)
+{
+  char status_str[MAX_STATUS_STRING_LEN + 1];
+  size_t len
+      = h->value_len > MAX_STATUS_STRING_LEN ? MAX_STATUS_STRING_LEN : h->value_len;
+  memcpy (status_str, h->value, len);
+  status_str[len] = '\0';
+  return atoi (status_str);
+}
+
+/**
+ * @brief Check if header is the :status pseudo-header.
+ */
+static int
+is_status_header (const SocketHPACK_Header *h)
+{
+  return h->name_len == STATUS_PSEUDO_HEADER_LEN
+         && strncmp (h->name, ":status", STATUS_PSEUDO_HEADER_LEN) == 0;
+}
+
+/**
+ * @brief Check if header is a pseudo-header (starts with ':').
+ */
+static int
+is_pseudo_header (const SocketHPACK_Header *h)
+{
+  return h->name_len > 0 && h->name[0] == ':';
+}
+
+/**
+ * @brief Check if header field sizes are valid.
+ */
+static int
+is_valid_header_size (const SocketHPACK_Header *h)
+{
+  return h->name_len <= MAX_HEADER_FIELD_SIZE
+         && h->value_len <= MAX_HEADER_FIELD_SIZE;
+}
+
+/**
+ * @brief Copy a single header to the response headers collection.
+ *
+ * @return Content-length value if this is that header, -1 otherwise
+ */
+static int64_t
+copy_header_to_response (Arena_T arena, SocketHTTP_Headers_T resp_headers,
+                         const SocketHPACK_Header *h)
+{
+  char *name = ALLOC (arena, h->name_len + 1);
+  if (!name)
+    return -1;
+  memcpy (name, h->name, h->name_len);
+  name[h->name_len] = '\0';
+
+  char *value = ALLOC (arena, h->value_len + 1);
+  if (!value)
+    return -1;
+  memcpy (value, h->value, h->value_len);
+  value[h->value_len] = '\0';
+
+  SocketHTTP_Headers_set (resp_headers, name, value);
+
+  if (h->name_len == CONTENT_LENGTH_HEADER_LEN
+      && strncasecmp (h->name, "content-length", CONTENT_LENGTH_HEADER_LEN) == 0)
+    return strtoll (value, NULL, 10);
+
+  return -1;
+}
+
+/**
+ * @brief Convert HPACK headers to response structure.
+ */
+static int
+curl_h2_headers_to_response (CurlSession_T session,
+                             const SocketHPACK_Header *headers, size_t count)
+{
+  if (!session || !headers)
+    return -1;
+
+  Arena_T arena = session->request_arena;
+  SocketHTTP_Headers_T resp_headers = SocketHTTP_Headers_new (arena);
+  if (!resp_headers)
+    return -1;
+
+  int status_code = 0;
+  int64_t content_length = -1;
+
+  for (size_t i = 0; i < count; i++)
+    {
+      const SocketHPACK_Header *h = &headers[i];
+
+      if (is_status_header (h))
+        {
+          status_code = parse_status_code (h);
+          continue;
+        }
+
+      if (is_pseudo_header (h) || !is_valid_header_size (h))
+        continue;
+
+      int64_t cl = copy_header_to_response (arena, resp_headers, h);
+      if (cl >= 0)
+        content_length = cl;
+    }
+
+  session->response.status_code = status_code;
+  session->response.version = HTTP_VERSION_2;
+  session->response.headers = resp_headers;
+  session->response.content_length = content_length;
+
+  return 0;
+}
+
+/**
+ * @brief Format header line for callback: "Name: Value\r\n".
+ */
+static int
+format_header_line (Arena_T arena, const SocketHPACK_Header *h,
+                    char **out_line, size_t *out_len)
+{
+  size_t line_len
+      = h->name_len + HEADER_SEPARATOR_LEN + h->value_len + HEADER_LINE_TERMINATOR_LEN;
+  char *line = ALLOC (arena, line_len + 1);
+  if (!line)
+    return -1;
+
+  int len = snprintf (line, line_len + 1, "%.*s: %.*s\r\n", (int)h->name_len,
+                      h->name, (int)h->value_len, h->value);
+  if (len < 0)
+    return -1;
+
+  *out_line = line;
+  *out_len = (size_t)len;
+  return 0;
+}
+
+/**
+ * @brief Invoke header callback for HTTP/2 response.
+ */
+static int
+curl_h2_invoke_header_callback (CurlSession_T session,
+                                const SocketHPACK_Header *headers, size_t count)
+{
+  if (!session || !session->options.header_callback || !headers)
+    return 0;
+
+  for (size_t i = 0; i < count; i++)
+    {
+      const SocketHPACK_Header *h = &headers[i];
+
+      if (is_pseudo_header (h))
+        continue;
+
+      char *line;
+      size_t len;
+      if (format_header_line (session->request_arena, h, &line, &len) != 0)
+        continue;
+
+      size_t written = session->options.header_callback (
+          line, 1, len, session->options.header_userdata);
+
+      if (written != len)
+        return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Get effective timeout from session options.
+ */
+static int
+get_timeout_ms (CurlSession_T session)
+{
+  int timeout_ms = session->options.request_timeout_ms;
+  return timeout_ms > 0 ? timeout_ms : CURL_H2_DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * @brief Wait for readable and process HTTP/2 frames.
+ */
+static CurlError
+wait_and_process_frames (CurlConnection *conn, int timeout_ms)
+{
+  int wait_result = curl_wait_readable (conn, timeout_ms);
+  if (wait_result < 0)
+    return CURL_ERROR_CONNECT;
+  if (wait_result == 0)
+    return CURL_ERROR_TIMEOUT;
+
+  if (SocketHTTP2_Conn_process (conn->h2_conn, 0) < 0)
+    return CURL_ERROR_PROTOCOL;
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Receive and parse HTTP/2 response headers.
+ */
+CurlError
+curl_receive_h2_headers (CurlSession_T session)
+{
+  if (!session || !session->conn)
+    return CURL_ERROR_CONNECT;
+
+  CurlConnection *conn = session->conn;
+  if (!conn->h2_conn || !conn->h2_stream)
+    return CURL_ERROR_PROTOCOL;
+
+  int timeout_ms = get_timeout_ms (session);
+  session->state = CURL_STATE_READING_HEADERS;
+
+  SocketHPACK_Header headers[CURL_H2_MAX_HEADERS];
+  size_t header_count = 0;
+  int end_stream = 0;
+
+  while (1)
+    {
+      CurlError err = wait_and_process_frames (conn, timeout_ms);
+      if (err != CURL_OK)
+        return err;
+
+      int result = SocketHTTP2_Stream_recv_headers (
+          conn->h2_stream, headers, CURL_H2_MAX_HEADERS, &header_count, &end_stream);
+
+      if (result > 0)
+        break;
+      if (result < 0)
+        return CURL_ERROR_PROTOCOL;
+    }
+
+  if (curl_h2_headers_to_response (session, headers, header_count) != 0)
+    return CURL_ERROR_PROTOCOL;
+
+  if (session->options.header_callback
+      && curl_h2_invoke_header_callback (session, headers, header_count) != 0)
+    return CURL_ERROR_ABORTED;
+
+  if (end_stream)
+    {
+      session->state = CURL_STATE_COMPLETE;
+      session->download_received = 0;
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Deliver data to write callback, with optional decompression.
+ *
+ * @return 0 on success, -1 on callback error, -2 on decompression error
+ */
+static int
+deliver_data (CurlSession_T session, CurlDecompressor *decomp,
+              const char *data, size_t len,
+              unsigned char *decomp_buf, size_t decomp_buf_size)
+{
+  if (!session->options.write_callback)
+    return 0;
+
+  if (decomp && !curl_decompressor_is_identity (decomp))
+    {
+      size_t decomp_written = 0;
+      if (curl_decompressor_decompress (decomp, (const unsigned char *)data, len,
+                                        decomp_buf, decomp_buf_size, &decomp_written)
+          != 0)
+        return -2;
+
+      if (decomp_written > 0)
+        {
+          size_t cb_written = session->options.write_callback (
+              decomp_buf, 1, decomp_written, session->options.write_userdata);
+          if (cb_written != decomp_written)
+            return -1;
+        }
+    }
+  else
+    {
+      size_t cb_written = session->options.write_callback (
+          (char *)data, 1, len, session->options.write_userdata);
+      if (cb_written != len)
+        return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Invoke progress callback.
+ *
+ * @return 0 to continue, non-zero if aborted
+ */
+static int
+invoke_progress (CurlSession_T session)
+{
+  if (!session->options.progress_callback)
+    return 0;
+
+  return session->options.progress_callback (
+      session->options.progress_userdata, session->download_total,
+      session->download_received, session->upload_total, session->upload_sent);
+}
+
+/**
+ * @brief Check if response has no body.
+ */
+static int
+is_no_body_response (CurlSession_T session)
+{
+  int status = session->response.status_code;
+  return status == CURL_HTTP_STATUS_NO_CONTENT
+         || status == CURL_HTTP_STATUS_NOT_MODIFIED
+         || session->request_method == HTTP_METHOD_HEAD;
+}
+
+/**
+ * @brief Stream HTTP/2 response body through callback.
+ */
+CurlError
+curl_receive_h2_body (CurlSession_T session)
+{
+  if (!session || !session->conn)
+    return CURL_ERROR_CONNECT;
+
+  CurlConnection *conn = session->conn;
+  if (!conn->h2_conn || !conn->h2_stream)
+    return CURL_ERROR_PROTOCOL;
+
+  if (session->state == CURL_STATE_COMPLETE)
+    return CURL_OK;
+
+  if (is_no_body_response (session))
+    {
+      session->state = CURL_STATE_COMPLETE;
+      session->download_received = 0;
+      return CURL_OK;
+    }
+
+  int timeout_ms = get_timeout_ms (session);
+  session->state = CURL_STATE_READING_BODY;
+  session->download_total = session->response.content_length;
+
+  char data_buf[CURL_H2_DATA_BUFFER_SIZE];
+  unsigned char decomp_buf[CURL_H2_DECOMP_BUFFER_SIZE];
+  int end_stream = 0;
+  CurlError error = CURL_OK;
+
+  CurlDecompressor *decomp = curl_session_create_decompressor (session);
+
+  while (!end_stream)
+    {
+      error = wait_and_process_frames (conn, timeout_ms);
+      if (error != CURL_OK)
+        goto cleanup;
+
+      ssize_t nread = SocketHTTP2_Stream_recv_data (conn->h2_stream, data_buf,
+                                                    sizeof (data_buf), &end_stream);
+      if (nread < 0)
+        {
+          error = CURL_ERROR_PROTOCOL;
+          goto cleanup;
+        }
+
+      if (nread > 0)
+        {
+          SocketHTTP2_Stream_window_update (conn->h2_stream, (uint32_t)nread);
+          SocketHTTP2_Conn_window_update (conn->h2_conn, (uint32_t)nread);
+
+          int rc = deliver_data (session, decomp, data_buf, (size_t)nread,
+                                 decomp_buf, sizeof (decomp_buf));
+          if (rc == -1)
+            {
+              error = CURL_ERROR_WRITE_CALLBACK;
+              goto cleanup;
+            }
+          if (rc == -2)
+            {
+              error = CURL_ERROR_PROTOCOL;
+              goto cleanup;
+            }
+
+          session->download_received += nread;
+
+          if (invoke_progress (session) != 0)
+            {
+              error = CURL_ERROR_ABORTED;
+              goto cleanup;
+            }
+        }
+
+      SocketHTTP2_Conn_flush (conn->h2_conn);
+    }
+
+  /* Finish decompression */
+  if (decomp && !curl_decompressor_is_identity (decomp)
+      && session->options.write_callback)
+    {
+      size_t decomp_written = 0;
+      if (curl_decompressor_finish (decomp, decomp_buf, sizeof (decomp_buf),
+                                    &decomp_written)
+              == 0
+          && decomp_written > 0)
+        {
+          session->options.write_callback (decomp_buf, 1, decomp_written,
+                                           session->options.write_userdata);
+        }
+    }
+
+  session->state = CURL_STATE_COMPLETE;
+
+cleanup:
+  curl_decompressor_free (&decomp);
+  return error;
+}
+
+/**
+ * @brief Receive complete HTTP/2 response (headers + body).
+ */
+CurlError
+curl_receive_h2_response (CurlSession_T session)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  CurlError err = curl_receive_h2_headers (session);
+  if (err != CURL_OK)
+    return err;
+
+  return curl_receive_h2_body (session);
+}
+
+/**
+ * @brief Get HTTP/2 stream state.
+ */
+int
+curl_h2_stream_state (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->h2_stream)
+    return -1;
+
+  return (int)SocketHTTP2_Stream_state (session->conn->h2_stream);
+}
+
+/**
+ * @brief Close HTTP/2 stream.
+ */
+void
+curl_h2_stream_close (CurlSession_T session, int error_code)
+{
+  if (!session || !session->conn || !session->conn->h2_stream)
+    return;
+
+  SocketHTTP2_Stream_close (session->conn->h2_stream,
+                            (SocketHTTP2_ErrorCode)error_code);
+}
+
+/**
+ * @brief Get current send window for HTTP/2 stream.
+ */
+int32_t
+curl_h2_send_window (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->h2_stream)
+    return 0;
+
+  return SocketHTTP2_Stream_send_window (session->conn->h2_stream);
+}
+
+/**
+ * @brief Get current receive window for HTTP/2 stream.
+ */
+int32_t
+curl_h2_recv_window (CurlSession_T session)
+{
+  if (!session || !session->conn || !session->conn->h2_stream)
+    return 0;
+
+  return SocketHTTP2_Stream_recv_window (session->conn->h2_stream);
+}

--- a/examples/curl/src/StreamingCurl_redirect.c
+++ b/examples/curl/src/StreamingCurl_redirect.c
@@ -1,0 +1,398 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_redirect.c
+ * @brief HTTP redirect handling for curl module.
+ *
+ * Implements redirect following with proper HTTP semantics:
+ * - 301/302: POST→GET transformation (legacy behavior)
+ * - 303: Always GET
+ * - 307/308: Preserve original method
+ * - Cross-origin redirect handling
+ * - Redirect count limiting
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+
+/* URL protocol prefix lengths */
+#define HTTP_PROTOCOL_PREFIX_LEN 7  /* "http://" */
+#define HTTPS_PROTOCOL_PREFIX_LEN 8 /* "https://" */
+
+/**
+ * @brief Check if status code is a redirect.
+ *
+ * @param status HTTP status code
+ * @return 1 if redirect, 0 otherwise
+ */
+static int
+is_redirect_status (int status)
+{
+  return (status == CURL_HTTP_STATUS_MOVED_PERMANENTLY || status == CURL_HTTP_STATUS_FOUND || status == CURL_HTTP_STATUS_SEE_OTHER || status == CURL_HTTP_STATUS_TEMPORARY_REDIRECT
+          || status == CURL_HTTP_STATUS_PERMANENT_REDIRECT);
+}
+
+/**
+ * @brief Determine if method should be changed to GET.
+ *
+ * According to HTTP specs:
+ * - 301/302: POST→GET (legacy browser behavior, widely adopted)
+ * - 303: Always change to GET
+ * - 307/308: Preserve original method
+ *
+ * @param status Redirect status code
+ * @param method Original request method
+ * @return 1 if should change to GET, 0 otherwise
+ */
+static int
+should_change_method_to_get (int status, SocketHTTP_Method method)
+{
+  /* 303 See Other: always GET */
+  if (status == CURL_HTTP_STATUS_SEE_OTHER)
+    return 1;
+
+  /* 301/302: POST becomes GET (legacy behavior) */
+  if ((status == CURL_HTTP_STATUS_MOVED_PERMANENTLY || status == CURL_HTTP_STATUS_FOUND) && method == HTTP_METHOD_POST)
+    return 1;
+
+  /* 307/308: preserve method */
+  return 0;
+}
+
+/**
+ * @brief Check if two hosts match (case-insensitive).
+ *
+ * @param host1 First hostname
+ * @param len1 Length of first hostname
+ * @param host2 Second hostname
+ * @param len2 Length of second hostname
+ * @return 1 if match, 0 otherwise
+ */
+static int
+hosts_match (const char *host1, size_t len1, const char *host2, size_t len2)
+{
+  if (len1 != len2)
+    return 0;
+
+  for (size_t i = 0; i < len1; i++)
+    {
+      if (tolower ((unsigned char)host1[i])
+          != tolower ((unsigned char)host2[i]))
+        return 0;
+    }
+
+  return 1;
+}
+
+int
+curl_is_redirect (CurlSession_T session)
+{
+  if (!session)
+    return 0;
+
+  int status = session->response.status_code;
+  return is_redirect_status (status);
+}
+
+int
+curl_redirect_status (CurlSession_T session)
+{
+  if (!session)
+    return 0;
+
+  return session->response.status_code;
+}
+
+const char *
+curl_redirect_location (CurlSession_T session)
+{
+  if (!session || !session->response.headers)
+    return NULL;
+
+  return SocketHTTP_Headers_get (session->response.headers, "Location");
+}
+
+int
+curl_redirect_changes_method (CurlSession_T session)
+{
+  if (!session)
+    return 0;
+
+  int status = session->response.status_code;
+  return should_change_method_to_get (status, session->request_method);
+}
+
+SocketHTTP_Method
+curl_redirect_method (CurlSession_T session)
+{
+  if (!session)
+    return HTTP_METHOD_GET;
+
+  int status = session->response.status_code;
+
+  if (should_change_method_to_get (status, session->request_method))
+    return HTTP_METHOD_GET;
+
+  return session->request_method;
+}
+
+int
+curl_redirect_preserves_body (CurlSession_T session)
+{
+  if (!session)
+    return 0;
+
+  int status = session->response.status_code;
+
+  /* 307/308 preserve body */
+  return (status == CURL_HTTP_STATUS_TEMPORARY_REDIRECT || status == CURL_HTTP_STATUS_PERMANENT_REDIRECT);
+}
+
+int
+curl_redirect_is_cross_origin (CurlSession_T session, const char *location)
+{
+  if (!session || !location)
+    return 0;
+
+  /* Parse the location URL */
+  CurlParsedURL new_url;
+  CurlError err = curl_internal_parse_url (location, 0, &new_url,
+                                           session->request_arena);
+
+  /* If parsing fails, treat as relative URL (same origin) */
+  if (err != CURL_OK)
+    return 0;
+
+  /* Compare with current URL */
+  return !curl_urls_same_origin (&session->current_url, &new_url);
+}
+
+ssize_t
+curl_resolve_redirect_url (CurlSession_T session, const char *location,
+                           char *output, size_t output_size)
+{
+  if (!session || !location || !output || output_size == 0)
+    return -1;
+
+  /* If location is absolute URL, use as-is */
+  if (strncasecmp (location, "http://", HTTP_PROTOCOL_PREFIX_LEN) == 0
+      || strncasecmp (location, "https://", HTTPS_PROTOCOL_PREFIX_LEN) == 0)
+    {
+      size_t len = strlen (location);
+      if (len >= output_size)
+        return -1;
+
+      memcpy (output, location, len);
+      output[len] = '\0';
+      return (ssize_t)len;
+    }
+
+  /* Otherwise, resolve relative to current URL */
+  return Curl_resolve_url (&session->current_url, location, output,
+                           output_size);
+}
+
+int
+curl_parse_redirect_url (CurlSession_T session, const char *location,
+                         CurlParsedURL *result)
+{
+  if (!session || !location || !result)
+    return -1;
+
+  char resolved[CURL_MAX_URL_BUFFER_LEN];
+  ssize_t len = curl_resolve_redirect_url (session, location, resolved,
+                                           sizeof (resolved));
+  if (len < 0)
+    return -1;
+
+  CurlError err = curl_internal_parse_url (resolved, (size_t)len, result,
+                                           session->request_arena);
+  if (err != CURL_OK)
+    return -1;
+
+  return 0;
+}
+
+int
+curl_should_follow_redirect (CurlSession_T session)
+{
+  if (!session)
+    return 0;
+
+  /* Check if redirects are enabled */
+  if (!session->options.follow_redirects)
+    return 0;
+
+  /* Check if this is a redirect response */
+  if (!curl_is_redirect (session))
+    return 0;
+
+  /* Check redirect limit */
+  if ((int)session->response.redirect_count >= session->options.max_redirects)
+    return 0;
+
+  /* Check for Location header */
+  const char *location = curl_redirect_location (session);
+  if (!location || *location == '\0')
+    return 0;
+
+  return 1;
+}
+
+CurlError
+curl_prepare_redirect (CurlSession_T session)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  /* Get location header */
+  const char *location = curl_redirect_location (session);
+  if (!location)
+    return CURL_ERROR_PROTOCOL;
+
+  /* Parse the new URL */
+  CurlParsedURL new_url;
+  if (curl_parse_redirect_url (session, location, &new_url) != 0)
+    return CURL_ERROR_INVALID_URL;
+
+  /* Check if this is cross-origin */
+  int cross_origin = !curl_urls_same_origin (&session->current_url, &new_url);
+
+  /* Determine new method */
+  SocketHTTP_Method new_method = curl_redirect_method (session);
+
+  /* If cross-origin or method changes, close existing connection */
+  if (cross_origin || (new_method != session->request_method))
+    {
+      if (session->conn && !curl_connection_reusable (session->conn, &new_url))
+        {
+          curl_connection_close (session->conn);
+          session->conn = NULL;
+        }
+    }
+
+  /* Update session state */
+  curl_url_copy (&session->current_url, &new_url, session->request_arena);
+  SocketHTTP_Method original_method = session->request_method;
+  session->request_method = new_method;
+  session->response.redirect_count++;
+
+  /* Clear request body for GET redirects (303 or 301/302 from POST) */
+  if (new_method == HTTP_METHOD_GET && original_method != HTTP_METHOD_GET)
+    {
+      session->upload_total = 0;
+      session->upload_sent = 0;
+    }
+
+  /* Reset state for new request */
+  session->state = CURL_STATE_IDLE;
+
+  return CURL_OK;
+}
+
+CurlError
+curl_handle_redirect (CurlSession_T session)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  /* Check if this is a redirect response */
+  if (!curl_is_redirect (session))
+    return CURL_OK;
+
+  /* Check if redirects are enabled */
+  if (!session->options.follow_redirects)
+    return CURL_OK;
+
+  /* Check redirect limit - return error if at limit */
+  if ((int)session->response.redirect_count >= session->options.max_redirects)
+    {
+      session->state = CURL_STATE_ERROR;
+      session->last_error = CURL_ERROR_TOO_MANY_REDIRECTS;
+      return CURL_ERROR_TOO_MANY_REDIRECTS;
+    }
+
+  /* Check for Location header */
+  const char *location = curl_redirect_location (session);
+  if (!location || *location == '\0')
+    return CURL_OK;
+
+  /* Prepare for redirect */
+  return curl_prepare_redirect (session);
+}
+
+int
+curl_get_redirect_count (CurlSession_T session)
+{
+  if (!session)
+    return 0;
+
+  return (int)session->response.redirect_count;
+}
+
+int
+curl_redirect_is_secure_downgrade (CurlSession_T session, const char *location)
+{
+  if (!session || !location)
+    return 0;
+
+  /* Parse the location URL */
+  CurlParsedURL new_url;
+  char resolved[CURL_MAX_URL_BUFFER_LEN];
+  ssize_t len = curl_resolve_redirect_url (session, location, resolved,
+                                           sizeof (resolved));
+  if (len < 0)
+    return 0;
+
+  CurlError err = curl_internal_parse_url (resolved, (size_t)len, &new_url,
+                                           session->request_arena);
+  if (err != CURL_OK)
+    return 0;
+
+  /* Check if going from HTTPS to HTTP */
+  return (session->current_url.is_secure && !new_url.is_secure);
+}
+
+int
+curl_redirect_is_same_host (CurlSession_T session, const char *location)
+{
+  if (!session || !location)
+    return 0;
+
+  /* Parse the location URL */
+  CurlParsedURL new_url;
+  char resolved[CURL_MAX_URL_BUFFER_LEN];
+  ssize_t len = curl_resolve_redirect_url (session, location, resolved,
+                                           sizeof (resolved));
+  if (len < 0)
+    return 1; /* Relative URL = same host */
+
+  CurlError err = curl_internal_parse_url (resolved, (size_t)len, &new_url,
+                                           session->request_arena);
+  if (err != CURL_OK)
+    return 1; /* Parsing failed = assume same host */
+
+  /* Compare hosts */
+  return hosts_match (session->current_url.host, session->current_url.host_len,
+                      new_url.host, new_url.host_len);
+}
+
+void
+curl_reset_redirect_count (CurlSession_T session)
+{
+  if (!session)
+    return;
+
+  session->response.redirect_count = 0;
+}

--- a/examples/curl/src/StreamingCurl_request.c
+++ b/examples/curl/src/StreamingCurl_request.c
@@ -1,0 +1,679 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_request.c
+ * @brief Request building and sending layer for streaming curl module.
+ *
+ * Implements HTTP request building with:
+ * - HTTP/1.1 request serialization (RFC 9112)
+ * - HTTP/2 HEADERS frame generation (RFC 9113)
+ * - Streaming request body via callbacks
+ * - Chunked transfer encoding for HTTP/1.1
+ * - DATA frame streaming for HTTP/2
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP1.h"
+#include "http/SocketHTTP2.h"
+#include "socket/Socket.h"
+#include "socket/SocketBuf.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Default timeout if none specified (30 seconds) */
+#define CURL_REQUEST_DEFAULT_TIMEOUT_MS 30000
+
+/* Buffer sizes */
+#define HOST_PORT_BUFFER_SIZE 16
+#define CONTENT_LENGTH_BUFFER_SIZE 32
+#define CHUNK_FRAMING_OVERHEAD 64
+
+/* HTTP/1.1 chunked transfer encoding constants */
+#define FINAL_CHUNK_SIZE 5 /* Length of "0\r\n\r\n" */
+
+/* HTTP/2 stream processing timeout */
+#define H2_PROCESS_TIMEOUT_MS 0
+
+/* HPACK never-index flag for sensitive headers */
+#define HPACK_NEVER_INDEX 1
+
+/* Query string separator */
+#define QUERY_SEPARATOR_SIZE 1 /* '?' character */
+
+/*
+ * Helper macro to add an HPACK header to the headers array.
+ * Increments count and respects max_headers limit.
+ */
+#define ADD_HPACK_HEADER(headers, count, max, n, nlen, v, vlen, sensitive)     \
+  do                                                                           \
+    {                                                                          \
+      if ((count) < (max))                                                     \
+        {                                                                      \
+          (headers)[(count)].name = (n);                                       \
+          (headers)[(count)].name_len = (nlen);                                \
+          (headers)[(count)].value = (v);                                      \
+          (headers)[(count)].value_len = (vlen);                               \
+          (headers)[(count)].never_index = (sensitive);                        \
+          (count)++;                                                           \
+        }                                                                      \
+    }                                                                          \
+  while (0)
+
+/**
+ * @brief Invoke progress callback if configured.
+ * @return Non-zero if abort requested, 0 otherwise.
+ */
+static int
+invoke_progress_callback (CurlSession_T session)
+{
+  if (!session->options.progress_callback)
+    return 0;
+
+  return session->options.progress_callback (
+      session->options.progress_userdata, session->download_total,
+      session->download_received, session->upload_total, session->upload_sent);
+}
+
+/**
+ * @brief Get effective timeout from session options.
+ */
+static int
+get_request_timeout (const CurlOptions *options)
+{
+  return (options->request_timeout_ms > 0) ? options->request_timeout_ms
+                                           : CURL_REQUEST_DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * @brief Send data with timeout, handling exceptions.
+ * @return CURL_OK on success, error code on failure.
+ */
+static CurlError
+send_with_timeout (Socket_T sock, const void *data, size_t len, int timeout_ms)
+{
+  volatile ssize_t sent = 0;
+
+  TRY { sent = Socket_sendall_timeout (sock, data, len, timeout_ms); }
+  EXCEPT (Socket_Failed) { return CURL_ERROR_CONNECT; }
+  END_TRY;
+
+  return (sent >= (ssize_t)len) ? CURL_OK : CURL_ERROR_TIMEOUT;
+}
+
+/**
+ * @brief Build the request path including query string.
+ */
+static char *
+build_request_path (const CurlParsedURL *url, Arena_T arena)
+{
+  if (!url || !url->path)
+    return curl_arena_strdup (arena, "/", 1);
+
+  size_t path_len = url->path_len;
+  size_t query_len = url->query ? url->query_len + QUERY_SEPARATOR_SIZE : 0;
+  size_t total_len = path_len + query_len;
+
+  char *path = ALLOC (arena, total_len + 1);
+  memcpy (path, url->path, path_len);
+
+  if (url->query && url->query_len > 0)
+    {
+      path[path_len] = '?';
+      memcpy (path + path_len + QUERY_SEPARATOR_SIZE, url->query,
+              url->query_len);
+    }
+
+  path[total_len] = '\0';
+  return path;
+}
+
+/**
+ * @brief Build Host header value.
+ */
+static char *
+build_host_header (const CurlParsedURL *url, Arena_T arena)
+{
+  if (!url || !url->host)
+    return NULL;
+
+  int default_port
+      = url->is_secure ? CURL_HTTPS_DEFAULT_PORT : CURL_HTTP_DEFAULT_PORT;
+  int port = url->port > 0 ? url->port : default_port;
+
+  if (port == default_port)
+    return curl_arena_strdup (arena, url->host, url->host_len);
+
+  size_t buf_size = url->host_len + HOST_PORT_BUFFER_SIZE;
+  char *host = ALLOC (arena, buf_size);
+  int len
+      = snprintf (host, buf_size, "%.*s:%d", (int)url->host_len, url->host,
+                  port);
+
+  if (len < 0 || (size_t)len >= buf_size)
+    return curl_arena_strdup (arena, url->host, url->host_len);
+
+  return host;
+}
+
+/**
+ * @brief Add standard request headers.
+ */
+static int
+add_standard_headers (SocketHTTP_Headers_T headers, const CurlParsedURL *url,
+                      const CurlOptions *options, Arena_T arena)
+{
+  char *host = build_host_header (url, arena);
+  if (host && SocketHTTP_Headers_set (headers, "Host", host) != 0)
+    return -1;
+
+  if (options->user_agent
+      && SocketHTTP_Headers_set (headers, "User-Agent", options->user_agent)
+             != 0)
+    return -1;
+
+  if (SocketHTTP_Headers_set (headers, "Accept", "*/*") != 0)
+    return -1;
+
+  if (options->accept_encoding
+      && SocketHTTP_Headers_set (headers, "Accept-Encoding",
+                                 "gzip, deflate, br")
+             != 0)
+    return -1;
+
+  if (SocketHTTP_Headers_set (headers, "Connection", "keep-alive") != 0)
+    return -1;
+
+  return 0;
+}
+
+/**
+ * @brief Add custom headers from session.
+ */
+static int
+add_custom_headers (SocketHTTP_Headers_T headers,
+                    const CurlCustomHeader *custom)
+{
+  for (const CurlCustomHeader *h = custom; h; h = h->next)
+    {
+      if (SocketHTTP_Headers_set (headers, h->name, h->value) != 0)
+        return -1;
+    }
+  return 0;
+}
+
+/**
+ * @brief Add body-related headers (Content-Length or Transfer-Encoding).
+ */
+static int
+add_body_headers (SocketHTTP_Headers_T headers, size_t body_len,
+                  int has_read_callback)
+{
+  if (body_len > 0)
+    {
+      char content_len[CONTENT_LENGTH_BUFFER_SIZE];
+      snprintf (content_len, sizeof (content_len), "%zu", body_len);
+      return SocketHTTP_Headers_set (headers, "Content-Length", content_len);
+    }
+
+  if (has_read_callback)
+    return SocketHTTP_Headers_set (headers, "Transfer-Encoding", "chunked");
+
+  return 0;
+}
+
+/**
+ * @brief Build and serialize HTTP/1.1 request.
+ */
+ssize_t
+curl_build_http1_request (CurlSession_T session, SocketHTTP_Method method,
+                          const void *body, size_t body_len, char *output,
+                          size_t output_size)
+{
+  if (!session || !output || output_size == 0)
+    return -1;
+
+  Arena_T arena = session->request_arena;
+  char *path = build_request_path (&session->current_url, arena);
+
+  SocketHTTP_Headers_T headers = SocketHTTP_Headers_new (arena);
+  if (!headers)
+    return -1;
+
+  if (add_standard_headers (headers, &session->current_url, &session->options,
+                            arena)
+          != 0
+      || add_custom_headers (headers, session->custom_headers) != 0)
+    return -1;
+
+  if (session->auth_header
+      && SocketHTTP_Headers_set (headers, "Authorization", session->auth_header)
+             != 0)
+    return -1;
+
+  if (add_body_headers (headers, body_len,
+                        session->options.read_callback != NULL)
+      != 0)
+    return -1;
+
+  SocketHTTP_Request request = { 0 };
+  request.method = method;
+  request.version = HTTP_VERSION_1_1;
+  request.path = path;
+  request.headers = headers;
+  request.has_body = (body && body_len > 0) || session->options.read_callback;
+  request.content_length = (body && body_len > 0) ? (int64_t)body_len : -1;
+
+  return SocketHTTP1_serialize_request (&request, output, output_size);
+}
+
+/**
+ * @brief Send HTTP/1.1 request with optional body.
+ */
+CurlError
+curl_send_http1_request (CurlSession_T session, SocketHTTP_Method method,
+                         const void *body, size_t body_len)
+{
+  if (!session || !session->conn || !session->conn->socket)
+    return CURL_ERROR_CONNECT;
+
+  int timeout_ms = get_request_timeout (&session->options);
+  char buffer[CURL_REQUEST_BUFFER_SIZE];
+
+  ssize_t header_len = curl_build_http1_request (session, method, body,
+                                                 body_len, buffer,
+                                                 sizeof (buffer));
+  if (header_len < 0)
+    return CURL_ERROR_PROTOCOL;
+
+  Socket_T sock = session->conn->socket;
+
+  CurlError err = send_with_timeout (sock, buffer, (size_t)header_len,
+                                     timeout_ms);
+  if (err != CURL_OK)
+    return err;
+
+  if (body && body_len > 0)
+    {
+      err = send_with_timeout (sock, body, body_len, timeout_ms);
+      if (err != CURL_OK)
+        return err;
+      session->upload_sent = (int64_t)body_len;
+    }
+  else if (session->options.read_callback)
+    {
+      return curl_send_chunked_body (session);
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Send chunked body using read callback.
+ */
+CurlError
+curl_send_chunked_body (CurlSession_T session)
+{
+  if (!session || !session->options.read_callback)
+    return CURL_ERROR_READ_CALLBACK;
+
+  if (!session->conn || !session->conn->socket)
+    return CURL_ERROR_CONNECT;
+
+  int timeout_ms = get_request_timeout (&session->options);
+  Socket_T sock = session->conn->socket;
+  char data_buf[CURL_CHUNK_BUFFER_SIZE];
+  char chunk_buf[CURL_CHUNK_BUFFER_SIZE + CHUNK_FRAMING_OVERHEAD];
+
+  session->upload_sent = 0;
+
+  while (1)
+    {
+      size_t nread = session->options.read_callback (
+          data_buf, 1, sizeof (data_buf), session->options.read_userdata);
+
+      if (nread == CURL_READFUNC_ABORT)
+        return CURL_ERROR_ABORTED;
+
+      if (nread == 0)
+        {
+          CurlError err = send_with_timeout (sock, "0\r\n\r\n", FINAL_CHUNK_SIZE,
+                                             timeout_ms);
+          if (err != CURL_OK)
+            return err;
+          break;
+        }
+
+      ssize_t chunk_len
+          = SocketHTTP1_chunk_encode (data_buf, nread, chunk_buf,
+                                      sizeof (chunk_buf));
+      if (chunk_len < 0)
+        return CURL_ERROR_PROTOCOL;
+
+      CurlError err = send_with_timeout (sock, chunk_buf, (size_t)chunk_len,
+                                         timeout_ms);
+      if (err != CURL_OK)
+        return err;
+
+      session->upload_sent += (int64_t)nread;
+
+      if (invoke_progress_callback (session))
+        return CURL_ERROR_ABORTED;
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Initialize HTTP/2 connection if not already done.
+ */
+static int
+ensure_h2_connection (CurlSession_T session)
+{
+  if (!session || !session->conn)
+    return -1;
+
+  if (session->conn->h2_conn)
+    return 0;
+
+  SocketHTTP2_Config config;
+  SocketHTTP2_config_defaults (&config, HTTP2_ROLE_CLIENT);
+
+  session->conn->h2_conn
+      = SocketHTTP2_Conn_new (session->conn->socket, &config, session->arena);
+  if (!session->conn->h2_conn)
+    return -1;
+
+  if (SocketHTTP2_Conn_handshake (session->conn->h2_conn) < 0)
+    {
+      SocketHTTP2_Conn_free (&session->conn->h2_conn);
+      return -1;
+    }
+
+  return 0;
+}
+
+/**
+ * @brief Build HTTP/2 pseudo-headers and regular headers.
+ */
+static int
+build_h2_headers (CurlSession_T session, SocketHTTP_Method method,
+                  SocketHPACK_Header *headers, size_t max_headers,
+                  size_t *header_count)
+{
+  if (!session || !headers || !header_count)
+    return -1;
+
+  Arena_T arena = session->request_arena;
+  size_t count = 0;
+
+  /* Pseudo-headers (required) */
+  const char *method_str = SocketHTTP_method_name (method);
+  if (!method_str)
+    method_str = "GET";
+
+  ADD_HPACK_HEADER (headers, count, max_headers, ":method", 7, method_str,
+                    strlen (method_str), 0);
+
+  const char *scheme = session->current_url.is_secure ? "https" : "http";
+  ADD_HPACK_HEADER (headers, count, max_headers, ":scheme", 7, scheme,
+                    strlen (scheme), 0);
+
+  char *authority = build_host_header (&session->current_url, arena);
+  if (authority)
+    ADD_HPACK_HEADER (headers, count, max_headers, ":authority", 10, authority,
+                      strlen (authority), 0);
+
+  char *path = build_request_path (&session->current_url, arena);
+  ADD_HPACK_HEADER (headers, count, max_headers, ":path", 5, path,
+                    strlen (path), 0);
+
+  /* Regular headers */
+  if (session->options.user_agent)
+    ADD_HPACK_HEADER (headers, count, max_headers, "user-agent", 10,
+                      session->options.user_agent,
+                      strlen (session->options.user_agent), 0);
+
+  ADD_HPACK_HEADER (headers, count, max_headers, "accept", 6, "*/*", 3, 0);
+
+  if (session->options.accept_encoding)
+    ADD_HPACK_HEADER (headers, count, max_headers, "accept-encoding", 15,
+                      "gzip, deflate, br", 17, 0);
+
+  if (session->auth_header)
+    ADD_HPACK_HEADER (headers, count, max_headers, "authorization", 13,
+                      session->auth_header, strlen (session->auth_header),
+                      HPACK_NEVER_INDEX);
+
+  /* Custom headers */
+  for (const CurlCustomHeader *h = session->custom_headers; h; h = h->next)
+    ADD_HPACK_HEADER (headers, count, max_headers, h->name, strlen (h->name),
+                      h->value, strlen (h->value), 0);
+
+  *header_count = count;
+  return 0;
+}
+
+/**
+ * @brief Send HTTP/2 request with optional body.
+ */
+CurlError
+curl_send_http2_request (CurlSession_T session, SocketHTTP_Method method,
+                         const void *body, size_t body_len)
+{
+  if (!session)
+    return CURL_ERROR_CONNECT;
+
+  if (ensure_h2_connection (session) != 0)
+    return CURL_ERROR_PROTOCOL;
+
+  SocketHTTP2_Stream_T stream
+      = SocketHTTP2_Stream_new (session->conn->h2_conn);
+  if (!stream)
+    return CURL_ERROR_PROTOCOL;
+
+  session->conn->h2_stream = stream;
+
+  SocketHPACK_Header headers[CURL_MAX_HEADER_COUNT_SMALL];
+  size_t header_count = 0;
+
+  if (build_h2_headers (session, method, headers, CURL_MAX_HEADER_COUNT_SMALL,
+                        &header_count)
+      != 0)
+    return CURL_ERROR_PROTOCOL;
+
+  int has_body = (body && body_len > 0) || session->options.read_callback;
+
+  if (SocketHTTP2_Stream_send_headers (stream, headers, header_count, !has_body)
+      != 0)
+    return CURL_ERROR_PROTOCOL;
+
+  SocketHTTP2_Conn_flush (session->conn->h2_conn);
+
+  if (body && body_len > 0)
+    return curl_send_h2_data (session, body, body_len, 1);
+
+  if (session->options.read_callback)
+    return curl_send_h2_streaming_body (session);
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Send DATA frame(s) for HTTP/2.
+ */
+CurlError
+curl_send_h2_data (CurlSession_T session, const void *data, size_t len,
+                   int end_stream)
+{
+  if (!session || !session->conn || !session->conn->h2_stream)
+    return CURL_ERROR_CONNECT;
+
+  SocketHTTP2_Stream_T stream = session->conn->h2_stream;
+  const unsigned char *ptr = (const unsigned char *)data;
+  size_t remaining = len;
+
+  while (remaining > 0)
+    {
+      size_t chunk_size
+          = (remaining > CURL_CHUNK_BUFFER_SIZE) ? CURL_CHUNK_BUFFER_SIZE
+                                                 : remaining;
+      int is_last = (remaining <= CURL_CHUNK_BUFFER_SIZE) && end_stream;
+
+      ssize_t sent
+          = SocketHTTP2_Stream_send_data (stream, ptr, chunk_size, is_last);
+
+      if (sent < 0)
+        return CURL_ERROR_PROTOCOL;
+
+      if (sent == 0)
+        {
+          /* Flow control - need to wait */
+          SocketHTTP2_Conn_process (session->conn->h2_conn,
+                                    H2_PROCESS_TIMEOUT_MS);
+          SocketHTTP2_Conn_flush (session->conn->h2_conn);
+          continue;
+        }
+
+      ptr += sent;
+      remaining -= (size_t)sent;
+      session->upload_sent += sent;
+
+      if (invoke_progress_callback (session))
+        return CURL_ERROR_ABORTED;
+    }
+
+  SocketHTTP2_Conn_flush (session->conn->h2_conn);
+  return CURL_OK;
+}
+
+/**
+ * @brief Send streaming body for HTTP/2 using read callback.
+ */
+CurlError
+curl_send_h2_streaming_body (CurlSession_T session)
+{
+  if (!session || !session->options.read_callback)
+    return CURL_ERROR_READ_CALLBACK;
+
+  if (!session->conn || !session->conn->h2_stream)
+    return CURL_ERROR_CONNECT;
+
+  char data_buf[CURL_CHUNK_BUFFER_SIZE];
+  session->upload_sent = 0;
+
+  while (1)
+    {
+      size_t nread = session->options.read_callback (
+          data_buf, 1, sizeof (data_buf), session->options.read_userdata);
+
+      if (nread == CURL_READFUNC_ABORT)
+        return CURL_ERROR_ABORTED;
+
+      if (nread == 0)
+        {
+          SocketHTTP2_Stream_send_data (session->conn->h2_stream, NULL, 0, 1);
+          SocketHTTP2_Conn_flush (session->conn->h2_conn);
+          break;
+        }
+
+      CurlError err = curl_send_h2_data (session, data_buf, nread, 0);
+      if (err != CURL_OK)
+        return err;
+    }
+
+  return CURL_OK;
+}
+
+/**
+ * @brief Send request using appropriate protocol.
+ */
+CurlError
+curl_send_request (CurlSession_T session, SocketHTTP_Method method,
+                   const void *body, size_t body_len)
+{
+  if (!session || !session->conn)
+    return CURL_ERROR_CONNECT;
+
+  session->state = CURL_STATE_SENDING_REQUEST;
+  session->request_method = method;
+
+  /* Initialize transfer state */
+  session->upload_total = body_len > 0 ? (int64_t)body_len : -1;
+  session->upload_sent = 0;
+  session->download_total = -1;
+  session->download_received = 0;
+
+  CurlError result = curl_connection_is_http2 (session->conn)
+                         ? curl_send_http2_request (session, method, body,
+                                                    body_len)
+                         : curl_send_http1_request (session, method, body,
+                                                    body_len);
+
+  session->state = (result == CURL_OK) ? CURL_STATE_READING_HEADERS
+                                       : CURL_STATE_ERROR;
+  if (result != CURL_OK)
+    session->last_error = result;
+
+  return result;
+}
+
+/**
+ * @brief Build request headers for a session.
+ */
+int
+curl_build_request_headers (CurlSession_T session, SocketHTTP_Method method,
+                            const char *content_type, size_t body_len)
+{
+  if (!session)
+    return -1;
+
+  (void)method; /* Reserved for future use */
+
+  Arena_T arena = session->request_arena;
+
+  session->request_headers = SocketHTTP_Headers_new (arena);
+  if (!session->request_headers)
+    return -1;
+
+  if (add_standard_headers (session->request_headers, &session->current_url,
+                            &session->options, arena)
+          != 0
+      || add_custom_headers (session->request_headers, session->custom_headers)
+             != 0)
+    return -1;
+
+  if (content_type
+      && SocketHTTP_Headers_set (session->request_headers, "Content-Type",
+                                 content_type)
+             != 0)
+    return -1;
+
+  /* Add Content-Length or Transfer-Encoding */
+  if (body_len > 0)
+    {
+      char len_str[CONTENT_LENGTH_BUFFER_SIZE];
+      snprintf (len_str, sizeof (len_str), "%zu", body_len);
+      if (SocketHTTP_Headers_set (session->request_headers, "Content-Length",
+                                  len_str)
+          != 0)
+        return -1;
+    }
+  else if (session->options.read_callback
+           && (!session->conn || !curl_connection_is_http2 (session->conn)))
+    {
+      if (SocketHTTP_Headers_set (session->request_headers, "Transfer-Encoding",
+                                  "chunked")
+          != 0)
+        return -1;
+    }
+
+  return 0;
+}

--- a/examples/curl/src/StreamingCurl_url.c
+++ b/examples/curl/src/StreamingCurl_url.c
@@ -1,0 +1,480 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file StreamingCurl_url.c
+ * @brief URL parsing implementation for streaming curl module.
+ *
+ * Wraps SocketHTTP_URI_parse() with curl-specific validation and
+ * convenience functions.
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/StreamingCurl.h"
+#include "http/SocketHTTP.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <string.h>
+
+/* URL parsing constants */
+#define HTTP_SCHEME_LEN 4
+#define HTTPS_SCHEME_LEN 5
+#define HTTP_SCHEME_PREFIX_LEN 7    /* "http://" */
+#define HTTPS_SCHEME_PREFIX_LEN 8   /* "https://" */
+#define DEFAULT_PATH "/"
+#define DEFAULT_PATH_LEN 1
+#define QUERY_CHAR_LEN 1            /* '?' */
+#define PATH_SEPARATOR_LEN 1        /* '/' */
+
+/* Exception definitions - format: { &self, "reason" } */
+const Except_T Curl_Failed = { &Curl_Failed, "Curl operation failed" };
+const Except_T Curl_DNSFailed = { &Curl_DNSFailed, "DNS resolution failed" };
+const Except_T Curl_ConnectFailed
+    = { &Curl_ConnectFailed, "Connection failed" };
+const Except_T Curl_TLSFailed = { &Curl_TLSFailed, "TLS handshake failed" };
+const Except_T Curl_Timeout = { &Curl_Timeout, "Operation timed out" };
+const Except_T Curl_ProtocolError
+    = { &Curl_ProtocolError, "HTTP protocol error" };
+const Except_T Curl_TooManyRedirects
+    = { &Curl_TooManyRedirects, "Too many redirects" };
+const Except_T Curl_InvalidURL = { &Curl_InvalidURL, "Invalid URL" };
+
+/* Error message table */
+static const char *error_strings[]
+    = { [CURL_OK] = "Success",
+        [CURL_ERROR_DNS] = "DNS resolution failed",
+        [CURL_ERROR_CONNECT] = "Connection failed",
+        [CURL_ERROR_TLS] = "TLS handshake failed",
+        [CURL_ERROR_TIMEOUT] = "Operation timed out",
+        [CURL_ERROR_PROTOCOL] = "HTTP protocol error",
+        [CURL_ERROR_TOO_MANY_REDIRECTS] = "Too many redirects",
+        [CURL_ERROR_INVALID_URL] = "Invalid URL",
+        [CURL_ERROR_WRITE_CALLBACK] = "Write callback failed",
+        [CURL_ERROR_READ_CALLBACK] = "Read callback failed",
+        [CURL_ERROR_OUT_OF_MEMORY] = "Out of memory",
+        [CURL_ERROR_ABORTED] = "Operation aborted" };
+
+const char *
+Curl_error_string (CurlError error)
+{
+  if (error >= 0 && error <= CURL_ERROR_ABORTED)
+    return error_strings[error];
+  return "Unknown error";
+}
+
+char *
+curl_arena_strdup (Arena_T arena, const char *str, size_t len)
+{
+  if (!str || len == 0)
+    return NULL;
+
+  char *copy = ALLOC (arena, len + 1);
+  memcpy (copy, str, len);
+  copy[len] = '\0';
+  return copy;
+}
+
+/**
+ * @brief Check if scheme is http or https.
+ */
+static int
+is_http_scheme (const char *scheme, size_t len)
+{
+  if (len == HTTP_SCHEME_LEN && strncasecmp (scheme, "http", HTTP_SCHEME_LEN) == 0)
+    return 1;
+  if (len == HTTPS_SCHEME_LEN && strncasecmp (scheme, "https", HTTPS_SCHEME_LEN) == 0)
+    return 1;
+  return 0;
+}
+
+CurlError
+Curl_parse_url (const char *url, size_t len, CurlParsedURL *result,
+                Arena_T arena)
+{
+  if (!url || !result || !arena)
+    return CURL_ERROR_INVALID_URL;
+
+  if (len == 0)
+    len = strlen (url);
+
+  /* Clear result */
+  memset (result, 0, sizeof (*result));
+
+  /* Use the existing URI parser */
+  SocketHTTP_URI uri;
+  SocketHTTP_URIResult parse_result
+      = SocketHTTP_URI_parse (url, len, &uri, arena);
+
+  if (parse_result != URI_PARSE_OK)
+    return CURL_ERROR_INVALID_URL;
+
+  /* Validate scheme is http or https */
+  if (!uri.scheme || !is_http_scheme (uri.scheme, uri.scheme_len))
+    return CURL_ERROR_INVALID_URL;
+
+  /* Validate host is present */
+  if (!uri.host || uri.host_len == 0)
+    return CURL_ERROR_INVALID_URL;
+
+  /* Copy components to result */
+  result->scheme = curl_arena_strdup (arena, uri.scheme, uri.scheme_len);
+  result->scheme_len = uri.scheme_len;
+
+  if (uri.userinfo && uri.userinfo_len > 0)
+    {
+      result->userinfo
+          = curl_arena_strdup (arena, uri.userinfo, uri.userinfo_len);
+      result->userinfo_len = uri.userinfo_len;
+    }
+
+  result->host = curl_arena_strdup (arena, uri.host, uri.host_len);
+  result->host_len = uri.host_len;
+
+  /* Determine if secure */
+  result->is_secure = SocketHTTP_URI_is_secure (&uri);
+
+  /* Handle port */
+  if (uri.port > 0)
+    {
+      result->port = uri.port;
+    }
+  else
+    {
+      result->port = result->is_secure ? CURL_HTTPS_DEFAULT_PORT : CURL_HTTP_DEFAULT_PORT;
+    }
+
+  /* Handle path - default to "/" if empty */
+  if (uri.path && uri.path_len > 0)
+    {
+      result->path = curl_arena_strdup (arena, uri.path, uri.path_len);
+      result->path_len = uri.path_len;
+    }
+  else
+    {
+      result->path = curl_arena_strdup (arena, DEFAULT_PATH, DEFAULT_PATH_LEN);
+      result->path_len = DEFAULT_PATH_LEN;
+    }
+
+  /* Copy query string if present */
+  if (uri.query && uri.query_len > 0)
+    {
+      result->query = curl_arena_strdup (arena, uri.query, uri.query_len);
+      result->query_len = uri.query_len;
+    }
+
+  /* Copy fragment if present */
+  if (uri.fragment && uri.fragment_len > 0)
+    {
+      result->fragment
+          = curl_arena_strdup (arena, uri.fragment, uri.fragment_len);
+      result->fragment_len = uri.fragment_len;
+    }
+
+  return CURL_OK;
+}
+
+int
+Curl_url_get_port (const CurlParsedURL *url)
+{
+  if (!url)
+    return CURL_HTTP_DEFAULT_PORT;
+
+  if (url->port > 0)
+    return url->port;
+
+  return url->is_secure ? CURL_HTTPS_DEFAULT_PORT : CURL_HTTP_DEFAULT_PORT;
+}
+
+ssize_t
+Curl_resolve_url (const CurlParsedURL *base, const char *relative,
+                  char *result, size_t result_size)
+{
+  if (!base || !relative || !result || result_size == 0)
+    return -1;
+
+  size_t rel_len = strlen (relative);
+  if (rel_len == 0)
+    return -1;
+
+  /* Check if relative is actually an absolute URL */
+  if (rel_len > HTTP_SCHEME_PREFIX_LEN
+      && (strncasecmp (relative, "http://", HTTP_SCHEME_PREFIX_LEN) == 0
+          || strncasecmp (relative, "https://", HTTPS_SCHEME_PREFIX_LEN) == 0))
+    {
+      /* It's an absolute URL, just copy it */
+      if (rel_len >= result_size)
+        return -1;
+      memcpy (result, relative, rel_len);
+      result[rel_len] = '\0';
+      return (ssize_t)rel_len;
+    }
+
+  /* Build the resolved URL */
+  size_t written = 0;
+  int n;
+
+  /* Start with scheme and host */
+  n = snprintf (result + written, result_size - written, "%s://",
+                base->scheme);
+  if (n < 0 || (size_t)n >= result_size - written)
+    return -1;
+  written += (size_t)n;
+
+  /* Add host */
+  if (base->host_len + written >= result_size)
+    return -1;
+  memcpy (result + written, base->host, base->host_len);
+  written += base->host_len;
+
+  /* Add port if non-default */
+  int default_port = base->is_secure ? CURL_HTTPS_DEFAULT_PORT : CURL_HTTP_DEFAULT_PORT;
+  if (base->port > 0 && base->port != default_port)
+    {
+      n = snprintf (result + written, result_size - written, ":%d",
+                    base->port);
+      if (n < 0 || (size_t)n >= result_size - written)
+        return -1;
+      written += (size_t)n;
+    }
+
+  /* Handle different relative URL forms */
+  if (relative[0] == '/')
+    {
+      /* Absolute path */
+      if (rel_len + written >= result_size)
+        return -1;
+      memcpy (result + written, relative, rel_len);
+      written += rel_len;
+    }
+  else if (relative[0] == '?')
+    {
+      /* Query string only - use base path */
+      if (base->path_len + written >= result_size)
+        return -1;
+      memcpy (result + written, base->path, base->path_len);
+      written += base->path_len;
+
+      if (rel_len + written >= result_size)
+        return -1;
+      memcpy (result + written, relative, rel_len);
+      written += rel_len;
+    }
+  else if (relative[0] == '#')
+    {
+      /* Fragment only - use base path and query */
+      if (base->path_len + written >= result_size)
+        return -1;
+      memcpy (result + written, base->path, base->path_len);
+      written += base->path_len;
+
+      if (base->query && base->query_len > 0)
+        {
+          if (QUERY_CHAR_LEN + base->query_len + written >= result_size)
+            return -1;
+          result[written++] = '?';
+          memcpy (result + written, base->query, base->query_len);
+          written += base->query_len;
+        }
+
+      if (rel_len + written >= result_size)
+        return -1;
+      memcpy (result + written, relative, rel_len);
+      written += rel_len;
+    }
+  else
+    {
+      /* Relative path - need to merge with base path */
+      /* Find the last slash in base path */
+      const char *last_slash = NULL;
+      if (base->path)
+        {
+          for (size_t i = base->path_len; i > 0; i--)
+            {
+              if (base->path[i - 1] == '/')
+                {
+                  last_slash = base->path + i - 1;
+                  break;
+                }
+            }
+        }
+
+      if (last_slash)
+        {
+          /* Copy base path up to and including last slash */
+          size_t prefix_len = (size_t)(last_slash - base->path) + 1;
+          if (prefix_len + written >= result_size)
+            return -1;
+          memcpy (result + written, base->path, prefix_len);
+          written += prefix_len;
+        }
+      else
+        {
+          /* No slash in base path, start from root */
+          if (PATH_SEPARATOR_LEN + written >= result_size)
+            return -1;
+          result[written++] = '/';
+        }
+
+      /* Append relative path */
+      if (rel_len + written >= result_size)
+        return -1;
+      memcpy (result + written, relative, rel_len);
+      written += rel_len;
+    }
+
+  result[written] = '\0';
+  return (ssize_t)written;
+}
+
+/* Internal helper used by other modules */
+CurlError
+curl_internal_parse_url (const char *url, size_t len, CurlParsedURL *result,
+                         Arena_T arena)
+{
+  return Curl_parse_url (url, len, result, arena);
+}
+
+int
+curl_urls_same_origin (const CurlParsedURL *a, const CurlParsedURL *b)
+{
+  if (!a || !b)
+    return 0;
+
+  /* Compare scheme (case-insensitive) */
+  if (a->scheme_len != b->scheme_len)
+    return 0;
+  if (strncasecmp (a->scheme, b->scheme, a->scheme_len) != 0)
+    return 0;
+
+  /* Compare host (case-insensitive) */
+  if (a->host_len != b->host_len)
+    return 0;
+  if (strncasecmp (a->host, b->host, a->host_len) != 0)
+    return 0;
+
+  /* Compare port */
+  int port_a = Curl_url_get_port (a);
+  int port_b = Curl_url_get_port (b);
+  if (port_a != port_b)
+    return 0;
+
+  return 1;
+}
+
+void
+curl_url_copy (CurlParsedURL *dst, const CurlParsedURL *src, Arena_T arena)
+{
+  if (!dst || !src || !arena)
+    return;
+
+  memset (dst, 0, sizeof (*dst));
+
+  if (src->scheme)
+    {
+      dst->scheme = curl_arena_strdup (arena, src->scheme, src->scheme_len);
+      dst->scheme_len = src->scheme_len;
+    }
+
+  if (src->userinfo)
+    {
+      dst->userinfo
+          = curl_arena_strdup (arena, src->userinfo, src->userinfo_len);
+      dst->userinfo_len = src->userinfo_len;
+    }
+
+  if (src->host)
+    {
+      dst->host = curl_arena_strdup (arena, src->host, src->host_len);
+      dst->host_len = src->host_len;
+    }
+
+  dst->port = src->port;
+
+  if (src->path)
+    {
+      dst->path = curl_arena_strdup (arena, src->path, src->path_len);
+      dst->path_len = src->path_len;
+    }
+
+  if (src->query)
+    {
+      dst->query = curl_arena_strdup (arena, src->query, src->query_len);
+      dst->query_len = src->query_len;
+    }
+
+  if (src->fragment)
+    {
+      dst->fragment
+          = curl_arena_strdup (arena, src->fragment, src->fragment_len);
+      dst->fragment_len = src->fragment_len;
+    }
+
+  dst->is_secure = src->is_secure;
+}
+
+void
+Curl_options_defaults (CurlOptions *options)
+{
+  if (!options)
+    return;
+
+  memset (options, 0, sizeof (*options));
+
+  /* Protocol settings */
+  options->max_version = HTTP_VERSION_2;
+  options->allow_http2_cleartext = 0;
+
+  /* Timeouts */
+  options->connect_timeout_ms = CURL_DEFAULT_CONNECT_TIMEOUT_MS;
+  options->request_timeout_ms = CURL_DEFAULT_REQUEST_TIMEOUT_MS; /* No limit */
+  options->dns_timeout_ms = CURL_DEFAULT_DNS_TIMEOUT_MS;
+
+  /* Redirects */
+  options->follow_redirects = 1;
+  options->max_redirects = CURL_DEFAULT_MAX_REDIRECTS;
+
+  /* TLS */
+  options->tls_context = NULL;
+  options->verify_ssl = 1;
+
+  /* Proxy */
+  options->proxy_url = NULL;
+
+  /* Request settings */
+  options->user_agent = "tetsuo-curl/1.0";
+  options->accept_encoding = 1;
+  options->auto_decompress = 1;
+
+  /* Callbacks */
+  options->write_callback = NULL;
+  options->write_userdata = NULL;
+  options->read_callback = NULL;
+  options->read_userdata = NULL;
+  options->progress_callback = NULL;
+  options->progress_userdata = NULL;
+  options->header_callback = NULL;
+  options->header_userdata = NULL;
+
+  /* Authentication */
+  options->auth.type = CURL_AUTH_NONE;
+  options->auth.username = NULL;
+  options->auth.password = NULL;
+  options->auth.token = NULL;
+
+  /* Cookies */
+  options->cookie_file = NULL;
+
+  /* Retry */
+  options->enable_retry = 0;
+  options->max_retries = CURL_DEFAULT_MAX_RETRIES;
+  options->retry_on_connection_error = 1;
+  options->retry_on_timeout = 1;
+  options->retry_on_5xx = 0;
+
+  /* Debug */
+  options->verbose = 0;
+}

--- a/examples/curl/src/curl_args.c
+++ b/examples/curl/src/curl_args.c
@@ -1,0 +1,611 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file curl_args.c
+ * @brief Command-line argument parsing for tcurl CLI tool.
+ *
+ * Parses curl-compatible command-line arguments and populates
+ * a TcurlOptions structure for the main program.
+ */
+
+#include "curl/StreamingCurl-private.h"
+#include "curl/curl_args.h"
+
+#include <ctype.h>
+#include <errno.h>
+#include <getopt.h>
+#include <limits.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Default values */
+#define DEFAULT_USER_AGENT "tcurl/1.0"
+#define DEFAULT_CONNECT_TIMEOUT 30
+#define DEFAULT_MAX_TIME 0
+
+/* Option values for long-only options (no short equivalent) */
+#define OPT_DATA_RAW 256
+#define OPT_DATA_BINARY 257
+#define OPT_HTTP2 258
+#define OPT_HTTP11 259
+#define OPT_HTTP10 260
+#define OPT_CONNECT_TIMEOUT 261
+#define OPT_COMPRESSED 262
+#define OPT_FAIL_WITH_BODY 263
+#define OPT_MAX_REDIRS 264
+#define OPT_RETRY 265
+
+/* Long options table */
+static struct option long_options[]
+    = { { "request", required_argument, NULL, 'X' },
+        { "header", required_argument, NULL, 'H' },
+        { "data", required_argument, NULL, 'd' },
+        { "data-raw", required_argument, NULL, OPT_DATA_RAW },
+        { "data-binary", required_argument, NULL, OPT_DATA_BINARY },
+        { "form", required_argument, NULL, 'F' },
+        { "output", required_argument, NULL, 'o' },
+        { "remote-name", no_argument, NULL, 'O' },
+        { "location", no_argument, NULL, 'L' },
+        { "insecure", no_argument, NULL, 'k' },
+        { "proxy", required_argument, NULL, 'x' },
+        { "user", required_argument, NULL, 'u' },
+        { "cookie", required_argument, NULL, 'b' },
+        { "cookie-jar", required_argument, NULL, 'c' },
+        { "user-agent", required_argument, NULL, 'A' },
+        { "referer", required_argument, NULL, 'e' },
+        { "verbose", no_argument, NULL, 'v' },
+        { "silent", no_argument, NULL, 's' },
+        { "show-error", no_argument, NULL, 'S' },
+        { "include", no_argument, NULL, 'i' },
+        { "head", no_argument, NULL, 'I' },
+        { "write-out", required_argument, NULL, 'w' },
+        { "http2", no_argument, NULL, OPT_HTTP2 },
+        { "http1.1", no_argument, NULL, OPT_HTTP11 },
+        { "http1.0", no_argument, NULL, OPT_HTTP10 },
+        { "connect-timeout", required_argument, NULL, OPT_CONNECT_TIMEOUT },
+        { "max-time", required_argument, NULL, 'm' },
+        { "compressed", no_argument, NULL, OPT_COMPRESSED },
+        { "fail", no_argument, NULL, 'f' },
+        { "fail-with-body", no_argument, NULL, OPT_FAIL_WITH_BODY },
+        { "max-redirs", required_argument, NULL, OPT_MAX_REDIRS },
+        { "retry", required_argument, NULL, OPT_RETRY },
+        { "help", no_argument, NULL, 'h' },
+        { "version", no_argument, NULL, 'V' },
+        { NULL, 0, NULL, 0 } };
+
+/* Short options string */
+static const char *short_options = "X:H:d:F:o:OLkx:u:b:c:A:e:vsSiIw:m:fhV";
+
+/*
+ * Data-driven option handling tables
+ */
+
+/* Boolean flag option: sets an int field to 1 */
+typedef struct
+{
+  int opt_val;
+  size_t offset;
+} BoolOption;
+
+/* String option: sets a const char* field to optarg */
+typedef struct
+{
+  int opt_val;
+  size_t offset;
+} StringOption;
+
+/* Integer option: parses optarg and sets an int field */
+typedef struct
+{
+  int opt_val;
+  size_t offset;
+  const char *name;
+} IntOption;
+
+/* HTTP version option: sets http_version field to a specific value */
+typedef struct
+{
+  int opt_val;
+  TcurlHttpVersion version;
+} HttpVersionOption;
+
+/* HTTP method mapping for Tcurl_get_http_method */
+typedef struct
+{
+  const char *name;
+  SocketHTTP_Method method;
+} HttpMethodEntry;
+
+/* Boolean options table */
+static const BoolOption bool_options[] = {
+  { 'O', offsetof (TcurlOptions, remote_name) },
+  { 'L', offsetof (TcurlOptions, follow_redirects) },
+  { 'k', offsetof (TcurlOptions, insecure) },
+  { 'v', offsetof (TcurlOptions, verbose) },
+  { 's', offsetof (TcurlOptions, silent) },
+  { 'S', offsetof (TcurlOptions, show_error) },
+  { 'i', offsetof (TcurlOptions, include_headers) },
+  { 'f', offsetof (TcurlOptions, fail_on_error) },
+  { 'h', offsetof (TcurlOptions, show_help) },
+  { 'V', offsetof (TcurlOptions, show_version) },
+  { OPT_COMPRESSED, offsetof (TcurlOptions, compressed) },
+  { 0, 0 }
+};
+
+/* String options table */
+static const StringOption string_options[] = {
+  { 'X', offsetof (TcurlOptions, method) },
+  { 'o', offsetof (TcurlOptions, output_file) },
+  { 'x', offsetof (TcurlOptions, proxy) },
+  { 'u', offsetof (TcurlOptions, user) },
+  { 'b', offsetof (TcurlOptions, cookie_file) },
+  { 'c', offsetof (TcurlOptions, cookie_jar) },
+  { 'A', offsetof (TcurlOptions, user_agent) },
+  { 'e', offsetof (TcurlOptions, referer) },
+  { 'w', offsetof (TcurlOptions, write_out) },
+  { 0, 0 }
+};
+
+/* Integer options table */
+static const IntOption int_options[] = {
+  { OPT_CONNECT_TIMEOUT, offsetof (TcurlOptions, connect_timeout),
+    "connect-timeout" },
+  { 'm', offsetof (TcurlOptions, max_time), "max-time" },
+  { OPT_MAX_REDIRS, offsetof (TcurlOptions, max_redirects), "max-redirs" },
+  { OPT_RETRY, offsetof (TcurlOptions, retry_count), "retry count" },
+  { 0, 0, NULL }
+};
+
+/* HTTP version options table */
+static const HttpVersionOption http_version_options[] = {
+  { OPT_HTTP2, TCURL_HTTP_2 },
+  { OPT_HTTP11, TCURL_HTTP_1_1 },
+  { OPT_HTTP10, TCURL_HTTP_1_0 },
+  { 0, 0 }
+};
+
+/* HTTP method lookup table */
+static const HttpMethodEntry http_methods[] = {
+  { "GET", HTTP_METHOD_GET },       { "HEAD", HTTP_METHOD_HEAD },
+  { "POST", HTTP_METHOD_POST },     { "PUT", HTTP_METHOD_PUT },
+  { "DELETE", HTTP_METHOD_DELETE }, { "OPTIONS", HTTP_METHOD_OPTIONS },
+  { "PATCH", HTTP_METHOD_PATCH },   { "TRACE", HTTP_METHOD_TRACE },
+  { "CONNECT", HTTP_METHOD_CONNECT }, { NULL, HTTP_METHOD_GET }
+};
+
+/*
+ * Generic option handlers
+ */
+
+static int
+handle_bool_option (TcurlOptions *opts, int opt_val)
+{
+  for (const BoolOption *entry = bool_options; entry->opt_val; entry++)
+    {
+      if (entry->opt_val == opt_val)
+        {
+          *(int *)((char *)opts + entry->offset) = 1;
+          return 1;
+        }
+    }
+  return 0;
+}
+
+static int
+handle_string_option (TcurlOptions *opts, int opt_val, const char *optarg)
+{
+  for (const StringOption *entry = string_options; entry->opt_val; entry++)
+    {
+      if (entry->opt_val == opt_val)
+        {
+          *(const char **)((char *)opts + entry->offset) = optarg;
+          return 1;
+        }
+    }
+  return 0;
+}
+
+static int
+parse_positive_long (const char *str, const char *option_name, long *result)
+{
+  char *endptr;
+  errno = 0;
+  long val = strtol (str, &endptr, CURL_DECIMAL_BASE);
+  if (errno != 0 || *endptr != '\0' || val < 0 || val > INT_MAX)
+    {
+      fprintf (stderr, "tcurl: Invalid %s: %s\n", option_name, str);
+      return -1;
+    }
+  *result = val;
+  return 0;
+}
+
+static int
+handle_int_option (TcurlOptions *opts, int opt_val, const char *optarg)
+{
+  for (const IntOption *entry = int_options; entry->opt_val; entry++)
+    {
+      if (entry->opt_val == opt_val)
+        {
+          long val;
+          if (parse_positive_long (optarg, entry->name, &val) != 0)
+            return -1;
+          *(int *)((char *)opts + entry->offset) = (int)val;
+          return 1;
+        }
+    }
+  return 0;
+}
+
+static int
+handle_http_version_option (TcurlOptions *opts, int opt_val)
+{
+  for (const HttpVersionOption *entry = http_version_options; entry->opt_val;
+       entry++)
+    {
+      if (entry->opt_val == opt_val)
+        {
+          opts->http_version = entry->version;
+          return 1;
+        }
+    }
+  return 0;
+}
+
+/*
+ * Special-case option handlers (options with side effects)
+ */
+
+static int
+handle_data_option (TcurlOptions *opts, const char *optarg)
+{
+  opts->data = optarg;
+  opts->data_len = strlen (optarg);
+  if (!opts->method)
+    opts->method = "POST";
+  return 0;
+}
+
+static int
+handle_form_option (TcurlOptions *opts, const char *optarg)
+{
+  opts->form_data = optarg;
+  if (!opts->method)
+    opts->method = "POST";
+  return 0;
+}
+
+static int
+handle_header_option (TcurlOptions *opts, const char *optarg)
+{
+  if (Tcurl_add_header (opts, optarg) < 0)
+    {
+      fprintf (stderr, "tcurl: Failed to add header\n");
+      return -1;
+    }
+  return 0;
+}
+
+static int
+handle_head_option (TcurlOptions *opts)
+{
+  opts->head_only = 1;
+  opts->method = "HEAD";
+  return 0;
+}
+
+static int
+handle_fail_with_body_option (TcurlOptions *opts)
+{
+  opts->fail_on_error = 1;
+  opts->fail_with_body = 1;
+  return 0;
+}
+
+/*
+ * Main option dispatch
+ */
+
+static int
+process_option (TcurlOptions *opts, int opt, const char *optarg)
+{
+  /* Try data-driven handlers first */
+  if (handle_bool_option (opts, opt))
+    return 0;
+  if (handle_string_option (opts, opt, optarg))
+    return 0;
+
+  int int_result = handle_int_option (opts, opt, optarg);
+  if (int_result != 0)
+    return (int_result < 0) ? -1 : 0;
+
+  if (handle_http_version_option (opts, opt))
+    return 0;
+
+  /* Special-case handlers */
+  switch (opt)
+    {
+    case 'H':
+      return handle_header_option (opts, optarg);
+    case 'd':
+    case OPT_DATA_RAW:
+    case OPT_DATA_BINARY:
+      return handle_data_option (opts, optarg);
+    case 'F':
+      return handle_form_option (opts, optarg);
+    case 'I':
+      return handle_head_option (opts);
+    case OPT_FAIL_WITH_BODY:
+      return handle_fail_with_body_option (opts);
+    default:
+      return 0;
+    }
+}
+
+/*
+ * Public API
+ */
+
+void
+Tcurl_options_init (TcurlOptions *opts)
+{
+  if (!opts)
+    return;
+
+  memset (opts, 0, sizeof (*opts));
+
+  opts->user_agent = DEFAULT_USER_AGENT;
+  opts->connect_timeout = DEFAULT_CONNECT_TIMEOUT;
+  opts->max_time = DEFAULT_MAX_TIME;
+  opts->follow_redirects = 0;
+  opts->max_redirects = CURL_DEFAULT_MAX_REDIRECTS;
+  opts->http_version = TCURL_HTTP_DEFAULT;
+  opts->compressed = 0;
+  opts->fail_on_error = 0;
+  opts->show_error = 0;
+}
+
+void
+Tcurl_options_free (TcurlOptions *opts)
+{
+  if (!opts)
+    return;
+
+  for (int i = 0; i < opts->header_count; i++)
+    free (opts->headers[i]);
+  free (opts->headers);
+
+  if (opts->data_allocated)
+    free ((void *)opts->data);
+
+  memset (opts, 0, sizeof (*opts));
+}
+
+int
+Tcurl_add_header (TcurlOptions *opts, const char *header)
+{
+  if (!opts || !header)
+    return -1;
+
+  char **new_headers
+      = realloc (opts->headers, (opts->header_count + 1) * sizeof (char *));
+  if (!new_headers)
+    return -1;
+
+  opts->headers = new_headers;
+  opts->headers[opts->header_count] = strdup (header);
+  if (!opts->headers[opts->header_count])
+    return -1;
+
+  opts->header_count++;
+  return 0;
+}
+
+static const char *
+get_filename_from_url (const char *url, char *buf, size_t buf_size)
+{
+  if (!url || !buf || buf_size == 0)
+    return NULL;
+
+  const char *last_slash = strrchr (url, '/');
+  if (!last_slash || last_slash[1] == '\0')
+    return NULL;
+
+  const char *filename = last_slash + 1;
+
+  /* Security checks */
+  if (filename[0] == '/' || strchr (filename, '%') || strstr (filename, ".."))
+    return NULL;
+
+  const char *query = strchr (filename, '?');
+  if (query)
+    {
+      size_t len = query - filename;
+      if (len >= buf_size)
+        len = buf_size - 1;
+      memcpy (buf, filename, len);
+      buf[len] = '\0';
+
+      if (strstr (buf, "..") || strchr (buf, '%'))
+        return NULL;
+
+      return buf;
+    }
+
+  return filename;
+}
+
+int
+Tcurl_parse_args (int argc, char **argv, TcurlOptions *opts)
+{
+  if (!opts)
+    return -1;
+
+  Tcurl_options_init (opts);
+
+  int opt;
+  int option_index = 0;
+  optind = 1;
+
+  while ((opt = getopt_long (argc, argv, short_options, long_options,
+                             &option_index))
+         != -1)
+    {
+      if (opt == '?')
+        return -1;
+
+      int result = process_option (opts, opt, optarg);
+      if (result != 0)
+        return result;
+
+      if (opts->show_help || opts->show_version)
+        return 0;
+    }
+
+  if (optind < argc)
+    {
+      opts->url = argv[optind];
+
+      if (opts->remote_name && !opts->output_file)
+        {
+          static _Thread_local char filename_buf[CURL_MAX_FILENAME_LEN];
+          opts->output_file
+              = get_filename_from_url (opts->url, filename_buf,
+                                       sizeof (filename_buf));
+          if (!opts->output_file)
+            {
+              fprintf (stderr, "tcurl: Cannot extract filename from URL\n");
+              return -1;
+            }
+        }
+    }
+
+  return 0;
+}
+
+int
+Tcurl_validate_args (const TcurlOptions *opts)
+{
+  if (!opts)
+    return -1;
+
+  if (!opts->show_help && !opts->show_version && !opts->url)
+    {
+      fprintf (stderr, "tcurl: No URL specified\n");
+      return -1;
+    }
+
+  if (opts->method)
+    {
+      int valid = 0;
+      for (const HttpMethodEntry *entry = http_methods; entry->name; entry++)
+        {
+          if (strcasecmp (opts->method, entry->name) == 0)
+            {
+              valid = 1;
+              break;
+            }
+        }
+      if (!valid)
+        {
+          fprintf (stderr, "tcurl: Unknown method: %s\n", opts->method);
+          return -1;
+        }
+    }
+
+  if (opts->connect_timeout < 0)
+    {
+      fprintf (stderr, "tcurl: Invalid connect-timeout\n");
+      return -1;
+    }
+
+  if (opts->max_time < 0)
+    {
+      fprintf (stderr, "tcurl: Invalid max-time\n");
+      return -1;
+    }
+
+  return 0;
+}
+
+void
+Tcurl_print_usage (const char *progname)
+{
+  const char *name = progname ? progname : "tcurl";
+
+  printf ("Usage: %s [options] <url>\n", name);
+  printf ("\n");
+  printf ("Transfer data from or to a server using HTTP/HTTPS.\n");
+  printf ("\n");
+  printf ("Options:\n");
+  printf ("  -X, --request METHOD     HTTP method (GET, POST, PUT, DELETE, "
+          "etc.)\n");
+  printf ("  -H, --header HEADER      Add header (can be used multiple "
+          "times)\n");
+  printf ("  -d, --data DATA          POST data (implies -X POST)\n");
+  printf ("  -F, --form DATA          Multipart form data\n");
+  printf ("  -o, --output FILE        Write response body to file\n");
+  printf ("  -O, --remote-name        Write to file named from URL\n");
+  printf ("  -L, --location           Follow redirects\n");
+  printf ("  -k, --insecure           Skip TLS certificate verification\n");
+  printf ("  -x, --proxy URL          Use proxy (http://host:port, "
+          "socks5://host:port)\n");
+  printf ("  -u, --user USER:PASS     Authentication credentials\n");
+  printf ("  -b, --cookie FILE        Read cookies from file\n");
+  printf ("  -c, --cookie-jar FILE    Write cookies to file\n");
+  printf ("  -A, --user-agent STRING  Set User-Agent header\n");
+  printf ("  -e, --referer URL        Set Referer header\n");
+  printf ("  -v, --verbose            Verbose output (show headers)\n");
+  printf ("  -s, --silent             Silent mode (no progress)\n");
+  printf ("  -S, --show-error         Show errors in silent mode\n");
+  printf ("  -i, --include            Include response headers in output\n");
+  printf ("  -I, --head               HEAD request (headers only)\n");
+  printf ("  -w, --write-out FORMAT   Custom output format\n");
+  printf ("  -f, --fail               Fail silently on HTTP errors\n");
+  printf ("      --http2              Prefer HTTP/2\n");
+  printf ("      --http1.1            Force HTTP/1.1\n");
+  printf ("      --connect-timeout SEC  Connection timeout\n");
+  printf ("  -m, --max-time SEC       Total timeout\n");
+  printf ("      --compressed         Request compressed response\n");
+  printf ("      --max-redirs NUM     Maximum number of redirects\n");
+  printf ("      --retry NUM          Number of retries on failure\n");
+  printf ("  -h, --help               Show this help\n");
+  printf ("  -V, --version            Show version\n");
+  printf ("\n");
+  printf ("Examples:\n");
+  printf ("  %s https://example.com\n", name);
+  printf ("  %s -o file.txt https://example.com/file.txt\n", name);
+  printf ("  %s -X POST -d 'key=value' https://api.example.com/data\n", name);
+  printf ("  %s -H 'Authorization: Bearer token' https://api.example.com\n",
+          name);
+  printf ("\n");
+}
+
+void
+Tcurl_print_version (void)
+{
+  printf ("tcurl 1.0.0\n");
+  printf ("Built with tetsuo-curl socket library\n");
+  printf ("Copyright (c) 2025 Tetsuo AI\n");
+}
+
+SocketHTTP_Method
+Tcurl_get_http_method (const TcurlOptions *opts)
+{
+  if (!opts || !opts->method)
+    return HTTP_METHOD_GET;
+
+  for (const HttpMethodEntry *entry = http_methods; entry->name; entry++)
+    {
+      if (strcasecmp (opts->method, entry->name) == 0)
+        return entry->method;
+    }
+
+  return HTTP_METHOD_GET;
+}

--- a/examples/curl/src/curl_main.c
+++ b/examples/curl/src/curl_main.c
@@ -1,0 +1,985 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file curl_main.c
+ * @brief Main entry point for tcurl CLI tool.
+ *
+ * Provides a curl-compatible command-line interface for HTTP requests
+ * using the StreamingCurl library.
+ */
+
+#include "core/Except.h"
+#include "curl/StreamingCurl.h"
+#include "curl/StreamingCurl-private.h"
+#include "curl/curl_args.h"
+
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <unistd.h>
+
+/* Constants */
+#define PERCENT_MULTIPLIER 100
+#define ASCII_PRINTABLE_MIN 32
+#define WRITEOUT_VAR_PREFIX_LEN 2
+#define WRITEOUT_VAR_SUFFIX_LEN 1
+#define ESCAPE_SEQUENCE_LEN 2
+#define MILLISECONDS_PER_SECOND 1000
+#define CONTENT_TYPE_HEADER_LEN 13
+#define HTTP_CLIENT_ERROR_MIN 400
+
+/* Exit codes (curl compatible) */
+#define EXIT_SUCCESS_CODE 0
+#define EXIT_UNSUPPORTED_PROTOCOL 1
+#define EXIT_FAILED_INIT 2
+#define EXIT_URL_MALFORMED 3
+#define EXIT_COULD_NOT_RESOLVE_HOST 6
+#define EXIT_COULDNT_CONNECT 7
+#define EXIT_HTTP_ERROR 22
+#define EXIT_WRITE_ERROR 23
+#define EXIT_OPERATION_TIMEOUT 28
+#define EXIT_SSL_CONNECT_ERROR 35
+#define EXIT_TOO_MANY_REDIRECTS 47
+#define EXIT_RECV_ERROR 56
+
+/* Global state for signal handling */
+static volatile sig_atomic_t g_interrupted = 0;
+
+/* Progress state */
+typedef struct
+{
+  TcurlOptions *opts;
+  int64_t last_progress_time;
+  int64_t last_dlnow;
+  int64_t last_ulnow;
+} ProgressState;
+
+/* Write callback context */
+typedef struct
+{
+  FILE *fp;
+  TcurlOptions *opts;
+  int64_t bytes_written;
+} WriteContext;
+
+/* Header callback context */
+typedef struct
+{
+  TcurlOptions *opts;
+  FILE *output;
+} HeaderContext;
+
+/* Main execution context - groups all state for the curl operation */
+typedef struct
+{
+  TcurlOptions opts;
+  WriteContext write_ctx;
+  HeaderContext header_ctx;
+  ProgressState progress_state;
+  CurlAuth auth;
+  char auth_username[CURL_MAX_CREDENTIAL_LEN];
+  char auth_password[CURL_MAX_CREDENTIAL_LEN];
+  CurlOptions curl_opts;
+  volatile FILE *output;
+  CurlSession_T session;
+} MainContext;
+
+/* Writeout variable handler context */
+typedef struct
+{
+  const CurlResponse *response;
+  int64_t bytes_written;
+} WriteoutContext;
+
+/* Writeout variable lookup entry */
+typedef struct
+{
+  const char *name;
+  void (*handler) (const WriteoutContext *ctx);
+} WriteoutVar;
+
+static void
+signal_handler (int sig)
+{
+  (void)sig;
+  g_interrupted = 1;
+}
+
+static void
+setup_signals (void)
+{
+  struct sigaction sa;
+  memset (&sa, 0, sizeof (sa));
+  sa.sa_handler = signal_handler;
+  sigemptyset (&sa.sa_mask);
+  sa.sa_flags = 0;
+
+  sigaction (SIGINT, &sa, NULL);
+  sigaction (SIGTERM, &sa, NULL);
+  signal (SIGPIPE, SIG_IGN);
+}
+
+static size_t
+write_callback (void *data, size_t size, size_t nmemb, void *userdata)
+{
+  WriteContext *ctx = (WriteContext *)userdata;
+
+  if (g_interrupted)
+    return 0;
+
+  size_t written = fwrite (data, size, nmemb, ctx->fp);
+  ctx->bytes_written += written;
+  return written;
+}
+
+static size_t
+header_callback (void *data, size_t size, size_t nmemb, void *userdata)
+{
+  HeaderContext *ctx = (HeaderContext *)userdata;
+  size_t total = size * nmemb;
+
+  if (ctx->opts->verbose || ctx->opts->include_headers)
+    {
+      FILE *out = ctx->opts->verbose ? stderr : ctx->output;
+      fwrite (data, size, nmemb, out);
+    }
+
+  return total;
+}
+
+static int
+should_skip_progress (ProgressState *state, int64_t now, int64_t dlnow,
+                      int64_t ulnow)
+{
+  return now == state->last_progress_time && dlnow == state->last_dlnow
+         && ulnow == state->last_ulnow;
+}
+
+static void
+show_download_progress (int64_t dltotal, int64_t dlnow)
+{
+  if (dltotal > 0)
+    {
+      int percent = (int)(dlnow * PERCENT_MULTIPLIER / dltotal);
+      fprintf (stderr, "\r  %% Total    %% Received\n");
+      fprintf (stderr, "\r%3d %8lld %3d %8lld", percent, (long long)dltotal,
+               percent, (long long)dlnow);
+    }
+  else if (dlnow > 0)
+    {
+      fprintf (stderr, "\rReceived: %lld bytes", (long long)dlnow);
+    }
+}
+
+static void
+show_upload_progress (int64_t ultotal, int64_t ulnow)
+{
+  if (ultotal > 0)
+    {
+      int percent = (int)(ulnow * PERCENT_MULTIPLIER / ultotal);
+      fprintf (stderr, "  Upload: %3d%% (%lld/%lld)", percent,
+               (long long)ulnow, (long long)ultotal);
+    }
+}
+
+static int
+progress_callback (void *userdata, int64_t dltotal, int64_t dlnow,
+                   int64_t ultotal, int64_t ulnow)
+{
+  ProgressState *state = (ProgressState *)userdata;
+
+  if (g_interrupted)
+    return 1;
+
+  if (state->opts->silent)
+    return 0;
+
+  int64_t now = (int64_t)time (NULL);
+  if (should_skip_progress (state, now, dlnow, ulnow))
+    return 0;
+
+  state->last_progress_time = now;
+  state->last_dlnow = dlnow;
+  state->last_ulnow = ulnow;
+
+  show_download_progress (dltotal, dlnow);
+  show_upload_progress (ultotal, ulnow);
+  fflush (stderr);
+
+  return 0;
+}
+
+static int
+error_to_exit_code (CurlError error)
+{
+  switch (error)
+    {
+    case CURL_OK:
+      return EXIT_SUCCESS_CODE;
+    case CURL_ERROR_DNS:
+      return EXIT_COULD_NOT_RESOLVE_HOST;
+    case CURL_ERROR_CONNECT:
+      return EXIT_COULDNT_CONNECT;
+    case CURL_ERROR_TLS:
+      return EXIT_SSL_CONNECT_ERROR;
+    case CURL_ERROR_TIMEOUT:
+      return EXIT_OPERATION_TIMEOUT;
+    case CURL_ERROR_TOO_MANY_REDIRECTS:
+      return EXIT_TOO_MANY_REDIRECTS;
+    case CURL_ERROR_INVALID_URL:
+      return EXIT_URL_MALFORMED;
+    case CURL_ERROR_WRITE_CALLBACK:
+      return EXIT_WRITE_ERROR;
+    case CURL_ERROR_PROTOCOL:
+      return EXIT_RECV_ERROR;
+    default:
+      return 1;
+    }
+}
+
+static int
+validate_header (const char *header)
+{
+  if (!header)
+    return -1;
+
+  for (const char *p = header; *p; p++)
+    {
+      if (*p == '\r' || *p == '\n' || (*p < ASCII_PRINTABLE_MIN && *p != '\t'))
+        return -1;
+    }
+
+  return 0;
+}
+
+static void
+parse_user_auth (const char *user_str, CurlAuth *auth, char *username_buf,
+                 size_t username_size, char *password_buf, size_t password_size)
+{
+  if (!user_str)
+    return;
+
+  auth->type = CURL_AUTH_BASIC;
+  const char *colon = strchr (user_str, ':');
+
+  if (colon)
+    {
+      size_t user_len = (size_t)(colon - user_str);
+      if (user_len >= username_size)
+        user_len = username_size - 1;
+      memcpy (username_buf, user_str, user_len);
+      username_buf[user_len] = '\0';
+      auth->username = username_buf;
+
+      size_t pass_len = strlen (colon + 1);
+      if (pass_len >= password_size)
+        pass_len = password_size - 1;
+      memcpy (password_buf, colon + 1, pass_len);
+      password_buf[pass_len] = '\0';
+      auth->password = password_buf;
+    }
+  else
+    {
+      auth->username = user_str;
+      auth->password = "";
+    }
+}
+
+static void
+secure_clear (void *ptr, size_t len)
+{
+  volatile unsigned char *p = ptr;
+  while (len--)
+    *p++ = 0;
+}
+
+/* Writeout variable handlers */
+static void
+writeout_http_code (const WriteoutContext *ctx)
+{
+  printf ("%d", ctx->response ? ctx->response->status_code : 0);
+}
+
+static void
+writeout_size_download (const WriteoutContext *ctx)
+{
+  printf ("%lld", (long long)ctx->bytes_written);
+}
+
+static void
+writeout_content_type (const WriteoutContext *ctx)
+{
+  if (ctx->response && ctx->response->headers)
+    {
+      const char *ct
+          = SocketHTTP_Headers_get (ctx->response->headers, "Content-Type");
+      printf ("%s", ct ? ct : "");
+    }
+}
+
+static const WriteoutVar writeout_vars[] = {
+  { "http_code", writeout_http_code },
+  { "size_download", writeout_size_download },
+  { "content_type", writeout_content_type },
+  { NULL, NULL }
+};
+
+static void
+handle_writeout_var (const char *varname, const WriteoutContext *ctx)
+{
+  for (const WriteoutVar *v = writeout_vars; v->name; v++)
+    {
+      if (strcmp (varname, v->name) == 0)
+        {
+          v->handler (ctx);
+          return;
+        }
+    }
+}
+
+static const char *
+parse_writeout_var (const char *p, const WriteoutContext *ctx)
+{
+  const char *end = strchr (p + WRITEOUT_VAR_PREFIX_LEN, '}');
+  if (!end)
+    return NULL;
+
+  size_t varlen = end - (p + WRITEOUT_VAR_PREFIX_LEN);
+  char varname[CURL_MAX_QOP_LEN];
+
+  if (varlen < sizeof (varname))
+    {
+      memcpy (varname, p + WRITEOUT_VAR_PREFIX_LEN, varlen);
+      varname[varlen] = '\0';
+      handle_writeout_var (varname, ctx);
+    }
+
+  return end + WRITEOUT_VAR_SUFFIX_LEN;
+}
+
+static void
+process_write_out (const char *format, const CurlResponse *response,
+                   int64_t bytes_written)
+{
+  if (!format)
+    return;
+
+  WriteoutContext ctx = { response, bytes_written };
+  const char *p = format;
+
+  while (*p)
+    {
+      if (*p == '%' && *(p + 1) == '{')
+        {
+          const char *next = parse_writeout_var (p, &ctx);
+          if (next)
+            {
+              p = next;
+              continue;
+            }
+        }
+      else if (*p == '\\' && *(p + 1) == 'n')
+        {
+          printf ("\n");
+          p += ESCAPE_SEQUENCE_LEN;
+          continue;
+        }
+      else if (*p == '\\' && *(p + 1) == 't')
+        {
+          printf ("\t");
+          p += ESCAPE_SEQUENCE_LEN;
+          continue;
+        }
+
+      putchar (*p);
+      p++;
+    }
+}
+
+static void
+configure_timeouts (CurlOptions *curl_opts, const TcurlOptions *opts)
+{
+  if (opts->connect_timeout > 0)
+    curl_opts->connect_timeout_ms
+        = opts->connect_timeout * MILLISECONDS_PER_SECOND;
+
+  if (opts->max_time > 0)
+    curl_opts->request_timeout_ms = opts->max_time * MILLISECONDS_PER_SECOND;
+}
+
+static void
+configure_http_version (CurlOptions *curl_opts, const TcurlOptions *opts)
+{
+  if (opts->http_version == TCURL_HTTP_2)
+    curl_opts->max_version = HTTP_VERSION_2;
+  else if (opts->http_version == TCURL_HTTP_1_1)
+    curl_opts->max_version = HTTP_VERSION_1_1;
+}
+
+static void
+configure_compression (CurlOptions *curl_opts, const TcurlOptions *opts)
+{
+  if (opts->compressed)
+    {
+      curl_opts->accept_encoding = 1;
+      curl_opts->auto_decompress = 1;
+    }
+}
+
+static void
+configure_optional_features (CurlOptions *curl_opts, const TcurlOptions *opts)
+{
+  if (opts->proxy)
+    curl_opts->proxy_url = opts->proxy;
+
+  if (opts->cookie_file || opts->cookie_jar)
+    curl_opts->cookie_file
+        = opts->cookie_file ? opts->cookie_file : opts->cookie_jar;
+
+  if (opts->retry_count > 0)
+    {
+      curl_opts->enable_retry = 1;
+      curl_opts->max_retries = opts->retry_count;
+    }
+}
+
+static void
+configure_callbacks (CurlOptions *curl_opts, WriteContext *write_ctx,
+                     HeaderContext *header_ctx, ProgressState *progress_state,
+                     int silent)
+{
+  curl_opts->write_callback = write_callback;
+  curl_opts->write_userdata = write_ctx;
+  curl_opts->header_callback = header_callback;
+  curl_opts->header_userdata = header_ctx;
+
+  if (!silent)
+    {
+      curl_opts->progress_callback = progress_callback;
+      curl_opts->progress_userdata = progress_state;
+    }
+}
+
+static void
+configure_curl_options (CurlOptions *curl_opts, TcurlOptions *opts,
+                        WriteContext *write_ctx, HeaderContext *header_ctx,
+                        ProgressState *progress_state, CurlAuth *auth)
+{
+  Curl_options_defaults (curl_opts);
+
+  curl_opts->follow_redirects = opts->follow_redirects;
+  curl_opts->max_redirects = opts->max_redirects;
+  curl_opts->verify_ssl = !opts->insecure;
+  curl_opts->user_agent = opts->user_agent;
+  curl_opts->verbose = opts->verbose;
+
+  configure_timeouts (curl_opts, opts);
+  configure_http_version (curl_opts, opts);
+  configure_compression (curl_opts, opts);
+  configure_optional_features (curl_opts, opts);
+  configure_callbacks (curl_opts, write_ctx, header_ctx, progress_state,
+                       opts->silent);
+
+  if (auth)
+    curl_opts->auth = *auth;
+}
+
+static int
+add_single_header (CurlSession_T session, char *header)
+{
+  if (validate_header (header) < 0)
+    {
+      fprintf (stderr,
+               "tcurl: Invalid header (contains control characters): %s\n",
+               header);
+      return -1;
+    }
+
+  char *colon = strchr (header, ':');
+  if (colon)
+    {
+      *colon = '\0';
+      const char *value = colon + 1;
+      while (*value == ' ')
+        value++;
+      Curl_session_set_header (session, header, value);
+      *colon = ':';
+    }
+
+  return 0;
+}
+
+static int
+add_custom_headers (CurlSession_T session, TcurlOptions *opts)
+{
+  for (int i = 0; i < opts->header_count; i++)
+    {
+      if (add_single_header (session, opts->headers[i]) < 0)
+        return -1;
+    }
+  return 0;
+}
+
+static int
+add_referer_header (CurlSession_T session, const char *referer)
+{
+  if (!referer)
+    return 0;
+
+  if (validate_header (referer) < 0)
+    {
+      fprintf (stderr, "tcurl: Invalid referer (contains control characters)\n");
+      return -1;
+    }
+
+  Curl_session_set_header (session, "Referer", referer);
+  return 0;
+}
+
+static void
+print_verbose_request (const TcurlOptions *opts)
+{
+  if (!opts->verbose)
+    return;
+
+  fprintf (stderr, "> %s %s\n", opts->method ? opts->method : "GET", opts->url);
+  fprintf (stderr, "> User-Agent: %s\n", opts->user_agent);
+
+  for (int i = 0; i < opts->header_count; i++)
+    fprintf (stderr, "> %s\n", opts->headers[i]);
+
+  fprintf (stderr, ">\n");
+}
+
+static int
+setup_session (CurlSession_T *session, TcurlOptions *opts,
+               CurlOptions *curl_opts)
+{
+  *session = Curl_session_new (curl_opts);
+
+  if (add_custom_headers (*session, opts) < 0)
+    RAISE (Curl_Failed);
+
+  if (add_referer_header (*session, opts->referer) < 0)
+    RAISE (Curl_Failed);
+
+  print_verbose_request (opts);
+  return 0;
+}
+
+static int
+has_custom_content_type (const TcurlOptions *opts)
+{
+  for (int i = 0; i < opts->header_count; i++)
+    {
+      if (strncasecmp (opts->headers[i], "Content-Type:",
+                       CONTENT_TYPE_HEADER_LEN)
+          == 0)
+        return 1;
+    }
+  return 0;
+}
+
+static CurlError
+execute_with_data (CurlSession_T session, TcurlOptions *opts,
+                   SocketHTTP_Method method)
+{
+  const char *content_type
+      = has_custom_content_type (opts) ? NULL : "application/x-www-form-urlencoded";
+
+  if (method == HTTP_METHOD_PUT)
+    return Curl_put (session, opts->url, content_type, opts->data,
+                     opts->data_len);
+
+  return Curl_post (session, opts->url, content_type, opts->data,
+                    opts->data_len);
+}
+
+static CurlError
+execute_request (CurlSession_T session, TcurlOptions *opts)
+{
+  SocketHTTP_Method method = Tcurl_get_http_method (opts);
+
+  if (opts->data && opts->data_len > 0)
+    return execute_with_data (session, opts, method);
+
+  if (opts->head_only)
+    return Curl_head (session, opts->url);
+
+  if (method == HTTP_METHOD_DELETE)
+    return Curl_delete (session, opts->url);
+
+  if (method == HTTP_METHOD_POST)
+    return Curl_post (session, opts->url, NULL, NULL, 0);
+
+  if (method == HTTP_METHOD_PUT)
+    return Curl_put (session, opts->url, NULL, NULL, 0);
+
+  return Curl_get (session, opts->url);
+}
+
+static void
+handle_output (TcurlOptions *opts, const CurlResponse *response,
+               int64_t bytes_written)
+{
+  if (opts->write_out)
+    process_write_out (opts->write_out, response, bytes_written);
+
+  if (opts->verbose && response)
+    {
+      fprintf (stderr, "\n< HTTP/%s %d\n",
+               response->version == HTTP_VERSION_2 ? "2" : "1.1",
+               response->status_code);
+    }
+}
+
+static void
+init_write_context (WriteContext *ctx, TcurlOptions *opts)
+{
+  ctx->fp = stdout;
+  ctx->opts = opts;
+  ctx->bytes_written = 0;
+}
+
+static void
+init_header_context (HeaderContext *ctx, TcurlOptions *opts)
+{
+  ctx->opts = opts;
+  ctx->output = stdout;
+}
+
+static void
+init_progress_state (ProgressState *state, TcurlOptions *opts)
+{
+  state->opts = opts;
+  state->last_progress_time = 0;
+  state->last_dlnow = 0;
+  state->last_ulnow = 0;
+}
+
+static void
+initialize_contexts (TcurlOptions *opts, WriteContext *write_ctx,
+                     HeaderContext *header_ctx, ProgressState *progress_state,
+                     CurlAuth *auth, char *auth_username, char *auth_password)
+{
+  init_write_context (write_ctx, opts);
+  init_header_context (header_ctx, opts);
+  init_progress_state (progress_state, opts);
+
+  if (opts->user)
+    {
+      parse_user_auth (opts->user, auth, auth_username, CURL_MAX_CREDENTIAL_LEN,
+                       auth_password, CURL_MAX_CREDENTIAL_LEN);
+    }
+}
+
+static int
+validate_output_path (const char *filename)
+{
+  struct stat st;
+
+  if (lstat (filename, &st) != 0)
+    return 0;
+
+  if (S_ISLNK (st.st_mode))
+    {
+      fprintf (stderr, "tcurl: Refusing to write to symbolic link: %s\n",
+               filename);
+      return -1;
+    }
+
+  if (!S_ISREG (st.st_mode))
+    {
+      fprintf (stderr, "tcurl: Refusing to write to non-regular file: %s\n",
+               filename);
+      return -1;
+    }
+
+  return 0;
+}
+
+static int
+open_output_file (const char *filename, volatile FILE **output_ptr)
+{
+  if (!filename)
+    {
+      *output_ptr = stdout;
+      return 0;
+    }
+
+  if (validate_output_path (filename) < 0)
+    RAISE (Curl_Failed);
+
+  *output_ptr = fopen (filename, "wb");
+  if (!*output_ptr)
+    {
+      fprintf (stderr, "tcurl: Cannot open '%s' for writing: %s\n", filename,
+               strerror (errno));
+      RAISE (Curl_Failed);
+    }
+
+  return 0;
+}
+
+static void
+report_error (const TcurlOptions *opts, CurlError result)
+{
+  if (!opts->silent || opts->show_error)
+    fprintf (stderr, "\ntcurl: %s\n", Curl_error_string (result));
+}
+
+static CurlError
+check_http_error (const TcurlOptions *opts, const CurlResponse *response)
+{
+  if (!opts->fail_on_error || !response)
+    return CURL_OK;
+
+  if (response->status_code >= HTTP_CLIENT_ERROR_MIN)
+    {
+      if (!opts->silent || opts->show_error)
+        {
+          fprintf (stderr, "\ntcurl: The requested URL returned error: %d\n",
+                   response->status_code);
+        }
+      return CURL_ERROR_PROTOCOL;
+    }
+
+  return CURL_OK;
+}
+
+static CurlError
+handle_request_result (TcurlOptions *opts, CurlSession_T session,
+                       CurlError result, int64_t bytes_written)
+{
+  if (result != CURL_OK)
+    {
+      report_error (opts, result);
+      return result;
+    }
+
+  const CurlResponse *response = Curl_session_response (session);
+  CurlError http_error = check_http_error (opts, response);
+
+  handle_output (opts, response, bytes_written);
+
+  return http_error != CURL_OK ? http_error : result;
+}
+
+static CurlError
+execute_curl_request (TcurlOptions *opts, CurlOptions *curl_opts,
+                      WriteContext *write_ctx, HeaderContext *header_ctx,
+                      volatile FILE **output)
+{
+  CurlSession_T session = NULL;
+
+  open_output_file (opts->output_file, output);
+  write_ctx->fp = (FILE *)*output;
+  header_ctx->output = (FILE *)*output;
+
+  setup_session (&session, opts, curl_opts);
+  CurlError result = execute_request (session, opts);
+  result = handle_request_result (opts, session, result, write_ctx->bytes_written);
+
+  if (session)
+    Curl_session_free (&session);
+
+  return result;
+}
+
+static void
+close_output_file (volatile FILE **output)
+{
+  if (*output != stdout && *output != NULL)
+    {
+      fclose ((FILE *)*output);
+      *output = stdout;
+    }
+}
+
+static void
+cleanup_session (CurlSession_T *session, volatile FILE **output,
+                 TcurlOptions *opts, char *auth_username, char *auth_password)
+{
+  close_output_file (output);
+
+  if (*session)
+    Curl_session_free (session);
+
+  Tcurl_options_free (opts);
+  secure_clear (auth_username, CURL_MAX_CREDENTIAL_LEN);
+  secure_clear (auth_password, CURL_MAX_CREDENTIAL_LEN);
+}
+
+static int
+parse_options (int argc, char **argv, TcurlOptions *opts)
+{
+  if (Tcurl_parse_args (argc, argv, opts) < 0)
+    return -EXIT_FAILED_INIT;
+
+  if (opts->show_help)
+    {
+      Tcurl_print_usage (argv[0]);
+      return EXIT_SUCCESS_CODE + 1;
+    }
+
+  if (opts->show_version)
+    {
+      Tcurl_print_version ();
+      return EXIT_SUCCESS_CODE + 1;
+    }
+
+  if (Tcurl_validate_args (opts) < 0)
+    {
+      Tcurl_print_usage (argv[0]);
+      return -EXIT_FAILED_INIT;
+    }
+
+  return 0;
+}
+
+static void
+print_error_message (const TcurlOptions *opts, const char *message)
+{
+  if (!opts->silent || opts->show_error)
+    fprintf (stderr, "tcurl: %s\n", message);
+}
+
+static void
+init_main_context (MainContext *ctx)
+{
+  memset (ctx, 0, sizeof (*ctx));
+  ctx->output = stdout;
+  ctx->session = NULL;
+}
+
+static void
+setup_main_context (MainContext *ctx)
+{
+  initialize_contexts (&ctx->opts, &ctx->write_ctx, &ctx->header_ctx,
+                       &ctx->progress_state, &ctx->auth, ctx->auth_username,
+                       ctx->auth_password);
+
+  configure_curl_options (&ctx->curl_opts, &ctx->opts, &ctx->write_ctx,
+                          &ctx->header_ctx, &ctx->progress_state,
+                          ctx->opts.user ? &ctx->auth : NULL);
+}
+
+static int
+process_result (CurlError result, const TcurlOptions *opts)
+{
+  if (result == CURL_OK)
+    return EXIT_SUCCESS_CODE;
+
+  int exit_code = error_to_exit_code (result);
+  if (result == CURL_ERROR_PROTOCOL && opts->fail_on_error)
+    exit_code = EXIT_HTTP_ERROR;
+
+  return exit_code;
+}
+
+/* Exception-to-exit-code mapping */
+typedef struct
+{
+  const Except_T *exception;
+  int exit_code;
+  const char *message;
+} ExceptionMapping;
+
+static const ExceptionMapping exception_map[] = {
+  { &Curl_DNSFailed, EXIT_COULD_NOT_RESOLVE_HOST, "Could not resolve host" },
+  { &Curl_ConnectFailed, EXIT_COULDNT_CONNECT, "Failed to connect" },
+  { &Curl_TLSFailed, EXIT_SSL_CONNECT_ERROR, "SSL/TLS handshake failed" },
+  { &Curl_Timeout, EXIT_OPERATION_TIMEOUT, "Operation timed out" },
+  { &Curl_TooManyRedirects, EXIT_TOO_MANY_REDIRECTS, "Maximum redirects exceeded" },
+  { &Curl_InvalidURL, EXIT_URL_MALFORMED, "Invalid URL" },
+  { &Curl_Failed, 1, "Request failed" },
+  { NULL, 0, NULL }
+};
+
+static int
+run_curl_main (MainContext *ctx)
+{
+  volatile int exit_code = EXIT_SUCCESS_CODE;
+  volatile CurlError result;
+
+  TRY
+  {
+    result = execute_curl_request (&ctx->opts, &ctx->curl_opts, &ctx->write_ctx,
+                                   &ctx->header_ctx, &ctx->output);
+    exit_code = process_result (result, &ctx->opts);
+  }
+  EXCEPT (Curl_DNSFailed)
+  {
+    exit_code = exception_map[0].exit_code;
+    print_error_message (&ctx->opts, exception_map[0].message);
+  }
+  EXCEPT (Curl_ConnectFailed)
+  {
+    exit_code = exception_map[1].exit_code;
+    print_error_message (&ctx->opts, exception_map[1].message);
+  }
+  EXCEPT (Curl_TLSFailed)
+  {
+    exit_code = exception_map[2].exit_code;
+    print_error_message (&ctx->opts, exception_map[2].message);
+  }
+  EXCEPT (Curl_Timeout)
+  {
+    exit_code = exception_map[3].exit_code;
+    print_error_message (&ctx->opts, exception_map[3].message);
+  }
+  EXCEPT (Curl_TooManyRedirects)
+  {
+    exit_code = exception_map[4].exit_code;
+    print_error_message (&ctx->opts, exception_map[4].message);
+  }
+  EXCEPT (Curl_InvalidURL)
+  {
+    exit_code = exception_map[5].exit_code;
+    print_error_message (&ctx->opts, exception_map[5].message);
+  }
+  EXCEPT (Curl_Failed)
+  {
+    exit_code = exception_map[6].exit_code;
+    print_error_message (&ctx->opts, exception_map[6].message);
+  }
+  FINALLY
+  {
+    cleanup_session (&ctx->session, &ctx->output, &ctx->opts, ctx->auth_username,
+                     ctx->auth_password);
+  }
+  END_TRY;
+
+  return exit_code;
+}
+
+int
+main (int argc, char **argv)
+{
+  MainContext ctx;
+  init_main_context (&ctx);
+
+  int parse_result = parse_options (argc, argv, &ctx.opts);
+  if (parse_result < 0)
+    return -parse_result;
+  if (parse_result > 0)
+    return EXIT_SUCCESS_CODE;
+
+  setup_signals ();
+  setup_main_context (&ctx);
+
+  int exit_code = run_curl_main (&ctx);
+
+  if (!ctx.opts.silent && !ctx.opts.verbose)
+    fprintf (stderr, "\n");
+
+  return exit_code;
+}


### PR DESCRIPTION
## Summary

Add the tcurl (tiny curl) example that demonstrates using the tetsuo-socket library to build a curl-like HTTP client. The example serves as a template for external consumers of the library.

**Build methods supported:**
- From within repo - uses local library build
- Standalone - auto-fetches library via CMake FetchContent
- System library - finds via pkg-config

Fixes #3221

## Test plan

- [x] Build tcurl from within `examples/curl/` directory
- [x] Verify `tcurl --version` works
- [ ] Test FetchContent build (standalone clone)
- [ ] Verify demo script works