### PR TITLE
docs: add maturity notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 # Socket Library
 
+> **Maturity Notice**: This library is functional and well-tested but newly released. It is appropriate for development, internal tooling, and controlled environments. Production deployment with untrusted network input should wait until the codebase has accumulated several months of real-world hardening.
+
 High-performance, exception-driven socket toolkit for POSIX systems. Provides a clean, modern C API for TCP, UDP, Unix domain sockets, HTTP/1.1, HTTP/2, QUIC, WebSocket, and TLS/DTLS with comprehensive error handling, zero-copy I/O, and cross-platform event polling.
 
 ## Features


### PR DESCRIPTION
## Summary
- Add a maturity notice to the top of README.md
- Clarifies the library is suitable for development and internal use
- Recommends waiting for additional hardening before public-facing production deployment

## Context
The library has comprehensive test coverage and fuzzing infrastructure, but is newly released. This notice sets appropriate expectations for users.