### PR TITLE
feat(qpack): implement RFC 9204 Section 4.5.1 - Field Section Prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-prefix.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -631,6 +634,7 @@ set(HTTP_HEADERS
     include/http/SocketHTTPClient.h
     include/http/SocketHTTPClient-private.h
     include/http/SocketHTTPServer.h
+    include/http/qpack/SocketQPACK-private.h
 )
 
 set(TEST_HEADERS
@@ -780,6 +784,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack_prefix
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/qpack/SocketQPACK-private.h
+++ b/include/http/qpack/SocketQPACK-private.h
@@ -1,0 +1,173 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-private.h
+ * @brief Internal QPACK header compression structures and constants.
+ * @internal
+ *
+ * Private implementation for QPACK (RFC 9204). Use SocketQPACK.h for public
+ * API.
+ */
+
+#ifndef SOCKETQPACK_PRIVATE_INCLUDED
+#define SOCKETQPACK_PRIVATE_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+
+/**
+ * @brief QPACK result codes for operations.
+ */
+typedef enum
+{
+  QPACK_OK = 0,
+  QPACK_INCOMPLETE,             /* Need more data */
+  QPACK_ERROR,                  /* Generic error */
+  QPACK_ERROR_INTEGER_OVERFLOW, /* Integer value too large */
+  QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT,
+  QPACK_ERROR_INVALID_BASE,
+  QPACK_ERROR_BUFFER_TOO_SMALL,
+} SocketQPACK_Result;
+
+/**
+ * @brief Decoded field section prefix (RFC 9204 Section 4.5.1).
+ *
+ * The prefix appears at the start of each encoded field section and provides:
+ * - Required Insert Count: Minimum dynamic table insertions needed to decode
+ * - Delta Base: Relative value for computing the absolute Base index
+ * - Base: Computed absolute index for relative references in the field section
+ */
+typedef struct
+{
+  size_t required_insert_count; /* Minimum inserts needed to decode */
+  int64_t delta_base;           /* Signed relative value from wire */
+  size_t base;                  /* Computed absolute base index */
+} SocketQPACK_FieldSectionPrefix;
+
+/**
+ * @brief Result of prefix decoding operation.
+ */
+typedef struct
+{
+  int status;                            /* 0 = success, <0 = error code */
+  size_t consumed;                       /* Bytes consumed from input */
+  SocketQPACK_FieldSectionPrefix prefix; /* Decoded prefix values */
+} SocketQPACK_DecodePrefixResult;
+
+/* ============================================================================
+ * Integer Encoding/Decoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode an integer using QPACK integer representation.
+ *
+ * RFC 9204 Section 4.1.1 specifies integer encoding identical to HPACK
+ * (RFC 7541 Section 5.1), using a variable-length encoding with a prefix.
+ *
+ * @param value       Value to encode
+ * @param prefix_bits Number of bits available in first byte (1-8)
+ * @param output      Output buffer
+ * @param output_size Size of output buffer
+ *
+ * @return Number of bytes written, or 0 on error
+ */
+extern size_t socketqpack_encode_integer (uint64_t value,
+                                          int prefix_bits,
+                                          unsigned char *output,
+                                          size_t output_size);
+
+/**
+ * @brief Decode an integer using QPACK integer representation.
+ *
+ * @param input       Input buffer
+ * @param input_len   Length of input buffer
+ * @param prefix_bits Number of bits available in first byte (1-8)
+ * @param value       [out] Decoded value
+ * @param consumed    [out] Number of bytes consumed
+ *
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result
+socketqpack_decode_integer (const unsigned char *input,
+                            size_t input_len,
+                            int prefix_bits,
+                            uint64_t *value,
+                            size_t *consumed);
+
+/* ============================================================================
+ * Field Section Prefix (RFC 9204 Section 4.5.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode a field section prefix.
+ *
+ * Encodes Required Insert Count (8-bit prefix) followed by Delta Base
+ * with sign bit (7-bit prefix).
+ *
+ * @param required_insert_count Required Insert Count value
+ * @param base                  Absolute Base index
+ * @param max_entries           Maximum entries in dynamic table
+ * @param output                Output buffer
+ * @param output_size           Size of output buffer
+ *
+ * @return Number of bytes written, or negative error code
+ */
+extern ssize_t socketqpack_encode_prefix (size_t required_insert_count,
+                                          size_t base,
+                                          size_t max_entries,
+                                          unsigned char *output,
+                                          size_t output_size);
+
+/**
+ * @brief Decode a field section prefix.
+ *
+ * Decodes Required Insert Count and Delta Base, computes absolute Base,
+ * and validates against dynamic table state.
+ *
+ * @param input         Input buffer
+ * @param input_len     Length of input buffer
+ * @param max_entries   Maximum entries in dynamic table
+ * @param total_inserts Total insertions into dynamic table so far
+ *
+ * @return Decode result with status, consumed bytes, and prefix values
+ */
+extern SocketQPACK_DecodePrefixResult
+socketqpack_decode_prefix (const unsigned char *input,
+                           size_t input_len,
+                           size_t max_entries,
+                           size_t total_inserts);
+
+/**
+ * @brief Validate a decoded prefix against dynamic table state.
+ *
+ * Checks that Required Insert Count does not exceed total_inserts and
+ * that Base is within valid range.
+ *
+ * @param prefix        Decoded prefix to validate
+ * @param total_inserts Total insertions into dynamic table so far
+ *
+ * @return QPACK_OK if valid, error code otherwise
+ */
+extern SocketQPACK_Result
+socketqpack_validate_prefix (const SocketQPACK_FieldSectionPrefix *prefix,
+                             size_t total_inserts);
+
+/**
+ * @brief Get string representation of QPACK result code.
+ *
+ * @param result Result code to convert
+ *
+ * @return Static string describing the result
+ */
+extern const char *socketqpack_result_string (SocketQPACK_Result result);
+
+#endif /* SOCKETQPACK_PRIVATE_INCLUDED */

--- a/src/http/qpack/SocketQPACK-prefix.c
+++ b/src/http/qpack/SocketQPACK-prefix.c
@@ -1,0 +1,505 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-prefix.c
+ * @brief QPACK Field Section Prefix encoding/decoding (RFC 9204 Section 4.5.1)
+ *
+ * Implements the Encoded Field Section Prefix which appears at the start of
+ * each encoded field section. The prefix contains:
+ * - Required Insert Count: encoded with 8-bit prefix
+ * - Sign bit (S) and Delta Base: encoded with 1+7 bit layout
+ *
+ * The Base is computed from Required Insert Count and Delta Base based on
+ * the sign bit.
+ */
+
+#include "http/qpack/SocketQPACK-private.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/* Integer encoding constants (same as HPACK, RFC 7541 Section 5.1) */
+#define QPACK_INT_CONTINUATION_MASK 0x80
+#define QPACK_INT_PAYLOAD_MASK 0x7F
+#define QPACK_INT_CONTINUATION_VALUE 128
+#define QPACK_MAX_INT_CONTINUATION_BYTES 10
+#define QPACK_MAX_SAFE_SHIFT 56
+
+/* Field section prefix bit layout */
+#define QPACK_PREFIX_RIC_BITS 8    /* Required Insert Count: 8-bit prefix */
+#define QPACK_PREFIX_BASE_BITS 7   /* Delta Base: 7-bit prefix */
+#define QPACK_PREFIX_SIGN_BIT 0x80 /* Sign bit in Delta Base octet */
+
+/* Buffer sizes */
+#define QPACK_INT_BUF_SIZE 16
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_ERROR_INTEGER_OVERFLOW] = "Integer overflow",
+  [QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT] = "Invalid Required Insert Count",
+  [QPACK_ERROR_INVALID_BASE] = "Invalid Base",
+  [QPACK_ERROR_BUFFER_TOO_SMALL] = "Buffer too small",
+};
+
+const char *
+socketqpack_result_string (SocketQPACK_Result result)
+{
+  if (result < 0 || result > QPACK_ERROR_BUFFER_TOO_SMALL)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Validation Helpers
+ * ============================================================================
+ */
+
+static inline bool
+valid_prefix_bits (int prefix_bits)
+{
+  return prefix_bits >= 1 && prefix_bits <= 8;
+}
+
+/* ============================================================================
+ * Integer Encoding (RFC 9204 Section 4.1.1, RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+static size_t
+encode_int_continuation (uint64_t value,
+                         unsigned char *output,
+                         size_t pos,
+                         size_t output_size)
+{
+  while (value >= QPACK_INT_CONTINUATION_VALUE && pos < output_size)
+    {
+      output[pos++] = (unsigned char)(QPACK_INT_CONTINUATION_MASK
+                                      | (value & QPACK_INT_PAYLOAD_MASK));
+      value >>= 7;
+    }
+
+  if (pos >= output_size)
+    return 0;
+
+  output[pos++] = (unsigned char)value;
+  return pos;
+}
+
+size_t
+socketqpack_encode_integer (uint64_t value,
+                            int prefix_bits,
+                            unsigned char *output,
+                            size_t output_size)
+{
+  uint64_t max_prefix;
+
+  if (output == NULL || output_size == 0 || !valid_prefix_bits (prefix_bits))
+    return 0;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  if (value < max_prefix)
+    {
+      output[0] = (unsigned char)value;
+      return 1;
+    }
+
+  output[0] = (unsigned char)max_prefix;
+  return encode_int_continuation (value - max_prefix, output, 1, output_size);
+}
+
+/* ============================================================================
+ * Integer Decoding (RFC 9204 Section 4.1.1, RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+static SocketQPACK_Result
+decode_int_continuation (const unsigned char *input,
+                         size_t input_len,
+                         size_t *pos,
+                         uint64_t *result,
+                         unsigned int *shift)
+{
+  uint64_t byte_val;
+  unsigned int continuation_count = 0;
+
+  do
+    {
+      if (*pos >= input_len)
+        return QPACK_INCOMPLETE;
+
+      continuation_count++;
+      if (continuation_count > QPACK_MAX_INT_CONTINUATION_BYTES)
+        return QPACK_ERROR_INTEGER_OVERFLOW;
+
+      byte_val = input[(*pos)++];
+
+      if (*shift > QPACK_MAX_SAFE_SHIFT)
+        return QPACK_ERROR_INTEGER_OVERFLOW;
+
+      uint64_t add_val = (byte_val & QPACK_INT_PAYLOAD_MASK) << *shift;
+      if (*result > UINT64_MAX - add_val)
+        return QPACK_ERROR_INTEGER_OVERFLOW;
+
+      *result += add_val;
+      *shift += 7;
+    }
+  while (byte_val & QPACK_INT_CONTINUATION_MASK);
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+socketqpack_decode_integer (const unsigned char *input,
+                            size_t input_len,
+                            int prefix_bits,
+                            uint64_t *value,
+                            size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t max_prefix;
+  uint64_t result;
+  unsigned int shift = 0;
+
+  if (input == NULL || value == NULL || consumed == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+  result = input[pos++] & max_prefix;
+
+  if (result < max_prefix)
+    {
+      *value = result;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  SocketQPACK_Result cont_result
+      = decode_int_continuation (input, input_len, &pos, &result, &shift);
+  if (cont_result != QPACK_OK)
+    return cont_result;
+
+  *value = result;
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Required Insert Count Encoding/Decoding (RFC 9204 Section 4.5.1.1)
+ * ============================================================================
+ *
+ * Required Insert Count is encoded modulo 2 * MaxEntries to reduce size.
+ * For decode, we use the formula:
+ *   if EncodedInsertCount > 0:
+ *     MaxValue = TotalNumberOfInserts + MaxEntries
+ *     FullRange = 2 * MaxEntries
+ *     if EncodedInsertCount > MaxValue % FullRange:
+ *       MaxValue -= FullRange
+ *     ReqInsertCount = MaxValue - (MaxValue % FullRange) + EncodedInsertCount
+ */
+
+static size_t
+encode_required_insert_count (size_t required_insert_count,
+                              size_t max_entries,
+                              unsigned char *output,
+                              size_t output_size)
+{
+  if (required_insert_count == 0)
+    {
+      /* Zero encodes directly as zero */
+      return socketqpack_encode_integer (
+          0, QPACK_PREFIX_RIC_BITS, output, output_size);
+    }
+
+  /* Encode as (RIC mod (2 * MaxEntries)) + 1 */
+  size_t full_range = 2 * max_entries;
+  size_t encoded = (required_insert_count % full_range) + 1;
+
+  return socketqpack_encode_integer (
+      encoded, QPACK_PREFIX_RIC_BITS, output, output_size);
+}
+
+static SocketQPACK_Result
+decode_required_insert_count (const unsigned char *input,
+                              size_t input_len,
+                              size_t max_entries,
+                              size_t total_inserts,
+                              size_t *required_insert_count,
+                              size_t *consumed)
+{
+  uint64_t encoded_insert_count;
+  SocketQPACK_Result result;
+
+  result = socketqpack_decode_integer (
+      input, input_len, QPACK_PREFIX_RIC_BITS, &encoded_insert_count, consumed);
+  if (result != QPACK_OK)
+    return result;
+
+  if (encoded_insert_count == 0)
+    {
+      *required_insert_count = 0;
+      return QPACK_OK;
+    }
+
+  /* RFC 9204 Section 4.5.1.1 decoding algorithm:
+   *
+   * FullRange = 2 * MaxEntries
+   * if EncodedInsertCount > 0:
+   *   MaxValue = TotalNumberOfInserts + MaxEntries
+   *   MaxWrapped = MaxValue % FullRange
+   *   if EncodedInsertCount > MaxWrapped:
+   *     MaxValue -= FullRange
+   *   ReqInsertCount = MaxValue - MaxWrapped + EncodedInsertCount - 1
+   *
+   * The -1 at the end is because encoding adds +1 to avoid zero.
+   */
+  if (max_entries == 0)
+    return QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT;
+
+  size_t full_range = 2 * max_entries;
+  size_t max_value = total_inserts + max_entries;
+  size_t max_wrapped = max_value % full_range;
+  size_t encoded = (size_t)encoded_insert_count;
+
+  if (encoded > max_wrapped)
+    {
+      if (max_value < full_range)
+        return QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT;
+      max_value -= full_range;
+    }
+
+  /* Subtract 1 because encoding adds 1 to avoid zero */
+  *required_insert_count = max_value - max_wrapped + encoded - 1;
+
+  /* Validate: Required Insert Count cannot be 0 when encoded was non-zero
+   * (This can happen if max_value - max_wrapped + encoded - 1 == 0) */
+  if (*required_insert_count == 0 && encoded_insert_count != 0)
+    return QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT;
+
+  /* Validate: Required Insert Count cannot exceed total inserts */
+  if (*required_insert_count > total_inserts)
+    return QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Delta Base Encoding/Decoding (RFC 9204 Section 4.5.1.2)
+ * ============================================================================
+ *
+ * Delta Base format:
+ *   +---+---+---+---+---+---+---+---+
+ *   | S |  Delta Base (7+)         |
+ *   +---+---------------------------+
+ *
+ * S=0: Base = ReqInsertCount + DeltaBase (Base >= ReqInsertCount)
+ * S=1: Base = ReqInsertCount - DeltaBase - 1 (Base < ReqInsertCount)
+ */
+
+static size_t
+encode_delta_base (size_t required_insert_count,
+                   size_t base,
+                   unsigned char *output,
+                   size_t output_size)
+{
+  unsigned char int_buf[QPACK_INT_BUF_SIZE];
+  size_t int_len;
+
+  if (base >= required_insert_count)
+    {
+      /* S=0: Delta Base = Base - Required Insert Count */
+      size_t delta = base - required_insert_count;
+      int_len = socketqpack_encode_integer (
+          delta, QPACK_PREFIX_BASE_BITS, int_buf, sizeof (int_buf));
+      if (int_len == 0 || int_len > output_size)
+        return 0;
+
+      /* First byte has S=0 (clear sign bit) */
+      output[0] = int_buf[0] & ~QPACK_PREFIX_SIGN_BIT;
+      memcpy (output + 1, int_buf + 1, int_len - 1);
+      return int_len;
+    }
+  else
+    {
+      /* S=1: Delta Base = Required Insert Count - Base - 1 */
+      size_t delta = required_insert_count - base - 1;
+      int_len = socketqpack_encode_integer (
+          delta, QPACK_PREFIX_BASE_BITS, int_buf, sizeof (int_buf));
+      if (int_len == 0 || int_len > output_size)
+        return 0;
+
+      /* First byte has S=1 (set sign bit) */
+      output[0] = int_buf[0] | QPACK_PREFIX_SIGN_BIT;
+      memcpy (output + 1, int_buf + 1, int_len - 1);
+      return int_len;
+    }
+}
+
+static SocketQPACK_Result
+decode_delta_base (const unsigned char *input,
+                   size_t input_len,
+                   size_t required_insert_count,
+                   SocketQPACK_FieldSectionPrefix *prefix,
+                   size_t *consumed)
+{
+  uint64_t delta_value;
+  SocketQPACK_Result result;
+  unsigned char sign_bit;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Extract sign bit from first byte */
+  sign_bit = input[0] & QPACK_PREFIX_SIGN_BIT;
+
+  /* Decode the integer value (7-bit prefix) */
+  result = socketqpack_decode_integer (
+      input, input_len, QPACK_PREFIX_BASE_BITS, &delta_value, consumed);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Compute Base based on sign bit */
+  if (sign_bit == 0)
+    {
+      /* S=0: Base = Required Insert Count + Delta Base */
+      prefix->delta_base = (int64_t)delta_value;
+      prefix->base = required_insert_count + (size_t)delta_value;
+    }
+  else
+    {
+      /* S=1: Base = Required Insert Count - Delta Base - 1 */
+      prefix->delta_base = -(int64_t)delta_value - 1;
+
+      /* Check for underflow */
+      if (delta_value >= required_insert_count)
+        return QPACK_ERROR_INVALID_BASE;
+
+      prefix->base = required_insert_count - (size_t)delta_value - 1;
+    }
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Field Section Prefix Public API (RFC 9204 Section 4.5.1)
+ * ============================================================================
+ */
+
+ssize_t
+socketqpack_encode_prefix (size_t required_insert_count,
+                           size_t base,
+                           size_t max_entries,
+                           unsigned char *output,
+                           size_t output_size)
+{
+  size_t pos = 0;
+  size_t bytes_written;
+
+  if (output == NULL || output_size == 0)
+    return -QPACK_ERROR;
+
+  /* Encode Required Insert Count (8-bit prefix) */
+  bytes_written = encode_required_insert_count (
+      required_insert_count, max_entries, output + pos, output_size - pos);
+  if (bytes_written == 0)
+    return -QPACK_ERROR_BUFFER_TOO_SMALL;
+  pos += bytes_written;
+
+  /* Encode Delta Base with sign bit (7-bit prefix) */
+  bytes_written = encode_delta_base (
+      required_insert_count, base, output + pos, output_size - pos);
+  if (bytes_written == 0)
+    return -QPACK_ERROR_BUFFER_TOO_SMALL;
+  pos += bytes_written;
+
+  return (ssize_t)pos;
+}
+
+SocketQPACK_DecodePrefixResult
+socketqpack_decode_prefix (const unsigned char *input,
+                           size_t input_len,
+                           size_t max_entries,
+                           size_t total_inserts)
+{
+  SocketQPACK_DecodePrefixResult result = { 0 };
+  size_t pos = 0;
+  size_t consumed;
+  SocketQPACK_Result status;
+
+  if (input == NULL || input_len == 0)
+    {
+      result.status = QPACK_INCOMPLETE;
+      return result;
+    }
+
+  /* Decode Required Insert Count */
+  status = decode_required_insert_count (input,
+                                         input_len,
+                                         max_entries,
+                                         total_inserts,
+                                         &result.prefix.required_insert_count,
+                                         &consumed);
+  if (status != QPACK_OK)
+    {
+      result.status = status;
+      return result;
+    }
+  pos += consumed;
+
+  /* Decode Delta Base and compute absolute Base */
+  status = decode_delta_base (input + pos,
+                              input_len - pos,
+                              result.prefix.required_insert_count,
+                              &result.prefix,
+                              &consumed);
+  if (status != QPACK_OK)
+    {
+      result.status = status;
+      return result;
+    }
+  pos += consumed;
+
+  result.status = QPACK_OK;
+  result.consumed = pos;
+  return result;
+}
+
+SocketQPACK_Result
+socketqpack_validate_prefix (const SocketQPACK_FieldSectionPrefix *prefix,
+                             size_t total_inserts)
+{
+  if (prefix == NULL)
+    return QPACK_ERROR;
+
+  /* Required Insert Count must not exceed total insertions */
+  if (prefix->required_insert_count > total_inserts)
+    return QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT;
+
+  /* Base validation is handled during decode */
+  /* Additional validation can be added here if needed */
+
+  return QPACK_OK;
+}

--- a/src/test/test_qpack_prefix.c
+++ b/src/test/test_qpack_prefix.c
@@ -1,0 +1,621 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_prefix.c
+ * @brief Unit tests for QPACK Field Section Prefix (RFC 9204 Section 4.5.1)
+ *
+ * Tests encoding and decoding of:
+ * - Required Insert Count (8-bit prefix integer)
+ * - Delta Base with sign bit (7-bit prefix)
+ * - Base computation from Delta Base and Required Insert Count
+ */
+
+#include "http/qpack/SocketQPACK-private.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Simple test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          test_failures++;                                                   \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+static int test_failures = 0;
+
+/* ============================================================================
+ * Integer Encoding Tests (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Test integer encoding with 8-bit prefix (single byte case)
+ */
+static void
+test_int_encode_8bit_small (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 42 with 8-bit prefix... ");
+
+  len = socketqpack_encode_integer (42, 8, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Expected 1 byte");
+  TEST_ASSERT (buf[0] == 42, "Expected 42");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding at prefix boundary (255)
+ */
+static void
+test_int_encode_8bit_boundary (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 254 with 8-bit prefix... ");
+
+  len = socketqpack_encode_integer (254, 8, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Expected 1 byte");
+  TEST_ASSERT (buf[0] == 254, "Expected 254");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding requiring multi-byte (>= 255 for 8-bit prefix)
+ */
+static void
+test_int_encode_8bit_large (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 300 with 8-bit prefix... ");
+
+  len = socketqpack_encode_integer (300, 8, buf, sizeof (buf));
+  TEST_ASSERT (len == 2, "Expected 2 bytes");
+  TEST_ASSERT (buf[0] == 0xFF, "First byte should be 255");
+  /* 300 - 255 = 45 = 0x2D */
+  TEST_ASSERT (buf[1] == 0x2D, "Second byte should be 0x2D (45)");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding with 7-bit prefix
+ */
+static void
+test_int_encode_7bit (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 100 with 7-bit prefix... ");
+
+  len = socketqpack_encode_integer (100, 7, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Expected 1 byte");
+  TEST_ASSERT (buf[0] == 100, "Expected 100");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding with 7-bit prefix at boundary
+ */
+static void
+test_int_encode_7bit_boundary (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 127 with 7-bit prefix... ");
+
+  /* 127 = 2^7 - 1 = max prefix value, needs continuation */
+  len = socketqpack_encode_integer (127, 7, buf, sizeof (buf));
+  TEST_ASSERT (len == 2, "Expected 2 bytes for value at boundary");
+  TEST_ASSERT (buf[0] == 0x7F, "First byte should be 127");
+  TEST_ASSERT (buf[1] == 0x00, "Second byte should be 0");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Integer Decoding Tests
+ * ============================================================================
+ */
+
+/**
+ * Test integer decoding (single byte)
+ */
+static void
+test_int_decode_small (void)
+{
+  unsigned char data[] = { 42 };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode 42... ");
+
+  result
+      = socketqpack_decode_integer (data, sizeof (data), 8, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == 42, "Value should be 42");
+  TEST_ASSERT (consumed == 1, "Should consume 1 byte");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer decoding (multi-byte)
+ */
+static void
+test_int_decode_large (void)
+{
+  /* 300 encoded with 8-bit prefix: 0xFF, 0x2D */
+  unsigned char data[] = { 0xFF, 0x2D };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode 300... ");
+
+  result
+      = socketqpack_decode_integer (data, sizeof (data), 8, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == 300, "Value should be 300");
+  TEST_ASSERT (consumed == 2, "Should consume 2 bytes");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer decoding with incomplete data
+ */
+static void
+test_int_decode_incomplete (void)
+{
+  /* Start of a multi-byte integer but missing continuation */
+  unsigned char data[] = { 0xFF };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode incomplete... ");
+
+  result
+      = socketqpack_decode_integer (data, sizeof (data), 8, &value, &consumed);
+  TEST_ASSERT (result == QPACK_INCOMPLETE, "Should return INCOMPLETE");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Required Insert Count Tests (RFC 9204 Section 4.5.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Test prefix with Required Insert Count = 0
+ */
+static void
+test_prefix_ric_zero (void)
+{
+  unsigned char buf[16];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Prefix with Required Insert Count = 0... ");
+
+  /* Encode: RIC=0, Base=0, max_entries=100 */
+  encoded_len = socketqpack_encode_prefix (0, 0, 100, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  /* Decode */
+  decoded = socketqpack_decode_prefix (buf, (size_t)encoded_len, 100, 0);
+  TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+  TEST_ASSERT (decoded.prefix.required_insert_count == 0, "RIC should be 0");
+  TEST_ASSERT (decoded.prefix.base == 0, "Base should be 0");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test prefix with small Required Insert Count
+ */
+static void
+test_prefix_ric_small (void)
+{
+  unsigned char buf[16];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Prefix with Required Insert Count = 10... ");
+
+  /* Encode: RIC=10, Base=10 (same as RIC, so DeltaBase=0, S=0) */
+  encoded_len = socketqpack_encode_prefix (10, 10, 100, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  /* Decode with total_inserts >= RIC */
+  decoded = socketqpack_decode_prefix (buf, (size_t)encoded_len, 100, 50);
+  TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+  TEST_ASSERT (decoded.prefix.required_insert_count == 10, "RIC should be 10");
+  TEST_ASSERT (decoded.prefix.base == 10, "Base should be 10");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Delta Base Tests (RFC 9204 Section 4.5.1.2)
+ * ============================================================================
+ */
+
+/**
+ * Test positive Delta Base (S=0, Base >= Required Insert Count)
+ */
+static void
+test_prefix_positive_delta_base (void)
+{
+  unsigned char buf[16];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Prefix with positive Delta Base (Base > RIC)... ");
+
+  /* Encode: RIC=42, Base=50 -> DeltaBase = 50-42 = 8, S=0 */
+  encoded_len = socketqpack_encode_prefix (42, 50, 100, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  /* Decode with total_inserts >= RIC */
+  decoded = socketqpack_decode_prefix (buf, (size_t)encoded_len, 100, 50);
+  TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+  TEST_ASSERT (decoded.prefix.required_insert_count == 42, "RIC should be 42");
+  TEST_ASSERT (decoded.prefix.base == 50, "Base should be 50");
+  TEST_ASSERT (decoded.prefix.delta_base == 8, "DeltaBase should be 8");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test negative Delta Base (S=1, Base < Required Insert Count)
+ */
+static void
+test_prefix_negative_delta_base (void)
+{
+  unsigned char buf[16];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Prefix with negative Delta Base (Base < RIC)... ");
+
+  /* Encode: RIC=42, Base=30 -> DeltaBase = 42-30-1 = 11, S=1 */
+  encoded_len = socketqpack_encode_prefix (42, 30, 100, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  /* Decode with total_inserts >= RIC */
+  decoded = socketqpack_decode_prefix (buf, (size_t)encoded_len, 100, 50);
+  TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+  TEST_ASSERT (decoded.prefix.required_insert_count == 42, "RIC should be 42");
+  TEST_ASSERT (decoded.prefix.base == 30, "Base should be 30");
+  TEST_ASSERT (decoded.prefix.delta_base == -12, "DeltaBase should be -12");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test Delta Base = 0 with S=0 (Base == RIC)
+ */
+static void
+test_prefix_delta_base_zero (void)
+{
+  unsigned char buf[16];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Prefix with Delta Base = 0 (Base == RIC)... ");
+
+  /* Encode: RIC=25, Base=25 -> DeltaBase = 0, S=0 */
+  encoded_len = socketqpack_encode_prefix (25, 25, 100, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  /* Decode */
+  decoded = socketqpack_decode_prefix (buf, (size_t)encoded_len, 100, 50);
+  TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+  TEST_ASSERT (decoded.prefix.required_insert_count == 25, "RIC should be 25");
+  TEST_ASSERT (decoded.prefix.base == 25, "Base should be 25");
+  TEST_ASSERT (decoded.prefix.delta_base == 0, "DeltaBase should be 0");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Round-Trip Tests
+ * ============================================================================
+ */
+
+/**
+ * Test round-trip encoding/decoding for various values
+ */
+static void
+test_prefix_roundtrip (void)
+{
+  unsigned char buf[32];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Round-trip encoding/decoding... ");
+
+  /* Test cases: (ric, base, max_entries, total_inserts) */
+  struct
+  {
+    size_t ric;
+    size_t base;
+    size_t max_entries;
+    size_t total_inserts;
+  } cases[] = {
+    { 0, 0, 100, 0 },       { 1, 1, 100, 10 },    { 10, 5, 100, 20 },
+    { 10, 15, 100, 20 },    { 50, 50, 100, 100 }, { 100, 150, 200, 150 },
+    { 200, 100, 256, 250 },
+  };
+
+  for (size_t i = 0; i < sizeof (cases) / sizeof (cases[0]); i++)
+    {
+      encoded_len = socketqpack_encode_prefix (
+          cases[i].ric, cases[i].base, cases[i].max_entries, buf, sizeof (buf));
+      TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+      decoded = socketqpack_decode_prefix (buf,
+                                           (size_t)encoded_len,
+                                           cases[i].max_entries,
+                                           cases[i].total_inserts);
+      TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+      TEST_ASSERT (decoded.prefix.required_insert_count == cases[i].ric,
+                   "RIC mismatch");
+      TEST_ASSERT (decoded.prefix.base == cases[i].base, "Base mismatch");
+    }
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Validation Tests
+ * ============================================================================
+ */
+
+/**
+ * Test validation: Required Insert Count exceeds total_inserts
+ */
+static void
+test_prefix_invalid_ric (void)
+{
+  unsigned char buf[16];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Validation: RIC > total_inserts... ");
+
+  /* Encode with RIC=50 */
+  encoded_len = socketqpack_encode_prefix (50, 50, 100, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  /* Decode with total_inserts < RIC (should fail) */
+  decoded = socketqpack_decode_prefix (buf, (size_t)encoded_len, 100, 30);
+  TEST_ASSERT (decoded.status == QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT,
+               "Should reject RIC > total_inserts");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test validation: validate_prefix function
+ */
+static void
+test_validate_prefix (void)
+{
+  SocketQPACK_FieldSectionPrefix prefix;
+  SocketQPACK_Result result;
+
+  printf ("  validate_prefix function... ");
+
+  /* Valid prefix */
+  prefix.required_insert_count = 10;
+  prefix.base = 15;
+  prefix.delta_base = 5;
+  result = socketqpack_validate_prefix (&prefix, 20);
+  TEST_ASSERT (result == QPACK_OK, "Valid prefix should pass");
+
+  /* Invalid: RIC > total_inserts */
+  prefix.required_insert_count = 30;
+  result = socketqpack_validate_prefix (&prefix, 20);
+  TEST_ASSERT (result == QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT,
+               "Should reject RIC > total_inserts");
+
+  /* NULL prefix */
+  result = socketqpack_validate_prefix (NULL, 20);
+  TEST_ASSERT (result == QPACK_ERROR, "Should reject NULL prefix");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Edge Cases
+ * ============================================================================
+ */
+
+/**
+ * Test edge case: max_entries = 0
+ */
+static void
+test_prefix_max_entries_zero (void)
+{
+  unsigned char buf[] = { 0x01, 0x00 }; /* Non-zero encoded RIC */
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Edge case: max_entries = 0... ");
+
+  decoded = socketqpack_decode_prefix (buf, sizeof (buf), 0, 10);
+  TEST_ASSERT (decoded.status == QPACK_ERROR_INVALID_REQUIRED_INSERT_COUNT,
+               "Should reject when max_entries is 0");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test edge case: empty input buffer
+ */
+static void
+test_prefix_empty_input (void)
+{
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Edge case: empty input... ");
+
+  decoded = socketqpack_decode_prefix (NULL, 0, 100, 50);
+  TEST_ASSERT (decoded.status == QPACK_INCOMPLETE,
+               "Should return INCOMPLETE for empty input");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test edge case: buffer too small for encoding
+ */
+static void
+test_prefix_buffer_too_small (void)
+{
+  unsigned char buf[1]; /* Too small for any prefix */
+  ssize_t encoded_len;
+
+  printf ("  Edge case: buffer too small... ");
+
+  /* This should fail because we need at least 2 bytes */
+  encoded_len = socketqpack_encode_prefix (100, 150, 256, buf, 0);
+  TEST_ASSERT (encoded_len < 0, "Should fail with 0-size buffer");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test edge case: large Required Insert Count (multi-octet encoding)
+ */
+static void
+test_prefix_large_ric (void)
+{
+  unsigned char buf[32];
+  ssize_t encoded_len;
+  SocketQPACK_DecodePrefixResult decoded;
+
+  printf ("  Edge case: large Required Insert Count... ");
+
+  /* Large RIC that requires multi-byte encoding */
+  size_t ric = 500;
+  size_t max_entries = 256;
+
+  encoded_len
+      = socketqpack_encode_prefix (ric, ric, max_entries, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Encoding should succeed");
+
+  decoded
+      = socketqpack_decode_prefix (buf, (size_t)encoded_len, max_entries, 600);
+  TEST_ASSERT (decoded.status == QPACK_OK, "Decoding should succeed");
+  TEST_ASSERT (decoded.prefix.required_insert_count == ric, "RIC should match");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Result String Test
+ * ============================================================================
+ */
+
+static void
+test_result_strings (void)
+{
+  printf ("  Result string conversion... ");
+
+  TEST_ASSERT (strcmp (socketqpack_result_string (QPACK_OK), "OK") == 0,
+               "QPACK_OK string");
+  TEST_ASSERT (socketqpack_result_string (QPACK_INCOMPLETE) != NULL,
+               "QPACK_INCOMPLETE string");
+  TEST_ASSERT (socketqpack_result_string (QPACK_ERROR_INTEGER_OVERFLOW) != NULL,
+               "QPACK_ERROR_INTEGER_OVERFLOW string");
+  TEST_ASSERT (socketqpack_result_string ((SocketQPACK_Result)999) != NULL,
+               "Unknown error string");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("QPACK Field Section Prefix Tests (RFC 9204 Section 4.5.1)\n");
+  printf ("=========================================================\n\n");
+
+  printf ("Integer Encoding Tests:\n");
+  test_int_encode_8bit_small ();
+  test_int_encode_8bit_boundary ();
+  test_int_encode_8bit_large ();
+  test_int_encode_7bit ();
+  test_int_encode_7bit_boundary ();
+
+  printf ("\nInteger Decoding Tests:\n");
+  test_int_decode_small ();
+  test_int_decode_large ();
+  test_int_decode_incomplete ();
+
+  printf ("\nRequired Insert Count Tests:\n");
+  test_prefix_ric_zero ();
+  test_prefix_ric_small ();
+
+  printf ("\nDelta Base Tests:\n");
+  test_prefix_positive_delta_base ();
+  test_prefix_negative_delta_base ();
+  test_prefix_delta_base_zero ();
+
+  printf ("\nRound-Trip Tests:\n");
+  test_prefix_roundtrip ();
+
+  printf ("\nValidation Tests:\n");
+  test_prefix_invalid_ric ();
+  test_validate_prefix ();
+
+  printf ("\nEdge Case Tests:\n");
+  test_prefix_max_entries_zero ();
+  test_prefix_empty_input ();
+  test_prefix_buffer_too_small ();
+  test_prefix_large_ric ();
+
+  printf ("\nMiscellaneous Tests:\n");
+  test_result_strings ();
+
+  printf ("\n=========================================================\n");
+  if (test_failures == 0)
+    {
+      printf ("All tests PASSED!\n");
+      return 0;
+    }
+  else
+    {
+      printf ("FAILED: %d test(s)\n", test_failures);
+      return 1;
+    }
+}


### PR DESCRIPTION
## Summary

Implements #3291 - RFC 9204 Section 4.5.1 (Encoded Field Section Prefix)

This PR adds the QPACK Field Section Prefix encoding/decoding, which is a critical component for QPACK header compression. The prefix appears at the start of each encoded field section and enables:

- Required Insert Count validation against dynamic table state
- Absolute Base computation from Delta Base for relative references
- Out-of-order processing and lossy transmission detection

## Changes

- **`include/http/qpack/SocketQPACK-private.h`** - Header with QPACK types and function declarations
- **`src/http/qpack/SocketQPACK-prefix.c`** - Implementation of prefix encode/decode
- **`src/test/test_qpack_prefix.c`** - Comprehensive test suite
- **`CMakeLists.txt`** - Build system integration

## Implementation Details

### Integer Encoding (RFC 9204 Section 4.1.1)
- Variable-length integer encoding with configurable prefix bits
- Identical to HPACK integer encoding (RFC 7541 Section 5.1)

### Required Insert Count (RFC 9204 Section 4.5.1.1)
- Encoded with 8-bit prefix using modular wrap: `(RIC mod 2*MaxEntries) + 1`
- Decodes using MaxValue-based unwrapping algorithm

### Delta Base (RFC 9204 Section 4.5.1.2)
- Sign bit (S) indicates whether Base >= or < Required Insert Count
- 7-bit prefix integer encoding for the delta value
- S=0: `Base = ReqInsertCount + DeltaBase`
- S=1: `Base = ReqInsertCount - DeltaBase - 1`

## Test Plan

- [x] Integer encoding with 8-bit and 7-bit prefixes
- [x] Integer decoding (single-byte and multi-byte)
- [x] Required Insert Count = 0 (special case)
- [x] Positive and negative Delta Base
- [x] Round-trip encode/decode verification
- [x] Validation: RIC > total_inserts rejection
- [x] Edge cases: empty input, buffer too small, max_entries = 0
- [x] All tests pass with ASan and UBSan enabled

Closes #3291