### PR TITLE
feat(quic): implement QUIC-specific TLS adjustments (RFC 9001 §8.1, §8.4)

### DIFF
--- a/include/quic/SocketQUICError.h
+++ b/include/quic/SocketQUICError.h
@@ -237,6 +237,22 @@ typedef enum
   TLS_ALERT_NO_APPLICATION_PROTOCOL = 120
 } SocketTLS_Alert;
 
+/* ============================================================================
+ * QUIC-Specific TLS Errors (RFC 9001 Section 8)
+ * ============================================================================
+ */
+
+/**
+ * @brief QUIC error for ALPN negotiation failure (RFC 9001 §8.1).
+ *
+ * Per RFC 9001: "If no compatible application protocol is negotiated,
+ * the endpoint MUST close the connection with a no_application_protocol
+ * TLS alert (QUIC error code 0x0178)."
+ *
+ * This is equivalent to QUIC_CRYPTO_ERROR(TLS_ALERT_NO_APPLICATION_PROTOCOL).
+ */
+#define QUIC_ERROR_NO_APPLICATION_PROTOCOL 0x0178
+
 /**
  * @brief Get human-readable name for a TLS alert.
  *

--- a/include/quic/SocketQUICTLS.h
+++ b/include/quic/SocketQUICTLS.h
@@ -392,4 +392,44 @@ SocketQUICTLS_get_peer_params (SocketQUICHandshake_T handshake);
  */
 extern const char *SocketQUICTLS_result_string (SocketQUICTLS_Result result);
 
+/* ============================================================================
+ * ALPN Functions (RFC 9001 Section 8.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Check if ALPN negotiation succeeded (RFC 9001 §8.1).
+ *
+ * Per RFC 9001 §8.1, ALPN is mandatory for QUIC connections. This function
+ * validates that an application protocol was successfully negotiated.
+ * Call after handshake completes.
+ *
+ * If ALPN negotiation failed, sets handshake->error_code to
+ * QUIC_ERROR_NO_APPLICATION_PROTOCOL (0x0178).
+ *
+ * @param handshake Handshake context.
+ *
+ * @return QUIC_TLS_OK if ALPN was negotiated, QUIC_TLS_ERROR_ALPN otherwise.
+ */
+extern SocketQUICTLS_Result
+SocketQUICTLS_check_alpn_negotiated (SocketQUICHandshake_T handshake);
+
+/**
+ * @brief Get negotiated ALPN protocol string.
+ *
+ * Retrieves the application protocol negotiated during TLS handshake.
+ * Valid only after handshake completes.
+ *
+ * @param handshake Handshake context.
+ * @param alpn      Output: pointer to ALPN string (NOT null-terminated).
+ *                  Valid until SSL object is freed.
+ * @param len       Output: ALPN string length in bytes.
+ *
+ * @return QUIC_TLS_OK if available, QUIC_TLS_ERROR_ALPN if not negotiated.
+ */
+extern SocketQUICTLS_Result
+SocketQUICTLS_get_alpn (SocketQUICHandshake_T handshake,
+                        const char **alpn,
+                        size_t *len);
+
 #endif /* SOCKETQUICTLS_INCLUDED */


### PR DESCRIPTION
## Summary

Implement QUIC-specific TLS behavior modifications per RFC 9001:

- **§8.1 (ALPN)**: ALPN is mandatory for QUIC connections
  - Add `QUIC_ERROR_NO_APPLICATION_PROTOCOL` (0x0178) error constant
  - Add `SocketQUICTLS_check_alpn_negotiated()` to validate ALPN
  - Add `SocketQUICTLS_get_alpn()` to retrieve negotiated protocol
  - Update ALPN callback to set proper error code on failure

- **§8.4 (Middlebox Compatibility)**: QUIC MUST NOT use middlebox compat mode
  - Disable `SSL_OP_ENABLE_MIDDLEBOX_COMPAT` in TLS context creation
  - QUIC does not use change_cipher_spec or legacy_session_id

Fixes #3240

## Changes

| File | Change |
|------|--------|
| `include/quic/SocketQUICError.h` | Add QUIC_ERROR_NO_APPLICATION_PROTOCOL constant |
| `include/quic/SocketQUICTLS.h` | Add function declarations for ALPN check/get |
| `src/quic/SocketQUICTLS.c` | Implement ALPN functions, disable middlebox compat, add stubs |
| `src/test/test_quic_tls.c` | Add 8 new test cases for ALPN functions |

## Test plan

- [x] All 75 QUIC TLS tests pass
- [x] All 133 project tests pass with sanitizers (ASan + UBSan)
- [x] Tests handle both QUIC-enabled and non-QUIC OpenSSL environments