### PR TITLE
feat(qpack): Implement RFC 9204 Section 4.2 - Encoder Stream Infrastructure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-encoder-stream.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -631,6 +634,7 @@ set(HTTP_HEADERS
     include/http/SocketHTTPClient.h
     include/http/SocketHTTPClient-private.h
     include/http/SocketHTTPServer.h
+    include/http/SocketQPACKEncoderStream.h
 )
 
 set(TEST_HEADERS
@@ -780,6 +784,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack_encoder_stream
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/SocketQPACKEncoderStream.h
+++ b/include/http/SocketQPACKEncoderStream.h
@@ -1,0 +1,289 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACKEncoderStream.h
+ * @brief QPACK Encoder Stream Infrastructure (RFC 9204 Section 4.2).
+ *
+ * Implements the encoder stream which carries unframed encoder instructions
+ * for QPACK header compression. The encoder stream is a unidirectional stream
+ * of type 0x02 used by the encoder to update the decoder about changes to
+ * the dynamic table.
+ *
+ * Thread Safety: Encoder stream instances are NOT thread-safe. One instance
+ * per connection recommended.
+ *
+ * @defgroup qpack_encoder_stream QPACK Encoder Stream Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.2
+ */
+
+#ifndef SOCKETQPACKENCODERSTREAM_INCLUDED
+#define SOCKETQPACKENCODERSTREAM_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/**
+ * @brief QPACK encoder stream type identifier (RFC 9204 Section 4.2).
+ *
+ * An encoder stream is a unidirectional stream of type 0x02.
+ */
+#define QPACK_ENCODER_STREAM_TYPE 0x02
+
+/**
+ * @brief Initial encoder stream buffer capacity.
+ *
+ * Conservative starting size for instruction accumulation. Buffer grows
+ * as needed via arena allocation.
+ */
+#ifndef QPACK_ENCODER_STREAM_INITIAL_CAPACITY
+#define QPACK_ENCODER_STREAM_INITIAL_CAPACITY 256
+#endif
+
+/**
+ * @brief Maximum encoder stream buffer size.
+ *
+ * Prevents unbounded memory growth from accumulated instructions.
+ */
+#ifndef QPACK_ENCODER_STREAM_MAX_CAPACITY
+#define QPACK_ENCODER_STREAM_MAX_CAPACITY (64 * 1024)
+#endif
+
+/**
+ * @brief Result codes for QPACK encoder stream operations.
+ */
+typedef enum
+{
+  QPACK_ENCODER_STREAM_OK = 0,        /**< Operation succeeded */
+  QPACK_ENCODER_STREAM_ERROR,         /**< Generic error */
+  QPACK_ENCODER_STREAM_BUFFER_FULL,   /**< Buffer capacity exceeded */
+  QPACK_ENCODER_STREAM_INVALID_PARAM, /**< Invalid parameter */
+  QPACK_ENCODER_STREAM_ALREADY_INIT,  /**< Stream already initialized */
+  QPACK_ENCODER_STREAM_NOT_INIT,      /**< Stream not initialized */
+  QPACK_ENCODER_STREAM_CLOSED         /**< Stream closure attempted (error) */
+} SocketQPACK_EncoderStream_Result;
+
+/**
+ * @brief Exception raised on encoder stream errors.
+ */
+extern const Except_T SocketQPACK_EncoderStream_Error;
+
+/**
+ * @brief Exception for critical stream closure (H3_CLOSED_CRITICAL_STREAM).
+ *
+ * RFC 9204 Section 4.2: The sender MUST NOT close the encoder stream
+ * before the connection closes.
+ */
+extern const Except_T SocketQPACK_H3_ClosedCriticalStream;
+
+/**
+ * @brief Opaque encoder stream type.
+ */
+typedef struct SocketQPACK_EncoderStream *SocketQPACK_EncoderStream_T;
+
+/**
+ * @brief Create a new QPACK encoder stream.
+ *
+ * Allocates and initializes an encoder stream with the given QUIC stream ID.
+ * The stream is marked as initialized and ready to buffer encoder instructions.
+ *
+ * @param arena     Arena for memory allocation (stream lifetime).
+ * @param stream_id QUIC unidirectional stream ID for this encoder stream.
+ *
+ * @return New encoder stream instance, or NULL on allocation failure.
+ *
+ * @note RFC 9204 Section 4.2: Each endpoint MUST initiate at most one
+ *       encoder stream. Use SocketQPACK_EncoderStream_is_initialized()
+ *       to check if a stream already exists for this connection.
+ *
+ * @threadsafe No
+ */
+extern SocketQPACK_EncoderStream_T
+SocketQPACK_EncoderStream_new (Arena_T arena, uint64_t stream_id);
+
+/**
+ * @brief Check if stream is initialized and active.
+ *
+ * @param stream Encoder stream instance.
+ *
+ * @return 1 if stream is initialized and open, 0 otherwise.
+ */
+extern int
+SocketQPACK_EncoderStream_is_initialized (SocketQPACK_EncoderStream_T stream);
+
+/**
+ * @brief Validate stream type matches encoder stream (0x02).
+ *
+ * Verifies that a received stream type identifier matches the expected
+ * encoder stream type per RFC 9204 Section 4.2.
+ *
+ * @param stream_type Stream type value to validate.
+ *
+ * @return 1 if valid (equals QPACK_ENCODER_STREAM_TYPE), 0 otherwise.
+ */
+extern int SocketQPACK_EncoderStream_validate_type (uint64_t stream_type);
+
+/**
+ * @brief Get the QUIC stream ID for this encoder stream.
+ *
+ * @param stream Encoder stream instance.
+ *
+ * @return QUIC stream ID, or 0 if stream is NULL.
+ */
+extern uint64_t
+SocketQPACK_EncoderStream_get_stream_id (SocketQPACK_EncoderStream_T stream);
+
+/**
+ * @brief Write a Set Dynamic Table Capacity instruction.
+ *
+ * RFC 9204 Section 4.3.1: Encodes a dynamic table capacity update.
+ *
+ * Format: 0b001xxxxx (5-bit prefix integer)
+ *
+ * @param stream   Encoder stream instance.
+ * @param capacity New dynamic table capacity.
+ *
+ * @return QPACK_ENCODER_STREAM_OK on success, error code otherwise.
+ */
+extern SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_capacity (SocketQPACK_EncoderStream_T stream,
+                                          uint64_t capacity);
+
+/**
+ * @brief Write an Insert With Name Reference instruction.
+ *
+ * RFC 9204 Section 4.3.2: Inserts a header with name from static or
+ * dynamic table reference and literal value.
+ *
+ * Format (static):  0b1xxxxxxx (6-bit prefix index, static bit = 1)
+ * Format (dynamic): 0b0xxxxxxx (6-bit prefix index, static bit = 0)
+ *
+ * @param stream      Encoder stream instance.
+ * @param is_static   1 if referencing static table, 0 for dynamic table.
+ * @param name_index  Index of name in referenced table.
+ * @param value       Header value bytes.
+ * @param value_len   Length of header value.
+ * @param use_huffman 1 to Huffman-encode value, 0 for literal.
+ *
+ * @return QPACK_ENCODER_STREAM_OK on success, error code otherwise.
+ */
+extern SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_insert_nameref (
+    SocketQPACK_EncoderStream_T stream,
+    int is_static,
+    uint64_t name_index,
+    const unsigned char *value,
+    size_t value_len,
+    int use_huffman);
+
+/**
+ * @brief Write an Insert With Literal Name instruction.
+ *
+ * RFC 9204 Section 4.3.3: Inserts a header with literal name and value.
+ *
+ * Format: 0b01xxxxxx (5-bit prefix for name length)
+ *
+ * @param stream           Encoder stream instance.
+ * @param name             Header name bytes.
+ * @param name_len         Length of header name.
+ * @param value            Header value bytes.
+ * @param value_len        Length of header value.
+ * @param use_huffman_name 1 to Huffman-encode name, 0 for literal.
+ * @param use_huffman_value 1 to Huffman-encode value, 0 for literal.
+ *
+ * @return QPACK_ENCODER_STREAM_OK on success, error code otherwise.
+ */
+extern SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_insert_literal (
+    SocketQPACK_EncoderStream_T stream,
+    const unsigned char *name,
+    size_t name_len,
+    const unsigned char *value,
+    size_t value_len,
+    int use_huffman_name,
+    int use_huffman_value);
+
+/**
+ * @brief Write a Duplicate instruction.
+ *
+ * RFC 9204 Section 4.3.4: Duplicates an existing dynamic table entry
+ * to add it again (refreshing it to the front).
+ *
+ * Format: 0b000xxxxx (5-bit prefix integer for relative index)
+ *
+ * @param stream        Encoder stream instance.
+ * @param relative_index Relative index of entry to duplicate (0 = newest).
+ *
+ * @return QPACK_ENCODER_STREAM_OK on success, error code otherwise.
+ */
+extern SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_duplicate (SocketQPACK_EncoderStream_T stream,
+                                           uint64_t relative_index);
+
+/**
+ * @brief Get the instruction buffer for transmission.
+ *
+ * Returns a pointer to the accumulated encoder instructions. The buffer
+ * contents should be sent via QUIC STREAM frames to the peer.
+ *
+ * @param stream     Encoder stream instance.
+ * @param buffer_len Output: length of buffer in bytes.
+ *
+ * @return Pointer to instruction buffer, or NULL if stream is NULL.
+ *
+ * @note The returned pointer is valid until the next write operation
+ *       or buffer reset.
+ */
+extern const unsigned char *
+SocketQPACK_EncoderStream_get_buffer (SocketQPACK_EncoderStream_T stream,
+                                      size_t *buffer_len);
+
+/**
+ * @brief Reset the instruction buffer after transmission.
+ *
+ * Clears the buffer to prepare for accumulating new instructions.
+ * Should be called after successfully sending the buffer contents.
+ *
+ * @param stream Encoder stream instance.
+ */
+extern void
+SocketQPACK_EncoderStream_reset_buffer (SocketQPACK_EncoderStream_T stream);
+
+/**
+ * @brief Mark stream as closed (triggers H3_CLOSED_CRITICAL_STREAM error).
+ *
+ * RFC 9204 Section 4.2: The sender MUST NOT close the encoder stream
+ * before the connection closes. Calling this function indicates an
+ * error condition.
+ *
+ * @param stream Encoder stream instance.
+ *
+ * @return QPACK_ENCODER_STREAM_CLOSED (always).
+ *
+ * @note This function is provided for error handling; the stream should
+ *       never be closed during normal operation.
+ */
+extern SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_close (SocketQPACK_EncoderStream_T stream);
+
+/**
+ * @brief Get string representation of result code.
+ *
+ * @param result Result code to convert.
+ *
+ * @return Human-readable string describing the result.
+ */
+extern const char *SocketQPACK_EncoderStream_result_string (
+    SocketQPACK_EncoderStream_Result result);
+
+/** @} */
+
+#endif /* SOCKETQPACKENCODERSTREAM_INCLUDED */

--- a/src/http/qpack/SocketQPACK-encoder-stream.c
+++ b/src/http/qpack/SocketQPACK-encoder-stream.c
@@ -1,0 +1,544 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK-encoder-stream.c - QPACK Encoder Stream (RFC 9204 Section 4.2)
+ *
+ * Implements encoder stream infrastructure for QPACK header compression.
+ * The encoder stream carries unframed encoder instructions to update the
+ * decoder about dynamic table changes.
+ */
+
+#include <assert.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "http/SocketHPACK.h"
+#include "http/SocketQPACKEncoderStream.h"
+
+/* ============================================================================
+ * QPACK Instruction Format Constants (RFC 9204 Section 4.3)
+ * ============================================================================
+ */
+
+/* Set Dynamic Table Capacity (4.3.1): 0b001xxxxx, 5-bit prefix */
+#define QPACK_INST_SET_CAPACITY_MASK 0xE0
+#define QPACK_INST_SET_CAPACITY_VAL 0x20
+#define QPACK_INST_SET_CAPACITY_PREFIX 5
+
+/* Insert With Name Reference (4.3.2): 0b1Txxxxxx, 6-bit prefix */
+#define QPACK_INST_INSERT_NAMEREF_MASK 0x80
+#define QPACK_INST_INSERT_NAMEREF_VAL 0x80
+#define QPACK_INST_INSERT_NAMEREF_PREFIX 6
+#define QPACK_INST_INSERT_NAMEREF_STATIC 0x40
+
+/* Insert With Literal Name (4.3.3): 0b01xxxxxx, 5-bit prefix */
+#define QPACK_INST_INSERT_LITERAL_MASK 0xC0
+#define QPACK_INST_INSERT_LITERAL_VAL 0x40
+#define QPACK_INST_INSERT_LITERAL_PREFIX 5
+
+/* Duplicate (4.3.4): 0b000xxxxx, 5-bit prefix */
+#define QPACK_INST_DUPLICATE_MASK 0xE0
+#define QPACK_INST_DUPLICATE_VAL 0x00
+#define QPACK_INST_DUPLICATE_PREFIX 5
+
+/* String encoding: 0b0xxxxxxx (literal) or 0b1xxxxxxx (Huffman) */
+#define QPACK_STRING_HUFFMAN_FLAG 0x80
+#define QPACK_STRING_PREFIX 7
+
+/* Buffer growth factor */
+#define BUFFER_GROWTH_FACTOR 2
+
+/* ============================================================================
+ * Exception Definitions
+ * ============================================================================
+ */
+
+const Except_T SocketQPACK_EncoderStream_Error
+    = { &SocketQPACK_EncoderStream_Error, "QPACK encoder stream error" };
+
+const Except_T SocketQPACK_H3_ClosedCriticalStream
+    = { &SocketQPACK_H3_ClosedCriticalStream,
+        "H3_CLOSED_CRITICAL_STREAM: encoder stream closed prematurely" };
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_ENCODER_STREAM_OK] = "OK",
+  [QPACK_ENCODER_STREAM_ERROR] = "Generic error",
+  [QPACK_ENCODER_STREAM_BUFFER_FULL] = "Buffer capacity exceeded",
+  [QPACK_ENCODER_STREAM_INVALID_PARAM] = "Invalid parameter",
+  [QPACK_ENCODER_STREAM_ALREADY_INIT] = "Stream already initialized",
+  [QPACK_ENCODER_STREAM_NOT_INIT] = "Stream not initialized",
+  [QPACK_ENCODER_STREAM_CLOSED]
+  = "Critical stream closed (H3_CLOSED_CRITICAL_STREAM)",
+};
+
+const char *
+SocketQPACK_EncoderStream_result_string (
+    SocketQPACK_EncoderStream_Result result)
+{
+  if (result < 0 || result > QPACK_ENCODER_STREAM_CLOSED)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Encoder Stream Structure
+ * ============================================================================
+ */
+
+struct SocketQPACK_EncoderStream
+{
+  Arena_T arena;         /* Arena for memory allocation */
+  uint64_t stream_id;    /* QUIC unidirectional stream ID */
+  unsigned char *buffer; /* Instruction buffer */
+  size_t buffer_len;     /* Current buffer length (bytes used) */
+  size_t buffer_cap;     /* Buffer capacity */
+  int is_initialized;    /* Stream has been established */
+  int is_closed;         /* Stream has been closed (error state) */
+};
+
+/* ============================================================================
+ * Buffer Management
+ * ============================================================================
+ */
+
+/**
+ * Ensure buffer has at least required_space bytes available.
+ * Grows buffer if necessary.
+ */
+static SocketQPACK_EncoderStream_Result
+ensure_buffer_space (SocketQPACK_EncoderStream_T stream, size_t required_space)
+{
+  size_t available;
+  size_t new_cap;
+  unsigned char *new_buffer;
+
+  if (stream == NULL)
+    return QPACK_ENCODER_STREAM_INVALID_PARAM;
+
+  available = stream->buffer_cap - stream->buffer_len;
+  if (available >= required_space)
+    return QPACK_ENCODER_STREAM_OK;
+
+  /* Calculate new capacity */
+  new_cap = stream->buffer_cap;
+  while (new_cap - stream->buffer_len < required_space)
+    {
+      if (new_cap > QPACK_ENCODER_STREAM_MAX_CAPACITY / BUFFER_GROWTH_FACTOR)
+        return QPACK_ENCODER_STREAM_BUFFER_FULL;
+      new_cap *= BUFFER_GROWTH_FACTOR;
+    }
+
+  if (new_cap > QPACK_ENCODER_STREAM_MAX_CAPACITY)
+    new_cap = QPACK_ENCODER_STREAM_MAX_CAPACITY;
+
+  if (new_cap - stream->buffer_len < required_space)
+    return QPACK_ENCODER_STREAM_BUFFER_FULL;
+
+  /* Allocate new buffer and copy existing data */
+  new_buffer = ALLOC (stream->arena, new_cap);
+  if (new_buffer == NULL)
+    return QPACK_ENCODER_STREAM_ERROR;
+
+  if (stream->buffer_len > 0 && stream->buffer != NULL)
+    memcpy (new_buffer, stream->buffer, stream->buffer_len);
+
+  stream->buffer = new_buffer;
+  stream->buffer_cap = new_cap;
+
+  return QPACK_ENCODER_STREAM_OK;
+}
+
+/**
+ * Append bytes to buffer.
+ */
+static SocketQPACK_EncoderStream_Result
+buffer_append (SocketQPACK_EncoderStream_T stream,
+               const unsigned char *data,
+               size_t len)
+{
+  SocketQPACK_EncoderStream_Result result;
+
+  result = ensure_buffer_space (stream, len);
+  if (result != QPACK_ENCODER_STREAM_OK)
+    return result;
+
+  memcpy (stream->buffer + stream->buffer_len, data, len);
+  stream->buffer_len += len;
+
+  return QPACK_ENCODER_STREAM_OK;
+}
+
+/* ============================================================================
+ * Integer Encoding (RFC 9204 Section 4.1.1 - uses RFC 7541 integer encoding)
+ * ============================================================================
+ */
+
+/**
+ * Encode integer with prefix and flags, append to buffer.
+ * Uses HPACK integer encoding from SocketHPACK.
+ */
+static SocketQPACK_EncoderStream_Result
+encode_int_to_buffer (SocketQPACK_EncoderStream_T stream,
+                      uint64_t value,
+                      int prefix_bits,
+                      unsigned char flags)
+{
+  unsigned char int_buf[16];
+  size_t int_len;
+  SocketQPACK_EncoderStream_Result result;
+
+  int_len
+      = SocketHPACK_int_encode (value, prefix_bits, int_buf, sizeof (int_buf));
+  if (int_len == 0)
+    return QPACK_ENCODER_STREAM_ERROR;
+
+  /* Combine first byte with flags */
+  int_buf[0] |= flags;
+
+  result = buffer_append (stream, int_buf, int_len);
+  return result;
+}
+
+/* ============================================================================
+ * String Encoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+/**
+ * Encode string literal and append to buffer.
+ */
+static SocketQPACK_EncoderStream_Result
+encode_string_to_buffer (SocketQPACK_EncoderStream_T stream,
+                         const unsigned char *str,
+                         size_t len,
+                         int use_huffman)
+{
+  unsigned char len_buf[16];
+  size_t len_bytes;
+  unsigned char flag;
+  SocketQPACK_EncoderStream_Result result;
+
+  if (use_huffman)
+    {
+      /* Calculate Huffman-encoded size */
+      size_t huffman_len = SocketHPACK_huffman_encoded_size (str, len);
+
+      /* Only use Huffman if it provides compression */
+      if (huffman_len < len)
+        {
+          /* Encode with Huffman */
+          unsigned char *huffman_buf;
+          ssize_t encoded_len;
+
+          flag = QPACK_STRING_HUFFMAN_FLAG;
+          len_bytes = SocketHPACK_int_encode (
+              huffman_len, QPACK_STRING_PREFIX, len_buf, sizeof (len_buf));
+          if (len_bytes == 0)
+            return QPACK_ENCODER_STREAM_ERROR;
+
+          len_buf[0] |= flag;
+
+          result = buffer_append (stream, len_buf, len_bytes);
+          if (result != QPACK_ENCODER_STREAM_OK)
+            return result;
+
+          /* Allocate temporary buffer for Huffman encoding */
+          huffman_buf = ALLOC (stream->arena, huffman_len + 8);
+          if (huffman_buf == NULL)
+            return QPACK_ENCODER_STREAM_ERROR;
+
+          encoded_len = SocketHPACK_huffman_encode (
+              str, len, huffman_buf, huffman_len + 8);
+          if (encoded_len < 0)
+            return QPACK_ENCODER_STREAM_ERROR;
+
+          return buffer_append (stream, huffman_buf, (size_t)encoded_len);
+        }
+    }
+
+  /* Literal encoding */
+  flag = 0;
+  len_bytes = SocketHPACK_int_encode (
+      len, QPACK_STRING_PREFIX, len_buf, sizeof (len_buf));
+  if (len_bytes == 0)
+    return QPACK_ENCODER_STREAM_ERROR;
+
+  len_buf[0] |= flag;
+
+  result = buffer_append (stream, len_buf, len_bytes);
+  if (result != QPACK_ENCODER_STREAM_OK)
+    return result;
+
+  return buffer_append (stream, str, len);
+}
+
+/* ============================================================================
+ * Public API - Stream Lifecycle
+ * ============================================================================
+ */
+
+SocketQPACK_EncoderStream_T
+SocketQPACK_EncoderStream_new (Arena_T arena, uint64_t stream_id)
+{
+  SocketQPACK_EncoderStream_T stream;
+
+  if (arena == NULL)
+    return NULL;
+
+  stream = ALLOC (arena, sizeof (*stream));
+  if (stream == NULL)
+    return NULL;
+
+  stream->arena = arena;
+  stream->stream_id = stream_id;
+  stream->buffer_cap = QPACK_ENCODER_STREAM_INITIAL_CAPACITY;
+  stream->buffer = ALLOC (arena, stream->buffer_cap);
+  if (stream->buffer == NULL)
+    return NULL;
+
+  stream->buffer_len = 0;
+  stream->is_initialized = 1;
+  stream->is_closed = 0;
+
+  return stream;
+}
+
+int
+SocketQPACK_EncoderStream_is_initialized (SocketQPACK_EncoderStream_T stream)
+{
+  if (stream == NULL)
+    return 0;
+  return stream->is_initialized && !stream->is_closed;
+}
+
+int
+SocketQPACK_EncoderStream_validate_type (uint64_t stream_type)
+{
+  return stream_type == QPACK_ENCODER_STREAM_TYPE;
+}
+
+uint64_t
+SocketQPACK_EncoderStream_get_stream_id (SocketQPACK_EncoderStream_T stream)
+{
+  if (stream == NULL)
+    return 0;
+  return stream->stream_id;
+}
+
+/* ============================================================================
+ * Public API - Encoder Instructions
+ * ============================================================================
+ */
+
+SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_capacity (SocketQPACK_EncoderStream_T stream,
+                                          uint64_t capacity)
+{
+  if (stream == NULL)
+    return QPACK_ENCODER_STREAM_INVALID_PARAM;
+
+  if (!stream->is_initialized)
+    return QPACK_ENCODER_STREAM_NOT_INIT;
+
+  if (stream->is_closed)
+    return QPACK_ENCODER_STREAM_CLOSED;
+
+  /* Set Dynamic Table Capacity instruction: 0b001xxxxx */
+  return encode_int_to_buffer (stream,
+                               capacity,
+                               QPACK_INST_SET_CAPACITY_PREFIX,
+                               QPACK_INST_SET_CAPACITY_VAL);
+}
+
+SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_insert_nameref (
+    SocketQPACK_EncoderStream_T stream,
+    int is_static,
+    uint64_t name_index,
+    const unsigned char *value,
+    size_t value_len,
+    int use_huffman)
+{
+  unsigned char flags;
+  SocketQPACK_EncoderStream_Result result;
+
+  if (stream == NULL || value == NULL)
+    return QPACK_ENCODER_STREAM_INVALID_PARAM;
+
+  if (!stream->is_initialized)
+    return QPACK_ENCODER_STREAM_NOT_INIT;
+
+  if (stream->is_closed)
+    return QPACK_ENCODER_STREAM_CLOSED;
+
+  /* Insert With Name Reference: 0b1Txxxxxx where T is static bit */
+  flags = QPACK_INST_INSERT_NAMEREF_VAL;
+  if (is_static)
+    flags |= QPACK_INST_INSERT_NAMEREF_STATIC;
+
+  result = encode_int_to_buffer (
+      stream, name_index, QPACK_INST_INSERT_NAMEREF_PREFIX, flags);
+  if (result != QPACK_ENCODER_STREAM_OK)
+    return result;
+
+  return encode_string_to_buffer (stream, value, value_len, use_huffman);
+}
+
+SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_insert_literal (
+    SocketQPACK_EncoderStream_T stream,
+    const unsigned char *name,
+    size_t name_len,
+    const unsigned char *value,
+    size_t value_len,
+    int use_huffman_name,
+    int use_huffman_value)
+{
+  SocketQPACK_EncoderStream_Result result;
+  unsigned char first_byte;
+  unsigned char int_buf[16];
+  size_t int_len;
+
+  if (stream == NULL || name == NULL || value == NULL)
+    return QPACK_ENCODER_STREAM_INVALID_PARAM;
+
+  if (!stream->is_initialized)
+    return QPACK_ENCODER_STREAM_NOT_INIT;
+
+  if (stream->is_closed)
+    return QPACK_ENCODER_STREAM_CLOSED;
+
+  /* Insert With Literal Name: 0b01Hxxxxx where H is Huffman flag for name */
+  first_byte = QPACK_INST_INSERT_LITERAL_VAL;
+  if (use_huffman_name)
+    first_byte |= 0x20; /* Huffman flag for name (bit 5) */
+
+  /* Encode name length with 5-bit prefix */
+  if (use_huffman_name)
+    {
+      size_t huffman_len = SocketHPACK_huffman_encoded_size (name, name_len);
+      if (huffman_len < name_len)
+        {
+          /* Use Huffman for name */
+          unsigned char *huffman_buf;
+          ssize_t encoded_len;
+
+          int_len = SocketHPACK_int_encode (huffman_len,
+                                            QPACK_INST_INSERT_LITERAL_PREFIX,
+                                            int_buf,
+                                            sizeof (int_buf));
+          if (int_len == 0)
+            return QPACK_ENCODER_STREAM_ERROR;
+
+          int_buf[0] |= first_byte;
+
+          result = buffer_append (stream, int_buf, int_len);
+          if (result != QPACK_ENCODER_STREAM_OK)
+            return result;
+
+          huffman_buf = ALLOC (stream->arena, huffman_len + 8);
+          if (huffman_buf == NULL)
+            return QPACK_ENCODER_STREAM_ERROR;
+
+          encoded_len = SocketHPACK_huffman_encode (
+              name, name_len, huffman_buf, huffman_len + 8);
+          if (encoded_len < 0)
+            return QPACK_ENCODER_STREAM_ERROR;
+
+          result = buffer_append (stream, huffman_buf, (size_t)encoded_len);
+          if (result != QPACK_ENCODER_STREAM_OK)
+            return result;
+
+          return encode_string_to_buffer (
+              stream, value, value_len, use_huffman_value);
+        }
+    }
+
+  /* Literal name (no Huffman or Huffman didn't compress) */
+  first_byte = QPACK_INST_INSERT_LITERAL_VAL; /* Reset, no Huffman bit */
+  int_len = SocketHPACK_int_encode (
+      name_len, QPACK_INST_INSERT_LITERAL_PREFIX, int_buf, sizeof (int_buf));
+  if (int_len == 0)
+    return QPACK_ENCODER_STREAM_ERROR;
+
+  int_buf[0] |= first_byte;
+
+  result = buffer_append (stream, int_buf, int_len);
+  if (result != QPACK_ENCODER_STREAM_OK)
+    return result;
+
+  result = buffer_append (stream, name, name_len);
+  if (result != QPACK_ENCODER_STREAM_OK)
+    return result;
+
+  return encode_string_to_buffer (stream, value, value_len, use_huffman_value);
+}
+
+SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_write_duplicate (SocketQPACK_EncoderStream_T stream,
+                                           uint64_t relative_index)
+{
+  if (stream == NULL)
+    return QPACK_ENCODER_STREAM_INVALID_PARAM;
+
+  if (!stream->is_initialized)
+    return QPACK_ENCODER_STREAM_NOT_INIT;
+
+  if (stream->is_closed)
+    return QPACK_ENCODER_STREAM_CLOSED;
+
+  /* Duplicate instruction: 0b000xxxxx */
+  return encode_int_to_buffer (stream,
+                               relative_index,
+                               QPACK_INST_DUPLICATE_PREFIX,
+                               QPACK_INST_DUPLICATE_VAL);
+}
+
+/* ============================================================================
+ * Public API - Buffer Access
+ * ============================================================================
+ */
+
+const unsigned char *
+SocketQPACK_EncoderStream_get_buffer (SocketQPACK_EncoderStream_T stream,
+                                      size_t *buffer_len)
+{
+  if (stream == NULL || buffer_len == NULL)
+    {
+      if (buffer_len != NULL)
+        *buffer_len = 0;
+      return NULL;
+    }
+
+  *buffer_len = stream->buffer_len;
+  return stream->buffer;
+}
+
+void
+SocketQPACK_EncoderStream_reset_buffer (SocketQPACK_EncoderStream_T stream)
+{
+  if (stream == NULL)
+    return;
+
+  stream->buffer_len = 0;
+}
+
+SocketQPACK_EncoderStream_Result
+SocketQPACK_EncoderStream_close (SocketQPACK_EncoderStream_T stream)
+{
+  if (stream == NULL)
+    return QPACK_ENCODER_STREAM_INVALID_PARAM;
+
+  /* RFC 9204 Section 4.2: Closing encoder stream is an error */
+  stream->is_closed = 1;
+  return QPACK_ENCODER_STREAM_CLOSED;
+}

--- a/src/test/test_qpack_encoder_stream.c
+++ b/src/test/test_qpack_encoder_stream.c
@@ -1,0 +1,708 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_qpack_encoder_stream.c - Unit tests for QPACK Encoder Stream
+ *
+ * Tests RFC 9204 Section 4.2 - Encoder Stream Infrastructure including:
+ * - Stream type validation (0x02)
+ * - Stream initialization and lifecycle
+ * - Set Dynamic Table Capacity instruction
+ * - Insert With Name Reference instruction
+ * - Insert With Literal Name instruction
+ * - Duplicate instruction
+ * - Buffer management
+ * - Error handling (closure, duplicate init)
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/SocketHPACK.h"
+#include "http/SocketQPACKEncoderStream.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * Test: Stream Type Validation
+ * RFC 9204 Section 4.2: An encoder stream is a unidirectional stream of
+ * type 0x02
+ * ============================================================================
+ */
+
+static void
+test_stream_type_validation (void)
+{
+  printf ("  Stream type 0x02 validation... ");
+
+  TEST_ASSERT (SocketQPACK_EncoderStream_validate_type (0x02) == 1,
+               "Type 0x02 should be valid");
+  TEST_ASSERT (SocketQPACK_EncoderStream_validate_type (0x00) == 0,
+               "Type 0x00 should be invalid");
+  TEST_ASSERT (SocketQPACK_EncoderStream_validate_type (0x01) == 0,
+               "Type 0x01 should be invalid");
+  TEST_ASSERT (SocketQPACK_EncoderStream_validate_type (0x03) == 0,
+               "Type 0x03 should be invalid");
+  TEST_ASSERT (SocketQPACK_EncoderStream_validate_type (0xFF) == 0,
+               "Type 0xFF should be invalid");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Stream Initialization
+ * ============================================================================
+ */
+
+static void
+test_stream_initialization (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+
+  printf ("  Stream initialization... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  TEST_ASSERT (stream != NULL, "Stream creation should succeed");
+  TEST_ASSERT (SocketQPACK_EncoderStream_is_initialized (stream) == 1,
+               "Stream should be initialized");
+  TEST_ASSERT (SocketQPACK_EncoderStream_get_stream_id (stream) == 0x02,
+               "Stream ID should match");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_stream_null_arena (void)
+{
+  SocketQPACK_EncoderStream_T stream;
+
+  printf ("  Stream with NULL arena... ");
+
+  stream = SocketQPACK_EncoderStream_new (NULL, 0x02);
+  TEST_ASSERT (stream == NULL, "NULL arena should return NULL stream");
+
+  printf ("PASS\n");
+}
+
+static void
+test_stream_null_checks (void)
+{
+  printf ("  NULL stream checks... ");
+
+  TEST_ASSERT (SocketQPACK_EncoderStream_is_initialized (NULL) == 0,
+               "NULL stream should not be initialized");
+  TEST_ASSERT (SocketQPACK_EncoderStream_get_stream_id (NULL) == 0,
+               "NULL stream ID should be 0");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Set Dynamic Table Capacity Instruction
+ * RFC 9204 Section 4.3.1
+ * ============================================================================
+ */
+
+static void
+test_capacity_instruction_small (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+
+  printf ("  Set Dynamic Table Capacity (small value)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Encode capacity 16 (fits in 5-bit prefix) */
+  result = SocketQPACK_EncoderStream_write_capacity (stream, 16);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len == 1, "Should encode to 1 byte");
+  /* 0b001xxxxx with xxxxx = 16 = 0b10000 = 0x30 */
+  TEST_ASSERT (buffer[0] == 0x30, "First byte should be 0x30");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_capacity_instruction_large (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+
+  printf ("  Set Dynamic Table Capacity (large value)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Encode capacity 4096 (needs multi-byte) */
+  result = SocketQPACK_EncoderStream_write_capacity (stream, 4096);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len > 1, "Should encode to multiple bytes");
+  /* First byte should have high bits 001 and max prefix (31) = 0x3F */
+  TEST_ASSERT ((buffer[0] & 0xE0) == 0x20, "High bits should be 001");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_capacity_instruction_zero (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+
+  printf ("  Set Dynamic Table Capacity (zero)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  result = SocketQPACK_EncoderStream_write_capacity (stream, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer_len == 1, "Should encode to 1 byte");
+  /* 0b00100000 = 0x20 */
+  TEST_ASSERT (buffer[0] == 0x20, "Should encode as 0x20");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Insert With Name Reference Instruction
+ * RFC 9204 Section 4.3.2
+ * ============================================================================
+ */
+
+static void
+test_insert_nameref_static (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+  const unsigned char value[] = "www.example.com";
+
+  printf ("  Insert With Name Reference (static)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Reference static table index 1 (:authority) */
+  result = SocketQPACK_EncoderStream_write_insert_nameref (
+      stream, 1, 1, value, sizeof (value) - 1, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len > 2, "Should have index byte and value");
+  /* First byte: 0b11xxxxxx (static=1, bit 6 set) with index 1 */
+  TEST_ASSERT ((buffer[0] & 0xC0) == 0xC0, "Should have static+nameref bits");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_insert_nameref_dynamic (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+  const unsigned char value[] = "bar";
+
+  printf ("  Insert With Name Reference (dynamic)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Reference dynamic table index 0 */
+  result = SocketQPACK_EncoderStream_write_insert_nameref (
+      stream, 0, 0, value, sizeof (value) - 1, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  /* First byte: 0b10xxxxxx (static=0) with index 0 */
+  TEST_ASSERT ((buffer[0] & 0xC0) == 0x80,
+               "Should have nameref bit, no static");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Insert With Literal Name Instruction
+ * RFC 9204 Section 4.3.3
+ * ============================================================================
+ */
+
+static void
+test_insert_literal (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+  const unsigned char name[] = "x-custom";
+  const unsigned char value[] = "custom-value";
+
+  printf ("  Insert With Literal Name... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  result = SocketQPACK_EncoderStream_write_insert_literal (
+      stream, name, sizeof (name) - 1, value, sizeof (value) - 1, 0, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  /* First byte: 0b01xxxxxx */
+  TEST_ASSERT ((buffer[0] & 0xC0) == 0x40, "Should have literal insert bits");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_insert_literal_empty_name (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char name[] = "";
+  const unsigned char value[] = "value";
+
+  printf ("  Insert With Literal Name (empty name)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  result = SocketQPACK_EncoderStream_write_insert_literal (
+      stream, name, 0, value, sizeof (value) - 1, 0, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Duplicate Instruction
+ * RFC 9204 Section 4.3.4
+ * ============================================================================
+ */
+
+static void
+test_duplicate_instruction (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+
+  printf ("  Duplicate instruction... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Duplicate entry at relative index 0 (newest) */
+  result = SocketQPACK_EncoderStream_write_duplicate (stream, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len == 1, "Should encode to 1 byte");
+  /* 0b000xxxxx with index 0 = 0x00 */
+  TEST_ASSERT (buffer[0] == 0x00, "Should be 0x00");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_duplicate_instruction_large_index (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char *buffer;
+  size_t buffer_len;
+
+  printf ("  Duplicate instruction (large index)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Duplicate entry at relative index 100 (needs multi-byte) */
+  result = SocketQPACK_EncoderStream_write_duplicate (stream, 100);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_OK, "Write should succeed");
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len > 1, "Should encode to multiple bytes");
+  /* First byte should have high bits 000 and max prefix (31) */
+  TEST_ASSERT ((buffer[0] & 0xE0) == 0x00, "High bits should be 000");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Buffer Management
+ * ============================================================================
+ */
+
+static void
+test_buffer_reset (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  const unsigned char *buffer;
+  size_t buffer_len;
+
+  printf ("  Buffer reset... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Write something */
+  SocketQPACK_EncoderStream_write_capacity (stream, 100);
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len > 0, "Buffer should have data");
+
+  /* Reset buffer */
+  SocketQPACK_EncoderStream_reset_buffer (stream);
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL after reset");
+  TEST_ASSERT (buffer_len == 0, "Buffer should be empty after reset");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_buffer_accumulation (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  const unsigned char *buffer;
+  size_t len1, len2;
+
+  printf ("  Buffer accumulation... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Write first instruction */
+  SocketQPACK_EncoderStream_write_capacity (stream, 100);
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &len1);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (len1 > 0, "First write should produce data");
+
+  /* Write second instruction */
+  SocketQPACK_EncoderStream_write_duplicate (stream, 0);
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &len2);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (len2 > len1, "Buffer should accumulate");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_buffer_get_null_checks (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  const unsigned char *buffer;
+  size_t buffer_len = 999;
+
+  printf ("  Buffer get NULL checks... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* NULL buffer_len pointer */
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, NULL);
+  TEST_ASSERT (buffer == NULL, "Should return NULL with NULL buffer_len");
+
+  /* NULL stream */
+  buffer = SocketQPACK_EncoderStream_get_buffer (NULL, &buffer_len);
+  TEST_ASSERT (buffer == NULL, "Should return NULL with NULL stream");
+  TEST_ASSERT (buffer_len == 0, "Buffer len should be set to 0");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Stream Closure (Error Condition)
+ * RFC 9204 Section 4.2: The sender MUST NOT close the encoder stream
+ * ============================================================================
+ */
+
+static void
+test_stream_closure (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  SocketQPACK_EncoderStream_Result result;
+
+  printf ("  Stream closure raises H3_CLOSED_CRITICAL_STREAM... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Close the stream (error condition) */
+  result = SocketQPACK_EncoderStream_close (stream);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_CLOSED,
+               "Close should return CLOSED status");
+
+  /* Further operations should fail */
+  TEST_ASSERT (SocketQPACK_EncoderStream_is_initialized (stream) == 0,
+               "Stream should no longer be active after close");
+
+  result = SocketQPACK_EncoderStream_write_capacity (stream, 100);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_CLOSED,
+               "Write after close should fail");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Operations on Uninitialized Stream
+ * ============================================================================
+ */
+
+static void
+test_operations_on_null_stream (void)
+{
+  SocketQPACK_EncoderStream_Result result;
+  const unsigned char value[] = "test";
+
+  printf ("  Operations on NULL stream... ");
+
+  result = SocketQPACK_EncoderStream_write_capacity (NULL, 100);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_INVALID_PARAM,
+               "Write capacity on NULL should fail");
+
+  result = SocketQPACK_EncoderStream_write_duplicate (NULL, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_INVALID_PARAM,
+               "Write duplicate on NULL should fail");
+
+  result = SocketQPACK_EncoderStream_write_insert_nameref (
+      NULL, 1, 0, value, 4, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_INVALID_PARAM,
+               "Write insert nameref on NULL should fail");
+
+  result = SocketQPACK_EncoderStream_write_insert_literal (
+      NULL, value, 4, value, 4, 0, 0);
+  TEST_ASSERT (result == QPACK_ENCODER_STREAM_INVALID_PARAM,
+               "Write insert literal on NULL should fail");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Result String
+ * ============================================================================
+ */
+
+static void
+test_result_string (void)
+{
+  const char *str;
+
+  printf ("  Result string conversion... ");
+
+  str = SocketQPACK_EncoderStream_result_string (QPACK_ENCODER_STREAM_OK);
+  TEST_ASSERT (str != NULL && strcmp (str, "OK") == 0, "OK string");
+
+  str = SocketQPACK_EncoderStream_result_string (QPACK_ENCODER_STREAM_CLOSED);
+  TEST_ASSERT (str != NULL, "CLOSED string should exist");
+
+  str = SocketQPACK_EncoderStream_result_string (
+      (SocketQPACK_EncoderStream_Result)999);
+  TEST_ASSERT (str != NULL && strcmp (str, "Unknown error") == 0,
+               "Unknown error string");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Multiple Instructions Without Framing
+ * RFC 9204 Section 4.2: Unframed sequence of encoder instructions
+ * ============================================================================
+ */
+
+static void
+test_unframed_instruction_sequence (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream;
+  const unsigned char *buffer;
+  size_t buffer_len;
+  const unsigned char name[] = "custom-header";
+  const unsigned char value[] = "custom-value";
+
+  printf ("  Unframed instruction sequence... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_EncoderStream_new (arena, 0x02);
+
+  /* Write multiple instructions */
+  SocketQPACK_EncoderStream_write_capacity (stream, 4096);
+  SocketQPACK_EncoderStream_write_insert_literal (
+      stream, name, sizeof (name) - 1, value, sizeof (value) - 1, 0, 0);
+  SocketQPACK_EncoderStream_write_duplicate (stream, 0);
+
+  buffer = SocketQPACK_EncoderStream_get_buffer (stream, &buffer_len);
+  TEST_ASSERT (buffer != NULL, "Buffer should not be NULL");
+  TEST_ASSERT (buffer_len > 0, "Buffer should have accumulated data");
+
+  /* Verify instructions are concatenated without framing */
+  /* First instruction: capacity (0b001xxxxx) */
+  TEST_ASSERT ((buffer[0] & 0xE0) == 0x20, "First should be capacity");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test: Only One Encoder Stream Per Direction
+ * RFC 9204 Section 4.2: Each endpoint MUST initiate at most one encoder stream
+ * ============================================================================
+ */
+
+static void
+test_single_encoder_stream (void)
+{
+  Arena_T arena;
+  SocketQPACK_EncoderStream_T stream1, stream2;
+
+  printf ("  Single encoder stream per connection... ");
+
+  arena = Arena_new ();
+
+  /* First stream should succeed */
+  stream1 = SocketQPACK_EncoderStream_new (arena, 0x02);
+  TEST_ASSERT (stream1 != NULL, "First stream should be created");
+  TEST_ASSERT (SocketQPACK_EncoderStream_is_initialized (stream1) == 1,
+               "First stream should be initialized");
+
+  /* Creating a second stream with different ID is allowed (different conn) */
+  stream2 = SocketQPACK_EncoderStream_new (arena, 0x06);
+  TEST_ASSERT (stream2 != NULL, "Second stream creation allowed");
+
+  /* Note: RFC requires tracking at connection level, not stream level.
+   * The caller is responsible for ensuring only one encoder stream per
+   * connection direction. */
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Main Test Runner
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("\n=== QPACK Encoder Stream Tests (RFC 9204 Section 4.2) ===\n\n");
+
+  printf ("Stream Type Validation:\n");
+  test_stream_type_validation ();
+
+  printf ("\nStream Initialization:\n");
+  test_stream_initialization ();
+  test_stream_null_arena ();
+  test_stream_null_checks ();
+
+  printf ("\nSet Dynamic Table Capacity (RFC 9204 Section 4.3.1):\n");
+  test_capacity_instruction_small ();
+  test_capacity_instruction_large ();
+  test_capacity_instruction_zero ();
+
+  printf ("\nInsert With Name Reference (RFC 9204 Section 4.3.2):\n");
+  test_insert_nameref_static ();
+  test_insert_nameref_dynamic ();
+
+  printf ("\nInsert With Literal Name (RFC 9204 Section 4.3.3):\n");
+  test_insert_literal ();
+  test_insert_literal_empty_name ();
+
+  printf ("\nDuplicate Instruction (RFC 9204 Section 4.3.4):\n");
+  test_duplicate_instruction ();
+  test_duplicate_instruction_large_index ();
+
+  printf ("\nBuffer Management:\n");
+  test_buffer_reset ();
+  test_buffer_accumulation ();
+  test_buffer_get_null_checks ();
+
+  printf ("\nStream Closure:\n");
+  test_stream_closure ();
+
+  printf ("\nError Handling:\n");
+  test_operations_on_null_stream ();
+  test_result_string ();
+
+  printf ("\nUnframed Instruction Sequence:\n");
+  test_unframed_instruction_sequence ();
+
+  printf ("\nSingle Encoder Stream Constraint:\n");
+  test_single_encoder_stream ();
+
+  printf ("\n=== All QPACK Encoder Stream Tests Passed ===\n\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements #3276 - QPACK Encoder Stream Infrastructure per RFC 9204 Section 4.2.

## Changes

- Add `include/http/SocketQPACKEncoderStream.h` - Public API header with stream type constant (0x02) and result codes
- Add `src/http/qpack/SocketQPACK-encoder-stream.c` - Full implementation including:
  - Stream lifecycle management (new, is_initialized, close)
  - Set Dynamic Table Capacity instruction (Section 4.3.1)
  - Insert With Name Reference instruction (Section 4.3.2)  
  - Insert With Literal Name instruction (Section 4.3.3)
  - Duplicate instruction (Section 4.3.4)
  - Buffer management for instruction accumulation
  - H3_CLOSED_CRITICAL_STREAM error handling
  - Integration with HPACK integer/Huffman encoding
- Add `src/test/test_qpack_encoder_stream.c` - Comprehensive test suite (21 test cases)
- Update `CMakeLists.txt` - Add new source file and test

## RFC Requirements Coverage

### MUST Requirements
- [x] Encoder stream type 0x02 validation
- [x] Each endpoint MUST initiate at most one encoder stream (caller enforced)
- [x] Sender MUST NOT close encoder stream before connection closes (H3_CLOSED_CRITICAL_STREAM)
- [x] Unframed sequence of encoder instructions

### SHOULD Requirements  
- [x] Encoder stream should be established early (design supports this)

## Test Plan

- [x] All 21 new QPACK encoder stream tests pass
- [x] All 140 existing tests pass with sanitizers (ASan + UBSan)
- [x] No memory leaks detected
- [x] Code formatted with clang-format

Closes #3276