### PR TITLE
feat(qpack): implement QPACK Indexed Field Line (RFC 9204 Section 4.5.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-representation.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -626,6 +629,7 @@ set(HTTP_HEADERS
     include/http/SocketHTTP1-private.h
     include/http/SocketHPACK.h
     include/http/SocketHPACK-private.h
+    include/http/SocketQPACK-private.h
     include/http/SocketHTTP2.h
     include/http/SocketHTTP2-private.h
     include/http/SocketHTTPClient.h
@@ -780,6 +784,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/SocketQPACK-private.h
+++ b/include/http/SocketQPACK-private.h
@@ -1,0 +1,241 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-private.h
+ * @brief Internal QPACK header compression structures (RFC 9204).
+ * @internal
+ *
+ * Private implementation for QPACK field line representations.
+ * QPACK is used for HTTP/3 header compression over QUIC.
+ */
+
+#ifndef SOCKETQPACK_PRIVATE_INCLUDED
+#define SOCKETQPACK_PRIVATE_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+
+/* ============================================================================
+ * QPACK Constants (RFC 9204)
+ * ============================================================================
+ */
+
+/** QPACK static table size (0-98 inclusive, RFC 9204 Appendix A) */
+#define QPACK_STATIC_TABLE_SIZE 99
+
+/** Minimum static index (RFC 9204 Section 3.1) */
+#define QPACK_STATIC_INDEX_MIN 0
+
+/** Maximum static index (RFC 9204 Section 3.1) */
+#define QPACK_STATIC_INDEX_MAX 98
+
+/** Indexed Field Line bit pattern: 1T followed by 6-bit index */
+#define QPACK_INDEXED_FIELD_MASK 0x80
+
+/** Type bit for static table in Indexed Field Line */
+#define QPACK_INDEXED_STATIC_BIT 0x40
+
+/** Prefix bits for indexed field index (6-bit prefix) */
+#define QPACK_INDEXED_PREFIX_BITS 6
+
+/* ============================================================================
+ * QPACK Error Codes
+ * ============================================================================
+ */
+
+typedef enum
+{
+  QPACK_OK = 0,
+  QPACK_INCOMPLETE,
+  QPACK_ERROR,
+  QPACK_ERROR_INVALID_INDEX,
+  QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC,
+  QPACK_ERROR_INDEX_OUT_OF_RANGE_DYNAMIC,
+  QPACK_ERROR_BASE_NOT_SET,
+  QPACK_ERROR_INTEGER_OVERFLOW
+} QPACK_Result;
+
+/* ============================================================================
+ * QPACK Representation Types (RFC 9204 Section 4.5)
+ * ============================================================================
+ */
+
+typedef enum
+{
+  QPACK_REP_INDEXED = 0,          /**< Indexed Field Line (Section 4.5.2) */
+  QPACK_REP_LITERAL_NAME = 1,     /**< Literal with name reference */
+  QPACK_REP_LITERAL_VALUE = 2,    /**< Literal with literal name */
+  QPACK_REP_INDEXED_POST_BASE = 3 /**< Indexed with post-base index */
+} QPACK_RepresentationType;
+
+/* ============================================================================
+ * QPACK Representation Structure
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK field line representation.
+ *
+ * Represents a decoded QPACK field line with its type, index information,
+ * and table reference type.
+ */
+typedef struct QPACK_Representation_T *QPACK_Representation_T;
+
+struct QPACK_Representation_T
+{
+  QPACK_RepresentationType type; /**< Representation type */
+  uint32_t index; /**< Static table index (0-98) or relative dynamic index */
+  int is_static;  /**< 1 if static table, 0 if dynamic table */
+  uint32_t absolute_idx; /**< Absolute index after Base conversion (dynamic) */
+};
+
+/* ============================================================================
+ * QPACK Decoder Context
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK decoder context for field section decoding.
+ *
+ * Contains state needed for decoding field sections, including the Base
+ * index for converting relative dynamic indices to absolute indices.
+ */
+typedef struct
+{
+  uint32_t required_insert_count; /**< Required Insert Count from prefix */
+  uint32_t base;        /**< Base index for dynamic table (RFC 9204 3.2.4) */
+  uint32_t max_dynamic; /**< Maximum dynamic table entries available */
+  int base_is_set;      /**< Whether Base has been initialized */
+} QPACK_DecoderContext;
+
+/* ============================================================================
+ * QPACK Static Table Entry
+ * ============================================================================
+ */
+
+/**
+ * @brief Static table entry (RFC 9204 Appendix A).
+ */
+typedef struct
+{
+  const char *name;
+  const char *value;
+  uint8_t name_len;
+  uint8_t value_len;
+} QPACK_StaticEntry;
+
+/* ============================================================================
+ * Static Table (RFC 9204 Appendix A)
+ * ============================================================================
+ */
+
+extern const QPACK_StaticEntry qpack_static_table[QPACK_STATIC_TABLE_SIZE];
+
+/* ============================================================================
+ * QPACK Indexed Field Line Functions (RFC 9204 Section 4.5.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode a static table index as Indexed Field Line.
+ *
+ * Encodes a field from the static table using the Indexed Field Line
+ * representation (pattern 1T with T=1 for static).
+ *
+ * @param index      Static table index (0-98)
+ * @param output     Output buffer
+ * @param output_len Output buffer length
+ * @return Bytes written, or -1 on error
+ */
+ssize_t qpack_encode_indexed_static (uint32_t index,
+                                     unsigned char *output,
+                                     size_t output_len);
+
+/**
+ * @brief Encode a dynamic table relative index as Indexed Field Line.
+ *
+ * Encodes a field from the dynamic table using the Indexed Field Line
+ * representation (pattern 1T with T=0 for dynamic).
+ *
+ * @param relative_index Relative index in dynamic table
+ * @param output         Output buffer
+ * @param output_len     Output buffer length
+ * @return Bytes written, or -1 on error
+ */
+ssize_t qpack_encode_indexed_dynamic (uint32_t relative_index,
+                                      unsigned char *output,
+                                      size_t output_len);
+
+/**
+ * @brief Decode an Indexed Field Line representation.
+ *
+ * Decodes the wire format for Indexed Field Line (RFC 9204 Section 4.5.2).
+ * First byte must match pattern 1T (high bit set).
+ *
+ * Wire format:
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 1 | T |      Index (6+)       |
+ * +---+---+-----------------------+
+ *
+ * @param input        Input buffer (first byte must be 0x80 or higher)
+ * @param input_len    Input buffer length
+ * @param ctx          Decoder context with Base for dynamic table
+ * @param rep          Output representation structure
+ * @param consumed     Output: bytes consumed from input
+ * @return QPACK_OK on success, error code otherwise
+ */
+QPACK_Result qpack_decode_indexed_field (const unsigned char *input,
+                                         size_t input_len,
+                                         const QPACK_DecoderContext *ctx,
+                                         struct QPACK_Representation_T *rep,
+                                         size_t *consumed);
+
+/**
+ * @brief Validate a static table index.
+ *
+ * @param index Index to validate (must be 0-98)
+ * @return QPACK_OK if valid, QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC otherwise
+ */
+QPACK_Result qpack_validate_static_index (uint32_t index);
+
+/**
+ * @brief Convert dynamic table relative index to absolute index.
+ *
+ * Per RFC 9204 Section 3.2.4:
+ *   absolute_index = Base - 1 - relative_index
+ *
+ * @param relative_index Relative index from wire format
+ * @param ctx            Decoder context with Base
+ * @param absolute_out   Output: absolute index
+ * @return QPACK_OK on success, error code otherwise
+ */
+QPACK_Result qpack_apply_base_offset (uint32_t relative_index,
+                                      const QPACK_DecoderContext *ctx,
+                                      uint32_t *absolute_out);
+
+/**
+ * @brief Get static table entry by index.
+ *
+ * @param index  Static table index (0-98)
+ * @param entry  Output: pointer to static entry (not a copy)
+ * @return QPACK_OK on success, QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC otherwise
+ */
+QPACK_Result qpack_static_get (uint32_t index, const QPACK_StaticEntry **entry);
+
+/**
+ * @brief Get result string for QPACK result code.
+ *
+ * @param result QPACK result code
+ * @return Human-readable string for the result
+ */
+const char *qpack_result_string (QPACK_Result result);
+
+#endif /* SOCKETQPACK_PRIVATE_INCLUDED */

--- a/src/http/qpack/SocketQPACK-representation.c
+++ b/src/http/qpack/SocketQPACK-representation.c
@@ -1,0 +1,458 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-representation.c
+ * @brief QPACK Indexed Field Line representation (RFC 9204 Section 4.5.2).
+ *
+ * Implements encoding and decoding of QPACK Indexed Field Line:
+ * - Pattern: 1T followed by 6-bit indexed value
+ * - T=1: Static table index (0-98)
+ * - T=0: Dynamic table relative index (converted via Base)
+ *
+ * Wire format:
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 1 | T |      Index (6+)       |
+ * +---+---+-----------------------+
+ */
+
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "http/SocketQPACK-private.h"
+
+#include "core/SocketUtil.h"
+#include "http/SocketHPACK.h" /* Reuse integer encoding from HPACK (RFC 7541) */
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *const qpack_result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_ERROR_INVALID_INDEX] = "Invalid table index",
+  [QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC] = "Static index out of range (>98)",
+  [QPACK_ERROR_INDEX_OUT_OF_RANGE_DYNAMIC]
+  = "Dynamic index out of range after Base conversion",
+  [QPACK_ERROR_BASE_NOT_SET] = "Base not set for dynamic table access",
+  [QPACK_ERROR_INTEGER_OVERFLOW] = "Integer overflow during decoding",
+};
+
+const char *
+qpack_result_string (QPACK_Result result)
+{
+  if (result < 0 || result > QPACK_ERROR_INTEGER_OVERFLOW)
+    return "Unknown QPACK error";
+  return qpack_result_strings[result];
+}
+
+/* ============================================================================
+ * QPACK Static Table (RFC 9204 Appendix A)
+ *
+ * The QPACK static table has 99 entries (indices 0-98).
+ * This differs from HPACK's 61 entries (indices 1-61).
+ * ============================================================================
+ */
+
+/* clang-format off */
+const QPACK_StaticEntry qpack_static_table[QPACK_STATIC_TABLE_SIZE] = {
+  /* Index 0: :authority */
+  { ":authority", "", 10, 0 },
+  /* Index 1: :path / */
+  { ":path", "/", 5, 1 },
+  /* Index 2: age 0 */
+  { "age", "0", 3, 1 },
+  /* Index 3: content-disposition */
+  { "content-disposition", "", 19, 0 },
+  /* Index 4: content-length 0 */
+  { "content-length", "0", 14, 1 },
+  /* Index 5: cookie */
+  { "cookie", "", 6, 0 },
+  /* Index 6: date */
+  { "date", "", 4, 0 },
+  /* Index 7: etag */
+  { "etag", "", 4, 0 },
+  /* Index 8: if-modified-since */
+  { "if-modified-since", "", 17, 0 },
+  /* Index 9: if-none-match */
+  { "if-none-match", "", 13, 0 },
+  /* Index 10: last-modified */
+  { "last-modified", "", 13, 0 },
+  /* Index 11: link */
+  { "link", "", 4, 0 },
+  /* Index 12: location */
+  { "location", "", 8, 0 },
+  /* Index 13: referer */
+  { "referer", "", 7, 0 },
+  /* Index 14: set-cookie */
+  { "set-cookie", "", 10, 0 },
+  /* Index 15: :method CONNECT */
+  { ":method", "CONNECT", 7, 7 },
+  /* Index 16: :method DELETE */
+  { ":method", "DELETE", 7, 6 },
+  /* Index 17: :method GET */
+  { ":method", "GET", 7, 3 },
+  /* Index 18: :method HEAD */
+  { ":method", "HEAD", 7, 4 },
+  /* Index 19: :method OPTIONS */
+  { ":method", "OPTIONS", 7, 7 },
+  /* Index 20: :method POST */
+  { ":method", "POST", 7, 4 },
+  /* Index 21: :method PUT */
+  { ":method", "PUT", 7, 3 },
+  /* Index 22: :scheme http */
+  { ":scheme", "http", 7, 4 },
+  /* Index 23: :scheme https */
+  { ":scheme", "https", 7, 5 },
+  /* Index 24: :status 103 */
+  { ":status", "103", 7, 3 },
+  /* Index 25: :status 200 */
+  { ":status", "200", 7, 3 },
+  /* Index 26: :status 304 */
+  { ":status", "304", 7, 3 },
+  /* Index 27: :status 404 */
+  { ":status", "404", 7, 3 },
+  /* Index 28: :status 503 */
+  { ":status", "503", 7, 3 },
+  /* Index 29: accept * / * */
+  { "accept", "*/*", 6, 3 },
+  /* Index 30: accept application/dns-message */
+  { "accept", "application/dns-message", 6, 23 },
+  /* Index 31: accept-encoding gzip, deflate, br */
+  { "accept-encoding", "gzip, deflate, br", 15, 17 },
+  /* Index 32: accept-ranges bytes */
+  { "accept-ranges", "bytes", 13, 5 },
+  /* Index 33: access-control-allow-headers cache-control */
+  { "access-control-allow-headers", "cache-control", 28, 13 },
+  /* Index 34: access-control-allow-headers content-type */
+  { "access-control-allow-headers", "content-type", 28, 12 },
+  /* Index 35: access-control-allow-origin * */
+  { "access-control-allow-origin", "*", 27, 1 },
+  /* Index 36: cache-control max-age=0 */
+  { "cache-control", "max-age=0", 13, 9 },
+  /* Index 37: cache-control max-age=2592000 */
+  { "cache-control", "max-age=2592000", 13, 15 },
+  /* Index 38: cache-control max-age=604800 */
+  { "cache-control", "max-age=604800", 13, 14 },
+  /* Index 39: cache-control no-cache */
+  { "cache-control", "no-cache", 13, 8 },
+  /* Index 40: cache-control no-store */
+  { "cache-control", "no-store", 13, 8 },
+  /* Index 41: cache-control public, max-age=31536000 */
+  { "cache-control", "public, max-age=31536000", 13, 24 },
+  /* Index 42: content-encoding br */
+  { "content-encoding", "br", 16, 2 },
+  /* Index 43: content-encoding gzip */
+  { "content-encoding", "gzip", 16, 4 },
+  /* Index 44: content-type application/dns-message */
+  { "content-type", "application/dns-message", 12, 23 },
+  /* Index 45: content-type application/javascript */
+  { "content-type", "application/javascript", 12, 22 },
+  /* Index 46: content-type application/json */
+  { "content-type", "application/json", 12, 16 },
+  /* Index 47: content-type application/x-www-form-urlencoded */
+  { "content-type", "application/x-www-form-urlencoded", 12, 33 },
+  /* Index 48: content-type image/gif */
+  { "content-type", "image/gif", 12, 9 },
+  /* Index 49: content-type image/jpeg */
+  { "content-type", "image/jpeg", 12, 10 },
+  /* Index 50: content-type image/png */
+  { "content-type", "image/png", 12, 9 },
+  /* Index 51: content-type text/css */
+  { "content-type", "text/css", 12, 8 },
+  /* Index 52: content-type text/html; charset=utf-8 */
+  { "content-type", "text/html; charset=utf-8", 12, 24 },
+  /* Index 53: content-type text/plain */
+  { "content-type", "text/plain", 12, 10 },
+  /* Index 54: content-type text/plain;charset=utf-8 */
+  { "content-type", "text/plain;charset=utf-8", 12, 24 },
+  /* Index 55: range bytes=0- */
+  { "range", "bytes=0-", 5, 8 },
+  /* Index 56: strict-transport-security max-age=31536000 */
+  { "strict-transport-security", "max-age=31536000", 25, 16 },
+  /* Index 57: strict-transport-security max-age=31536000; includesubdomains */
+  { "strict-transport-security", "max-age=31536000; includesubdomains", 25, 35 },
+  /* Index 58: strict-transport-security max-age=31536000; includesubdomains; preload */
+  { "strict-transport-security", "max-age=31536000; includesubdomains; preload", 25, 44 },
+  /* Index 59: vary accept-encoding */
+  { "vary", "accept-encoding", 4, 15 },
+  /* Index 60: vary origin */
+  { "vary", "origin", 4, 6 },
+  /* Index 61: x-content-type-options nosniff */
+  { "x-content-type-options", "nosniff", 22, 7 },
+  /* Index 62: x-xss-protection 1; mode=block */
+  { "x-xss-protection", "1; mode=block", 16, 13 },
+  /* Index 63: :status 100 */
+  { ":status", "100", 7, 3 },
+  /* Index 64: :status 204 */
+  { ":status", "204", 7, 3 },
+  /* Index 65: :status 206 */
+  { ":status", "206", 7, 3 },
+  /* Index 66: :status 302 */
+  { ":status", "302", 7, 3 },
+  /* Index 67: :status 400 */
+  { ":status", "400", 7, 3 },
+  /* Index 68: :status 403 */
+  { ":status", "403", 7, 3 },
+  /* Index 69: :status 421 */
+  { ":status", "421", 7, 3 },
+  /* Index 70: :status 425 */
+  { ":status", "425", 7, 3 },
+  /* Index 71: :status 500 */
+  { ":status", "500", 7, 3 },
+  /* Index 72: accept-language */
+  { "accept-language", "", 15, 0 },
+  /* Index 73: access-control-allow-credentials FALSE */
+  { "access-control-allow-credentials", "FALSE", 32, 5 },
+  /* Index 74: access-control-allow-credentials TRUE */
+  { "access-control-allow-credentials", "TRUE", 32, 4 },
+  /* Index 75: access-control-allow-headers * */
+  { "access-control-allow-headers", "*", 28, 1 },
+  /* Index 76: access-control-allow-methods get */
+  { "access-control-allow-methods", "get", 28, 3 },
+  /* Index 77: access-control-allow-methods get, post, options */
+  { "access-control-allow-methods", "get, post, options", 28, 18 },
+  /* Index 78: access-control-allow-methods options */
+  { "access-control-allow-methods", "options", 28, 7 },
+  /* Index 79: access-control-expose-headers content-length */
+  { "access-control-expose-headers", "content-length", 29, 14 },
+  /* Index 80: access-control-request-headers content-type */
+  { "access-control-request-headers", "content-type", 30, 12 },
+  /* Index 81: access-control-request-method get */
+  { "access-control-request-method", "get", 29, 3 },
+  /* Index 82: access-control-request-method post */
+  { "access-control-request-method", "post", 29, 4 },
+  /* Index 83: alt-svc clear */
+  { "alt-svc", "clear", 7, 5 },
+  /* Index 84: authorization */
+  { "authorization", "", 13, 0 },
+  /* Index 85: content-security-policy script-src 'none'; object-src 'none'; base-uri 'none' */
+  { "content-security-policy", "script-src 'none'; object-src 'none'; base-uri 'none'", 23, 52 },
+  /* Index 86: early-data 1 */
+  { "early-data", "1", 10, 1 },
+  /* Index 87: expect-ct */
+  { "expect-ct", "", 9, 0 },
+  /* Index 88: forwarded */
+  { "forwarded", "", 9, 0 },
+  /* Index 89: if-range */
+  { "if-range", "", 8, 0 },
+  /* Index 90: origin */
+  { "origin", "", 6, 0 },
+  /* Index 91: purpose prefetch */
+  { "purpose", "prefetch", 7, 8 },
+  /* Index 92: server */
+  { "server", "", 6, 0 },
+  /* Index 93: timing-allow-origin * */
+  { "timing-allow-origin", "*", 19, 1 },
+  /* Index 94: upgrade-insecure-requests 1 */
+  { "upgrade-insecure-requests", "1", 25, 1 },
+  /* Index 95: user-agent */
+  { "user-agent", "", 10, 0 },
+  /* Index 96: x-forwarded-for */
+  { "x-forwarded-for", "", 15, 0 },
+  /* Index 97: x-frame-options deny */
+  { "x-frame-options", "deny", 15, 4 },
+  /* Index 98: x-frame-options sameorigin */
+  { "x-frame-options", "sameorigin", 15, 10 },
+};
+/* clang-format on */
+
+/* ============================================================================
+ * Static Table Access
+ * ============================================================================
+ */
+
+QPACK_Result
+qpack_validate_static_index (uint32_t index)
+{
+  if (index > QPACK_STATIC_INDEX_MAX)
+    return QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC;
+  return QPACK_OK;
+}
+
+QPACK_Result
+qpack_static_get (uint32_t index, const QPACK_StaticEntry **entry)
+{
+  if (entry == NULL)
+    return QPACK_ERROR;
+
+  QPACK_Result result = qpack_validate_static_index (index);
+  if (result != QPACK_OK)
+    return result;
+
+  *entry = &qpack_static_table[index];
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Base Offset Conversion (RFC 9204 Section 3.2.4)
+ *
+ * For dynamic table access, the wire format uses relative indices that
+ * must be converted to absolute indices using the Base value from the
+ * field section prefix.
+ *
+ * absolute_index = Base - 1 - relative_index
+ * ============================================================================
+ */
+
+QPACK_Result
+qpack_apply_base_offset (uint32_t relative_index,
+                         const QPACK_DecoderContext *ctx,
+                         uint32_t *absolute_out)
+{
+  if (ctx == NULL || absolute_out == NULL)
+    return QPACK_ERROR;
+
+  if (!ctx->base_is_set)
+    return QPACK_ERROR_BASE_NOT_SET;
+
+  /* Check for underflow: Base must be > relative_index */
+  if (ctx->base == 0 || relative_index >= ctx->base)
+    return QPACK_ERROR_INDEX_OUT_OF_RANGE_DYNAMIC;
+
+  *absolute_out = ctx->base - 1 - relative_index;
+
+  /* Validate against max dynamic entries if set */
+  if (ctx->max_dynamic > 0 && *absolute_out >= ctx->max_dynamic)
+    return QPACK_ERROR_INDEX_OUT_OF_RANGE_DYNAMIC;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Encoding Functions
+ * ============================================================================
+ */
+
+ssize_t
+qpack_encode_indexed_static (uint32_t index,
+                             unsigned char *output,
+                             size_t output_len)
+{
+  if (output == NULL || output_len == 0)
+    return -1;
+
+  /* Validate static index range */
+  if (qpack_validate_static_index (index) != QPACK_OK)
+    return -1;
+
+  /* Use HPACK integer encoding with 6-bit prefix */
+  unsigned char int_buf[16];
+  size_t int_len
+      = SocketHPACK_int_encode (index, QPACK_INDEXED_PREFIX_BITS, int_buf, 16);
+  if (int_len == 0 || int_len > output_len)
+    return -1;
+
+  /* Set pattern bits: 1T where T=1 for static (0xC0) */
+  output[0]
+      = (QPACK_INDEXED_FIELD_MASK | QPACK_INDEXED_STATIC_BIT) | int_buf[0];
+
+  /* Copy continuation bytes if any */
+  for (size_t i = 1; i < int_len; i++)
+    output[i] = int_buf[i];
+
+  return (ssize_t)int_len;
+}
+
+ssize_t
+qpack_encode_indexed_dynamic (uint32_t relative_index,
+                              unsigned char *output,
+                              size_t output_len)
+{
+  if (output == NULL || output_len == 0)
+    return -1;
+
+  /* Use HPACK integer encoding with 6-bit prefix */
+  unsigned char int_buf[16];
+  size_t int_len = SocketHPACK_int_encode (
+      relative_index, QPACK_INDEXED_PREFIX_BITS, int_buf, 16);
+  if (int_len == 0 || int_len > output_len)
+    return -1;
+
+  /* Set pattern bits: 1T where T=0 for dynamic (0x80) */
+  output[0] = QPACK_INDEXED_FIELD_MASK | int_buf[0];
+
+  /* Copy continuation bytes if any */
+  for (size_t i = 1; i < int_len; i++)
+    output[i] = int_buf[i];
+
+  return (ssize_t)int_len;
+}
+
+/* ============================================================================
+ * Decoding Functions
+ * ============================================================================
+ */
+
+QPACK_Result
+qpack_decode_indexed_field (const unsigned char *input,
+                            size_t input_len,
+                            const QPACK_DecoderContext *ctx,
+                            struct QPACK_Representation_T *rep,
+                            size_t *consumed)
+{
+  if (input == NULL || rep == NULL || consumed == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Verify this is an Indexed Field Line (high bit set) */
+  if ((input[0] & QPACK_INDEXED_FIELD_MASK) == 0)
+    return QPACK_ERROR_INVALID_INDEX;
+
+  /* Extract type bit (T): 1 = static, 0 = dynamic */
+  int is_static = (input[0] & QPACK_INDEXED_STATIC_BIT) != 0;
+
+  /* Decode 6-bit prefixed integer */
+  uint64_t index;
+  size_t int_consumed;
+  SocketHPACK_Result hpack_result = SocketHPACK_int_decode (
+      input, input_len, QPACK_INDEXED_PREFIX_BITS, &index, &int_consumed);
+
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERROR_INTEGER_OVERFLOW;
+
+  /* Check for 32-bit overflow */
+  if (index > UINT32_MAX)
+    return QPACK_ERROR_INTEGER_OVERFLOW;
+
+  rep->type = QPACK_REP_INDEXED;
+  rep->index = (uint32_t)index;
+  rep->is_static = is_static;
+  rep->absolute_idx = 0;
+
+  if (is_static)
+    {
+      /* Validate static index */
+      QPACK_Result result = qpack_validate_static_index (rep->index);
+      if (result != QPACK_OK)
+        return result;
+
+      rep->absolute_idx = rep->index;
+    }
+  else
+    {
+      /* Dynamic table: convert relative to absolute via Base */
+      if (ctx == NULL)
+        return QPACK_ERROR_BASE_NOT_SET;
+
+      QPACK_Result result
+          = qpack_apply_base_offset (rep->index, ctx, &rep->absolute_idx);
+      if (result != QPACK_OK)
+        return result;
+    }
+
+  *consumed = int_consumed;
+  return QPACK_OK;
+}

--- a/src/test/test_qpack.c
+++ b/src/test/test_qpack.c
@@ -1,0 +1,504 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack.c
+ * @brief Unit tests for QPACK Indexed Field Line (RFC 9204 Section 4.5.2).
+ *
+ * Tests encoding and decoding of QPACK Indexed Field Line representations:
+ * - Static table encoding/decoding (indices 0-98)
+ * - Dynamic table encoding/decoding with Base conversion
+ * - Variable-length integer encoding for indices > 63
+ * - Error handling for out-of-range indices
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "http/SocketQPACK-private.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Static Table Encoding Tests
+ * ============================================================================
+ */
+
+/* Test encoding static table index 0 (:authority with empty value) */
+TEST (qpack_encode_static_index_0)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_static (0, output, sizeof (output));
+
+  /* Index 0 with T=1 (static) should encode as 0xC0 (11000000) */
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0xC0, output[0]);
+}
+
+/* Test encoding static table index 1 (:path /) */
+TEST (qpack_encode_static_index_1)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_static (1, output, sizeof (output));
+
+  /* Index 1 with T=1 (static) should encode as 0xC1 (11000001) */
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0xC1, output[0]);
+}
+
+/* Test encoding static table index 17 (:method GET) */
+TEST (qpack_encode_static_index_17)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_static (17, output, sizeof (output));
+
+  /* Index 17 with T=1 (static) should encode as 0xD1 (11010001)
+   * Pattern: 11 (indexed+static) + 010001 (17 in 6 bits) */
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0xD1, output[0]);
+}
+
+/* Test encoding maximum static table index 98 */
+TEST (qpack_encode_static_index_98)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_static (98, output, sizeof (output));
+
+  /* Index 98 requires variable-length encoding:
+   * First byte: 11111111 (0xFF) - pattern + max prefix value (63)
+   * Second byte: 98 - 63 = 35 (0x23) */
+  ASSERT_EQ (2, len);
+  ASSERT_EQ (0xFF, output[0]);
+  ASSERT_EQ (0x23, output[1]);
+}
+
+/* Test encoding static table index 63 (at boundary) */
+TEST (qpack_encode_static_index_63)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_static (63, output, sizeof (output));
+
+  /* Index 63 is exactly the max 6-bit prefix value
+   * Requires continuation: 11111111 + 00000000 */
+  ASSERT_EQ (2, len);
+  ASSERT_EQ (0xFF, output[0]);
+  ASSERT_EQ (0x00, output[1]);
+}
+
+/* Test reject static table index 99 (out of range) */
+TEST (qpack_encode_static_index_99_rejected)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_static (99, output, sizeof (output));
+
+  /* Index 99 is out of range, should return -1 */
+  ASSERT_EQ (-1, len);
+}
+
+/* ============================================================================
+ * Dynamic Table Encoding Tests
+ * ============================================================================
+ */
+
+/* Test encoding dynamic table relative index 0 */
+TEST (qpack_encode_dynamic_index_0)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_dynamic (0, output, sizeof (output));
+
+  /* Relative index 0 with T=0 (dynamic) should encode as 0x80 (10000000) */
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x80, output[0]);
+}
+
+/* Test encoding dynamic table relative index 5 */
+TEST (qpack_encode_dynamic_index_5)
+{
+  unsigned char output[16];
+  ssize_t len = qpack_encode_indexed_dynamic (5, output, sizeof (output));
+
+  /* Relative index 5 with T=0 (dynamic) should encode as 0x85 (10000101) */
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0x85, output[0]);
+}
+
+/* ============================================================================
+ * Static Table Decoding Tests
+ * ============================================================================
+ */
+
+/* Test decoding static table index 0 */
+TEST (qpack_decode_static_index_0)
+{
+  unsigned char input[] = { 0xC0 }; /* Static index 0 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, consumed);
+  ASSERT_EQ (QPACK_REP_INDEXED, rep.type);
+  ASSERT_EQ (0, rep.index);
+  ASSERT_EQ (1, rep.is_static);
+  ASSERT_EQ (0, rep.absolute_idx);
+}
+
+/* Test decoding static table index 1 */
+TEST (qpack_decode_static_index_1)
+{
+  unsigned char input[] = { 0xC1 }; /* Static index 1 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, consumed);
+  ASSERT_EQ (1, rep.index);
+  ASSERT_EQ (1, rep.is_static);
+}
+
+/* Test decoding static table index 98 (requires variable-length) */
+TEST (qpack_decode_static_index_98)
+{
+  unsigned char input[] = { 0xFF, 0x23 }; /* Static index 98: 63 + 35 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2, consumed);
+  ASSERT_EQ (98, rep.index);
+  ASSERT_EQ (1, rep.is_static);
+}
+
+/* Test reject static table index 99 during decode */
+TEST (qpack_decode_static_index_99_rejected)
+{
+  unsigned char input[] = { 0xFF, 0x24 }; /* Static index 99: 63 + 36 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC, result);
+}
+
+/* ============================================================================
+ * Dynamic Table Decoding with Base Conversion
+ * ============================================================================
+ */
+
+/* Test decoding dynamic relative index 0 with Base=100 -> absolute 99 */
+TEST (qpack_decode_dynamic_base_100_relative_0)
+{
+  unsigned char input[] = { 0x80 }; /* Dynamic relative index 0 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+  QPACK_DecoderContext ctx = {
+    .required_insert_count = 0, .base = 100, .max_dynamic = 0, .base_is_set = 1
+  };
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), &ctx, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, consumed);
+  ASSERT_EQ (0, rep.index); /* Relative index */
+  ASSERT_EQ (0, rep.is_static);
+  ASSERT_EQ (99, rep.absolute_idx); /* Base - 1 - relative = 100 - 1 - 0 */
+}
+
+/* Test decoding dynamic relative index 5 with Base=100 -> absolute 94 */
+TEST (qpack_decode_dynamic_base_100_relative_5)
+{
+  unsigned char input[] = { 0x85 }; /* Dynamic relative index 5 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+  QPACK_DecoderContext ctx = {
+    .required_insert_count = 0, .base = 100, .max_dynamic = 0, .base_is_set = 1
+  };
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), &ctx, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (5, rep.index);
+  ASSERT_EQ (0, rep.is_static);
+  ASSERT_EQ (94, rep.absolute_idx); /* Base - 1 - relative = 100 - 1 - 5 */
+}
+
+/* Test dynamic table access without Base set fails */
+TEST (qpack_decode_dynamic_base_not_set)
+{
+  unsigned char input[] = { 0x80 }; /* Dynamic relative index 0 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+  QPACK_DecoderContext ctx = {
+    .required_insert_count = 0, .base = 0, .max_dynamic = 0, .base_is_set = 0
+  };
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), &ctx, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_ERROR_BASE_NOT_SET, result);
+}
+
+/* Test dynamic table access with NULL context fails */
+TEST (qpack_decode_dynamic_null_context)
+{
+  unsigned char input[] = { 0x80 }; /* Dynamic relative index 0 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_ERROR_BASE_NOT_SET, result);
+}
+
+/* Test dynamic index out of range when relative >= Base */
+TEST (qpack_decode_dynamic_out_of_range)
+{
+  unsigned char input[] = { 0x85 }; /* Dynamic relative index 5 */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+  QPACK_DecoderContext ctx
+      = { .required_insert_count = 0,
+          .base = 5, /* Base = 5, relative = 5 -> underflow */
+          .max_dynamic = 0,
+          .base_is_set = 1 };
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), &ctx, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_ERROR_INDEX_OUT_OF_RANGE_DYNAMIC, result);
+}
+
+/* ============================================================================
+ * Variable-Length Integer Tests
+ * ============================================================================
+ */
+
+/* Test 6-bit integer overflow (index > 63) encoding/decoding roundtrip */
+TEST (qpack_roundtrip_index_64)
+{
+  unsigned char output[16];
+  ssize_t enc_len = qpack_encode_indexed_static (64, output, sizeof (output));
+  ASSERT (enc_len > 1); /* Should require continuation bytes */
+
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+  QPACK_Result result = qpack_decode_indexed_field (
+      output, (size_t)enc_len, NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ ((size_t)enc_len, consumed);
+  ASSERT_EQ (64, rep.index);
+  ASSERT_EQ (1, rep.is_static);
+}
+
+/* Test roundtrip for all static table entries */
+TEST (qpack_roundtrip_all_static)
+{
+  for (uint32_t i = 0; i <= QPACK_STATIC_INDEX_MAX; i++)
+    {
+      unsigned char output[16];
+      ssize_t enc_len
+          = qpack_encode_indexed_static (i, output, sizeof (output));
+      ASSERT (enc_len > 0);
+
+      struct QPACK_Representation_T rep;
+      size_t consumed;
+      QPACK_Result result = qpack_decode_indexed_field (
+          output, (size_t)enc_len, NULL, &rep, &consumed);
+
+      ASSERT_EQ (QPACK_OK, result);
+      ASSERT_EQ ((size_t)enc_len, consumed);
+      ASSERT_EQ (i, rep.index);
+      ASSERT_EQ (1, rep.is_static);
+    }
+}
+
+/* ============================================================================
+ * Static Table Content Tests
+ * ============================================================================
+ */
+
+/* Test static table entry 0: :authority */
+TEST (qpack_static_table_entry_0)
+{
+  const QPACK_StaticEntry *entry;
+  QPACK_Result result = qpack_static_get (0, &entry);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_NOT_NULL (entry);
+  ASSERT (strcmp (entry->name, ":authority") == 0);
+  ASSERT_EQ (10, entry->name_len);
+  ASSERT_EQ (0, entry->value_len);
+}
+
+/* Test static table entry 17: :method GET */
+TEST (qpack_static_table_entry_17)
+{
+  const QPACK_StaticEntry *entry;
+  QPACK_Result result = qpack_static_get (17, &entry);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_NOT_NULL (entry);
+  ASSERT (strcmp (entry->name, ":method") == 0);
+  ASSERT (strcmp (entry->value, "GET") == 0);
+}
+
+/* Test static table entry 25: :status 200 */
+TEST (qpack_static_table_entry_25)
+{
+  const QPACK_StaticEntry *entry;
+  QPACK_Result result = qpack_static_get (25, &entry);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_NOT_NULL (entry);
+  ASSERT (strcmp (entry->name, ":status") == 0);
+  ASSERT (strcmp (entry->value, "200") == 0);
+}
+
+/* Test static table entry 98: x-frame-options sameorigin */
+TEST (qpack_static_table_entry_98)
+{
+  const QPACK_StaticEntry *entry;
+  QPACK_Result result = qpack_static_get (98, &entry);
+
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_NOT_NULL (entry);
+  ASSERT (strcmp (entry->name, "x-frame-options") == 0);
+  ASSERT (strcmp (entry->value, "sameorigin") == 0);
+}
+
+/* Test static table entry 99 (out of range) */
+TEST (qpack_static_table_entry_99_rejected)
+{
+  const QPACK_StaticEntry *entry;
+  QPACK_Result result = qpack_static_get (99, &entry);
+
+  ASSERT_EQ (QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC, result);
+}
+
+/* ============================================================================
+ * Error Handling Tests
+ * ============================================================================
+ */
+
+/* Test incomplete input during decode */
+TEST (qpack_decode_incomplete_input)
+{
+  /* Variable-length integer that needs 2 bytes but only 1 provided */
+  unsigned char input[] = { 0xFF }; /* Needs continuation */
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result = qpack_decode_indexed_field (
+      input, sizeof (input), NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_INCOMPLETE, result);
+}
+
+/* Test empty input during decode */
+TEST (qpack_decode_empty_input)
+{
+  struct QPACK_Representation_T rep;
+  size_t consumed;
+
+  QPACK_Result result
+      = qpack_decode_indexed_field (NULL, 0, NULL, &rep, &consumed);
+
+  ASSERT_EQ (QPACK_ERROR, result);
+}
+
+/* Test NULL output pointer for encode */
+TEST (qpack_encode_null_output)
+{
+  ssize_t len = qpack_encode_indexed_static (0, NULL, 0);
+  ASSERT_EQ (-1, len);
+}
+
+/* Test qpack_result_string returns valid strings */
+TEST (qpack_result_string_valid)
+{
+  ASSERT_NOT_NULL (qpack_result_string (QPACK_OK));
+  ASSERT_NOT_NULL (qpack_result_string (QPACK_ERROR));
+  ASSERT_NOT_NULL (qpack_result_string (QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC));
+  ASSERT_NOT_NULL (qpack_result_string (QPACK_ERROR_BASE_NOT_SET));
+}
+
+/* ============================================================================
+ * Base Offset Calculation Tests
+ * ============================================================================
+ */
+
+/* Test base offset conversion directly */
+TEST (qpack_apply_base_offset_basic)
+{
+  QPACK_DecoderContext ctx
+      = { .base = 100, .max_dynamic = 0, .base_is_set = 1 };
+  uint32_t absolute;
+
+  QPACK_Result result = qpack_apply_base_offset (0, &ctx, &absolute);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (99, absolute);
+
+  result = qpack_apply_base_offset (5, &ctx, &absolute);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (94, absolute);
+
+  result = qpack_apply_base_offset (99, &ctx, &absolute);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, absolute);
+}
+
+/* Test base offset with max_dynamic validation */
+TEST (qpack_apply_base_offset_max_dynamic)
+{
+  QPACK_DecoderContext ctx
+      = { .base = 100, .max_dynamic = 50, .base_is_set = 1 };
+  uint32_t absolute;
+
+  /* Absolute 99 exceeds max_dynamic 50 */
+  QPACK_Result result = qpack_apply_base_offset (0, &ctx, &absolute);
+  ASSERT_EQ (QPACK_ERROR_INDEX_OUT_OF_RANGE_DYNAMIC, result);
+
+  /* Absolute 49 is within max_dynamic 50 */
+  result = qpack_apply_base_offset (50, &ctx, &absolute);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (49, absolute);
+}
+
+/* Test validate_static_index function */
+TEST (qpack_validate_static_index)
+{
+  ASSERT_EQ (QPACK_OK, qpack_validate_static_index (0));
+  ASSERT_EQ (QPACK_OK, qpack_validate_static_index (98));
+  ASSERT_EQ (QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC,
+             qpack_validate_static_index (99));
+  ASSERT_EQ (QPACK_ERROR_INDEX_OUT_OF_RANGE_STATIC,
+             qpack_validate_static_index (100));
+}
+
+/* ============================================================================
+ * Main - Run All Tests
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Implements QPACK header compression for HTTP/3 over QUIC per RFC 9204 Section 4.5.2:

- Add QPACK static table with 99 entries (RFC 9204 Appendix A)
- Implement Indexed Field Line encoding/decoding (pattern 1T + 6-bit prefix)
- Support static table indices (T=1) for indices 0-98
- Support dynamic table relative indices (T=0) with Base conversion
- Reuse HPACK variable-length integer encoding for multi-byte indices

## Changes

- `include/http/SocketQPACK-private.h` - QPACK types, constants, and function declarations
- `src/http/qpack/SocketQPACK-representation.c` - Implementation with static table data
- `src/test/test_qpack.c` - 31 comprehensive tests
- `CMakeLists.txt` - Build integration

## Test Plan

- [x] All 31 QPACK tests pass with sanitizers enabled
- [x] Roundtrip encoding/decoding for all 99 static table entries
- [x] Dynamic table Base offset conversion tested
- [x] Error handling for out-of-range indices
- [x] Variable-length integer encoding for indices >= 63

Closes #3295