### PR TITLE
feat(qpack): implement RFC 9204 Section 4.4.2 Stream Cancellation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-decoder.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -626,6 +629,8 @@ set(HTTP_HEADERS
     include/http/SocketHTTP1-private.h
     include/http/SocketHPACK.h
     include/http/SocketHPACK-private.h
+    include/http/SocketQPACK.h
+    include/http/SocketQPACK-private.h
     include/http/SocketHTTP2.h
     include/http/SocketHTTP2-private.h
     include/http/SocketHTTPClient.h
@@ -780,6 +785,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/SocketQPACK-private.h
+++ b/include/http/SocketQPACK-private.h
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-private.h
+ * @brief Internal QPACK header compression structures and constants.
+ * @internal
+ *
+ * Private implementation for QPACK (RFC 9204). Use SocketQPACK.h for public
+ * API.
+ */
+
+#ifndef SOCKETQPACK_PRIVATE_INCLUDED
+#define SOCKETQPACK_PRIVATE_INCLUDED
+
+#include "http/SocketQPACK.h"
+#include <stdint.h>
+
+#include "core/SocketSecurity.h"
+
+/* Hash table size for stream reference lookup (must be power of 2) */
+#define QPACK_STREAM_REF_HASH_SIZE 64
+#define QPACK_STREAM_REF_HASH_MASK (QPACK_STREAM_REF_HASH_SIZE - 1)
+
+/* Initial capacity for entry indices array per stream */
+#define QPACK_INITIAL_ENTRY_CAPACITY 8
+
+/* Average dynamic entry size estimate */
+#define QPACK_AVERAGE_DYNAMIC_ENTRY_SIZE 50
+
+/* Minimum dynamic table capacity */
+#define QPACK_MIN_DYNAMIC_TABLE_CAPACITY 16
+
+/* Integer encoding constants (same as HPACK RFC 7541 Section 5.1) */
+#define QPACK_INT_CONTINUATION_MASK 0x80
+#define QPACK_INT_PAYLOAD_MASK 0x7F
+#define QPACK_INT_CONTINUATION_VALUE 128
+#define QPACK_INT_BUF_SIZE 16
+#define QPACK_MAX_INT_CONTINUATION_BYTES 10
+#define QPACK_MAX_SAFE_SHIFT 56
+
+/**
+ * QPACK Decoder internal structure.
+ */
+struct SocketQPACK_Decoder
+{
+  SocketQPACK_Table_T table;
+  size_t max_table_size;
+  size_t max_blocked_streams;
+  size_t max_header_size;
+  size_t max_header_list_size;
+
+  /* Stream reference tracking via hash table */
+  SocketQPACK_StreamRef *stream_refs[QPACK_STREAM_REF_HASH_SIZE];
+
+  Arena_T arena;
+};
+
+/**
+ * Hash function for stream ID lookup.
+ */
+static inline size_t
+qpack_stream_hash (uint64_t stream_id)
+{
+  /* Simple hash: use lower bits after mixing */
+  uint64_t h = stream_id;
+  h ^= h >> 33;
+  h *= 0xff51afd7ed558ccdULL;
+  h ^= h >> 33;
+  return (size_t)(h & QPACK_STREAM_REF_HASH_MASK);
+}
+
+/**
+ * Calculate entry size (name + value + overhead).
+ */
+static inline size_t
+qpack_entry_size (size_t name_len, size_t value_len)
+{
+  size_t temp;
+  if (SocketSecurity_check_add (name_len, value_len, &temp)
+      && SocketSecurity_check_add (temp, SOCKETQPACK_ENTRY_OVERHEAD, &temp))
+    {
+      return temp;
+    }
+  return SIZE_MAX;
+}
+
+/**
+ * Validate prefix bits for integer encoding.
+ */
+static inline int
+qpack_valid_prefix_bits (int prefix_bits)
+{
+  return prefix_bits >= 1 && prefix_bits <= 8;
+}
+
+#endif /* SOCKETQPACK_PRIVATE_INCLUDED */

--- a/include/http/SocketQPACK.h
+++ b/include/http/SocketQPACK.h
@@ -1,0 +1,349 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression/decompression for HTTP/3 (RFC 9204).
+ *
+ * Implements QPACK algorithm with static table (99 entries), dynamic table
+ * (FIFO eviction), and per-stream reference tracking. Based on HPACK (RFC 7541)
+ * with modifications for QUIC's out-of-order delivery.
+ *
+ * Thread Safety: Encoder/decoder instances are NOT thread-safe. One instance
+ * per connection recommended.
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/* Default configuration values */
+#ifndef SOCKETQPACK_DEFAULT_TABLE_SIZE
+#define SOCKETQPACK_DEFAULT_TABLE_SIZE 4096
+#endif
+
+#ifndef SOCKETQPACK_MAX_TABLE_SIZE
+#define SOCKETQPACK_MAX_TABLE_SIZE (64 * 1024)
+#endif
+
+#ifndef SOCKETQPACK_MAX_BLOCKED_STREAMS
+#define SOCKETQPACK_MAX_BLOCKED_STREAMS 100
+#endif
+
+/* Static table size (RFC 9204 Appendix A) */
+#define SOCKETQPACK_STATIC_TABLE_SIZE 99
+
+/* Entry overhead: 32 bytes per RFC 9204 Section 3.2.1 */
+#define SOCKETQPACK_ENTRY_OVERHEAD 32
+
+/* Maximum number of streams to track references for */
+#ifndef SOCKETQPACK_MAX_STREAM_REFS
+#define SOCKETQPACK_MAX_STREAM_REFS 256
+#endif
+
+/* Maximum entries in dynamic table */
+#ifndef SOCKETQPACK_MAX_DYNAMIC_ENTRIES
+#define SOCKETQPACK_MAX_DYNAMIC_ENTRIES 128
+#endif
+
+/* ============================================================================
+ * Decoder Stream Instruction Patterns (RFC 9204 Section 4.4)
+ * ============================================================================
+ */
+
+/* Section Acknowledgement: 1xxxxxxx (prefix 1) */
+#define QPACK_DECODER_SECTION_ACK_MASK 0x80
+#define QPACK_DECODER_SECTION_ACK_PREFIX 7
+
+/* Stream Cancellation: 01xxxxxx (prefix 01) */
+#define QPACK_DECODER_STREAM_CANCEL_MASK 0xC0
+#define QPACK_DECODER_STREAM_CANCEL_VAL 0x40
+#define QPACK_DECODER_STREAM_CANCEL_PREFIX 6
+
+/* Insert Count Increment: 00xxxxxx (prefix 00) */
+#define QPACK_DECODER_INSERT_COUNT_MASK 0xC0
+#define QPACK_DECODER_INSERT_COUNT_VAL 0x00
+#define QPACK_DECODER_INSERT_COUNT_PREFIX 6
+
+/* ============================================================================
+ * Exception Definition
+ * ============================================================================
+ */
+
+extern const Except_T SocketQPACK_Error;
+extern const Except_T SocketQPACK_DecompressionFailed;
+
+/* ============================================================================
+ * Result Codes
+ * ============================================================================
+ */
+
+typedef enum
+{
+  QPACK_OK = 0,
+  QPACK_INCOMPLETE,           /* Need more data */
+  QPACK_ERROR,                /* Generic error */
+  QPACK_ERROR_INVALID_INDEX,  /* Invalid table index */
+  QPACK_ERROR_HUFFMAN,        /* Huffman decoding error */
+  QPACK_ERROR_INTEGER,        /* Integer overflow */
+  QPACK_ERROR_TABLE_SIZE,     /* Invalid dynamic table size */
+  QPACK_ERROR_HEADER_SIZE,    /* Header too large */
+  QPACK_ERROR_LIST_SIZE,      /* Header list too large */
+  QPACK_ERROR_STREAM_ID,      /* Invalid stream ID */
+  QPACK_ERROR_DECODER_STREAM, /* Decoder stream error */
+  QPACK_ERROR_ENCODER_STREAM  /* Encoder stream error */
+} SocketQPACK_Result;
+
+/* ============================================================================
+ * Header Structure
+ * ============================================================================
+ */
+
+typedef struct
+{
+  const char *name;
+  size_t name_len;
+  const char *value;
+  size_t value_len;
+  int never_index;
+} SocketQPACK_Header;
+
+/* ============================================================================
+ * Stream Reference Tracking
+ * ============================================================================
+ *
+ * QPACK requires tracking which streams reference which dynamic table entries.
+ * When a stream is cancelled, all its references must be released.
+ */
+
+/**
+ * Entry reference from a specific stream.
+ */
+typedef struct SocketQPACK_EntryRef
+{
+  uint64_t stream_id;                /* Stream that holds this reference */
+  struct SocketQPACK_EntryRef *next; /* Next ref for this entry */
+} SocketQPACK_EntryRef;
+
+/**
+ * Dynamic table entry with reference tracking.
+ */
+typedef struct
+{
+  char *name;
+  size_t name_len;
+  char *value;
+  size_t value_len;
+  int ref_count;              /* Total number of references */
+  SocketQPACK_EntryRef *refs; /* List of streams referencing this entry */
+} SocketQPACK_DynamicEntry;
+
+/**
+ * Stream reference tracking for fast cancellation lookup.
+ */
+typedef struct SocketQPACK_StreamRef
+{
+  uint64_t stream_id;                 /* Stream identifier */
+  int *entry_indices;                 /* Array of entry indices referenced */
+  int entry_count;                    /* Number of entries referenced */
+  int entry_capacity;                 /* Capacity of entry_indices array */
+  struct SocketQPACK_StreamRef *next; /* Hash collision chain */
+} SocketQPACK_StreamRef;
+
+/* ============================================================================
+ * Dynamic Table
+ * ============================================================================
+ */
+
+typedef struct SocketQPACK_Table *SocketQPACK_Table_T;
+
+struct SocketQPACK_Table
+{
+  SocketQPACK_DynamicEntry *entries;
+  size_t capacity;       /* Number of entry slots */
+  size_t head;           /* Insert position (newest) */
+  size_t tail;           /* Oldest entry position */
+  size_t count;          /* Number of entries */
+  size_t size;           /* Current size in bytes */
+  size_t max_size;       /* Maximum size from settings */
+  uint64_t insert_count; /* Absolute insert count for QPACK */
+  Arena_T arena;
+};
+
+/** Create dynamic table with FIFO eviction (RFC 9204 Section 3.2). */
+extern SocketQPACK_Table_T
+SocketQPACK_Table_new (size_t max_size, Arena_T arena);
+
+extern void SocketQPACK_Table_free (SocketQPACK_Table_T *table);
+
+/** Update max size, evicting oldest entries if necessary. */
+extern void
+SocketQPACK_Table_set_max_size (SocketQPACK_Table_T table, size_t max_size);
+
+extern size_t SocketQPACK_Table_size (SocketQPACK_Table_T table);
+extern size_t SocketQPACK_Table_count (SocketQPACK_Table_T table);
+extern size_t SocketQPACK_Table_max_size (SocketQPACK_Table_T table);
+extern uint64_t SocketQPACK_Table_insert_count (SocketQPACK_Table_T table);
+
+/** Get entry by absolute index. */
+extern SocketQPACK_Result SocketQPACK_Table_get (SocketQPACK_Table_T table,
+                                                 size_t index,
+                                                 SocketQPACK_Header *header);
+
+extern SocketQPACK_Result SocketQPACK_Table_add (SocketQPACK_Table_T table,
+                                                 const char *name,
+                                                 size_t name_len,
+                                                 const char *value,
+                                                 size_t value_len);
+
+/* ============================================================================
+ * Decoder
+ * ============================================================================
+ */
+
+typedef struct SocketQPACK_Decoder *SocketQPACK_Decoder_T;
+
+typedef struct
+{
+  size_t max_table_size;
+  size_t max_blocked_streams;
+  size_t max_header_size;
+  size_t max_header_list_size;
+} SocketQPACK_DecoderConfig;
+
+extern void
+SocketQPACK_decoder_config_defaults (SocketQPACK_DecoderConfig *config);
+
+extern SocketQPACK_Decoder_T
+SocketQPACK_Decoder_new (const SocketQPACK_DecoderConfig *config,
+                         Arena_T arena);
+
+extern void SocketQPACK_Decoder_free (SocketQPACK_Decoder_T *decoder);
+
+extern SocketQPACK_Table_T
+SocketQPACK_Decoder_get_table (SocketQPACK_Decoder_T decoder);
+
+/* ============================================================================
+ * Stream Cancellation (RFC 9204 Section 4.4.2)
+ * ============================================================================
+ *
+ * When a stream is cancelled or reset, the decoder sends a Stream Cancellation
+ * instruction to notify the encoder that all dynamic table references held by
+ * that stream can be released.
+ */
+
+/**
+ * Decode Stream Cancellation instruction from decoder stream.
+ *
+ * Wire format (RFC 9204 Section 4.4.2):
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 0 | 1 |     Stream ID (6+)    |
+ * +---+---+-----------------------+
+ *
+ * @param decoder   QPACK decoder instance
+ * @param input     Input buffer containing instruction
+ * @param input_len Length of input buffer
+ * @param consumed  Output: bytes consumed from input
+ * @param stream_id Output: cancelled stream ID (if successful)
+ *
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result
+SocketQPACK_decode_stream_cancel (SocketQPACK_Decoder_T decoder,
+                                  const unsigned char *input,
+                                  size_t input_len,
+                                  size_t *consumed,
+                                  uint64_t *stream_id);
+
+/**
+ * Release all dynamic table references held by a stream.
+ *
+ * Called internally by SocketQPACK_decode_stream_cancel after parsing
+ * the stream ID, or can be called directly when a stream is reset.
+ *
+ * @param decoder   QPACK decoder instance
+ * @param stream_id Stream ID to release references for
+ *
+ * @return QPACK_OK on success, or appropriate error code
+ */
+extern SocketQPACK_Result
+SocketQPACK_stream_cancel_release_refs (SocketQPACK_Decoder_T decoder,
+                                        uint64_t stream_id);
+
+/**
+ * Validate stream ID for cancellation.
+ *
+ * @param stream_id Stream ID to validate
+ *
+ * @return QPACK_OK if valid, QPACK_ERROR_STREAM_ID if invalid
+ */
+extern SocketQPACK_Result
+SocketQPACK_stream_cancel_validate_id (uint64_t stream_id);
+
+/**
+ * Add a reference from a stream to a dynamic table entry.
+ *
+ * @param decoder     QPACK decoder instance
+ * @param stream_id   Stream holding the reference
+ * @param entry_index Dynamic table entry index (0-based)
+ *
+ * @return QPACK_OK on success
+ */
+extern SocketQPACK_Result
+SocketQPACK_add_stream_reference (SocketQPACK_Decoder_T decoder,
+                                  uint64_t stream_id,
+                                  size_t entry_index);
+
+/**
+ * Check if a byte represents a Stream Cancellation instruction.
+ *
+ * @param byte First byte of potential instruction
+ *
+ * @return 1 if this is a Stream Cancellation, 0 otherwise
+ */
+extern int SocketQPACK_is_stream_cancel_instruction (unsigned char byte);
+
+/* ============================================================================
+ * Integer Encoding/Decoding (RFC 7541 Section 5.1)
+ * ============================================================================
+ *
+ * QPACK uses the same integer encoding as HPACK.
+ */
+
+/** Encode integer with prefix (RFC 7541 Section 5.1). */
+extern size_t SocketQPACK_int_encode (uint64_t value,
+                                      int prefix_bits,
+                                      unsigned char *output,
+                                      size_t output_size);
+
+/** Decode integer with prefix (RFC 7541 Section 5.1). */
+extern SocketQPACK_Result SocketQPACK_int_decode (const unsigned char *input,
+                                                  size_t input_len,
+                                                  int prefix_bits,
+                                                  uint64_t *value,
+                                                  size_t *consumed);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK-decoder.c
+++ b/src/http/qpack/SocketQPACK-decoder.c
@@ -1,0 +1,779 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK-decoder.c - QPACK Decoder (RFC 9204)
+ *
+ * Implements QPACK decoder functionality including:
+ * - Stream Cancellation instruction (Section 4.4.2)
+ * - Dynamic table management
+ * - Per-stream reference tracking
+ * - Integer encoding/decoding (reuses HPACK RFC 7541 Section 5.1)
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "http/SocketQPACK.h"
+#include "http/SocketQPACK-private.h"
+
+#include "core/SocketSecurity.h"
+
+/* ============================================================================
+ * Exception Definitions
+ * ============================================================================
+ */
+
+const Except_T SocketQPACK_Error
+    = { &SocketQPACK_Error, "QPACK compression error" };
+
+const Except_T SocketQPACK_DecompressionFailed
+    = { &SocketQPACK_DecompressionFailed, "QPACK decompression failed" };
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_ERROR_INVALID_INDEX] = "Invalid table index",
+  [QPACK_ERROR_HUFFMAN] = "Huffman decoding error",
+  [QPACK_ERROR_INTEGER] = "Integer overflow",
+  [QPACK_ERROR_TABLE_SIZE] = "Invalid dynamic table size",
+  [QPACK_ERROR_HEADER_SIZE] = "Header too large",
+  [QPACK_ERROR_LIST_SIZE] = "Header list too large",
+  [QPACK_ERROR_STREAM_ID] = "Invalid stream ID",
+  [QPACK_ERROR_DECODER_STREAM] = "Decoder stream error",
+  [QPACK_ERROR_ENCODER_STREAM] = "Encoder stream error",
+};
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if (result < 0 || result > QPACK_ERROR_ENCODER_STREAM)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Integer Encoding/Decoding (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+static size_t
+encode_int_continuation (uint64_t value,
+                         unsigned char *output,
+                         size_t pos,
+                         size_t output_size)
+{
+  while (value >= QPACK_INT_CONTINUATION_VALUE && pos < output_size)
+    {
+      output[pos++] = (unsigned char)(QPACK_INT_CONTINUATION_MASK
+                                      | (value & QPACK_INT_PAYLOAD_MASK));
+      value >>= 7;
+    }
+
+  if (pos >= output_size)
+    return 0;
+
+  output[pos++] = (unsigned char)value;
+  return pos;
+}
+
+size_t
+SocketQPACK_int_encode (uint64_t value,
+                        int prefix_bits,
+                        unsigned char *output,
+                        size_t output_size)
+{
+  uint64_t max_prefix;
+
+  if (output == NULL || output_size == 0
+      || !qpack_valid_prefix_bits (prefix_bits))
+    return 0;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  if (value < max_prefix)
+    {
+      output[0] = (unsigned char)value;
+      return 1;
+    }
+
+  output[0] = (unsigned char)max_prefix;
+  return encode_int_continuation (value - max_prefix, output, 1, output_size);
+}
+
+static SocketQPACK_Result
+decode_int_continuation (const unsigned char *input,
+                         size_t input_len,
+                         size_t *pos,
+                         uint64_t *result,
+                         unsigned int *shift)
+{
+  uint64_t byte_val;
+  unsigned int continuation_count = 0;
+
+  do
+    {
+      if (*pos >= input_len)
+        return QPACK_INCOMPLETE;
+
+      continuation_count++;
+      if (continuation_count > QPACK_MAX_INT_CONTINUATION_BYTES)
+        return QPACK_ERROR_INTEGER;
+
+      byte_val = input[(*pos)++];
+
+      if (*shift > QPACK_MAX_SAFE_SHIFT)
+        return QPACK_ERROR_INTEGER;
+
+      uint64_t add_val = (byte_val & QPACK_INT_PAYLOAD_MASK) << *shift;
+      if (*result > UINT64_MAX - add_val)
+        return QPACK_ERROR_INTEGER;
+
+      *result += add_val;
+      *shift += 7;
+    }
+  while (byte_val & QPACK_INT_CONTINUATION_MASK);
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_int_decode (const unsigned char *input,
+                        size_t input_len,
+                        int prefix_bits,
+                        uint64_t *value,
+                        size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t max_prefix;
+  uint64_t result;
+  unsigned int shift = 0;
+
+  if (input == NULL || value == NULL || consumed == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!qpack_valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+  result = input[pos++] & max_prefix;
+
+  if (result < max_prefix)
+    {
+      *value = result;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  SocketQPACK_Result cont_result
+      = decode_int_continuation (input, input_len, &pos, &result, &shift);
+  if (cont_result != QPACK_OK)
+    return cont_result;
+
+  *value = result;
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Dynamic Table
+ * ============================================================================
+ */
+
+SocketQPACK_Table_T
+SocketQPACK_Table_new (size_t max_size, Arena_T arena)
+{
+  SocketQPACK_Table_T table;
+  size_t capacity;
+
+  assert (arena != NULL);
+
+  table = ALLOC (arena, sizeof (*table));
+  if (table == NULL)
+    return NULL;
+
+  /* Calculate initial capacity based on average entry size */
+  if (max_size > 0)
+    {
+      capacity = max_size / QPACK_AVERAGE_DYNAMIC_ENTRY_SIZE;
+      if (capacity < QPACK_MIN_DYNAMIC_TABLE_CAPACITY)
+        capacity = QPACK_MIN_DYNAMIC_TABLE_CAPACITY;
+      if (capacity > SOCKETQPACK_MAX_DYNAMIC_ENTRIES)
+        capacity = SOCKETQPACK_MAX_DYNAMIC_ENTRIES;
+    }
+  else
+    {
+      capacity = 0;
+    }
+
+  table->entries = NULL;
+  if (capacity > 0)
+    {
+      table->entries
+          = CALLOC (arena, capacity, sizeof (SocketQPACK_DynamicEntry));
+    }
+
+  table->capacity = capacity;
+  table->head = 0;
+  table->tail = 0;
+  table->count = 0;
+  table->size = 0;
+  table->max_size = max_size;
+  table->insert_count = 0;
+  table->arena = arena;
+
+  return table;
+}
+
+void
+SocketQPACK_Table_free (SocketQPACK_Table_T *table)
+{
+  if (table == NULL || *table == NULL)
+    return;
+  /* Arena handles all memory deallocation */
+  *table = NULL;
+}
+
+void
+SocketQPACK_Table_set_max_size (SocketQPACK_Table_T table, size_t max_size)
+{
+  assert (table != NULL);
+
+  if (max_size > SOCKETQPACK_MAX_TABLE_SIZE)
+    max_size = SOCKETQPACK_MAX_TABLE_SIZE;
+
+  /* Evict entries if needed */
+  while (table->size > max_size && table->count > 0)
+    {
+      /* Evict oldest entry (FIFO) */
+      SocketQPACK_DynamicEntry *entry = &table->entries[table->tail];
+      size_t entry_size = qpack_entry_size (entry->name_len, entry->value_len);
+
+      if (entry_size != SIZE_MAX && entry_size <= table->size)
+        table->size -= entry_size;
+      else
+        table->size = 0;
+
+      /* Clear entry references */
+      entry->name = NULL;
+      entry->name_len = 0;
+      entry->value = NULL;
+      entry->value_len = 0;
+      entry->ref_count = 0;
+      entry->refs = NULL;
+
+      table->tail = (table->tail + 1) % table->capacity;
+      table->count--;
+    }
+
+  table->max_size = max_size;
+}
+
+size_t
+SocketQPACK_Table_size (SocketQPACK_Table_T table)
+{
+  assert (table != NULL);
+  return table->size;
+}
+
+size_t
+SocketQPACK_Table_count (SocketQPACK_Table_T table)
+{
+  assert (table != NULL);
+  return table->count;
+}
+
+size_t
+SocketQPACK_Table_max_size (SocketQPACK_Table_T table)
+{
+  assert (table != NULL);
+  return table->max_size;
+}
+
+uint64_t
+SocketQPACK_Table_insert_count (SocketQPACK_Table_T table)
+{
+  assert (table != NULL);
+  return table->insert_count;
+}
+
+SocketQPACK_Result
+SocketQPACK_Table_get (SocketQPACK_Table_T table,
+                       size_t index,
+                       SocketQPACK_Header *header)
+{
+  size_t actual_index;
+  SocketQPACK_DynamicEntry *entry;
+
+  assert (table != NULL);
+  assert (header != NULL);
+
+  if (index == 0 || index > table->count)
+    return QPACK_ERROR_INVALID_INDEX;
+
+  /* Convert 1-based index to actual ring buffer position */
+  /* Index 1 = most recent (head - 1), index count = oldest (tail) */
+  actual_index = (table->head + table->capacity - index) % table->capacity;
+  entry = &table->entries[actual_index];
+
+  header->name = entry->name;
+  header->name_len = entry->name_len;
+  header->value = entry->value;
+  header->value_len = entry->value_len;
+  header->never_index = 0;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_Table_add (SocketQPACK_Table_T table,
+                       const char *name,
+                       size_t name_len,
+                       const char *value,
+                       size_t value_len)
+{
+  size_t entry_size;
+  SocketQPACK_DynamicEntry *entry;
+
+  assert (table != NULL);
+
+  entry_size = qpack_entry_size (name_len, value_len);
+  if (entry_size == SIZE_MAX)
+    return QPACK_ERROR;
+
+  /* Check if entry fits in table at all */
+  if (entry_size > table->max_size)
+    {
+      /* Entry too large - clear table and return OK per RFC */
+      while (table->count > 0)
+        {
+          SocketQPACK_DynamicEntry *old = &table->entries[table->tail];
+          size_t old_size = qpack_entry_size (old->name_len, old->value_len);
+          if (old_size != SIZE_MAX && old_size <= table->size)
+            table->size -= old_size;
+          table->tail = (table->tail + 1) % table->capacity;
+          table->count--;
+        }
+      table->size = 0;
+      table->insert_count++;
+      return QPACK_OK;
+    }
+
+  /* Evict entries to make room */
+  while (table->size + entry_size > table->max_size && table->count > 0)
+    {
+      SocketQPACK_DynamicEntry *old = &table->entries[table->tail];
+      size_t old_size = qpack_entry_size (old->name_len, old->value_len);
+      if (old_size != SIZE_MAX && old_size <= table->size)
+        table->size -= old_size;
+      table->tail = (table->tail + 1) % table->capacity;
+      table->count--;
+    }
+
+  /* Check capacity */
+  if (table->capacity == 0)
+    return QPACK_ERROR;
+
+  if (table->count >= table->capacity)
+    {
+      /* Table full - evict oldest */
+      SocketQPACK_DynamicEntry *old = &table->entries[table->tail];
+      size_t old_size = qpack_entry_size (old->name_len, old->value_len);
+      if (old_size != SIZE_MAX && old_size <= table->size)
+        table->size -= old_size;
+      table->tail = (table->tail + 1) % table->capacity;
+      table->count--;
+    }
+
+  /* Insert new entry at head */
+  entry = &table->entries[table->head];
+
+  /* Copy name */
+  entry->name = ALLOC (table->arena, name_len + 1);
+  if (entry->name == NULL)
+    return QPACK_ERROR;
+  memcpy (entry->name, name, name_len);
+  entry->name[name_len] = '\0';
+  entry->name_len = name_len;
+
+  /* Copy value */
+  entry->value = ALLOC (table->arena, value_len + 1);
+  if (entry->value == NULL)
+    return QPACK_ERROR;
+  memcpy (entry->value, value, value_len);
+  entry->value[value_len] = '\0';
+  entry->value_len = value_len;
+
+  entry->ref_count = 0;
+  entry->refs = NULL;
+
+  table->head = (table->head + 1) % table->capacity;
+  table->count++;
+  table->size += entry_size;
+  table->insert_count++;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Decoder Configuration
+ * ============================================================================
+ */
+
+void
+SocketQPACK_decoder_config_defaults (SocketQPACK_DecoderConfig *config)
+{
+  if (config == NULL)
+    return;
+
+  config->max_table_size = SOCKETQPACK_DEFAULT_TABLE_SIZE;
+  config->max_blocked_streams = SOCKETQPACK_MAX_BLOCKED_STREAMS;
+  config->max_header_size = 8 * 1024;       /* 8KB per header */
+  config->max_header_list_size = 64 * 1024; /* 64KB total */
+}
+
+/* ============================================================================
+ * Decoder Implementation
+ * ============================================================================
+ */
+
+SocketQPACK_Decoder_T
+SocketQPACK_Decoder_new (const SocketQPACK_DecoderConfig *config, Arena_T arena)
+{
+  SocketQPACK_Decoder_T decoder;
+  SocketQPACK_DecoderConfig default_config;
+
+  assert (arena != NULL);
+
+  if (config == NULL)
+    {
+      SocketQPACK_decoder_config_defaults (&default_config);
+      config = &default_config;
+    }
+
+  decoder = ALLOC (arena, sizeof (*decoder));
+  if (decoder == NULL)
+    return NULL;
+
+  decoder->table = SocketQPACK_Table_new (config->max_table_size, arena);
+  if (decoder->table == NULL)
+    return NULL;
+
+  decoder->max_table_size = config->max_table_size;
+  decoder->max_blocked_streams = config->max_blocked_streams;
+  decoder->max_header_size = config->max_header_size;
+  decoder->max_header_list_size = config->max_header_list_size;
+  decoder->arena = arena;
+
+  /* Initialize stream reference hash table */
+  for (size_t i = 0; i < QPACK_STREAM_REF_HASH_SIZE; i++)
+    decoder->stream_refs[i] = NULL;
+
+  return decoder;
+}
+
+void
+SocketQPACK_Decoder_free (SocketQPACK_Decoder_T *decoder)
+{
+  if (decoder == NULL || *decoder == NULL)
+    return;
+
+  SocketQPACK_Table_free (&(*decoder)->table);
+  /* Arena handles all other memory */
+  *decoder = NULL;
+}
+
+SocketQPACK_Table_T
+SocketQPACK_Decoder_get_table (SocketQPACK_Decoder_T decoder)
+{
+  assert (decoder != NULL);
+  return decoder->table;
+}
+
+/* ============================================================================
+ * Stream Reference Tracking
+ * ============================================================================
+ */
+
+/**
+ * Find or create stream reference entry.
+ */
+static SocketQPACK_StreamRef *
+find_or_create_stream_ref (SocketQPACK_Decoder_T decoder, uint64_t stream_id)
+{
+  size_t hash = qpack_stream_hash (stream_id);
+  SocketQPACK_StreamRef *ref = decoder->stream_refs[hash];
+
+  /* Search existing entries */
+  while (ref != NULL)
+    {
+      if (ref->stream_id == stream_id)
+        return ref;
+      ref = ref->next;
+    }
+
+  /* Create new entry */
+  ref = ALLOC (decoder->arena, sizeof (*ref));
+  if (ref == NULL)
+    return NULL;
+
+  ref->stream_id = stream_id;
+  ref->entry_capacity = QPACK_INITIAL_ENTRY_CAPACITY;
+  ref->entry_indices
+      = ALLOC (decoder->arena, ref->entry_capacity * sizeof (int));
+  if (ref->entry_indices == NULL)
+    return NULL;
+
+  ref->entry_count = 0;
+  ref->next = decoder->stream_refs[hash];
+  decoder->stream_refs[hash] = ref;
+
+  return ref;
+}
+
+/**
+ * Find stream reference entry (no create).
+ */
+static SocketQPACK_StreamRef *
+find_stream_ref (SocketQPACK_Decoder_T decoder, uint64_t stream_id)
+{
+  size_t hash = qpack_stream_hash (stream_id);
+  SocketQPACK_StreamRef *ref = decoder->stream_refs[hash];
+
+  while (ref != NULL)
+    {
+      if (ref->stream_id == stream_id)
+        return ref;
+      ref = ref->next;
+    }
+
+  return NULL;
+}
+
+/**
+ * Remove stream reference from hash table.
+ */
+static void
+remove_stream_ref (SocketQPACK_Decoder_T decoder, uint64_t stream_id)
+{
+  size_t hash = qpack_stream_hash (stream_id);
+  SocketQPACK_StreamRef **prev = &decoder->stream_refs[hash];
+  SocketQPACK_StreamRef *ref = *prev;
+
+  while (ref != NULL)
+    {
+      if (ref->stream_id == stream_id)
+        {
+          *prev = ref->next;
+          /* Memory freed by arena */
+          return;
+        }
+      prev = &ref->next;
+      ref = ref->next;
+    }
+}
+
+SocketQPACK_Result
+SocketQPACK_add_stream_reference (SocketQPACK_Decoder_T decoder,
+                                  uint64_t stream_id,
+                                  size_t entry_index)
+{
+  SocketQPACK_StreamRef *ref;
+  SocketQPACK_DynamicEntry *entry;
+  SocketQPACK_EntryRef *entry_ref;
+  size_t actual_index;
+
+  assert (decoder != NULL);
+
+  if (entry_index == 0 || entry_index > decoder->table->count)
+    return QPACK_ERROR_INVALID_INDEX;
+
+  /* Find or create stream reference tracking */
+  ref = find_or_create_stream_ref (decoder, stream_id);
+  if (ref == NULL)
+    return QPACK_ERROR;
+
+  /* Grow entry_indices array if needed */
+  if (ref->entry_count >= ref->entry_capacity)
+    {
+      size_t new_capacity = ref->entry_capacity * 2;
+      int *new_indices = ALLOC (decoder->arena, new_capacity * sizeof (int));
+      if (new_indices == NULL)
+        return QPACK_ERROR;
+      memcpy (new_indices, ref->entry_indices, ref->entry_count * sizeof (int));
+      ref->entry_indices = new_indices;
+      ref->entry_capacity = new_capacity;
+    }
+
+  /* Add entry index to stream's list */
+  ref->entry_indices[ref->entry_count++] = (int)entry_index;
+
+  /* Update entry's reference count and list */
+  actual_index = (decoder->table->head + decoder->table->capacity - entry_index)
+                 % decoder->table->capacity;
+  entry = &decoder->table->entries[actual_index];
+  entry->ref_count++;
+
+  /* Add stream to entry's reference list */
+  entry_ref = ALLOC (decoder->arena, sizeof (*entry_ref));
+  if (entry_ref == NULL)
+    return QPACK_ERROR;
+
+  entry_ref->stream_id = stream_id;
+  entry_ref->next = entry->refs;
+  entry->refs = entry_ref;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Stream Cancellation (RFC 9204 Section 4.4.2)
+ * ============================================================================
+ */
+
+int
+SocketQPACK_is_stream_cancel_instruction (unsigned char byte)
+{
+  return (byte & QPACK_DECODER_STREAM_CANCEL_MASK)
+         == QPACK_DECODER_STREAM_CANCEL_VAL;
+}
+
+SocketQPACK_Result
+SocketQPACK_stream_cancel_validate_id (uint64_t stream_id)
+{
+  /* Stream ID 0 is reserved for the connection itself (not a request stream) */
+  /* In HTTP/3, request streams are client-initiated bidirectional streams
+   * which have IDs like 0, 4, 8, 12, etc. (multiples of 4).
+   * However, stream ID 0 itself is a valid HTTP/3 request stream.
+   * For QPACK stream cancellation, we allow any stream ID > 0 for safety,
+   * but the actual validation may be context-dependent. */
+
+  /* Per the issue specification: stream ID 0 is reserved for connection */
+  /* We'll validate that stream_id is not 0 */
+  if (stream_id == 0)
+    return QPACK_ERROR_STREAM_ID;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_stream_cancel_release_refs (SocketQPACK_Decoder_T decoder,
+                                        uint64_t stream_id)
+{
+  SocketQPACK_StreamRef *ref;
+
+  assert (decoder != NULL);
+
+  /* Find stream's references */
+  ref = find_stream_ref (decoder, stream_id);
+  if (ref == NULL)
+    {
+      /* Stream not found in tracking - this is OK per RFC, just warn */
+      /* The stream may have never referenced any dynamic table entries,
+       * or it was already cleaned up. This is not an error. */
+      return QPACK_OK;
+    }
+
+  /* Release each entry reference */
+  for (int i = 0; i < ref->entry_count; i++)
+    {
+      size_t entry_index = (size_t)ref->entry_indices[i];
+      size_t actual_index;
+      SocketQPACK_DynamicEntry *entry;
+      SocketQPACK_EntryRef **prev_ref;
+      SocketQPACK_EntryRef *entry_ref;
+
+      /* Validate entry index is still valid */
+      if (entry_index == 0 || entry_index > decoder->table->count)
+        continue;
+
+      actual_index
+          = (decoder->table->head + decoder->table->capacity - entry_index)
+            % decoder->table->capacity;
+      entry = &decoder->table->entries[actual_index];
+
+      /* Decrement reference count */
+      if (entry->ref_count > 0)
+        entry->ref_count--;
+
+      /* Remove this stream from entry's reference list */
+      prev_ref = &entry->refs;
+      entry_ref = entry->refs;
+      while (entry_ref != NULL)
+        {
+          if (entry_ref->stream_id == stream_id)
+            {
+              *prev_ref = entry_ref->next;
+              /* Memory freed by arena */
+              break;
+            }
+          prev_ref = &entry_ref->next;
+          entry_ref = entry_ref->next;
+        }
+    }
+
+  /* Remove stream from hash table */
+  remove_stream_ref (decoder, stream_id);
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_decode_stream_cancel (SocketQPACK_Decoder_T decoder,
+                                  const unsigned char *input,
+                                  size_t input_len,
+                                  size_t *consumed,
+                                  uint64_t *stream_id)
+{
+  uint64_t id;
+  size_t bytes_consumed;
+  SocketQPACK_Result result;
+
+  assert (decoder != NULL);
+  assert (consumed != NULL);
+  assert (stream_id != NULL);
+
+  if (input == NULL || input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Verify this is a Stream Cancellation instruction */
+  if (!SocketQPACK_is_stream_cancel_instruction (input[0]))
+    return QPACK_ERROR_DECODER_STREAM;
+
+  /* Decode stream ID with 6-bit prefix */
+  result = SocketQPACK_int_decode (input,
+                                   input_len,
+                                   QPACK_DECODER_STREAM_CANCEL_PREFIX,
+                                   &id,
+                                   &bytes_consumed);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Validate stream ID */
+  result = SocketQPACK_stream_cancel_validate_id (id);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Release all references for this stream */
+  result = SocketQPACK_stream_cancel_release_refs (decoder, id);
+  if (result != QPACK_OK)
+    return result;
+
+  *consumed = bytes_consumed;
+  *stream_id = id;
+
+  return QPACK_OK;
+}

--- a/src/test/test_qpack.c
+++ b/src/test/test_qpack.c
@@ -1,0 +1,615 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_qpack.c - Unit tests for QPACK Header Compression (RFC 9204)
+ *
+ * Tests QPACK implementation including:
+ * - Integer encoding/decoding (RFC 7541 Section 5.1)
+ * - Dynamic table operations
+ * - Stream Cancellation instruction (Section 4.4.2)
+ * - Per-stream reference tracking
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/SocketQPACK.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Simple test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * Integer Encoding Tests (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+/**
+ * Test integer encoding with 6-bit prefix (used by Stream Cancellation)
+ */
+static void
+test_int_encode_6bit_small (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 4 with 6-bit prefix... ");
+
+  len = SocketQPACK_int_encode (4, 6, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Expected 1 byte");
+  TEST_ASSERT (buf[0] == 0x04, "Expected 0x04 (4)");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding at prefix boundary
+ */
+static void
+test_int_encode_6bit_boundary (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 63 with 6-bit prefix (boundary)... ");
+
+  /* 63 = 2^6 - 1, fits exactly in prefix */
+  len = SocketQPACK_int_encode (62, 6, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Expected 1 byte for value < max prefix");
+  TEST_ASSERT (buf[0] == 62, "Expected 62");
+
+  /* 63 requires continuation */
+  len = SocketQPACK_int_encode (63, 6, buf, sizeof (buf));
+  TEST_ASSERT (len == 2, "Expected 2 bytes for max prefix value");
+  TEST_ASSERT (buf[0] == 0x3F, "First byte should be 63 (2^6 - 1)");
+  TEST_ASSERT (buf[1] == 0x00, "Second byte should be 0");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding requiring multi-byte
+ */
+static void
+test_int_encode_6bit_large (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 1000 with 6-bit prefix... ");
+
+  /* 1000 = 63 + 937 = 63 + (937 & 0x7F) | 0x80, (937 >> 7) */
+  /* 937 = 0x3A9 = 0b1110101001 */
+  /* 937 & 0x7F = 0x29 = 41, 937 >> 7 = 7 */
+  /* So: 63, 41|0x80, 7 = 0x3F, 0xA9, 0x07 */
+  len = SocketQPACK_int_encode (1000, 6, buf, sizeof (buf));
+  TEST_ASSERT (len == 3, "Expected 3 bytes");
+  TEST_ASSERT (buf[0] == 0x3F, "First byte should be 63");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer decoding - small value
+ */
+static void
+test_int_decode_6bit_small (void)
+{
+  /* Stream ID 4 encoded: 01000100 = 0x44 */
+  unsigned char data[] = { 0x44 };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode 4 from 0x44... ");
+
+  result = SocketQPACK_int_decode (data, sizeof (data), 6, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == 4, "Value should be 4");
+  TEST_ASSERT (consumed == 1, "Should consume 1 byte");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer decoding - multi-byte
+ */
+static void
+test_int_decode_6bit_large (void)
+{
+  /* Stream ID > 63 requires continuation bytes */
+  /* Encode 127 with 6-bit prefix: 63 + 64 = 63, then 64 */
+  /* 64 = 0x40, no continuation needed */
+  unsigned char data[] = { 0x3F, 0x40 };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode 127 (multi-byte)... ");
+
+  result = SocketQPACK_int_decode (data, sizeof (data), 6, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == 127, "Value should be 127 (63 + 64)");
+  TEST_ASSERT (consumed == 2, "Should consume 2 bytes");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer decode with incomplete data
+ */
+static void
+test_int_decode_incomplete (void)
+{
+  /* Continuation byte expected but not present */
+  unsigned char data[] = { 0x3F };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode incomplete data... ");
+
+  result = SocketQPACK_int_decode (data, sizeof (data), 6, &value, &consumed);
+  TEST_ASSERT (result == QPACK_INCOMPLETE, "Should return incomplete");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Dynamic Table Tests
+ * ============================================================================
+ */
+
+/**
+ * Test dynamic table creation
+ */
+static void
+test_table_create (void)
+{
+  Arena_T arena;
+  SocketQPACK_Table_T table;
+
+  printf ("  Dynamic table creation... ");
+
+  arena = Arena_new ();
+  table = SocketQPACK_Table_new (4096, arena);
+
+  TEST_ASSERT (table != NULL, "Table should be created");
+  TEST_ASSERT (SocketQPACK_Table_count (table) == 0, "Table should be empty");
+  TEST_ASSERT (SocketQPACK_Table_size (table) == 0, "Table size should be 0");
+  TEST_ASSERT (SocketQPACK_Table_max_size (table) == 4096,
+               "Max size should be 4096");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test dynamic table add and get
+ */
+static void
+test_table_add_get (void)
+{
+  Arena_T arena;
+  SocketQPACK_Table_T table;
+  SocketQPACK_Header header;
+  SocketQPACK_Result result;
+
+  printf ("  Dynamic table add and get... ");
+
+  arena = Arena_new ();
+  table = SocketQPACK_Table_new (4096, arena);
+
+  /* Add an entry */
+  result = SocketQPACK_Table_add (table, "content-type", 12, "text/html", 9);
+  TEST_ASSERT (result == QPACK_OK, "Add should succeed");
+  TEST_ASSERT (SocketQPACK_Table_count (table) == 1, "Count should be 1");
+
+  /* Get the entry (index 1 = most recent) */
+  result = SocketQPACK_Table_get (table, 1, &header);
+  TEST_ASSERT (result == QPACK_OK, "Get should succeed");
+  TEST_ASSERT (header.name_len == 12, "Name length should be 12");
+  TEST_ASSERT (strncmp (header.name, "content-type", 12) == 0,
+               "Name should match");
+  TEST_ASSERT (header.value_len == 9, "Value length should be 9");
+  TEST_ASSERT (strncmp (header.value, "text/html", 9) == 0,
+               "Value should match");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Stream Cancellation Tests (RFC 9204 Section 4.4.2)
+ * ============================================================================
+ */
+
+/**
+ * Test Stream Cancellation instruction detection
+ */
+static void
+test_stream_cancel_detect (void)
+{
+  printf ("  Stream Cancellation instruction detection... ");
+
+  /* Stream Cancellation: 01xxxxxx */
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0x40) == 1,
+               "0x40 should be stream cancel");
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0x44) == 1,
+               "0x44 should be stream cancel");
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0x7F) == 1,
+               "0x7F should be stream cancel");
+
+  /* Section Acknowledgement: 1xxxxxxx */
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0x80) == 0,
+               "0x80 should NOT be stream cancel");
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0xFF) == 0,
+               "0xFF should NOT be stream cancel");
+
+  /* Insert Count Increment: 00xxxxxx */
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0x00) == 0,
+               "0x00 should NOT be stream cancel");
+  TEST_ASSERT (SocketQPACK_is_stream_cancel_instruction (0x3F) == 0,
+               "0x3F should NOT be stream cancel");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoding single-octet stream cancellation (ID < 64)
+ */
+static void
+test_stream_cancel_single_octet (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  unsigned char data[] = { 0x44 }; /* 01000100 = stream ID 4 */
+  size_t consumed;
+  uint64_t stream_id;
+  SocketQPACK_Result result;
+
+  printf ("  Decode single-octet stream cancellation (ID=4)... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data, sizeof (data), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_OK, "Decode should succeed");
+  TEST_ASSERT (consumed == 1, "Should consume 1 byte");
+  TEST_ASSERT (stream_id == 4, "Stream ID should be 4");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoding multi-octet stream cancellation (ID >= 64)
+ */
+static void
+test_stream_cancel_multi_octet (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  /* 01111111 00000000 = stream ID 63 (boundary case) */
+  unsigned char data1[] = { 0x7F, 0x00 };
+  /* 01111111 01000000 = stream ID 127 (63 + 64) */
+  unsigned char data2[] = { 0x7F, 0x40 };
+  size_t consumed;
+  uint64_t stream_id;
+  SocketQPACK_Result result;
+
+  printf ("  Decode multi-octet stream cancellation... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  /* Test stream ID 63 */
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data1, sizeof (data1), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_OK, "Decode should succeed for ID 63");
+  TEST_ASSERT (consumed == 2, "Should consume 2 bytes");
+  TEST_ASSERT (stream_id == 63, "Stream ID should be 63");
+
+  /* Test stream ID 127 */
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data2, sizeof (data2), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_OK, "Decode should succeed for ID 127");
+  TEST_ASSERT (consumed == 2, "Should consume 2 bytes");
+  TEST_ASSERT (stream_id == 127, "Stream ID should be 127");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test stream ID validation (reject ID 0)
+ */
+static void
+test_stream_cancel_invalid_id (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  unsigned char data[] = { 0x40 }; /* 01000000 = stream ID 0 */
+  size_t consumed;
+  uint64_t stream_id;
+  SocketQPACK_Result result;
+
+  printf ("  Reject stream cancellation with ID 0... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data, sizeof (data), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_ERROR_STREAM_ID, "Should reject stream ID 0");
+
+  /* Also test the validation function directly */
+  TEST_ASSERT (SocketQPACK_stream_cancel_validate_id (0)
+                   == QPACK_ERROR_STREAM_ID,
+               "validate_id should reject 0");
+  TEST_ASSERT (SocketQPACK_stream_cancel_validate_id (1) == QPACK_OK,
+               "validate_id should accept 1");
+  TEST_ASSERT (SocketQPACK_stream_cancel_validate_id (100) == QPACK_OK,
+               "validate_id should accept 100");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test pattern discrimination (not a stream cancellation)
+ */
+static void
+test_stream_cancel_wrong_pattern (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  /* 00111111 = Insert Count Increment pattern, not Stream Cancel */
+  unsigned char data[] = { 0x3F };
+  size_t consumed;
+  uint64_t stream_id;
+  SocketQPACK_Result result;
+
+  printf ("  Reject wrong instruction pattern... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data, sizeof (data), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_ERROR_DECODER_STREAM,
+               "Should reject wrong pattern");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test releasing references for stream with no references
+ */
+static void
+test_stream_cancel_no_refs (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  SocketQPACK_Result result;
+
+  printf ("  Handle cancellation for stream with no refs... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  /* Release refs for stream that never had any - should succeed gracefully */
+  result = SocketQPACK_stream_cancel_release_refs (decoder, 999);
+  TEST_ASSERT (result == QPACK_OK, "Should succeed even if stream has no refs");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test adding and releasing stream references
+ */
+static void
+test_stream_refs_add_release (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  SocketQPACK_Table_T table;
+  SocketQPACK_Header header;
+  SocketQPACK_Result result;
+
+  printf ("  Add and release stream references... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  table = SocketQPACK_Decoder_get_table (decoder);
+  TEST_ASSERT (table != NULL, "Table should exist");
+
+  /* Add some entries to the dynamic table */
+  result = SocketQPACK_Table_add (table, "content-type", 12, "text/html", 9);
+  TEST_ASSERT (result == QPACK_OK, "Add entry 1 should succeed");
+
+  result = SocketQPACK_Table_add (table, "content-length", 14, "1234", 4);
+  TEST_ASSERT (result == QPACK_OK, "Add entry 2 should succeed");
+
+  result = SocketQPACK_Table_add (table, "cache-control", 13, "no-cache", 8);
+  TEST_ASSERT (result == QPACK_OK, "Add entry 3 should succeed");
+
+  /* Add references from stream 1 to entries 1 and 3 */
+  result = SocketQPACK_add_stream_reference (decoder, 1, 1);
+  TEST_ASSERT (result == QPACK_OK, "Add ref to entry 1 should succeed");
+
+  result = SocketQPACK_add_stream_reference (decoder, 1, 3);
+  TEST_ASSERT (result == QPACK_OK, "Add ref to entry 3 should succeed");
+
+  /* Add reference from stream 2 to entry 2 */
+  result = SocketQPACK_add_stream_reference (decoder, 2, 2);
+  TEST_ASSERT (result == QPACK_OK, "Add ref from stream 2 should succeed");
+
+  /* Release stream 1's references */
+  result = SocketQPACK_stream_cancel_release_refs (decoder, 1);
+  TEST_ASSERT (result == QPACK_OK, "Release refs should succeed");
+
+  /* Entries should still be accessible */
+  result = SocketQPACK_Table_get (table, 1, &header);
+  TEST_ASSERT (result == QPACK_OK, "Entry 1 should still exist");
+
+  /* Release stream 1 again - should succeed (no-op) */
+  result = SocketQPACK_stream_cancel_release_refs (decoder, 1);
+  TEST_ASSERT (result == QPACK_OK, "Re-release should succeed");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test incomplete Stream Cancellation instruction
+ */
+static void
+test_stream_cancel_incomplete (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  /* 0x7F starts multi-byte encoding but no continuation */
+  unsigned char data[] = { 0x7F };
+  size_t consumed;
+  uint64_t stream_id;
+  SocketQPACK_Result result;
+
+  printf ("  Handle incomplete stream cancellation... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  TEST_ASSERT (decoder != NULL, "Decoder should be created");
+
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data, sizeof (data), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_INCOMPLETE,
+               "Should return incomplete for missing continuation");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Integration Tests
+ * ============================================================================
+ */
+
+/**
+ * Test full Stream Cancellation flow with dynamic table
+ */
+static void
+test_stream_cancel_integration (void)
+{
+  Arena_T arena;
+  SocketQPACK_Decoder_T decoder;
+  SocketQPACK_Table_T table;
+  SocketQPACK_Result result;
+  /* Stream ID 5 encoded: 01000101 = 0x45 */
+  unsigned char data[] = { 0x45 };
+  size_t consumed;
+  uint64_t stream_id;
+
+  printf ("  Integration: full stream cancellation flow... ");
+
+  arena = Arena_new ();
+  decoder = SocketQPACK_Decoder_new (NULL, arena);
+  table = SocketQPACK_Decoder_get_table (decoder);
+
+  /* Setup: Add entries and references */
+  SocketQPACK_Table_add (table, "x-custom-header", 15, "value1", 6);
+  SocketQPACK_Table_add (table, "x-another", 9, "value2", 6);
+
+  /* Stream 5 references entry 1 */
+  SocketQPACK_add_stream_reference (decoder, 5, 1);
+
+  /* Process stream cancellation instruction */
+  result = SocketQPACK_decode_stream_cancel (
+      decoder, data, sizeof (data), &consumed, &stream_id);
+  TEST_ASSERT (result == QPACK_OK, "Decode should succeed");
+  TEST_ASSERT (stream_id == 5, "Stream ID should be 5");
+
+  /* Verify table is still intact */
+  TEST_ASSERT (SocketQPACK_Table_count (table) == 2,
+               "Table should still have 2 entries");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Main Test Runner
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("QPACK Header Compression Tests (RFC 9204)\n");
+  printf ("==========================================\n\n");
+
+  printf ("Integer Encoding Tests:\n");
+  test_int_encode_6bit_small ();
+  test_int_encode_6bit_boundary ();
+  test_int_encode_6bit_large ();
+  test_int_decode_6bit_small ();
+  test_int_decode_6bit_large ();
+  test_int_decode_incomplete ();
+
+  printf ("\nDynamic Table Tests:\n");
+  test_table_create ();
+  test_table_add_get ();
+
+  printf ("\nStream Cancellation Tests (RFC 9204 Section 4.4.2):\n");
+  test_stream_cancel_detect ();
+  test_stream_cancel_single_octet ();
+  test_stream_cancel_multi_octet ();
+  test_stream_cancel_invalid_id ();
+  test_stream_cancel_wrong_pattern ();
+  test_stream_cancel_no_refs ();
+  test_stream_refs_add_release ();
+  test_stream_cancel_incomplete ();
+
+  printf ("\nIntegration Tests:\n");
+  test_stream_cancel_integration ();
+
+  printf ("\n==========================================\n");
+  printf ("All QPACK tests passed!\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.4.2 - Stream Cancellation instruction for QPACK header compression.

## Changes

- Add QPACK module header (`include/http/SocketQPACK.h`) with decoder stream instruction patterns
- Add QPACK private header (`include/http/SocketQPACK-private.h`) with internal structures
- Implement Stream Cancellation decoder (`src/http/qpack/SocketQPACK-decoder.c`):
  - Integer encoding/decoding (RFC 7541 Section 5.1)
  - Dynamic table with FIFO eviction
  - Per-stream reference tracking via hash table
  - Stream Cancellation instruction parsing (pattern 01, 6-bit prefix)
  - Reference release on cancellation
- Add comprehensive tests (`src/test/test_qpack.c`)
- Update CMakeLists.txt with new sources and test

## Wire Format (RFC 9204 Section 4.4.2)

```
  0   1   2   3   4   5   6   7
+---+---+---+---+---+---+---+---+
| 0 | 1 |     Stream ID (6+)    |
+---+---+-----------------------+
```

## Test Plan

- [x] Tests pass with sanitizers (ASan + UBSan)
- [x] 140/140 tests pass in full suite
- [x] Stream Cancellation decoding tests:
  - Single-octet (ID < 64)
  - Multi-octet (ID >= 64)
  - Invalid ID rejection (ID = 0)
  - Wrong pattern rejection
  - Incomplete data handling
  - Reference tracking and release

Closes #3282