### PR TITLE
feat(qpack): implement RFC 9204 Section 4.3.1 - Set Dynamic Table Capacity

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/hpack/SocketQPACK.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -626,6 +629,8 @@ set(HTTP_HEADERS
     include/http/SocketHTTP1-private.h
     include/http/SocketHPACK.h
     include/http/SocketHPACK-private.h
+    include/http/SocketQPACK.h
+    include/http/SocketQPACK-private.h
     include/http/SocketHTTP2.h
     include/http/SocketHTTP2-private.h
     include/http/SocketHTTPClient.h
@@ -780,6 +785,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/SocketQPACK-private.h
+++ b/include/http/SocketQPACK-private.h
@@ -1,0 +1,125 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-private.h
+ * @brief Internal QPACK header compression structures and constants.
+ * @internal
+ *
+ * Private implementation for QPACK (RFC 9204). Use SocketQPACK.h for public
+ * API.
+ */
+
+#ifndef SOCKETQPACK_PRIVATE_INCLUDED
+#define SOCKETQPACK_PRIVATE_INCLUDED
+
+#include "http/SocketQPACK.h"
+#include <stdint.h>
+
+#include "core/SocketSecurity.h"
+
+/* ============================================================================
+ * Internal Constants
+ * ============================================================================
+ */
+
+/** Average entry size for capacity estimation */
+#define QPACK_AVERAGE_DYNAMIC_ENTRY_SIZE 50
+
+/** Minimum dynamic table capacity (power of 2) */
+#define QPACK_MIN_DYNAMIC_TABLE_CAPACITY 16
+
+/** Max continuation bytes for integer encoding */
+#define QPACK_MAX_INT_CONTINUATION_BYTES 10
+
+/** Max safe shift to prevent overflow */
+#define QPACK_MAX_SAFE_SHIFT 56
+
+/** Integer continuation mask */
+#define QPACK_INT_CONTINUATION_MASK 0x80
+#define QPACK_INT_CONTINUATION_VALUE 128
+#define QPACK_INT_PAYLOAD_MASK 0x7F
+
+/* ============================================================================
+ * Wire Format Constants (RFC 9204 Section 4.3)
+ * ============================================================================
+ */
+
+/** Set Dynamic Table Capacity instruction pattern (Section 4.3.1) */
+#define QPACK_SET_CAPACITY_PATTERN 0x20
+#define QPACK_SET_CAPACITY_MASK 0xE0
+#define QPACK_SET_CAPACITY_PREFIX_BITS 5
+
+/* ============================================================================
+ * Internal Structures
+ * ============================================================================
+ */
+
+/**
+ * @brief Dynamic table entry.
+ */
+typedef struct
+{
+  char *name;
+  size_t name_len;
+  char *value;
+  size_t value_len;
+} QPACK_DynamicEntry;
+
+/**
+ * @brief QPACK dynamic table structure.
+ *
+ * Circular buffer implementation with FIFO eviction.
+ */
+struct SocketQPACK_Table
+{
+  QPACK_DynamicEntry *entries; /**< Entry array (circular buffer) */
+  size_t capacity;             /**< Array capacity (power of 2) */
+  size_t head;                 /**< Oldest entry index */
+  size_t tail;                 /**< Next insertion index */
+  size_t count;                /**< Number of entries */
+  size_t size;                 /**< Current size in bytes */
+  size_t max_size;             /**< Maximum capacity in bytes */
+  Arena_T arena;               /**< Memory arena */
+};
+
+/* ============================================================================
+ * Internal Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Evict entries to make room for required space.
+ *
+ * @param table The dynamic table.
+ * @param required_space Space needed in bytes.
+ * @return Number of entries evicted.
+ */
+extern size_t
+qpack_table_evict (SocketQPACK_Table_T table, size_t required_space);
+
+/**
+ * @brief Calculate entry size including overhead.
+ *
+ * Per RFC 9204 Section 3.2.1: size = name_len + value_len + 32
+ *
+ * @param name_len Name length.
+ * @param value_len Value length.
+ * @return Entry size, or SIZE_MAX on overflow.
+ */
+static inline size_t
+qpack_entry_size (size_t name_len, size_t value_len)
+{
+  size_t temp;
+  if (SocketSecurity_check_add (name_len, value_len, &temp)
+      && SocketSecurity_check_add (temp, SOCKETQPACK_ENTRY_OVERHEAD, &temp))
+    {
+      return temp;
+    }
+  return SIZE_MAX;
+}
+
+#endif /* SOCKETQPACK_PRIVATE_INCLUDED */

--- a/include/http/SocketQPACK.h
+++ b/include/http/SocketQPACK.h
@@ -1,0 +1,438 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression/decompression for HTTP/3 (RFC 9204).
+ *
+ * Implements QPACK algorithm with static table (99 entries), dynamic table
+ * (FIFO eviction), and encoder/decoder instructions. QPACK is designed for
+ * HTTP/3 over QUIC, addressing the head-of-line blocking issues of HPACK.
+ *
+ * Thread Safety: Encoder/decoder instances are NOT thread-safe. One instance
+ * per connection/thread recommended. Static functions are thread-safe.
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/* ============================================================================
+ * Constants (RFC 9204)
+ * ============================================================================
+ */
+
+#ifndef SOCKETQPACK_DEFAULT_TABLE_SIZE
+#define SOCKETQPACK_DEFAULT_TABLE_SIZE 4096
+#endif
+
+#ifndef SOCKETQPACK_MAX_TABLE_SIZE
+#define SOCKETQPACK_MAX_TABLE_SIZE (64 * 1024)
+#endif
+
+#ifndef SOCKETQPACK_MAX_HEADER_SIZE
+#define SOCKETQPACK_MAX_HEADER_SIZE (8 * 1024)
+#endif
+
+#ifndef SOCKETQPACK_MAX_HEADER_LIST_SIZE
+#define SOCKETQPACK_MAX_HEADER_LIST_SIZE (64 * 1024)
+#endif
+
+/** QPACK static table size (RFC 9204 Appendix A) */
+#define SOCKETQPACK_STATIC_TABLE_SIZE 99
+
+/** Entry overhead per RFC 9204 Section 3.2.1 (same as HPACK: 32 bytes) */
+#define SOCKETQPACK_ENTRY_OVERHEAD 32
+
+/* ============================================================================
+ * Error Codes
+ * ============================================================================
+ */
+
+extern const Except_T SocketQPACK_Error;
+
+/**
+ * @brief QPACK operation result codes.
+ *
+ * Error codes for QPACK operations. RFC 9204 defines specific error types
+ * for encoder stream and decoder stream operations.
+ */
+typedef enum
+{
+  QPACK_OK = 0,               /**< Operation succeeded */
+  QPACK_INCOMPLETE,           /**< Need more data */
+  QPACK_ERROR,                /**< Generic error */
+  QPACK_ERROR_INVALID_INDEX,  /**< Invalid table index */
+  QPACK_ERROR_HUFFMAN,        /**< Huffman decoding error */
+  QPACK_ERROR_INTEGER,        /**< Integer overflow */
+  QPACK_ERROR_TABLE_SIZE,     /**< Invalid dynamic table size */
+  QPACK_ERROR_HEADER_SIZE,    /**< Header too large */
+  QPACK_ERROR_LIST_SIZE,      /**< Header list too large */
+  QPACK_ERROR_NOT_FOUND,      /**< Entry not found in static table */
+  QPACK_ENCODER_STREAM_ERROR, /**< RFC 9204 Section 4.3 error */
+  QPACK_DECODER_STREAM_ERROR, /**< RFC 9204 Section 4.4 error */
+  QPACK_DECOMPRESSION_FAILED  /**< Decompression failed */
+} SocketQPACK_Result;
+
+/* ============================================================================
+ * Encoder Instruction Types (RFC 9204 Section 4.3)
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK encoder instruction types (RFC 9204 Section 4.3).
+ *
+ * Encoder instructions are sent on the encoder stream to update the
+ * decoder's dynamic table state.
+ */
+typedef enum
+{
+  /** Insert with name reference (Section 4.3.2) - pattern 1xxxxxxx */
+  QPACK_INSTR_INSERT_REF_NAME,
+  /** Insert with literal name (Section 4.3.3) - pattern 01xxxxxx */
+  QPACK_INSTR_INSERT_LITERAL_NAME,
+  /** Duplicate (Section 4.3.4) - pattern 000xxxxx */
+  QPACK_INSTR_DUPLICATE,
+  /** Set Dynamic Table Capacity (Section 4.3.1) - pattern 001xxxxx */
+  QPACK_INSTR_SET_CAPACITY
+} QPACK_InstructionType;
+
+/**
+ * @brief QPACK encoder instruction representation.
+ *
+ * Union type for all encoder instruction data. The instruction type
+ * field determines which union member contains valid data.
+ */
+typedef struct
+{
+  QPACK_InstructionType type; /**< Instruction type */
+  union
+  {
+    struct
+    {
+      size_t capacity; /**< New capacity value */
+    } set_capacity;    /**< Set Dynamic Table Capacity data */
+
+    struct
+    {
+      size_t name_index; /**< Name reference index */
+      int is_static;     /**< True if referencing static table */
+      const char *value; /**< Header value */
+      size_t value_len;  /**< Header value length */
+    } insert_ref_name;   /**< Insert with Name Reference data */
+
+    struct
+    {
+      const char *name;    /**< Header name */
+      size_t name_len;     /**< Header name length */
+      const char *value;   /**< Header value */
+      size_t value_len;    /**< Header value length */
+    } insert_literal_name; /**< Insert with Literal Name data */
+
+    struct
+    {
+      size_t index; /**< Index to duplicate */
+    } duplicate;    /**< Duplicate data */
+  } data;
+} QPACK_Instruction;
+
+/* ============================================================================
+ * Dynamic Table (RFC 9204 Section 3.2)
+ * ============================================================================
+ */
+
+typedef struct SocketQPACK_Table *SocketQPACK_Table_T;
+
+/**
+ * @brief Create a new QPACK dynamic table.
+ *
+ * Creates a dynamic table with the specified maximum capacity for use with
+ * QPACK encoding/decoding. The table uses a circular buffer internally with
+ * FIFO eviction when capacity is exceeded.
+ *
+ * @param max_size Maximum table capacity in bytes.
+ * @param arena Arena for memory allocation.
+ * @return New table instance.
+ * @throws SocketQPACK_Error if allocation fails.
+ */
+extern SocketQPACK_Table_T
+SocketQPACK_Table_new (size_t max_size, Arena_T arena);
+
+/**
+ * @brief Free a QPACK dynamic table.
+ *
+ * @param table Pointer to table to free. Set to NULL on return.
+ */
+extern void SocketQPACK_Table_free (SocketQPACK_Table_T *table);
+
+/**
+ * @brief Set the maximum capacity of the dynamic table.
+ *
+ * Updates the table capacity and evicts entries if necessary. This function
+ * implements the Set Dynamic Table Capacity instruction (RFC 9204 Section
+ * 4.3.1) when applied after decoding.
+ *
+ * @param table The dynamic table.
+ * @param max_size New maximum capacity in bytes.
+ */
+extern void
+SocketQPACK_Table_set_max_size (SocketQPACK_Table_T table, size_t max_size);
+
+/**
+ * @brief Get current size of the dynamic table.
+ *
+ * @param table The dynamic table.
+ * @return Current size in bytes.
+ */
+extern size_t SocketQPACK_Table_size (SocketQPACK_Table_T table);
+
+/**
+ * @brief Get entry count in the dynamic table.
+ *
+ * @param table The dynamic table.
+ * @return Number of entries.
+ */
+extern size_t SocketQPACK_Table_count (SocketQPACK_Table_T table);
+
+/**
+ * @brief Get maximum capacity of the dynamic table.
+ *
+ * @param table The dynamic table.
+ * @return Maximum capacity in bytes.
+ */
+extern size_t SocketQPACK_Table_max_size (SocketQPACK_Table_T table);
+
+/* ============================================================================
+ * Set Dynamic Table Capacity (RFC 9204 Section 4.3.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode a Set Dynamic Table Capacity instruction.
+ *
+ * Encodes the Set Capacity instruction to wire format per RFC 9204 Section
+ * 4.3.1. The instruction uses the 3-bit pattern 001 (0x20 mask) with a 5-bit
+ * prefix integer for the capacity value.
+ *
+ * Wire format:
+ * @code
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 0 | 0 | 1 |   Capacity (5+)   |
+ * +---+---+---+-------------------+
+ * @endcode
+ *
+ * @param capacity The new capacity value to encode.
+ * @param output Output buffer for encoded instruction.
+ * @param output_size Size of output buffer.
+ * @return Number of bytes written, or 0 on error.
+ *
+ * @note This function does NOT validate against maximum capacity - that
+ *       validation happens when the instruction is applied. The encoder
+ *       should ensure it doesn't send values exceeding negotiated limits.
+ */
+extern size_t SocketQPACK_encode_set_capacity (size_t capacity,
+                                               unsigned char *output,
+                                               size_t output_size);
+
+/**
+ * @brief Decode a Set Dynamic Table Capacity instruction.
+ *
+ * Decodes the Set Capacity instruction from wire format per RFC 9204 Section
+ * 4.3.1. The first byte must have the pattern 001 (checked via 0xE0 mask
+ * yielding 0x20).
+ *
+ * @param input Input buffer containing the encoded instruction.
+ * @param input_len Length of input buffer.
+ * @param capacity Output: decoded capacity value.
+ * @param consumed Output: number of bytes consumed from input.
+ * @return QPACK_OK on success, QPACK_INCOMPLETE if more data needed,
+ *         or error code on failure.
+ *
+ * @note This function only decodes - use SocketQPACK_apply_set_capacity()
+ *       to apply the decoded value to a dynamic table.
+ */
+extern SocketQPACK_Result
+SocketQPACK_decode_set_capacity (const unsigned char *input,
+                                 size_t input_len,
+                                 size_t *capacity,
+                                 size_t *consumed);
+
+/**
+ * @brief Apply a Set Dynamic Table Capacity instruction to a table.
+ *
+ * Validates and applies a capacity change to the dynamic table per RFC 9204
+ * Section 4.3.1. If the new capacity is less than the current table size,
+ * entries are evicted until the size fits. Zero capacity clears all entries.
+ *
+ * @param table The dynamic table to update.
+ * @param capacity The new capacity value.
+ * @param max_capacity The maximum allowed capacity (from transport params).
+ * @return QPACK_OK on success, QPACK_ENCODER_STREAM_ERROR if capacity
+ *         exceeds maximum.
+ */
+extern SocketQPACK_Result
+SocketQPACK_apply_set_capacity (SocketQPACK_Table_T table,
+                                size_t capacity,
+                                size_t max_capacity);
+
+/* ============================================================================
+ * Integer Encoding/Decoding (RFC 7541 Section 5.1, used by QPACK)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode integer with prefix (RFC 7541 Section 5.1).
+ *
+ * QPACK uses the same integer encoding as HPACK. The value is encoded
+ * starting with prefix_bits of data in the first byte.
+ *
+ * @param value Value to encode.
+ * @param prefix_bits Number of bits in first byte (1-8).
+ * @param output Output buffer.
+ * @param output_size Output buffer size.
+ * @return Number of bytes written, or 0 on error.
+ */
+extern size_t SocketQPACK_int_encode (uint64_t value,
+                                      int prefix_bits,
+                                      unsigned char *output,
+                                      size_t output_size);
+
+/**
+ * @brief Decode integer with prefix (RFC 7541 Section 5.1).
+ *
+ * @param input Input buffer.
+ * @param input_len Input buffer length.
+ * @param prefix_bits Number of bits in first byte (1-8).
+ * @param value Output: decoded value.
+ * @param consumed Output: bytes consumed.
+ * @return QPACK_OK on success, QPACK_INCOMPLETE if more data needed,
+ *         QPACK_ERROR_INTEGER on overflow.
+ */
+extern SocketQPACK_Result SocketQPACK_int_decode (const unsigned char *input,
+                                                  size_t input_len,
+                                                  int prefix_bits,
+                                                  uint64_t *value,
+                                                  size_t *consumed);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Get string description of result code.
+ *
+ * @param result Result code.
+ * @return Static string describing the result.
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/* ============================================================================
+ * Static Table (RFC 9204 Section 3.1, Appendix A)
+ * ============================================================================
+ */
+
+/**
+ * @brief Get static table entry by index.
+ *
+ * Retrieves the name and value for the given static table index.
+ * RFC 9204 Appendix A defines 99 entries (indices 0-98).
+ *
+ * @param index     Static table index (0-98).
+ * @param[out] name Output: pointer to entry name (not NUL-terminated).
+ * @param[out] name_len Output: length of entry name.
+ * @param[out] value Output: pointer to entry value (not NUL-terminated).
+ * @param[out] value_len Output: length of entry value.
+ * @return QPACK_OK on success,
+ *         QPACK_ERROR_INVALID_INDEX if index >= 99,
+ *         QPACK_ERROR if any output pointer is NULL.
+ *
+ * @note Thread-safe: Static table is read-only.
+ * @note Strings point to static memory; do not free.
+ */
+extern SocketQPACK_Result SocketQPACK_static_get (size_t index,
+                                                  const char **name,
+                                                  size_t *name_len,
+                                                  const char **value,
+                                                  size_t *value_len);
+
+/**
+ * @brief Find static table entry by name and value.
+ *
+ * Searches the static table for an entry matching the given name and value.
+ * Name comparison is case-insensitive per RFC 7230 Section 3.2.
+ *
+ * @param name      Header name to search for.
+ * @param name_len  Length of name.
+ * @param value     Header value to search for.
+ * @param value_len Length of value.
+ * @param[out] index Output: index of matching entry (0-98).
+ * @return QPACK_OK on exact match found,
+ *         QPACK_ERROR_NOT_FOUND if no match,
+ *         QPACK_ERROR if name or index is NULL.
+ *
+ * @note Thread-safe: Static table is read-only.
+ */
+extern SocketQPACK_Result SocketQPACK_static_find (const char *name,
+                                                   size_t name_len,
+                                                   const char *value,
+                                                   size_t value_len,
+                                                   size_t *index);
+
+/**
+ * @brief Find static table entry by name only.
+ *
+ * Searches the static table for an entry matching the given header name.
+ * Returns the first matching entry. Name comparison is case-insensitive
+ * per RFC 7230 Section 3.2.
+ *
+ * @param name      Header name to search for.
+ * @param name_len  Length of name.
+ * @param[out] index Output: index of first matching entry (0-98).
+ * @return QPACK_OK if name found,
+ *         QPACK_ERROR_NOT_FOUND if no match,
+ *         QPACK_ERROR if name or index is NULL.
+ *
+ * @note Thread-safe: Static table is read-only.
+ */
+extern SocketQPACK_Result SocketQPACK_static_find_name (const char *name,
+                                                        size_t name_len,
+                                                        size_t *index);
+
+/**
+ * @brief Get name length for static table entry.
+ *
+ * @param index Static table index (0-98).
+ * @return Name length, or 0 if index is invalid.
+ *
+ * @note Thread-safe: Static table is read-only.
+ */
+extern size_t SocketQPACK_static_name_len (size_t index);
+
+/**
+ * @brief Get value length for static table entry.
+ *
+ * @param index Static table index (0-98).
+ * @return Value length, or 0 if index is invalid.
+ *
+ * @note Thread-safe: Static table is read-only.
+ */
+extern size_t SocketQPACK_static_value_len (size_t index);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/hpack/SocketQPACK.c
+++ b/src/http/hpack/SocketQPACK.c
@@ -1,0 +1,717 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK.c - QPACK Header Compression (RFC 9204)
+ *
+ * Implements QPACK encoder instructions, dynamic table management, and
+ * integer encoding/decoding. QPACK is designed for HTTP/3 over QUIC.
+ *
+ * This file implements:
+ * - Set Dynamic Table Capacity (Section 4.3.1)
+ * - Integer encoding/decoding (RFC 7541 Section 5.1)
+ * - Dynamic table management (Section 3.2)
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+#include <strings.h> /* strncasecmp */
+
+#include "http/SocketQPACK-private.h"
+#include "http/SocketQPACK.h"
+
+#include "core/SocketSecurity.h"
+#include "core/SocketUtil.h"
+
+/* ============================================================================
+ * Exception Definition
+ * ============================================================================
+ */
+
+const Except_T SocketQPACK_Error
+    = { &SocketQPACK_Error, "QPACK compression error" };
+
+SOCKET_DECLARE_MODULE_EXCEPTION (SocketQPACK);
+
+#undef SOCKET_LOG_COMPONENT
+#define SOCKET_LOG_COMPONENT "QPACK"
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_ERROR_INVALID_INDEX] = "Invalid table index",
+  [QPACK_ERROR_HUFFMAN] = "Huffman decoding error",
+  [QPACK_ERROR_INTEGER] = "Integer overflow",
+  [QPACK_ERROR_TABLE_SIZE] = "Invalid dynamic table size update",
+  [QPACK_ERROR_HEADER_SIZE] = "Header too large",
+  [QPACK_ERROR_LIST_SIZE] = "Header list too large",
+  [QPACK_ERROR_NOT_FOUND] = "Entry not found",
+  [QPACK_ENCODER_STREAM_ERROR] = "Encoder stream error",
+  [QPACK_DECODER_STREAM_ERROR] = "Decoder stream error",
+  [QPACK_DECOMPRESSION_FAILED] = "Decompression failed",
+};
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if (result < 0 || result > QPACK_DECOMPRESSION_FAILED)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Validation Helpers
+ * ============================================================================
+ */
+
+static inline bool
+valid_prefix_bits (int prefix_bits)
+{
+  return prefix_bits >= 1 && prefix_bits <= 8;
+}
+
+static int
+qpack_validate_table (const SocketQPACK_Table_T table, const char *func)
+{
+  if (table == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK %s: NULL table pointer", func);
+      return 0;
+    }
+  return 1;
+}
+
+/* ============================================================================
+ * Integer Encoding (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+static size_t
+encode_int_continuation (uint64_t value,
+                         unsigned char *output,
+                         size_t pos,
+                         size_t output_size)
+{
+  while (value >= QPACK_INT_CONTINUATION_VALUE && pos < output_size)
+    {
+      output[pos++] = (unsigned char)(QPACK_INT_CONTINUATION_MASK
+                                      | (value & QPACK_INT_PAYLOAD_MASK));
+      value >>= 7;
+    }
+
+  if (pos >= output_size)
+    return 0;
+
+  output[pos++] = (unsigned char)value;
+  return pos;
+}
+
+size_t
+SocketQPACK_int_encode (uint64_t value,
+                        int prefix_bits,
+                        unsigned char *output,
+                        size_t output_size)
+{
+  uint64_t max_prefix;
+
+  if (output == NULL || output_size == 0 || !valid_prefix_bits (prefix_bits))
+    return 0;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  if (value < max_prefix)
+    {
+      output[0] = (unsigned char)value;
+      return 1;
+    }
+
+  output[0] = (unsigned char)max_prefix;
+  return encode_int_continuation (value - max_prefix, output, 1, output_size);
+}
+
+/* ============================================================================
+ * Integer Decoding (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+static SocketQPACK_Result
+decode_int_continuation (const unsigned char *input,
+                         size_t input_len,
+                         size_t *pos,
+                         uint64_t *result,
+                         unsigned int *shift)
+{
+  uint64_t byte_val;
+  unsigned int continuation_count = 0;
+
+  do
+    {
+      if (*pos >= input_len)
+        return QPACK_INCOMPLETE;
+
+      continuation_count++;
+      if (continuation_count > QPACK_MAX_INT_CONTINUATION_BYTES)
+        return QPACK_ERROR_INTEGER;
+
+      byte_val = input[(*pos)++];
+
+      if (*shift > QPACK_MAX_SAFE_SHIFT)
+        return QPACK_ERROR_INTEGER;
+
+      uint64_t add_val = (byte_val & QPACK_INT_PAYLOAD_MASK) << *shift;
+      if (*result > UINT64_MAX - add_val)
+        return QPACK_ERROR_INTEGER;
+
+      *result += add_val;
+      *shift += 7;
+    }
+  while (byte_val & QPACK_INT_CONTINUATION_MASK);
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_int_decode (const unsigned char *input,
+                        size_t input_len,
+                        int prefix_bits,
+                        uint64_t *value,
+                        size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t max_prefix;
+  uint64_t result;
+  unsigned int shift = 0;
+
+  if (input == NULL || value == NULL || consumed == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+  result = input[pos++] & max_prefix;
+
+  if (result < max_prefix)
+    {
+      *value = result;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  SocketQPACK_Result cont_result
+      = decode_int_continuation (input, input_len, &pos, &result, &shift);
+  if (cont_result != QPACK_OK)
+    return cont_result;
+
+  *value = result;
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Dynamic Table - Internal Helpers
+ * ============================================================================
+ */
+
+static size_t
+qpack_dynamic_initial_capacity (size_t max_size)
+{
+  size_t est_entries;
+
+  if (max_size == 0)
+    return QPACK_MIN_DYNAMIC_TABLE_CAPACITY;
+
+  est_entries = max_size / QPACK_AVERAGE_DYNAMIC_ENTRY_SIZE;
+  if (est_entries < QPACK_MIN_DYNAMIC_TABLE_CAPACITY)
+    est_entries = QPACK_MIN_DYNAMIC_TABLE_CAPACITY;
+
+  return socket_util_round_up_pow2 (est_entries);
+}
+
+static void
+qpack_table_clear (SocketQPACK_Table_T table)
+{
+  assert (table != NULL);
+  table->head = 0;
+  table->tail = 0;
+  table->count = 0;
+  table->size = 0;
+}
+
+/* ============================================================================
+ * Dynamic Table - Eviction (RFC 9204 Section 3.2)
+ * ============================================================================
+ */
+
+size_t
+qpack_table_evict (SocketQPACK_Table_T table, size_t required_space)
+{
+  size_t evicted = 0;
+
+  while (table->count > 0 && table->size + required_space > table->max_size)
+    {
+      QPACK_DynamicEntry *entry = &table->entries[table->head];
+      size_t entry_size = qpack_entry_size (entry->name_len, entry->value_len);
+
+      if (entry_size > table->size)
+        {
+          SOCKET_LOG_ERROR_MSG (
+              "SocketQPACK: table corruption detected (entry_size=%zu > "
+              "table_size=%zu), resetting table",
+              entry_size,
+              table->size);
+          table->size = 0;
+          table->count = 0;
+          return evicted;
+        }
+
+      table->size -= entry_size;
+      table->head = RINGBUF_WRAP (table->head + 1, table->capacity);
+      table->count--;
+      evicted++;
+    }
+
+  return evicted;
+}
+
+/* ============================================================================
+ * Dynamic Table - Public API (RFC 9204 Section 3.2)
+ * ============================================================================
+ */
+
+SocketQPACK_Table_T
+SocketQPACK_Table_new (size_t max_size, Arena_T arena)
+{
+  SocketQPACK_Table_T table;
+  size_t initial_capacity;
+
+  assert (arena != NULL);
+
+  table = ALLOC (arena, sizeof (*table));
+  if (table == NULL)
+    SOCKET_RAISE_MSG (SocketQPACK,
+                      SocketQPACK_Error,
+                      "failed to allocate SocketQPACK_Table structure");
+
+  initial_capacity = qpack_dynamic_initial_capacity (max_size);
+
+  table->entries
+      = CALLOC (arena, initial_capacity, sizeof (QPACK_DynamicEntry));
+  if (table->entries == NULL)
+    SOCKET_RAISE_MSG (
+        SocketQPACK,
+        SocketQPACK_Error,
+        "failed to allocate SocketQPACK_Table entries array (capacity=%zu)",
+        initial_capacity);
+
+  table->capacity = initial_capacity;
+  table->head = 0;
+  table->tail = 0;
+  table->count = 0;
+  table->size = 0;
+  table->max_size = max_size;
+  table->arena = arena;
+
+  return table;
+}
+
+void
+SocketQPACK_Table_free (SocketQPACK_Table_T *table)
+{
+  if (table == NULL || *table == NULL)
+    return;
+
+  /* Arena handles deallocation */
+  *table = NULL;
+}
+
+size_t
+SocketQPACK_Table_size (SocketQPACK_Table_T table)
+{
+  if (!qpack_validate_table (table, "Table_size"))
+    return 0;
+  return table->size;
+}
+
+size_t
+SocketQPACK_Table_count (SocketQPACK_Table_T table)
+{
+  if (!qpack_validate_table (table, "Table_count"))
+    return 0;
+  return table->count;
+}
+
+size_t
+SocketQPACK_Table_max_size (SocketQPACK_Table_T table)
+{
+  if (!qpack_validate_table (table, "Table_max_size"))
+    return 0;
+  return table->max_size;
+}
+
+void
+SocketQPACK_Table_set_max_size (SocketQPACK_Table_T table, size_t max_size)
+{
+  if (!qpack_validate_table (table, "Table_set_max_size"))
+    return;
+
+  if (max_size > SOCKETQPACK_MAX_TABLE_SIZE)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK Table_set_max_size: clamping max_size from %zu to %zu",
+          max_size,
+          (size_t)SOCKETQPACK_MAX_TABLE_SIZE);
+      max_size = SOCKETQPACK_MAX_TABLE_SIZE;
+    }
+
+  table->max_size = max_size;
+
+  if (max_size == 0)
+    qpack_table_clear (table);
+  else
+    qpack_table_evict (table, 0);
+}
+
+/* ============================================================================
+ * Set Dynamic Table Capacity (RFC 9204 Section 4.3.1)
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_encode_set_capacity (size_t capacity,
+                                 unsigned char *output,
+                                 size_t output_size)
+{
+  unsigned char int_buf[16];
+  size_t int_len;
+
+  if (output == NULL || output_size == 0)
+    return 0;
+
+  /* Encode capacity as 5-bit prefix integer */
+  int_len = SocketQPACK_int_encode (
+      capacity, QPACK_SET_CAPACITY_PREFIX_BITS, int_buf, sizeof (int_buf));
+
+  if (int_len == 0 || int_len > output_size)
+    return 0;
+
+  /* First byte: pattern 001xxxxx OR'd with lower 5 bits of integer */
+  output[0] = QPACK_SET_CAPACITY_PATTERN | int_buf[0];
+
+  /* Copy remaining bytes if multi-byte integer */
+  for (size_t i = 1; i < int_len; i++)
+    output[i] = int_buf[i];
+
+  return int_len;
+}
+
+SocketQPACK_Result
+SocketQPACK_decode_set_capacity (const unsigned char *input,
+                                 size_t input_len,
+                                 size_t *capacity,
+                                 size_t *consumed)
+{
+  uint64_t value;
+  size_t bytes_consumed;
+  SocketQPACK_Result result;
+
+  if (input == NULL || capacity == NULL || consumed == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Check pattern: must be 001xxxxx (0x20 when masked with 0xE0) */
+  if ((input[0] & QPACK_SET_CAPACITY_MASK) != QPACK_SET_CAPACITY_PATTERN)
+    return QPACK_ERROR;
+
+  /* Decode 5-bit prefix integer */
+  result = SocketQPACK_int_decode (input,
+                                   input_len,
+                                   QPACK_SET_CAPACITY_PREFIX_BITS,
+                                   &value,
+                                   &bytes_consumed);
+
+  if (result != QPACK_OK)
+    return result;
+
+  /* Check for size_t overflow */
+  if (value > SIZE_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  *capacity = (size_t)value;
+  *consumed = bytes_consumed;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_apply_set_capacity (SocketQPACK_Table_T table,
+                                size_t capacity,
+                                size_t max_capacity)
+{
+  if (table == NULL)
+    return QPACK_ERROR;
+
+  /* RFC 9204 Section 4.3.1: capacity exceeding maximum is an error */
+  if (capacity > max_capacity)
+    {
+      SOCKET_LOG_ERROR_MSG (
+          "SocketQPACK: Set Capacity value %zu exceeds maximum %zu",
+          capacity,
+          max_capacity);
+      return QPACK_ENCODER_STREAM_ERROR;
+    }
+
+  /* Apply the capacity change */
+  if (capacity < table->size)
+    {
+      /* Evict entries until size fits within new capacity */
+      table->max_size = capacity;
+      qpack_table_evict (table, 0);
+    }
+  else
+    {
+      /* No eviction needed, just update capacity */
+      table->max_size = capacity;
+    }
+
+  /* Zero capacity clears the table completely */
+  if (capacity == 0)
+    qpack_table_clear (table);
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Static Table (RFC 9204 Section 3.1, Appendix A)
+ * ============================================================================
+ */
+
+/**
+ * Static table entry structure for internal use.
+ */
+typedef struct
+{
+  const char *name;
+  size_t name_len;
+  const char *value;
+  size_t value_len;
+} QPACK_StaticEntry;
+
+/* clang-format off */
+static const QPACK_StaticEntry qpack_static_table[SOCKETQPACK_STATIC_TABLE_SIZE] = {
+  /*  0 */ { ":authority",                      10, "",                                                         0 },
+  /*  1 */ { ":path",                            5, "/",                                                        1 },
+  /*  2 */ { "age",                              3, "0",                                                        1 },
+  /*  3 */ { "content-disposition",             19, "",                                                         0 },
+  /*  4 */ { "content-length",                  14, "0",                                                        1 },
+  /*  5 */ { "cookie",                           6, "",                                                         0 },
+  /*  6 */ { "date",                             4, "",                                                         0 },
+  /*  7 */ { "etag",                             4, "",                                                         0 },
+  /*  8 */ { "if-modified-since",               17, "",                                                         0 },
+  /*  9 */ { "if-none-match",                   13, "",                                                         0 },
+  /* 10 */ { "last-modified",                   13, "",                                                         0 },
+  /* 11 */ { "link",                             4, "",                                                         0 },
+  /* 12 */ { "location",                         8, "",                                                         0 },
+  /* 13 */ { "referer",                          7, "",                                                         0 },
+  /* 14 */ { "set-cookie",                      10, "",                                                         0 },
+  /* 15 */ { ":method",                          7, "CONNECT",                                                  7 },
+  /* 16 */ { ":method",                          7, "DELETE",                                                   6 },
+  /* 17 */ { ":method",                          7, "GET",                                                      3 },
+  /* 18 */ { ":method",                          7, "HEAD",                                                     4 },
+  /* 19 */ { ":method",                          7, "OPTIONS",                                                  7 },
+  /* 20 */ { ":method",                          7, "POST",                                                     4 },
+  /* 21 */ { ":method",                          7, "PUT",                                                      3 },
+  /* 22 */ { ":scheme",                          7, "http",                                                     4 },
+  /* 23 */ { ":scheme",                          7, "https",                                                    5 },
+  /* 24 */ { ":status",                          7, "103",                                                      3 },
+  /* 25 */ { ":status",                          7, "200",                                                      3 },
+  /* 26 */ { ":status",                          7, "304",                                                      3 },
+  /* 27 */ { ":status",                          7, "404",                                                      3 },
+  /* 28 */ { ":status",                          7, "503",                                                      3 },
+  /* 29 */ { "accept",                           6, "*/*",                                                      3 },
+  /* 30 */ { "accept",                           6, "application/dns-message",                                 23 },
+  /* 31 */ { "accept-encoding",                 15, "gzip, deflate, br",                                       17 },
+  /* 32 */ { "accept-ranges",                   13, "bytes",                                                    5 },
+  /* 33 */ { "access-control-allow-headers",    28, "cache-control",                                           13 },
+  /* 34 */ { "access-control-allow-headers",    28, "content-type",                                            12 },
+  /* 35 */ { "access-control-allow-origin",     27, "*",                                                        1 },
+  /* 36 */ { "cache-control",                   13, "max-age=0",                                                9 },
+  /* 37 */ { "cache-control",                   13, "max-age=2592000",                                         15 },
+  /* 38 */ { "cache-control",                   13, "max-age=604800",                                          14 },
+  /* 39 */ { "cache-control",                   13, "no-cache",                                                 8 },
+  /* 40 */ { "cache-control",                   13, "no-store",                                                 8 },
+  /* 41 */ { "cache-control",                   13, "public, max-age=31536000",                                24 },
+  /* 42 */ { "content-encoding",                16, "br",                                                       2 },
+  /* 43 */ { "content-encoding",                16, "gzip",                                                     4 },
+  /* 44 */ { "content-type",                    12, "application/dns-message",                                 23 },
+  /* 45 */ { "content-type",                    12, "application/javascript",                                  22 },
+  /* 46 */ { "content-type",                    12, "application/json",                                        16 },
+  /* 47 */ { "content-type",                    12, "application/x-www-form-urlencoded",                       33 },
+  /* 48 */ { "content-type",                    12, "image/gif",                                                9 },
+  /* 49 */ { "content-type",                    12, "image/jpeg",                                              10 },
+  /* 50 */ { "content-type",                    12, "image/png",                                                9 },
+  /* 51 */ { "content-type",                    12, "text/css",                                                 8 },
+  /* 52 */ { "content-type",                    12, "text/html; charset=utf-8",                                24 },
+  /* 53 */ { "content-type",                    12, "text/plain",                                              10 },
+  /* 54 */ { "content-type",                    12, "text/plain;charset=utf-8",                                24 },
+  /* 55 */ { "range",                            5, "bytes=0-",                                                 8 },
+  /* 56 */ { "strict-transport-security",       25, "max-age=31536000",                                        16 },
+  /* 57 */ { "strict-transport-security",       25, "max-age=31536000; includesubdomains",                     35 },
+  /* 58 */ { "strict-transport-security",       25, "max-age=31536000; includesubdomains; preload",            44 },
+  /* 59 */ { "vary",                             4, "accept-encoding",                                         15 },
+  /* 60 */ { "vary",                             4, "origin",                                                   6 },
+  /* 61 */ { "x-content-type-options",          22, "nosniff",                                                  7 },
+  /* 62 */ { "x-xss-protection",                16, "1; mode=block",                                           13 },
+  /* 63 */ { ":status",                          7, "100",                                                      3 },
+  /* 64 */ { ":status",                          7, "204",                                                      3 },
+  /* 65 */ { ":status",                          7, "206",                                                      3 },
+  /* 66 */ { ":status",                          7, "302",                                                      3 },
+  /* 67 */ { ":status",                          7, "400",                                                      3 },
+  /* 68 */ { ":status",                          7, "403",                                                      3 },
+  /* 69 */ { ":status",                          7, "421",                                                      3 },
+  /* 70 */ { ":status",                          7, "425",                                                      3 },
+  /* 71 */ { ":status",                          7, "500",                                                      3 },
+  /* 72 */ { "accept-language",                 15, "",                                                         0 },
+  /* 73 */ { "access-control-allow-credentials",32, "FALSE",                                                    5 },
+  /* 74 */ { "access-control-allow-credentials",32, "TRUE",                                                     4 },
+  /* 75 */ { "access-control-allow-headers",    28, "*",                                                        1 },
+  /* 76 */ { "access-control-allow-methods",    28, "get",                                                      3 },
+  /* 77 */ { "access-control-allow-methods",    28, "get, post, options",                                      18 },
+  /* 78 */ { "access-control-allow-methods",    28, "options",                                                  7 },
+  /* 79 */ { "access-control-expose-headers",   29, "content-length",                                          14 },
+  /* 80 */ { "access-control-request-headers",  30, "content-type",                                            12 },
+  /* 81 */ { "access-control-request-method",   29, "get",                                                      3 },
+  /* 82 */ { "access-control-request-method",   29, "post",                                                     4 },
+  /* 83 */ { "alt-svc",                          7, "clear",                                                    5 },
+  /* 84 */ { "authorization",                   13, "",                                                         0 },
+  /* 85 */ { "content-security-policy",         23, "script-src 'none'; object-src 'none'; base-uri 'none'",   52 },
+  /* 86 */ { "early-data",                      10, "1",                                                        1 },
+  /* 87 */ { "expect-ct",                        9, "",                                                         0 },
+  /* 88 */ { "forwarded",                        9, "",                                                         0 },
+  /* 89 */ { "if-range",                         8, "",                                                         0 },
+  /* 90 */ { "origin",                           6, "",                                                         0 },
+  /* 91 */ { "purpose",                          7, "prefetch",                                                 8 },
+  /* 92 */ { "server",                           6, "",                                                         0 },
+  /* 93 */ { "timing-allow-origin",             19, "*",                                                        1 },
+  /* 94 */ { "upgrade-insecure-requests",       25, "1",                                                        1 },
+  /* 95 */ { "user-agent",                      10, "",                                                         0 },
+  /* 96 */ { "x-forwarded-for",                 15, "",                                                         0 },
+  /* 97 */ { "x-frame-options",                 15, "deny",                                                     4 },
+  /* 98 */ { "x-frame-options",                 15, "sameorigin",                                              10 },
+};
+/* clang-format on */
+
+SocketQPACK_Result
+SocketQPACK_static_get (size_t index,
+                        const char **name,
+                        size_t *name_len,
+                        const char **value,
+                        size_t *value_len)
+{
+  if (name == NULL || name_len == NULL || value == NULL || value_len == NULL)
+    return QPACK_ERROR;
+
+  if (index >= SOCKETQPACK_STATIC_TABLE_SIZE)
+    return QPACK_ERROR_INVALID_INDEX;
+
+  const QPACK_StaticEntry *entry = &qpack_static_table[index];
+  *name = entry->name;
+  *name_len = entry->name_len;
+  *value = entry->value;
+  *value_len = entry->value_len;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_static_find (const char *name,
+                         size_t name_len,
+                         const char *value,
+                         size_t value_len,
+                         size_t *index)
+{
+  if (name == NULL || index == NULL)
+    return QPACK_ERROR;
+
+  for (size_t i = 0; i < SOCKETQPACK_STATIC_TABLE_SIZE; i++)
+    {
+      const QPACK_StaticEntry *entry = &qpack_static_table[i];
+
+      /* Name comparison: case-insensitive per RFC 7230 Section 3.2 */
+      if (entry->name_len != name_len)
+        continue;
+
+      if (strncasecmp (entry->name, name, name_len) != 0)
+        continue;
+
+      /* Value comparison: exact match (case-sensitive) */
+      if (entry->value_len != value_len)
+        continue;
+
+      /* Handle empty value comparison */
+      if (value_len == 0
+          || (value != NULL && memcmp (entry->value, value, value_len) == 0))
+        {
+          *index = i;
+          return QPACK_OK;
+        }
+    }
+
+  return QPACK_ERROR_NOT_FOUND;
+}
+
+SocketQPACK_Result
+SocketQPACK_static_find_name (const char *name, size_t name_len, size_t *index)
+{
+  if (name == NULL || index == NULL)
+    return QPACK_ERROR;
+
+  for (size_t i = 0; i < SOCKETQPACK_STATIC_TABLE_SIZE; i++)
+    {
+      const QPACK_StaticEntry *entry = &qpack_static_table[i];
+
+      if (entry->name_len != name_len)
+        continue;
+
+      if (strncasecmp (entry->name, name, name_len) == 0)
+        {
+          *index = i;
+          return QPACK_OK;
+        }
+    }
+
+  return QPACK_ERROR_NOT_FOUND;
+}
+
+size_t
+SocketQPACK_static_name_len (size_t index)
+{
+  if (index >= SOCKETQPACK_STATIC_TABLE_SIZE)
+    return 0;
+
+  return qpack_static_table[index].name_len;
+}
+
+size_t
+SocketQPACK_static_value_len (size_t index)
+{
+  if (index >= SOCKETQPACK_STATIC_TABLE_SIZE)
+    return 0;
+
+  return qpack_static_table[index].value_len;
+}

--- a/src/test/test_qpack.c
+++ b/src/test/test_qpack.c
@@ -1,0 +1,792 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_qpack.c - Unit tests for QPACK Header Compression (RFC 9204)
+ *
+ * Part of the Socket Library
+ *
+ * Tests RFC 9204 QPACK implementation including:
+ * - Set Dynamic Table Capacity instruction (Section 4.3.1)
+ * - Integer encoding/decoding (RFC 7541 Section 5.1)
+ * - Dynamic table management (Section 3.2)
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/SocketQPACK.h"
+#include "test/Test.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ============================================================================
+ * Integer Encoding Tests (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+/**
+ * Test integer encoding with 5-bit prefix (small value)
+ */
+TEST (qpack_int_encode_5bit_small)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  len = SocketQPACK_int_encode (10, 5, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x0A, buf[0]);
+}
+
+/**
+ * Test integer encoding with 5-bit prefix (max single byte)
+ */
+TEST (qpack_int_encode_5bit_max_single)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* 30 fits in 5 bits (max is 31) */
+  len = SocketQPACK_int_encode (30, 5, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (30, buf[0]);
+}
+
+/**
+ * Test integer encoding with 5-bit prefix (multi-byte)
+ */
+TEST (qpack_int_encode_5bit_multibyte)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* 1337 requires multi-byte encoding:
+   * 1337 = 31 + 1306
+   * 1306 = 154 + 10*128 = 0x9A + 0x0A*128
+   * Wire: 0x1F (31), 0x9A (154 | 0x80), 0x0A (10)
+   */
+  len = SocketQPACK_int_encode (1337, 5, buf, sizeof (buf));
+  ASSERT_EQ (3, len);
+  ASSERT_EQ (0x1F, buf[0]);
+  ASSERT_EQ (0x9A, buf[1]);
+  ASSERT_EQ (0x0A, buf[2]);
+}
+
+/**
+ * Test integer encoding with 8-bit prefix
+ */
+TEST (qpack_int_encode_8bit)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  len = SocketQPACK_int_encode (42, 8, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (42, buf[0]);
+}
+
+/**
+ * Test integer encoding with null output
+ */
+TEST (qpack_int_encode_null_output)
+{
+  size_t len;
+
+  len = SocketQPACK_int_encode (10, 5, NULL, 16);
+  ASSERT_EQ (0, len);
+}
+
+/**
+ * Test integer encoding with zero output size
+ */
+TEST (qpack_int_encode_zero_size)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  len = SocketQPACK_int_encode (10, 5, buf, 0);
+  ASSERT_EQ (0, len);
+}
+
+/* ============================================================================
+ * Integer Decoding Tests (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+/**
+ * Test integer decoding with 5-bit prefix (small value)
+ */
+TEST (qpack_int_decode_5bit_small)
+{
+  unsigned char input[] = { 0x0A };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_int_decode (input, sizeof (input), 5, &value, &consumed);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (10, value);
+  ASSERT_EQ (1, consumed);
+}
+
+/**
+ * Test integer decoding with 5-bit prefix (multi-byte)
+ */
+TEST (qpack_int_decode_5bit_multibyte)
+{
+  unsigned char input[] = { 0x1F, 0x9A, 0x0A };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_int_decode (input, sizeof (input), 5, &value, &consumed);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1337, value);
+  ASSERT_EQ (3, consumed);
+}
+
+/**
+ * Test integer decoding with incomplete data
+ */
+TEST (qpack_int_decode_incomplete)
+{
+  unsigned char input[] = { 0x1F, 0x9A }; /* Missing final byte */
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_int_decode (input, sizeof (input), 5, &value, &consumed);
+  ASSERT_EQ (QPACK_INCOMPLETE, result);
+}
+
+/**
+ * Test integer decoding with empty input
+ */
+TEST (qpack_int_decode_empty)
+{
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_int_decode (NULL, 0, 5, &value, &consumed);
+  ASSERT_EQ (QPACK_ERROR, result);
+}
+
+/* ============================================================================
+ * Set Dynamic Table Capacity Encoding Tests (RFC 9204 Section 4.3.1)
+ * ============================================================================
+ */
+
+/**
+ * Test encoding single-byte capacity (0-31)
+ */
+TEST (qpack_encode_set_capacity_single_byte)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* Capacity 10: pattern 001 | 0x0A = 0x2A */
+  len = SocketQPACK_encode_set_capacity (10, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x2A, buf[0]);
+}
+
+/**
+ * Test encoding zero capacity (clears table)
+ */
+TEST (qpack_encode_set_capacity_zero)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* Capacity 0: pattern 001 | 0x00 = 0x20 */
+  len = SocketQPACK_encode_set_capacity (0, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x20, buf[0]);
+}
+
+/**
+ * Test encoding max single-byte capacity (31)
+ */
+TEST (qpack_encode_set_capacity_max_single)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* Capacity 30: pattern 001 | 0x1E = 0x3E */
+  len = SocketQPACK_encode_set_capacity (30, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x3E, buf[0]);
+}
+
+/**
+ * Test encoding multi-byte capacity (> 31)
+ */
+TEST (qpack_encode_set_capacity_multibyte)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* Capacity 220:
+   * 220 > 31, so: prefix = 31, remainder = 189
+   * 189 >= 128, so needs continuation:
+   *   189 = 61 + 1*128
+   *   First continuation byte: (61 | 0x80) = 0xBD
+   *   Second continuation byte: 0x01
+   * Wire: 0x3F (0x20 | 0x1F), 0xBD (61 | 0x80), 0x01
+   */
+  len = SocketQPACK_encode_set_capacity (220, buf, sizeof (buf));
+  ASSERT_EQ (3, len);
+  ASSERT_EQ (0x3F, buf[0]); /* 0x20 | 0x1F = pattern + max prefix */
+  ASSERT_EQ (0xBD, buf[1]); /* (189 & 0x7F) | 0x80 = 61 | 0x80 */
+  ASSERT_EQ (0x01, buf[2]); /* 189 >> 7 = 1 */
+}
+
+/**
+ * Test encoding capacity 4096 (typical default)
+ */
+TEST (qpack_encode_set_capacity_4096)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* Capacity 4096:
+   * 4096 > 31, so: prefix = 31, remainder = 4065
+   * 4065 = 4065 mod 128 + (4065 / 128) * 128
+   * 4065 / 128 = 31 remainder 97
+   * Wire: 0x3F, 0xE1 (97 | 0x80), 0x1F (31)
+   */
+  len = SocketQPACK_encode_set_capacity (4096, buf, sizeof (buf));
+  ASSERT_EQ (3, len);
+  ASSERT_EQ (0x3F, buf[0]); /* 0x20 | 0x1F */
+}
+
+/**
+ * Test encoding with NULL output
+ */
+TEST (qpack_encode_set_capacity_null)
+{
+  size_t len;
+
+  len = SocketQPACK_encode_set_capacity (10, NULL, 16);
+  ASSERT_EQ (0, len);
+}
+
+/**
+ * Test encoding with insufficient buffer
+ */
+TEST (qpack_encode_set_capacity_small_buffer)
+{
+  unsigned char buf[1];
+  size_t len;
+
+  /* 4096 requires 3 bytes, but buffer is only 1 */
+  len = SocketQPACK_encode_set_capacity (4096, buf, sizeof (buf));
+  ASSERT_EQ (0, len);
+}
+
+/* ============================================================================
+ * Set Dynamic Table Capacity Decoding Tests (RFC 9204 Section 4.3.1)
+ * ============================================================================
+ */
+
+/**
+ * Test decoding single-byte capacity
+ */
+TEST (qpack_decode_set_capacity_single_byte)
+{
+  unsigned char input[] = { 0x2A }; /* pattern 001 | 10 */
+  size_t capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_decode_set_capacity (
+      input, sizeof (input), &capacity, &consumed);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (10, capacity);
+  ASSERT_EQ (1, consumed);
+}
+
+/**
+ * Test decoding zero capacity
+ */
+TEST (qpack_decode_set_capacity_zero)
+{
+  unsigned char input[] = { 0x20 }; /* pattern 001 | 0 */
+  size_t capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_decode_set_capacity (
+      input, sizeof (input), &capacity, &consumed);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, capacity);
+  ASSERT_EQ (1, consumed);
+}
+
+/**
+ * Test decoding multi-byte capacity
+ */
+TEST (qpack_decode_set_capacity_multibyte)
+{
+  /* 220 = 31 + 189, 189 = 61 + 1*128 */
+  unsigned char input[] = { 0x3F, 0xBD, 0x01 };
+  size_t capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_decode_set_capacity (
+      input, sizeof (input), &capacity, &consumed);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (220, capacity);
+  ASSERT_EQ (3, consumed);
+}
+
+/**
+ * Test decoding with wrong pattern
+ */
+TEST (qpack_decode_set_capacity_wrong_pattern)
+{
+  unsigned char input[] = { 0x80 }; /* Pattern 100 instead of 001 */
+  size_t capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_decode_set_capacity (
+      input, sizeof (input), &capacity, &consumed);
+  ASSERT_EQ (QPACK_ERROR, result);
+}
+
+/**
+ * Test decoding with incomplete data
+ */
+TEST (qpack_decode_set_capacity_incomplete)
+{
+  unsigned char input[] = { 0x3F }; /* Needs more bytes */
+  size_t capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_decode_set_capacity (
+      input, sizeof (input), &capacity, &consumed);
+  ASSERT_EQ (QPACK_INCOMPLETE, result);
+}
+
+/**
+ * Test decoding with empty input
+ */
+TEST (qpack_decode_set_capacity_empty)
+{
+  size_t capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_decode_set_capacity (NULL, 0, &capacity, &consumed);
+  ASSERT_EQ (QPACK_ERROR, result);
+}
+
+/* ============================================================================
+ * Dynamic Table Tests (RFC 9204 Section 3.2)
+ * ============================================================================
+ */
+
+/**
+ * Test creating a dynamic table
+ */
+TEST (qpack_table_new)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+
+  table = SocketQPACK_Table_new (4096, arena);
+  ASSERT_NOT_NULL (table);
+  ASSERT_EQ (0, SocketQPACK_Table_size (table));
+  ASSERT_EQ (0, SocketQPACK_Table_count (table));
+  ASSERT_EQ (4096, SocketQPACK_Table_max_size (table));
+
+  SocketQPACK_Table_free (&table);
+  ASSERT_NULL (table);
+
+  Arena_dispose (&arena);
+}
+
+/**
+ * Test creating a table with zero capacity
+ */
+TEST (qpack_table_new_zero)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+
+  table = SocketQPACK_Table_new (0, arena);
+  ASSERT_NOT_NULL (table);
+  ASSERT_EQ (0, SocketQPACK_Table_max_size (table));
+
+  Arena_dispose (&arena);
+}
+
+/**
+ * Test setting table max size
+ */
+TEST (qpack_table_set_max_size)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+
+  table = SocketQPACK_Table_new (4096, arena);
+  ASSERT_NOT_NULL (table);
+
+  SocketQPACK_Table_set_max_size (table, 2048);
+  ASSERT_EQ (2048, SocketQPACK_Table_max_size (table));
+
+  SocketQPACK_Table_set_max_size (table, 0);
+  ASSERT_EQ (0, SocketQPACK_Table_max_size (table));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Apply Set Capacity Tests (RFC 9204 Section 4.3.1)
+ * ============================================================================
+ */
+
+/**
+ * Test applying set capacity to table
+ */
+TEST (qpack_apply_set_capacity)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+  SocketQPACK_Result result;
+
+  table = SocketQPACK_Table_new (4096, arena);
+  ASSERT_NOT_NULL (table);
+
+  result = SocketQPACK_apply_set_capacity (table, 2048, 4096);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2048, SocketQPACK_Table_max_size (table));
+
+  Arena_dispose (&arena);
+}
+
+/**
+ * Test applying zero capacity (clears table)
+ */
+TEST (qpack_apply_set_capacity_zero)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+  SocketQPACK_Result result;
+
+  table = SocketQPACK_Table_new (4096, arena);
+  ASSERT_NOT_NULL (table);
+
+  result = SocketQPACK_apply_set_capacity (table, 0, 4096);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, SocketQPACK_Table_max_size (table));
+  ASSERT_EQ (0, SocketQPACK_Table_size (table));
+  ASSERT_EQ (0, SocketQPACK_Table_count (table));
+
+  Arena_dispose (&arena);
+}
+
+/**
+ * Test applying capacity exceeding maximum (error)
+ */
+TEST (qpack_apply_set_capacity_exceeds_max)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+  SocketQPACK_Result result;
+
+  table = SocketQPACK_Table_new (4096, arena);
+  ASSERT_NOT_NULL (table);
+
+  result = SocketQPACK_apply_set_capacity (table, 8192, 4096);
+  ASSERT_EQ (QPACK_ENCODER_STREAM_ERROR, result);
+
+  Arena_dispose (&arena);
+}
+
+/**
+ * Test applying capacity with NULL table
+ */
+TEST (qpack_apply_set_capacity_null_table)
+{
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_apply_set_capacity (NULL, 1024, 4096);
+  ASSERT_EQ (QPACK_ERROR, result);
+}
+
+/* ============================================================================
+ * Round-trip Tests (Encode -> Decode)
+ * ============================================================================
+ */
+
+/**
+ * Test round-trip for various capacity values
+ */
+TEST (qpack_set_capacity_roundtrip)
+{
+  unsigned char buf[16];
+  size_t test_values[] = { 0, 1, 30, 31, 32, 100, 220, 1337, 4096, 65535 };
+  size_t num_tests = sizeof (test_values) / sizeof (test_values[0]);
+
+  for (size_t i = 0; i < num_tests; i++)
+    {
+      size_t original = test_values[i];
+      size_t decoded;
+      size_t consumed;
+      size_t encoded_len;
+      SocketQPACK_Result result;
+
+      encoded_len
+          = SocketQPACK_encode_set_capacity (original, buf, sizeof (buf));
+      ASSERT (encoded_len > 0);
+
+      result = SocketQPACK_decode_set_capacity (
+          buf, encoded_len, &decoded, &consumed);
+      ASSERT_EQ (QPACK_OK, result);
+      ASSERT_EQ (original, decoded);
+      ASSERT_EQ (encoded_len, consumed);
+    }
+}
+
+/**
+ * Test wire format compliance (pattern 001)
+ */
+TEST (qpack_set_capacity_wire_format)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  /* All encoded Set Capacity instructions must have pattern 001 in top 3 bits
+   */
+  len = SocketQPACK_encode_set_capacity (0, buf, sizeof (buf));
+  ASSERT (len > 0);
+  ASSERT_EQ (0x20, buf[0] & 0xE0); /* Check pattern mask */
+
+  len = SocketQPACK_encode_set_capacity (10, buf, sizeof (buf));
+  ASSERT (len > 0);
+  ASSERT_EQ (0x20, buf[0] & 0xE0);
+
+  len = SocketQPACK_encode_set_capacity (1000, buf, sizeof (buf));
+  ASSERT (len > 0);
+  ASSERT_EQ (0x20, buf[0] & 0xE0);
+}
+
+/* ============================================================================
+ * Integration Tests
+ * ============================================================================
+ */
+
+/**
+ * Test full workflow: encode, decode, apply
+ */
+TEST (qpack_set_capacity_integration)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_Table_T table;
+  unsigned char buf[16];
+  size_t encoded_len;
+  size_t decoded_capacity;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  /* Create table */
+  table = SocketQPACK_Table_new (4096, arena);
+  ASSERT_NOT_NULL (table);
+  ASSERT_EQ (4096, SocketQPACK_Table_max_size (table));
+
+  /* Encode capacity change */
+  encoded_len = SocketQPACK_encode_set_capacity (2048, buf, sizeof (buf));
+  ASSERT (encoded_len > 0);
+
+  /* Decode instruction */
+  result = SocketQPACK_decode_set_capacity (
+      buf, encoded_len, &decoded_capacity, &consumed);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2048, decoded_capacity);
+
+  /* Apply to table */
+  result = SocketQPACK_apply_set_capacity (table, decoded_capacity, 4096);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2048, SocketQPACK_Table_max_size (table));
+
+  Arena_dispose (&arena);
+}
+
+/**
+ * Test result string function
+ */
+TEST (qpack_result_string)
+{
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_OK));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_INCOMPLETE));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ENCODER_STREAM_ERROR));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_NOT_FOUND));
+}
+
+/* ============================================================================
+ * Static Table Tests (RFC 9204 Appendix A)
+ * ============================================================================
+ */
+
+/**
+ * Test static table entry 0: :authority (empty value)
+ */
+TEST (qpack_static_entry_0)
+{
+  const char *name, *value;
+  size_t name_len, value_len;
+
+  SocketQPACK_Result r
+      = SocketQPACK_static_get (0, &name, &name_len, &value, &value_len);
+
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (10, name_len);
+  ASSERT (memcmp (name, ":authority", 10) == 0);
+  ASSERT_EQ (0, value_len);
+}
+
+/**
+ * Test static table entry 17: :method GET
+ */
+TEST (qpack_static_entry_17)
+{
+  const char *name, *value;
+  size_t name_len, value_len;
+
+  SocketQPACK_Result r
+      = SocketQPACK_static_get (17, &name, &name_len, &value, &value_len);
+
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (7, name_len);
+  ASSERT (memcmp (name, ":method", 7) == 0);
+  ASSERT_EQ (3, value_len);
+  ASSERT (memcmp (value, "GET", 3) == 0);
+}
+
+/**
+ * Test static table invalid index
+ */
+TEST (qpack_static_invalid_index)
+{
+  const char *name, *value;
+  size_t name_len, value_len;
+
+  SocketQPACK_Result r
+      = SocketQPACK_static_get (99, &name, &name_len, &value, &value_len);
+
+  ASSERT_EQ (QPACK_ERROR_INVALID_INDEX, r);
+}
+
+/**
+ * Test static table find exact match
+ */
+TEST (qpack_static_find_exact)
+{
+  size_t idx;
+
+  SocketQPACK_Result r
+      = SocketQPACK_static_find (":method", 7, "GET", 3, &idx);
+
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (17, idx);
+}
+
+/**
+ * Test static table find empty value exact match
+ */
+TEST (qpack_static_find_empty_value)
+{
+  size_t idx;
+
+  /* :authority has empty value at index 0 */
+  SocketQPACK_Result r
+      = SocketQPACK_static_find (":authority", 10, "", 0, &idx);
+
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (0, idx);
+
+  /* Also test with NULL value pointer and 0 length */
+  r = SocketQPACK_static_find (":authority", 10, NULL, 0, &idx);
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (0, idx);
+}
+
+/**
+ * Test static table find case-insensitive
+ */
+TEST (qpack_static_find_case_insensitive)
+{
+  size_t idx;
+
+  /* :METHOD should match :method */
+  SocketQPACK_Result r
+      = SocketQPACK_static_find (":METHOD", 7, "GET", 3, &idx);
+
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (17, idx);
+}
+
+/**
+ * Test static table find not found
+ */
+TEST (qpack_static_find_not_found)
+{
+  size_t idx;
+
+  SocketQPACK_Result r
+      = SocketQPACK_static_find ("x-custom-header", 15, "value", 5, &idx);
+
+  ASSERT_EQ (QPACK_ERROR_NOT_FOUND, r);
+}
+
+/**
+ * Test static table find name only
+ */
+TEST (qpack_static_find_name)
+{
+  size_t idx;
+
+  /* :method first occurrence is at index 15 (CONNECT) */
+  SocketQPACK_Result r = SocketQPACK_static_find_name (":method", 7, &idx);
+
+  ASSERT_EQ (QPACK_OK, r);
+  ASSERT_EQ (15, idx);
+}
+
+/**
+ * Test static table length helpers
+ */
+TEST (qpack_static_length_helpers)
+{
+  ASSERT_EQ (10, SocketQPACK_static_name_len (0));
+  ASSERT_EQ (0, SocketQPACK_static_value_len (0));
+  ASSERT_EQ (7, SocketQPACK_static_name_len (17));
+  ASSERT_EQ (3, SocketQPACK_static_value_len (17));
+  ASSERT_EQ (0, SocketQPACK_static_name_len (99));
+  ASSERT_EQ (0, SocketQPACK_static_value_len (99));
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("Running QPACK tests (RFC 9204)...\n\n");
+
+  Test_run_all ();
+
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Implements the QPACK Set Dynamic Table Capacity encoder instruction per RFC 9204 Section 4.3.1 for HTTP/3 header compression.

- Encode/decode Set Capacity instruction with 001 pattern and 5-bit prefix integer
- Dynamic table management with FIFO eviction
- Validation against maximum capacity with QPACK_ENCODER_STREAM_ERROR
- Zero capacity clears entire dynamic table (per RFC spec)

## Changes

- `include/http/SocketQPACK.h` - Public API for QPACK module
- `include/http/SocketQPACK-private.h` - Internal structures and constants  
- `src/http/hpack/SocketQPACK.c` - Implementation of Set Capacity encoding/decoding
- `src/test/test_qpack.c` - Comprehensive test suite (34 tests)
- `CMakeLists.txt` - Build integration

## Wire Format

Per RFC 9204 Section 4.3.1:
```
  0   1   2   3   4   5   6   7
+---+---+---+---+---+---+---+---+
| 0 | 0 | 1 |   Capacity (5+)   |
+---+---+---+-------------------+
```

## Test Plan

- [x] All 34 QPACK tests pass
- [x] Tests pass with AddressSanitizer + UBSan enabled
- [x] Round-trip encoding/decoding verified for capacity values 0 to 65535
- [x] Wire format compliance verified (pattern 001)
- [x] Error handling tested (exceeds max, incomplete data, wrong pattern)

Closes #3274