### PR TITLE
feat(quic): implement session resumption and HelloRetryRequest (RFC 9001 §4.5, §4.7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,6 +423,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICAck.c
     src/quic/SocketQUICLoss.c
     src/quic/SocketQUICTLS.c
+    src/quic/SocketQUICSession.c
 
 )
 
@@ -652,6 +653,7 @@ set(QUIC_HEADERS
     include/quic/SocketQUICAck.h
     include/quic/SocketQUICLoss.h
     include/quic/SocketQUICTLS.h
+    include/quic/SocketQUICSession.h
 )
 
 set(SIMPLE_HEADERS
@@ -834,6 +836,7 @@ set(TEST_SOURCES
     test_quic_ack
     test_quic_loss
     test_quic_key_discard
+    test_quic_session
 )
 
 # TLS tests (only built when TLS is enabled)

--- a/include/quic/SocketQUICSession.h
+++ b/include/quic/SocketQUICSession.h
@@ -1,0 +1,479 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICSession.h
+ * @brief QUIC Session Resumption and HelloRetryRequest (RFC 9001 §4.5, §4.7).
+ *
+ * Session Resumption (§4.5):
+ * - NewSessionTicket messages carried in CRYPTO frames after handshake
+ * - Clients store tickets for subsequent 0-RTT connections
+ * - Servers use tickets to restore session state
+ *
+ * HelloRetryRequest (§4.7):
+ * - Server requests different key share or validates client
+ * - Client responds with new ClientHello
+ * - Initial keys updated after HRR with new transcript hash
+ *
+ * Thread Safety: Functions are not thread-safe per session context.
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9001#section-4.5
+ * @see https://www.rfc-editor.org/rfc/rfc9001#section-4.7
+ */
+
+#ifndef SOCKETQUICSESSION_INCLUDED
+#define SOCKETQUICSESSION_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICHandshake.h"
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/**
+ * @brief Maximum session ticket size (RFC 8446 §4.6.1).
+ *
+ * TLS 1.3 recommends tickets be compact for QUIC due to ClientHello size.
+ */
+#define QUIC_SESSION_MAX_TICKET_SIZE 2048
+
+/**
+ * @brief Maximum HRR cookie size (RFC 8446 §4.2.2).
+ *
+ * Servers may include a cookie in HelloRetryRequest for stateless retry.
+ */
+#define QUIC_SESSION_MAX_COOKIE_SIZE 256
+
+/**
+ * @brief Maximum age for session resumption (RFC 8446 §4.6.1).
+ *
+ * TLS 1.3 limits resumption to 7 days (604800 seconds).
+ */
+#define QUIC_SESSION_MAX_AGE_SECONDS 604800
+
+/**
+ * @brief QUIC 0-RTT sentinel value (RFC 9001 §4.6.1).
+ *
+ * NewSessionTicket max_early_data_size must be 0xffffffff to enable 0-RTT.
+ */
+#define QUIC_SESSION_0RTT_SENTINEL 0xffffffffUL
+
+/* ============================================================================
+ * Types
+ * ============================================================================
+ */
+
+/**
+ * @brief Result codes for session operations.
+ */
+typedef enum
+{
+  QUIC_SESSION_OK = 0,             /**< Success */
+  QUIC_SESSION_ERROR_NULL,         /**< NULL argument */
+  QUIC_SESSION_ERROR_STATE,        /**< Invalid state for operation */
+  QUIC_SESSION_ERROR_TICKET,       /**< Invalid or expired ticket */
+  QUIC_SESSION_ERROR_HRR,          /**< HelloRetryRequest error */
+  QUIC_SESSION_ERROR_COOKIE,       /**< Cookie validation failed */
+  QUIC_SESSION_ERROR_MEMORY,       /**< Memory allocation failed */
+  QUIC_SESSION_ERROR_TRANSPORT,    /**< Transport parameter mismatch */
+  QUIC_SESSION_ERROR_ALPN,         /**< ALPN mismatch on resumption */
+  QUIC_SESSION_ERROR_EXPIRED,      /**< Session ticket expired */
+  QUIC_SESSION_ERROR_NOT_RESUMABLE /**< Session cannot be resumed */
+} SocketQUICSession_Result;
+
+/**
+ * @brief Session resumption state.
+ */
+typedef enum
+{
+  QUIC_SESSION_STATE_NONE = 0,   /**< No session/resumption */
+  QUIC_SESSION_STATE_STORED,     /**< Ticket stored, can attempt resumption */
+  QUIC_SESSION_STATE_ATTEMPTING, /**< Currently attempting resumption */
+  QUIC_SESSION_STATE_RESUMED,    /**< Successfully resumed */
+  QUIC_SESSION_STATE_NEW         /**< New session (no resumption) */
+} SocketQUICSessionState;
+
+/**
+ * @brief HelloRetryRequest state tracking.
+ */
+typedef struct
+{
+  int hrr_received;               /**< HRR received from server */
+  int hrr_sent;                   /**< HRR sent by server */
+  uint8_t cookie[QUIC_SESSION_MAX_COOKIE_SIZE]; /**< HRR cookie data */
+  size_t cookie_len;              /**< Cookie length in bytes */
+  uint8_t transcript_hash[32];    /**< CH1 transcript hash after HRR */
+  int transcript_hash_valid;      /**< Transcript hash computed */
+} SocketQUICHRR_T;
+
+/**
+ * @brief Session ticket storage for resumption.
+ */
+typedef struct
+{
+  uint8_t ticket[QUIC_SESSION_MAX_TICKET_SIZE]; /**< Ticket data */
+  size_t ticket_len;                /**< Ticket length in bytes */
+  uint32_t lifetime;                /**< Ticket lifetime in seconds */
+  uint32_t age_add;                 /**< Ticket age obfuscator (RFC 8446) */
+  uint64_t issue_time;              /**< Timestamp when ticket was issued */
+  uint32_t max_early_data;          /**< max_early_data_size (0xffffffff for 0-RTT) */
+  int valid;                        /**< Ticket is valid */
+} SocketQUICTicket_T;
+
+/**
+ * @brief Transport parameters saved for 0-RTT validation.
+ *
+ * Per RFC 9001 §4.6.3, these parameters from the original connection
+ * must be validated when attempting 0-RTT.
+ */
+typedef struct
+{
+  uint64_t initial_max_data;          /**< initial_max_data from server */
+  uint64_t initial_max_stream_data_bidi_local;
+  uint64_t initial_max_stream_data_bidi_remote;
+  uint64_t initial_max_stream_data_uni;
+  uint64_t initial_max_streams_bidi;
+  uint64_t initial_max_streams_uni;
+  uint64_t active_connection_id_limit;
+  int params_valid;                   /**< Parameters are valid */
+} SocketQUICSessionParams_T;
+
+/**
+ * @brief Complete session context for resumption and HRR.
+ */
+typedef struct SocketQUICSession *SocketQUICSession_T;
+
+struct SocketQUICSession
+{
+  Arena_T arena;                      /**< Memory arena */
+  SocketQUICSessionState state;       /**< Current session state */
+  SocketQUICHRR_T hrr;                /**< HelloRetryRequest tracking */
+  SocketQUICTicket_T ticket;          /**< Stored session ticket */
+  SocketQUICSessionParams_T params;   /**< Transport params for 0-RTT */
+  char alpn[32];                      /**< ALPN protocol from original conn */
+  size_t alpn_len;                    /**< ALPN length */
+  int enable_0rtt;                    /**< 0-RTT enabled for this session */
+  void *ssl_session;                  /**< OpenSSL SSL_SESSION* (opaque) */
+};
+
+/* ============================================================================
+ * Exceptions
+ * ============================================================================
+ */
+
+extern const Except_T SocketQUICSession_Failed;
+
+/* ============================================================================
+ * Lifecycle Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Create a new session context.
+ *
+ * @param arena Memory arena for allocations.
+ *
+ * @return Session context, or NULL on allocation failure.
+ */
+extern SocketQUICSession_T SocketQUICSession_new (Arena_T arena);
+
+/**
+ * @brief Free session context and securely clear sensitive data.
+ *
+ * @param session Pointer to session context (set to NULL after).
+ */
+extern void SocketQUICSession_free (SocketQUICSession_T *session);
+
+/* ============================================================================
+ * Session Ticket Functions (RFC 9001 §4.5)
+ * ============================================================================
+ */
+
+/**
+ * @brief Store a session ticket for future resumption.
+ *
+ * Called after handshake when NewSessionTicket is received.
+ * Validates max_early_data_size sentinel for 0-RTT capability.
+ *
+ * @param session      Session context.
+ * @param ticket_data  Raw ticket data from NewSessionTicket.
+ * @param ticket_len   Ticket data length.
+ * @param lifetime     Ticket lifetime in seconds.
+ * @param age_add      Ticket age obfuscator value.
+ * @param max_early_data max_early_data_size from NewSessionTicket.
+ *
+ * @return QUIC_SESSION_OK on success, error code otherwise.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_store_ticket (SocketQUICSession_T session,
+                                const uint8_t *ticket_data,
+                                size_t ticket_len,
+                                uint32_t lifetime,
+                                uint32_t age_add,
+                                uint32_t max_early_data);
+
+/**
+ * @brief Check if session can be resumed with 0-RTT.
+ *
+ * Verifies ticket validity, expiration, and 0-RTT capability.
+ *
+ * @param session Session context.
+ *
+ * @return Non-zero if 0-RTT resumption is possible, 0 otherwise.
+ */
+extern int SocketQUICSession_can_attempt_0rtt (SocketQUICSession_T session);
+
+/**
+ * @brief Check if session can be resumed (with or without 0-RTT).
+ *
+ * Verifies ticket validity and expiration only.
+ *
+ * @param session Session context.
+ *
+ * @return Non-zero if resumption is possible, 0 otherwise.
+ */
+extern int SocketQUICSession_can_resume (SocketQUICSession_T session);
+
+/**
+ * @brief Get obfuscated ticket age for ClientHello.
+ *
+ * Per RFC 8446 §4.2.11.1, obfuscated_ticket_age =
+ * (current_time - issue_time + age_add) mod 2^32
+ *
+ * @param session Session context.
+ *
+ * @return Obfuscated ticket age, or 0 if no valid ticket.
+ */
+extern uint32_t
+SocketQUICSession_get_obfuscated_age (SocketQUICSession_T session);
+
+/**
+ * @brief Save transport parameters for 0-RTT validation.
+ *
+ * Per RFC 9001 §4.6.3, these must be saved with the ticket.
+ *
+ * @param session Session context.
+ * @param params  Transport parameters from server.
+ *
+ * @return QUIC_SESSION_OK on success.
+ */
+extern SocketQUICSession_Result SocketQUICSession_save_transport_params (
+    SocketQUICSession_T session, const SocketQUICTransportParams_T *params);
+
+/**
+ * @brief Validate transport parameters for 0-RTT.
+ *
+ * Per RFC 9001 §4.6.3, server's new parameters must be at least
+ * as permissive as the remembered parameters.
+ *
+ * @param session    Session context.
+ * @param new_params Server's new transport parameters.
+ *
+ * @return QUIC_SESSION_OK if valid, QUIC_SESSION_ERROR_TRANSPORT if not.
+ */
+extern SocketQUICSession_Result SocketQUICSession_validate_transport_params (
+    SocketQUICSession_T session, const SocketQUICTransportParams_T *new_params);
+
+/**
+ * @brief Clear stored session ticket.
+ *
+ * Securely erases ticket data.
+ *
+ * @param session Session context.
+ */
+extern void SocketQUICSession_clear_ticket (SocketQUICSession_T session);
+
+/* ============================================================================
+ * HelloRetryRequest Functions (RFC 9001 §4.7)
+ * ============================================================================
+ */
+
+/**
+ * @brief Notify that HelloRetryRequest was received (client).
+ *
+ * Updates session state and stores any cookie from HRR.
+ *
+ * @param session    Session context.
+ * @param cookie     Cookie data from HRR (may be NULL).
+ * @param cookie_len Cookie length (0 if no cookie).
+ *
+ * @return QUIC_SESSION_OK on success.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_on_hrr_received (SocketQUICSession_T session,
+                                   const uint8_t *cookie,
+                                   size_t cookie_len);
+
+/**
+ * @brief Notify that HelloRetryRequest was sent (server).
+ *
+ * Updates session state for server-side HRR tracking.
+ *
+ * @param session Session context.
+ *
+ * @return QUIC_SESSION_OK on success.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_on_hrr_sent (SocketQUICSession_T session);
+
+/**
+ * @brief Check if HelloRetryRequest was received.
+ *
+ * @param session Session context.
+ *
+ * @return Non-zero if HRR was received, 0 otherwise.
+ */
+extern int SocketQUICSession_is_hrr (SocketQUICSession_T session);
+
+/**
+ * @brief Get HRR cookie for second ClientHello.
+ *
+ * @param session    Session context.
+ * @param cookie     Output: cookie data pointer.
+ * @param cookie_len Output: cookie length.
+ *
+ * @return QUIC_SESSION_OK if cookie available, error otherwise.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_get_hrr_cookie (SocketQUICSession_T session,
+                                  const uint8_t **cookie,
+                                  size_t *cookie_len);
+
+/**
+ * @brief Store transcript hash for post-HRR operations.
+ *
+ * After HRR, the transcript hash includes a synthetic message.
+ * This hash is needed for key derivation.
+ *
+ * @param session Session context.
+ * @param hash    32-byte transcript hash.
+ *
+ * @return QUIC_SESSION_OK on success.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_set_hrr_transcript (SocketQUICSession_T session,
+                                      const uint8_t hash[32]);
+
+/**
+ * @brief Check if HRR causes 0-RTT rejection.
+ *
+ * Per RFC 9001 §4.6.2, server always rejects 0-RTT if HRR is sent.
+ *
+ * @param session Session context.
+ *
+ * @return Non-zero if 0-RTT is rejected due to HRR, 0 otherwise.
+ */
+extern int SocketQUICSession_hrr_rejects_0rtt (SocketQUICSession_T session);
+
+/* ============================================================================
+ * State Query Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Get current session state.
+ *
+ * @param session Session context.
+ *
+ * @return Current session state.
+ */
+extern SocketQUICSessionState
+SocketQUICSession_get_state (SocketQUICSession_T session);
+
+/**
+ * @brief Check if session was resumed.
+ *
+ * @param session Session context.
+ *
+ * @return Non-zero if session was resumed, 0 otherwise.
+ */
+extern int SocketQUICSession_is_resumed (SocketQUICSession_T session);
+
+/**
+ * @brief Mark session as successfully resumed.
+ *
+ * Called when server accepts resumption.
+ *
+ * @param session Session context.
+ */
+extern void SocketQUICSession_mark_resumed (SocketQUICSession_T session);
+
+/**
+ * @brief Mark session as new (resumption failed or not attempted).
+ *
+ * @param session Session context.
+ */
+extern void SocketQUICSession_mark_new (SocketQUICSession_T session);
+
+/* ============================================================================
+ * ALPN Functions (RFC 9001 §4.6.3)
+ * ============================================================================
+ */
+
+/**
+ * @brief Save ALPN protocol for 0-RTT validation.
+ *
+ * Per RFC 9001 §4.6.3, ALPN from original connection must match.
+ *
+ * @param session  Session context.
+ * @param alpn     ALPN protocol string.
+ * @param alpn_len ALPN length.
+ *
+ * @return QUIC_SESSION_OK on success.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_save_alpn (SocketQUICSession_T session,
+                             const char *alpn,
+                             size_t alpn_len);
+
+/**
+ * @brief Validate ALPN for 0-RTT.
+ *
+ * ALPN from new connection must match the remembered ALPN.
+ *
+ * @param session  Session context.
+ * @param alpn     ALPN from new connection.
+ * @param alpn_len ALPN length.
+ *
+ * @return QUIC_SESSION_OK if match, QUIC_SESSION_ERROR_ALPN if not.
+ */
+extern SocketQUICSession_Result
+SocketQUICSession_validate_alpn (SocketQUICSession_T session,
+                                 const char *alpn,
+                                 size_t alpn_len);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Get string representation of session state.
+ *
+ * @param state Session state.
+ *
+ * @return Human-readable string.
+ */
+extern const char *
+SocketQUICSession_state_string (SocketQUICSessionState state);
+
+/**
+ * @brief Get string representation of result code.
+ *
+ * @param result Result code.
+ *
+ * @return Human-readable string.
+ */
+extern const char *
+SocketQUICSession_result_string (SocketQUICSession_Result result);
+
+#endif /* SOCKETQUICSESSION_INCLUDED */

--- a/src/quic/SocketQUICSession.c
+++ b/src/quic/SocketQUICSession.c
@@ -1,0 +1,533 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICSession.c
+ * @brief QUIC Session Resumption and HelloRetryRequest (RFC 9001 §4.5, §4.7).
+ */
+
+#include "quic/SocketQUICSession.h"
+
+#include <string.h>
+#include <time.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "core/SocketConfig.h"
+
+#if SOCKET_HAS_TLS
+#include <openssl/crypto.h>
+#endif
+
+/* ============================================================================
+ * Module Exception
+ * ============================================================================
+ */
+
+const Except_T SocketQUICSession_Failed
+    = { &SocketQUICSession_Failed, "SocketQUICSession_Failed" };
+
+/* ============================================================================
+ * String Tables
+ * ============================================================================
+ */
+
+static const char *const state_strings[] = {
+  [QUIC_SESSION_STATE_NONE] = "NONE",
+  [QUIC_SESSION_STATE_STORED] = "STORED",
+  [QUIC_SESSION_STATE_ATTEMPTING] = "ATTEMPTING",
+  [QUIC_SESSION_STATE_RESUMED] = "RESUMED",
+  [QUIC_SESSION_STATE_NEW] = "NEW",
+};
+
+static const char *const result_strings[] = {
+  [QUIC_SESSION_OK] = "OK",
+  [QUIC_SESSION_ERROR_NULL] = "NULL argument",
+  [QUIC_SESSION_ERROR_STATE] = "Invalid state",
+  [QUIC_SESSION_ERROR_TICKET] = "Invalid ticket",
+  [QUIC_SESSION_ERROR_HRR] = "HelloRetryRequest error",
+  [QUIC_SESSION_ERROR_COOKIE] = "Cookie validation failed",
+  [QUIC_SESSION_ERROR_MEMORY] = "Memory allocation failed",
+  [QUIC_SESSION_ERROR_TRANSPORT] = "Transport parameter mismatch",
+  [QUIC_SESSION_ERROR_ALPN] = "ALPN mismatch",
+  [QUIC_SESSION_ERROR_EXPIRED] = "Session expired",
+  [QUIC_SESSION_ERROR_NOT_RESUMABLE] = "Session not resumable",
+};
+
+/* ============================================================================
+ * Internal Helpers
+ * ============================================================================
+ */
+
+/**
+ * @brief Get current time in seconds since epoch.
+ */
+static uint64_t
+get_current_time (void)
+{
+  return (uint64_t)time (NULL);
+}
+
+/**
+ * @brief Securely clear sensitive memory.
+ */
+static void
+secure_clear (void *ptr, size_t len)
+{
+  if (ptr == NULL || len == 0)
+    return;
+
+#if SOCKET_HAS_TLS
+  OPENSSL_cleanse (ptr, len);
+#else
+  volatile unsigned char *p = ptr;
+  while (len--)
+    *p++ = 0;
+#endif
+}
+
+/**
+ * @brief Check if ticket has expired.
+ */
+static int
+ticket_is_expired (const SocketQUICTicket_T *ticket)
+{
+  if (!ticket->valid)
+    return 1;
+
+  uint64_t now = get_current_time ();
+
+  /* Handle clock skew - if current time is before issue time, treat as expired */
+  if (now < ticket->issue_time)
+    return 1;
+
+  uint64_t age = now - ticket->issue_time;
+
+  if (age > ticket->lifetime)
+    return 1;
+
+  if (age > QUIC_SESSION_MAX_AGE_SECONDS)
+    return 1;
+
+  return 0;
+}
+
+/* ============================================================================
+ * Lifecycle Functions
+ * ============================================================================
+ */
+
+SocketQUICSession_T
+SocketQUICSession_new (Arena_T arena)
+{
+  if (arena == NULL)
+    return NULL;
+
+  SocketQUICSession_T session
+      = Arena_alloc (arena, sizeof (*session), __FILE__, __LINE__);
+  if (session == NULL)
+    return NULL;
+
+  memset (session, 0, sizeof (*session));
+  session->arena = arena;
+  session->state = QUIC_SESSION_STATE_NONE;
+
+  return session;
+}
+
+void
+SocketQUICSession_free (SocketQUICSession_T *session)
+{
+  if (session == NULL || *session == NULL)
+    return;
+
+  SocketQUICSession_T s = *session;
+
+  secure_clear (s->ticket.ticket, s->ticket.ticket_len);
+  secure_clear (s->hrr.cookie, s->hrr.cookie_len);
+  secure_clear (s->hrr.transcript_hash, sizeof (s->hrr.transcript_hash));
+
+  memset (s, 0, sizeof (*s));
+  *session = NULL;
+}
+
+/* ============================================================================
+ * Session Ticket Functions (RFC 9001 §4.5)
+ * ============================================================================
+ */
+
+SocketQUICSession_Result
+SocketQUICSession_store_ticket (SocketQUICSession_T session,
+                                const uint8_t *ticket_data,
+                                size_t ticket_len,
+                                uint32_t lifetime,
+                                uint32_t age_add,
+                                uint32_t max_early_data)
+{
+  if (session == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (ticket_data == NULL || ticket_len == 0)
+    return QUIC_SESSION_ERROR_TICKET;
+
+  if (ticket_len > QUIC_SESSION_MAX_TICKET_SIZE)
+    return QUIC_SESSION_ERROR_TICKET;
+
+  if (lifetime == 0 || lifetime > QUIC_SESSION_MAX_AGE_SECONDS)
+    return QUIC_SESSION_ERROR_TICKET;
+
+  secure_clear (session->ticket.ticket, session->ticket.ticket_len);
+
+  memcpy (session->ticket.ticket, ticket_data, ticket_len);
+  session->ticket.ticket_len = ticket_len;
+  session->ticket.lifetime = lifetime;
+  session->ticket.age_add = age_add;
+  session->ticket.issue_time = get_current_time ();
+  session->ticket.max_early_data = max_early_data;
+  session->ticket.valid = 1;
+
+  if (max_early_data == QUIC_SESSION_0RTT_SENTINEL)
+    session->enable_0rtt = 1;
+  else
+    session->enable_0rtt = 0;
+
+  session->state = QUIC_SESSION_STATE_STORED;
+
+  return QUIC_SESSION_OK;
+}
+
+int
+SocketQUICSession_can_attempt_0rtt (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return 0;
+
+  if (!session->ticket.valid)
+    return 0;
+
+  if (ticket_is_expired (&session->ticket))
+    return 0;
+
+  if (session->ticket.max_early_data != QUIC_SESSION_0RTT_SENTINEL)
+    return 0;
+
+  if (!session->enable_0rtt)
+    return 0;
+
+  if (!session->params.params_valid)
+    return 0;
+
+  return 1;
+}
+
+int
+SocketQUICSession_can_resume (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return 0;
+
+  if (!session->ticket.valid)
+    return 0;
+
+  if (ticket_is_expired (&session->ticket))
+    return 0;
+
+  return 1;
+}
+
+uint32_t
+SocketQUICSession_get_obfuscated_age (SocketQUICSession_T session)
+{
+  if (session == NULL || !session->ticket.valid)
+    return 0;
+
+  uint64_t now = get_current_time ();
+  uint64_t age_ms = (now - session->ticket.issue_time) * 1000;
+
+  return (uint32_t)((age_ms + session->ticket.age_add) & 0xffffffffUL);
+}
+
+SocketQUICSession_Result
+SocketQUICSession_save_transport_params (
+    SocketQUICSession_T session, const SocketQUICTransportParams_T *params)
+{
+  if (session == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (params == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  session->params.initial_max_data = params->initial_max_data;
+  session->params.initial_max_stream_data_bidi_local
+      = params->initial_max_stream_data_bidi_local;
+  session->params.initial_max_stream_data_bidi_remote
+      = params->initial_max_stream_data_bidi_remote;
+  session->params.initial_max_stream_data_uni
+      = params->initial_max_stream_data_uni;
+  session->params.initial_max_streams_bidi = params->initial_max_streams_bidi;
+  session->params.initial_max_streams_uni = params->initial_max_streams_uni;
+  session->params.active_connection_id_limit
+      = params->active_connection_id_limit;
+  session->params.params_valid = 1;
+
+  return QUIC_SESSION_OK;
+}
+
+SocketQUICSession_Result
+SocketQUICSession_validate_transport_params (
+    SocketQUICSession_T session, const SocketQUICTransportParams_T *new_params)
+{
+  if (session == NULL || new_params == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (!session->params.params_valid)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  const SocketQUICSessionParams_T *saved = &session->params;
+
+  if (new_params->initial_max_data < saved->initial_max_data)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  if (new_params->initial_max_stream_data_bidi_local
+      < saved->initial_max_stream_data_bidi_local)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  if (new_params->initial_max_stream_data_bidi_remote
+      < saved->initial_max_stream_data_bidi_remote)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  if (new_params->initial_max_stream_data_uni
+      < saved->initial_max_stream_data_uni)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  if (new_params->initial_max_streams_bidi < saved->initial_max_streams_bidi)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  if (new_params->initial_max_streams_uni < saved->initial_max_streams_uni)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  if (new_params->active_connection_id_limit < saved->active_connection_id_limit)
+    return QUIC_SESSION_ERROR_TRANSPORT;
+
+  return QUIC_SESSION_OK;
+}
+
+void
+SocketQUICSession_clear_ticket (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return;
+
+  secure_clear (session->ticket.ticket, session->ticket.ticket_len);
+  memset (&session->ticket, 0, sizeof (session->ticket));
+  session->enable_0rtt = 0;
+
+  if (session->state == QUIC_SESSION_STATE_STORED)
+    session->state = QUIC_SESSION_STATE_NONE;
+}
+
+/* ============================================================================
+ * HelloRetryRequest Functions (RFC 9001 §4.7)
+ * ============================================================================
+ */
+
+SocketQUICSession_Result
+SocketQUICSession_on_hrr_received (SocketQUICSession_T session,
+                                   const uint8_t *cookie,
+                                   size_t cookie_len)
+{
+  if (session == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (cookie_len > QUIC_SESSION_MAX_COOKIE_SIZE)
+    return QUIC_SESSION_ERROR_COOKIE;
+
+  session->hrr.hrr_received = 1;
+
+  if (cookie != NULL && cookie_len > 0)
+    {
+      memcpy (session->hrr.cookie, cookie, cookie_len);
+      session->hrr.cookie_len = cookie_len;
+    }
+  else
+    {
+      session->hrr.cookie_len = 0;
+    }
+
+  return QUIC_SESSION_OK;
+}
+
+SocketQUICSession_Result
+SocketQUICSession_on_hrr_sent (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  session->hrr.hrr_sent = 1;
+
+  return QUIC_SESSION_OK;
+}
+
+int
+SocketQUICSession_is_hrr (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return 0;
+
+  return session->hrr.hrr_received || session->hrr.hrr_sent;
+}
+
+SocketQUICSession_Result
+SocketQUICSession_get_hrr_cookie (SocketQUICSession_T session,
+                                  const uint8_t **cookie,
+                                  size_t *cookie_len)
+{
+  if (session == NULL || cookie == NULL || cookie_len == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (!session->hrr.hrr_received)
+    return QUIC_SESSION_ERROR_HRR;
+
+  if (session->hrr.cookie_len == 0)
+    return QUIC_SESSION_ERROR_COOKIE;
+
+  *cookie = session->hrr.cookie;
+  *cookie_len = session->hrr.cookie_len;
+
+  return QUIC_SESSION_OK;
+}
+
+SocketQUICSession_Result
+SocketQUICSession_set_hrr_transcript (SocketQUICSession_T session,
+                                      const uint8_t hash[32])
+{
+  if (session == NULL || hash == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  memcpy (session->hrr.transcript_hash, hash, 32);
+  session->hrr.transcript_hash_valid = 1;
+
+  return QUIC_SESSION_OK;
+}
+
+int
+SocketQUICSession_hrr_rejects_0rtt (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return 0;
+
+  return session->hrr.hrr_sent != 0;
+}
+
+/* ============================================================================
+ * State Query Functions
+ * ============================================================================
+ */
+
+SocketQUICSessionState
+SocketQUICSession_get_state (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return QUIC_SESSION_STATE_NONE;
+
+  return session->state;
+}
+
+int
+SocketQUICSession_is_resumed (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return 0;
+
+  return session->state == QUIC_SESSION_STATE_RESUMED;
+}
+
+void
+SocketQUICSession_mark_resumed (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return;
+
+  session->state = QUIC_SESSION_STATE_RESUMED;
+}
+
+void
+SocketQUICSession_mark_new (SocketQUICSession_T session)
+{
+  if (session == NULL)
+    return;
+
+  session->state = QUIC_SESSION_STATE_NEW;
+}
+
+/* ============================================================================
+ * ALPN Functions (RFC 9001 §4.6.3)
+ * ============================================================================
+ */
+
+SocketQUICSession_Result
+SocketQUICSession_save_alpn (SocketQUICSession_T session,
+                             const char *alpn,
+                             size_t alpn_len)
+{
+  if (session == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (alpn == NULL || alpn_len == 0)
+    return QUIC_SESSION_ERROR_ALPN;
+
+  if (alpn_len >= sizeof (session->alpn))
+    return QUIC_SESSION_ERROR_ALPN;
+
+  memcpy (session->alpn, alpn, alpn_len);
+  session->alpn[alpn_len] = '\0';
+  session->alpn_len = alpn_len;
+
+  return QUIC_SESSION_OK;
+}
+
+SocketQUICSession_Result
+SocketQUICSession_validate_alpn (SocketQUICSession_T session,
+                                 const char *alpn,
+                                 size_t alpn_len)
+{
+  if (session == NULL || alpn == NULL)
+    return QUIC_SESSION_ERROR_NULL;
+
+  if (session->alpn_len == 0)
+    return QUIC_SESSION_OK;
+
+  if (alpn_len != session->alpn_len)
+    return QUIC_SESSION_ERROR_ALPN;
+
+  if (memcmp (session->alpn, alpn, alpn_len) != 0)
+    return QUIC_SESSION_ERROR_ALPN;
+
+  return QUIC_SESSION_OK;
+}
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+const char *
+SocketQUICSession_state_string (SocketQUICSessionState state)
+{
+  if (state < 0 || (size_t)state >= sizeof (state_strings) / sizeof (char *))
+    return "UNKNOWN";
+
+  return state_strings[state];
+}
+
+const char *
+SocketQUICSession_result_string (SocketQUICSession_Result result)
+{
+  if (result < 0 || (size_t)result >= sizeof (result_strings) / sizeof (char *))
+    return "UNKNOWN";
+
+  return result_strings[result];
+}

--- a/src/test/test_quic_session.c
+++ b/src/test/test_quic_session.c
@@ -1,0 +1,944 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_quic_session.c
+ * @brief Tests for QUIC Session Resumption and HelloRetryRequest (RFC 9001 §4.5, §4.7).
+ *
+ * Covers:
+ * - Session ticket storage and validation
+ * - 0-RTT capability detection
+ * - Ticket expiration handling
+ * - Transport parameter validation for 0-RTT
+ * - HelloRetryRequest state tracking
+ * - ALPN validation for resumption
+ */
+
+#include <string.h>
+#include <time.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICSession.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Lifecycle Tests
+ * ============================================================================
+ */
+
+TEST (session_new_creates_session)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+  ASSERT_NOT_NULL (session);
+
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_NONE);
+
+  SocketQUICSession_free (&session);
+  ASSERT_NULL (session);
+
+  Arena_dispose (&arena);
+}
+
+TEST (session_new_null_arena_returns_null)
+{
+  SocketQUICSession_T session = SocketQUICSession_new (NULL);
+  ASSERT_NULL (session);
+}
+
+TEST (session_free_null_is_safe)
+{
+  SocketQUICSession_free (NULL);
+  /* Should not crash */
+
+  SocketQUICSession_T session = NULL;
+  SocketQUICSession_free (&session);
+  /* Should not crash */
+}
+
+/* ============================================================================
+ * Session Ticket Tests (RFC 9001 §4.5)
+ * ============================================================================
+ */
+
+TEST (session_store_ticket_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+  ASSERT_NOT_NULL (session);
+
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  SocketQUICSession_Result result = SocketQUICSession_store_ticket (
+      session, ticket_data, sizeof (ticket_data), 86400, /* 24 hours */
+      0x12345678,                                        /* age_add */
+      QUIC_SESSION_0RTT_SENTINEL                         /* enable 0-RTT */
+  );
+
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_STORED);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_null_session)
+{
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0, sizeof (ticket_data));
+  SocketQUICSession_Result result
+      = SocketQUICSession_store_ticket (NULL, ticket_data, 64, 86400, 0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+}
+
+TEST (session_store_ticket_null_data)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_store_ticket (session, NULL, 64, 86400, 0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TICKET);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_zero_length)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  SocketQUICSession_Result result
+      = SocketQUICSession_store_ticket (session, ticket_data, 0, 86400, 0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TICKET);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_too_large)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* Ticket larger than max size should fail */
+  uint8_t ticket_data[1];
+  SocketQUICSession_Result result = SocketQUICSession_store_ticket (
+      session, ticket_data, QUIC_SESSION_MAX_TICKET_SIZE + 1, 86400, 0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TICKET);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_zero_lifetime)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  SocketQUICSession_Result result = SocketQUICSession_store_ticket (
+      session, ticket_data, sizeof (ticket_data), 0, /* zero lifetime */
+      0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TICKET);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_exceeds_max_age)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  /* Lifetime exceeding 7 days should fail per RFC 8446 */
+  SocketQUICSession_Result result = SocketQUICSession_store_ticket (
+      session, ticket_data, sizeof (ticket_data),
+      QUIC_SESSION_MAX_AGE_SECONDS + 1, 0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TICKET);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_exact_max_size)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* Exactly max size should succeed */
+  uint8_t ticket_data[QUIC_SESSION_MAX_TICKET_SIZE];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  SocketQUICSession_Result result = SocketQUICSession_store_ticket (
+      session, ticket_data, QUIC_SESSION_MAX_TICKET_SIZE, 86400, 0, 0);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_store_ticket_replaces_previous)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* Store first ticket */
+  uint8_t ticket1[64];
+  memset (ticket1, 0xAA, sizeof (ticket1));
+  SocketQUICSession_store_ticket (session, ticket1, sizeof (ticket1), 86400,
+                                  0x11111111, 0);
+
+  /* Store second ticket - should replace first */
+  uint8_t ticket2[32];
+  memset (ticket2, 0xBB, sizeof (ticket2));
+  SocketQUICSession_Result result = SocketQUICSession_store_ticket (
+      session, ticket2, sizeof (ticket2), 3600, 0x22222222,
+      QUIC_SESSION_0RTT_SENTINEL);
+
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  /* Verify new ticket properties */
+  uint32_t age = SocketQUICSession_get_obfuscated_age (session);
+  /* age_add should be from second ticket */
+  ASSERT (age >= 0x22222222 && age < 0x22222222 + 1000);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * 0-RTT Capability Tests (RFC 9001 §4.6.1)
+ * ============================================================================
+ */
+
+TEST (session_can_attempt_0rtt_with_sentinel)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  /* Store ticket with 0-RTT sentinel */
+  SocketQUICSession_store_ticket (session, ticket_data, sizeof (ticket_data),
+                                  86400, 0x12345678,
+                                  QUIC_SESSION_0RTT_SENTINEL);
+
+  /* Need to save transport params for 0-RTT to work */
+  SocketQUICTransportParams_T params;
+  memset (&params, 0, sizeof (params));
+  params.initial_max_data = 65536;
+  params.initial_max_streams_bidi = 100;
+  SocketQUICSession_save_transport_params (session, &params);
+
+  ASSERT_NE (SocketQUICSession_can_attempt_0rtt (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_cannot_attempt_0rtt_without_sentinel)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  /* Store ticket without 0-RTT sentinel */
+  SocketQUICSession_store_ticket (session, ticket_data, sizeof (ticket_data),
+                                  86400, 0x12345678,
+                                  0 /* NOT the sentinel */
+  );
+
+  ASSERT_EQ (SocketQUICSession_can_attempt_0rtt (session), 0);
+
+  /* Can still resume though */
+  ASSERT_NE (SocketQUICSession_can_resume (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_cannot_attempt_0rtt_without_params)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  /* Store ticket with 0-RTT sentinel but no transport params */
+  SocketQUICSession_store_ticket (session, ticket_data, sizeof (ticket_data),
+                                  86400, 0x12345678, QUIC_SESSION_0RTT_SENTINEL);
+
+  /* Should fail because no transport params saved */
+  ASSERT_EQ (SocketQUICSession_can_attempt_0rtt (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_can_resume_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  SocketQUICSession_store_ticket (session, ticket_data, sizeof (ticket_data),
+                                  86400, 0x12345678, 0);
+
+  ASSERT_NE (SocketQUICSession_can_resume (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_cannot_resume_null)
+{
+  ASSERT_EQ (SocketQUICSession_can_resume (NULL), 0);
+}
+
+TEST (session_cannot_resume_no_ticket)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* No ticket stored */
+  ASSERT_EQ (SocketQUICSession_can_resume (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Obfuscated Age Tests (RFC 8446 §4.2.11.1)
+ * ============================================================================
+ */
+
+TEST (session_get_obfuscated_age_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  uint32_t age_add = 0x12345678;
+
+  SocketQUICSession_store_ticket (session, ticket_data, sizeof (ticket_data),
+                                  86400, age_add, 0);
+
+  /* Age should include age_add obfuscation */
+  uint32_t obfuscated = SocketQUICSession_get_obfuscated_age (session);
+  /* For a just-issued ticket, age ~= age_add (within a second) */
+  ASSERT (obfuscated >= age_add && obfuscated < age_add + 1000);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_get_obfuscated_age_null)
+{
+  ASSERT_EQ (SocketQUICSession_get_obfuscated_age (NULL), 0);
+}
+
+TEST (session_get_obfuscated_age_no_ticket)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  ASSERT_EQ (SocketQUICSession_get_obfuscated_age (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Transport Parameter Tests (RFC 9001 §4.6.3)
+ * ============================================================================
+ */
+
+TEST (session_save_transport_params_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICTransportParams_T params;
+  memset (&params, 0, sizeof (params));
+  params.initial_max_data = 65536;
+  params.initial_max_stream_data_bidi_local = 32768;
+  params.initial_max_streams_bidi = 100;
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_save_transport_params (session, &params);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_save_transport_params_null)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_save_transport_params (session, NULL);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+
+  result = SocketQUICSession_save_transport_params (NULL, NULL);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_transport_params_ok)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICTransportParams_T saved_params;
+  memset (&saved_params, 0, sizeof (saved_params));
+  saved_params.initial_max_data = 65536;
+  saved_params.initial_max_streams_bidi = 100;
+
+  SocketQUICSession_save_transport_params (session, &saved_params);
+
+  /* New params that are MORE permissive should pass */
+  SocketQUICTransportParams_T new_params;
+  memset (&new_params, 0, sizeof (new_params));
+  new_params.initial_max_data = 131072; /* greater than saved */
+  new_params.initial_max_streams_bidi = 200;
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_transport_params (session, &new_params);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_transport_params_equal)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICTransportParams_T params;
+  memset (&params, 0, sizeof (params));
+  params.initial_max_data = 65536;
+  params.initial_max_streams_bidi = 100;
+
+  SocketQUICSession_save_transport_params (session, &params);
+
+  /* Equal params should pass */
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_transport_params (session, &params);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_transport_params_less_permissive)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICTransportParams_T saved_params;
+  memset (&saved_params, 0, sizeof (saved_params));
+  saved_params.initial_max_data = 65536;
+  saved_params.initial_max_streams_bidi = 100;
+
+  SocketQUICSession_save_transport_params (session, &saved_params);
+
+  /* New params that are LESS permissive should fail */
+  SocketQUICTransportParams_T new_params;
+  memset (&new_params, 0, sizeof (new_params));
+  new_params.initial_max_data = 32768; /* less than saved */
+  new_params.initial_max_streams_bidi = 100;
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_transport_params (session, &new_params);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TRANSPORT);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_transport_params_no_saved)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICTransportParams_T new_params;
+  memset (&new_params, 0, sizeof (new_params));
+
+  /* No params saved - should fail */
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_transport_params (session, &new_params);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TRANSPORT);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_transport_params_connid_limit)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICTransportParams_T saved_params;
+  memset (&saved_params, 0, sizeof (saved_params));
+  saved_params.active_connection_id_limit = 8;
+
+  SocketQUICSession_save_transport_params (session, &saved_params);
+
+  /* Less permissive active_connection_id_limit should fail */
+  SocketQUICTransportParams_T new_params;
+  memset (&new_params, 0, sizeof (new_params));
+  new_params.active_connection_id_limit = 4; /* less than saved */
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_transport_params (session, &new_params);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_TRANSPORT);
+
+  /* Equal or greater should pass */
+  new_params.active_connection_id_limit = 8;
+  result = SocketQUICSession_validate_transport_params (session, &new_params);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  new_params.active_connection_id_limit = 16;
+  result = SocketQUICSession_validate_transport_params (session, &new_params);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Ticket Clear Tests
+ * ============================================================================
+ */
+
+TEST (session_clear_ticket_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t ticket_data[64];
+  memset (ticket_data, 0xAB, sizeof (ticket_data));
+
+  SocketQUICSession_store_ticket (session, ticket_data, sizeof (ticket_data),
+                                  86400, 0, QUIC_SESSION_0RTT_SENTINEL);
+
+  ASSERT_NE (SocketQUICSession_can_resume (session), 0);
+
+  SocketQUICSession_clear_ticket (session);
+
+  ASSERT_EQ (SocketQUICSession_can_resume (session), 0);
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_NONE);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_clear_ticket_null_is_safe)
+{
+  SocketQUICSession_clear_ticket (NULL);
+  /* Should not crash */
+}
+
+/* ============================================================================
+ * HelloRetryRequest Tests (RFC 9001 §4.7)
+ * ============================================================================
+ */
+
+TEST (session_on_hrr_received_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  ASSERT_EQ (SocketQUICSession_is_hrr (session), 0);
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_on_hrr_received (session, NULL, 0);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+  ASSERT_NE (SocketQUICSession_is_hrr (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_on_hrr_received_with_cookie)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t cookie[32];
+  memset (cookie, 0xCC, sizeof (cookie));
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_on_hrr_received (session, cookie, sizeof (cookie));
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  const uint8_t *retrieved_cookie;
+  size_t cookie_len;
+  result = SocketQUICSession_get_hrr_cookie (session, &retrieved_cookie,
+                                             &cookie_len);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+  ASSERT_EQ (cookie_len, sizeof (cookie));
+  ASSERT_EQ (memcmp (retrieved_cookie, cookie, sizeof (cookie)), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_on_hrr_received_cookie_too_large)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t cookie[1];
+  SocketQUICSession_Result result = SocketQUICSession_on_hrr_received (
+      session, cookie, QUIC_SESSION_MAX_COOKIE_SIZE + 1);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_COOKIE);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_on_hrr_received_null)
+{
+  SocketQUICSession_Result result
+      = SocketQUICSession_on_hrr_received (NULL, NULL, 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+}
+
+TEST (session_on_hrr_sent_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  ASSERT_EQ (SocketQUICSession_is_hrr (session), 0);
+
+  SocketQUICSession_Result result = SocketQUICSession_on_hrr_sent (session);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+  ASSERT_NE (SocketQUICSession_is_hrr (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_on_hrr_sent_null)
+{
+  SocketQUICSession_Result result = SocketQUICSession_on_hrr_sent (NULL);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+}
+
+TEST (session_hrr_rejects_0rtt)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* Before HRR, 0-RTT is not rejected by HRR */
+  ASSERT_EQ (SocketQUICSession_hrr_rejects_0rtt (session), 0);
+
+  /* Server sends HRR */
+  SocketQUICSession_on_hrr_sent (session);
+
+  /* After HRR, 0-RTT should be rejected per RFC 9001 §4.6.2 */
+  ASSERT_NE (SocketQUICSession_hrr_rejects_0rtt (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_get_hrr_cookie_no_hrr)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  const uint8_t *cookie;
+  size_t len;
+  SocketQUICSession_Result result
+      = SocketQUICSession_get_hrr_cookie (session, &cookie, &len);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_HRR);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_get_hrr_cookie_no_cookie)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* HRR received but no cookie */
+  SocketQUICSession_on_hrr_received (session, NULL, 0);
+
+  const uint8_t *cookie;
+  size_t len;
+  SocketQUICSession_Result result
+      = SocketQUICSession_get_hrr_cookie (session, &cookie, &len);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_COOKIE);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_set_hrr_transcript_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  uint8_t hash[32];
+  memset (hash, 0xDD, sizeof (hash));
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_set_hrr_transcript (session, hash);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_set_hrr_transcript_null)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_set_hrr_transcript (session, NULL);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+
+  result = SocketQUICSession_set_hrr_transcript (NULL, NULL);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * State Query Tests
+ * ============================================================================
+ */
+
+TEST (session_state_transitions)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_NONE);
+
+  /* Store a ticket */
+  uint8_t ticket[64];
+  SocketQUICSession_store_ticket (session, ticket, sizeof (ticket), 86400, 0,
+                                  0);
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_STORED);
+
+  /* Mark as resumed */
+  SocketQUICSession_mark_resumed (session);
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_RESUMED);
+  ASSERT_NE (SocketQUICSession_is_resumed (session), 0);
+
+  /* Mark as new */
+  SocketQUICSession_mark_new (session);
+  ASSERT_EQ (SocketQUICSession_get_state (session), QUIC_SESSION_STATE_NEW);
+  ASSERT_EQ (SocketQUICSession_is_resumed (session), 0);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_get_state_null)
+{
+  ASSERT_EQ (SocketQUICSession_get_state (NULL), QUIC_SESSION_STATE_NONE);
+}
+
+TEST (session_is_resumed_null)
+{
+  ASSERT_EQ (SocketQUICSession_is_resumed (NULL), 0);
+}
+
+TEST (session_mark_resumed_null_is_safe)
+{
+  SocketQUICSession_mark_resumed (NULL);
+  /* Should not crash */
+}
+
+TEST (session_mark_new_null_is_safe)
+{
+  SocketQUICSession_mark_new (NULL);
+  /* Should not crash */
+}
+
+/* ============================================================================
+ * ALPN Tests (RFC 9001 §4.6.3)
+ * ============================================================================
+ */
+
+TEST (session_save_alpn_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  const char *alpn = "h3";
+  SocketQUICSession_Result result
+      = SocketQUICSession_save_alpn (session, alpn, strlen (alpn));
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_save_alpn_null)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICSession_Result result = SocketQUICSession_save_alpn (NULL, "h3", 2);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_NULL);
+
+  result = SocketQUICSession_save_alpn (session, NULL, 2);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_ALPN);
+
+  result = SocketQUICSession_save_alpn (session, "h3", 0);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_ALPN);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_alpn_match)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  const char *alpn = "h3";
+  SocketQUICSession_save_alpn (session, alpn, strlen (alpn));
+
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_alpn (session, alpn, strlen (alpn));
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_alpn_mismatch)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICSession_save_alpn (session, "h3", 2);
+
+  /* Different ALPN should fail */
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_alpn (session, "h2", 2);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_ALPN);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_alpn_length_mismatch)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  SocketQUICSession_save_alpn (session, "h3", 2);
+
+  /* Different length should fail */
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_alpn (session, "h3-29", 5);
+  ASSERT_EQ (result, QUIC_SESSION_ERROR_ALPN);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+TEST (session_validate_alpn_no_saved_ok)
+{
+  Arena_T arena = Arena_new ();
+  SocketQUICSession_T session = SocketQUICSession_new (arena);
+
+  /* No ALPN saved - should pass (no validation needed) */
+  SocketQUICSession_Result result
+      = SocketQUICSession_validate_alpn (session, "h3", 2);
+  ASSERT_EQ (result, QUIC_SESSION_OK);
+
+  SocketQUICSession_free (&session);
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * String Conversion Tests
+ * ============================================================================
+ */
+
+TEST (session_state_string)
+{
+  const char *s;
+
+  s = SocketQUICSession_state_string (QUIC_SESSION_STATE_NONE);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "NONE"), 0);
+
+  s = SocketQUICSession_state_string (QUIC_SESSION_STATE_STORED);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "STORED"), 0);
+
+  s = SocketQUICSession_state_string (QUIC_SESSION_STATE_RESUMED);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "RESUMED"), 0);
+
+  s = SocketQUICSession_state_string ((SocketQUICSessionState)999);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "UNKNOWN"), 0);
+}
+
+TEST (session_result_string)
+{
+  const char *s;
+
+  s = SocketQUICSession_result_string (QUIC_SESSION_OK);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "OK"), 0);
+
+  s = SocketQUICSession_result_string (QUIC_SESSION_ERROR_NULL);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "NULL argument"), 0);
+
+  s = SocketQUICSession_result_string (QUIC_SESSION_ERROR_TRANSPORT);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "Transport parameter mismatch"), 0);
+
+  s = SocketQUICSession_result_string ((SocketQUICSession_Result)999);
+  ASSERT_NOT_NULL (s);
+  ASSERT_EQ (strcmp (s, "UNKNOWN"), 0);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Implement QUIC session resumption per RFC 9001 §4.5
- Implement HelloRetryRequest handling per RFC 9001 §4.7
- Add 0-RTT capability detection and transport parameter validation (§4.6.3)
- Add ALPN validation for resumed connections
- Include secure memory clearing with OPENSSL_cleanse

## Changes
| File | Lines | Purpose |
|------|-------|---------|
| `include/quic/SocketQUICSession.h` | 479 | Header with types, constants, API |
| `src/quic/SocketQUICSession.c` | 533 | Implementation |
| `src/test/test_quic_session.c` | 944 | 54 comprehensive tests |

## Test plan
- [x] All 54 unit tests pass
- [x] AddressSanitizer clean
- [x] UndefinedBehaviorSanitizer clean
- [x] Boundary conditions tested
- [x] NULL pointer handling tested
- [x] Clock skew protection verified

Fixes #3241