### PR TITLE
feat(qpack): implement RFC 9204 Section 4.3.3 - Insert with Literal Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,11 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-encoder.c
+    src/http/qpack/SocketQPACK-table.c
+    src/http/qpack/SocketQPACK-huffman.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -631,6 +636,8 @@ set(HTTP_HEADERS
     include/http/SocketHTTPClient.h
     include/http/SocketHTTPClient-private.h
     include/http/SocketHTTPServer.h
+    include/http/qpack/SocketQPACK.h
+    include/http/qpack/SocketQPACK-private.h
 )
 
 set(TEST_HEADERS
@@ -780,6 +787,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/qpack/SocketQPACK-private.h
+++ b/include/http/qpack/SocketQPACK-private.h
@@ -1,0 +1,174 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-private.h
+ * @brief Internal QPACK header compression structures and constants.
+ * @internal
+ *
+ * Private implementation for QPACK (RFC 9204). Use SocketQPACK.h for public
+ * API.
+ */
+
+#ifndef SOCKETQPACK_PRIVATE_INCLUDED
+#define SOCKETQPACK_PRIVATE_INCLUDED
+
+#include "http/qpack/SocketQPACK.h"
+#include <stdint.h>
+
+#include "core/SocketSecurity.h"
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+#define QPACK_AVERAGE_DYNAMIC_ENTRY_SIZE 50
+#define QPACK_MIN_DYNAMIC_TABLE_CAPACITY 16
+
+/* Huffman encoding constants (same as HPACK - RFC 7541 Appendix B) */
+#define QPACK_HUFFMAN_SYMBOLS 257
+#define QPACK_HUFFMAN_EOS 256
+#define QPACK_HUFFMAN_MAX_BITS 30
+#define QPACK_HUFFMAN_NUM_STATES 256
+#define QPACK_HUFFMAN_STATE_ERROR 0xFF
+#define QPACK_HUFFMAN_STATE_ACCEPT 0xFE
+
+/* Integer encoding limits */
+#define QPACK_INT_BUF_SIZE 16
+#define QPACK_MAX_INT_CONTINUATION_BYTES 10
+#define QPACK_MAX_SAFE_SHIFT 56
+
+/* String encoding */
+#define QPACK_STRING_HUFFMAN_FLAG 0x80
+#define QPACK_STRING_LITERAL_FLAG 0x00
+#define QPACK_HUFFMAN_RATIO 2
+
+/* Encoder stream instruction patterns (RFC 9204 Section 4.3) */
+#define QPACK_INSERT_WITH_NAME_REF_STATIC 0x80 /* 1xxxxxxx - S=1 */
+#define QPACK_INSERT_WITH_NAME_REF_DYNAMIC                                    \
+  0x00                                         /* 0xxxxxxx - S=0 (after mask) \
+                                                */
+#define QPACK_INSERT_WITH_LITERAL_NAME 0x40    /* 01xxxxxx */
+#define QPACK_INSERT_LITERAL_NAME_MASK 0xC0    /* Top 2 bits */
+#define QPACK_INSERT_LITERAL_NAME_PATTERN 0x40 /* Pattern 01 */
+#define QPACK_SET_DYNAMIC_TABLE_CAPACITY 0x20  /* 001xxxxx */
+#define QPACK_DUPLICATE 0x00                   /* 000xxxxx */
+
+/* Prefix bits for Insert with Literal Name */
+#define QPACK_INSERT_LITERAL_NAME_PREFIX 5  /* 5-bit prefix for name length */
+#define QPACK_INSERT_LITERAL_VALUE_PREFIX 7 /* 7-bit prefix for value length \
+                                             */
+
+/* ============================================================================
+ * Internal Structures
+ * ============================================================================
+ */
+
+/**
+ * @brief Dynamic table entry.
+ */
+typedef struct
+{
+  char *name;
+  size_t name_len;
+  char *value;
+  size_t value_len;
+} QPACK_DynamicEntry;
+
+/**
+ * @brief QPACK dynamic table structure.
+ *
+ * Uses a ring buffer for FIFO eviction. Unlike HPACK, QPACK uses
+ * absolute indices for referencing entries.
+ */
+struct SocketQPACK_DynamicTable
+{
+  QPACK_DynamicEntry *entries;
+  size_t capacity;      /**< Ring buffer capacity */
+  size_t head;          /**< Oldest entry index */
+  size_t tail;          /**< Next insertion index */
+  size_t count;         /**< Current entry count */
+  size_t size;          /**< Current size in bytes */
+  size_t max_size;      /**< Maximum size in bytes */
+  size_t insert_count;  /**< Total entries ever inserted (for absolute index)
+                         */
+  size_t dropped_count; /**< Entries evicted (for absolute index calculation) */
+  Arena_T arena;
+};
+
+/**
+ * @brief Static table entry (compact form).
+ */
+typedef struct
+{
+  const char *name;
+  const char *value;
+  uint8_t name_len;
+  uint8_t value_len;
+} QPACK_StaticEntry;
+
+/* ============================================================================
+ * Huffman Tables (shared with HPACK)
+ * ============================================================================
+ */
+
+typedef struct
+{
+  uint32_t code;
+  uint8_t bits;
+} QPACK_HuffmanSymbol;
+
+typedef struct
+{
+  uint8_t next_state;
+  uint8_t flags;
+  uint8_t sym;
+} QPACK_HuffmanTransition;
+
+#define QPACK_DFA_ACCEPT 0x01
+#define QPACK_DFA_EOS 0x02
+#define QPACK_DFA_ERROR 0x04
+#define QPACK_DFA_SYM2 0x08
+
+/* External Huffman tables (defined in SocketQPACK-huffman.c) */
+extern const QPACK_HuffmanSymbol qpack_huffman_encode[QPACK_HUFFMAN_SYMBOLS];
+extern const QPACK_HuffmanTransition
+    qpack_huffman_decode[QPACK_HUFFMAN_NUM_STATES][16];
+
+/* External static table (defined in SocketQPACK-table.c) */
+extern const QPACK_StaticEntry
+    qpack_static_table[SOCKETQPACK_STATIC_TABLE_SIZE];
+
+/* ============================================================================
+ * Internal Helper Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Calculate entry size (name_len + value_len + overhead).
+ */
+static inline size_t
+qpack_entry_size (size_t name_len, size_t value_len)
+{
+  size_t temp;
+  if (SocketSecurity_check_add (name_len, value_len, &temp)
+      && SocketSecurity_check_add (temp, SOCKETQPACK_ENTRY_OVERHEAD, &temp))
+    {
+      return temp;
+    }
+  return SIZE_MAX;
+}
+
+/**
+ * @brief Evict entries from table until required_space fits.
+ *
+ * @return Number of entries evicted
+ */
+extern size_t
+qpack_table_evict (SocketQPACK_DynamicTable_T table, size_t required_space);
+
+#endif /* SOCKETQPACK_PRIVATE_INCLUDED */

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -1,0 +1,449 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression for HTTP/3 (RFC 9204).
+ *
+ * Implements QPACK algorithm with static table (99 entries), dynamic table
+ * (ring buffer), and Huffman encoding. Based on HPACK but with out-of-order
+ * delivery support for QUIC streams.
+ *
+ * Thread Safety: Encoder/decoder instances are NOT thread-safe. One instance
+ * per connection recommended.
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/* ============================================================================
+ * Constants (RFC 9204)
+ * ============================================================================
+ */
+
+/** Default dynamic table size (RFC 9204) */
+#ifndef SOCKETQPACK_DEFAULT_TABLE_SIZE
+#define SOCKETQPACK_DEFAULT_TABLE_SIZE 4096
+#endif
+
+/** Maximum dynamic table size */
+#ifndef SOCKETQPACK_MAX_TABLE_SIZE
+#define SOCKETQPACK_MAX_TABLE_SIZE (64 * 1024)
+#endif
+
+/** Maximum header size */
+#ifndef SOCKETQPACK_MAX_HEADER_SIZE
+#define SOCKETQPACK_MAX_HEADER_SIZE (8 * 1024)
+#endif
+
+/** Maximum header list size */
+#ifndef SOCKETQPACK_MAX_HEADER_LIST_SIZE
+#define SOCKETQPACK_MAX_HEADER_LIST_SIZE (64 * 1024)
+#endif
+
+/** Static table size (RFC 9204 Appendix A) */
+#define SOCKETQPACK_STATIC_TABLE_SIZE 99
+
+/** Entry overhead per dynamic table entry (name_len + value_len + 32) */
+#define SOCKETQPACK_ENTRY_OVERHEAD 32
+
+/* ============================================================================
+ * Exception
+ * ============================================================================
+ */
+
+/** Exception raised on QPACK errors */
+extern const Except_T SocketQPACK_Error;
+
+/* ============================================================================
+ * Result Codes
+ * ============================================================================
+ */
+
+typedef enum
+{
+  QPACK_OK = 0,
+  QPACK_INCOMPLETE,
+  QPACK_ERROR,
+  QPACK_ERROR_INVALID_INDEX,
+  QPACK_ERROR_HUFFMAN,
+  QPACK_ERROR_INTEGER,
+  QPACK_ERROR_TABLE_SIZE,
+  QPACK_ERROR_HEADER_SIZE,
+  QPACK_ERROR_LIST_SIZE,
+  QPACK_ERROR_BOMB,
+  QPACK_ERROR_DECOMPRESSION_FAILED
+} SocketQPACK_Result;
+
+/* ============================================================================
+ * Data Structures
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK header structure
+ */
+typedef struct
+{
+  const char *name;
+  size_t name_len;
+  const char *value;
+  size_t value_len;
+  int never_index;
+} SocketQPACK_Header;
+
+/**
+ * @brief Insert with Literal Name instruction (RFC 9204 Section 4.3.3)
+ *
+ * Used when the header name is not in the static table and must be
+ * encoded as a literal string.
+ */
+typedef struct
+{
+  const unsigned char *name;
+  size_t name_len;
+  const unsigned char *value;
+  size_t value_len;
+  int name_huffman;  /**< Use Huffman encoding for name */
+  int value_huffman; /**< Use Huffman encoding for value */
+} SocketQPACK_InsertLiteralInstruction;
+
+/* ============================================================================
+ * Dynamic Table
+ * ============================================================================
+ */
+
+typedef struct SocketQPACK_DynamicTable *SocketQPACK_DynamicTable_T;
+
+/**
+ * @brief Create a new QPACK dynamic table.
+ *
+ * @param max_size Maximum table size in bytes
+ * @param arena    Memory arena for allocations
+ * @return New dynamic table instance
+ */
+extern SocketQPACK_DynamicTable_T
+SocketQPACK_DynamicTable_new (size_t max_size, Arena_T arena);
+
+/**
+ * @brief Free dynamic table resources.
+ *
+ * @param table Pointer to table (set to NULL after)
+ */
+extern void SocketQPACK_DynamicTable_free (SocketQPACK_DynamicTable_T *table);
+
+/**
+ * @brief Insert a header into the dynamic table.
+ *
+ * @param table     Dynamic table
+ * @param name      Header name
+ * @param name_len  Name length
+ * @param value     Header value
+ * @param value_len Value length
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result
+SocketQPACK_DynamicTable_insert (SocketQPACK_DynamicTable_T table,
+                                 const char *name,
+                                 size_t name_len,
+                                 const char *value,
+                                 size_t value_len);
+
+/**
+ * @brief Get entry by absolute index.
+ *
+ * @param table  Dynamic table
+ * @param index  Absolute index (0 = first inserted)
+ * @param header Output header structure
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result
+SocketQPACK_DynamicTable_get (SocketQPACK_DynamicTable_T table,
+                              size_t index,
+                              SocketQPACK_Header *header);
+
+/**
+ * @brief Get current table size in bytes.
+ */
+extern size_t SocketQPACK_DynamicTable_size (SocketQPACK_DynamicTable_T table);
+
+/**
+ * @brief Get number of entries in table.
+ */
+extern size_t SocketQPACK_DynamicTable_count (SocketQPACK_DynamicTable_T table);
+
+/**
+ * @brief Get maximum table size.
+ */
+extern size_t
+SocketQPACK_DynamicTable_max_size (SocketQPACK_DynamicTable_T table);
+
+/**
+ * @brief Set maximum table size (may trigger evictions).
+ */
+extern void
+SocketQPACK_DynamicTable_set_max_size (SocketQPACK_DynamicTable_T table,
+                                       size_t max_size);
+
+/**
+ * @brief Get the insert count (number of entries ever inserted).
+ *
+ * Used for tracking required insert count in QPACK.
+ */
+extern size_t
+SocketQPACK_DynamicTable_insert_count (SocketQPACK_DynamicTable_T table);
+
+/* ============================================================================
+ * Integer Encoding/Decoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode integer with prefix.
+ *
+ * @param value       Value to encode
+ * @param prefix_bits Number of prefix bits (1-8)
+ * @param output      Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or 0 on error
+ */
+extern size_t SocketQPACK_int_encode (uint64_t value,
+                                      int prefix_bits,
+                                      unsigned char *output,
+                                      size_t output_size);
+
+/**
+ * @brief Decode integer with prefix.
+ *
+ * @param input       Input buffer
+ * @param input_len   Input buffer length
+ * @param prefix_bits Number of prefix bits (1-8)
+ * @param value       Output value
+ * @param consumed    Bytes consumed
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result SocketQPACK_int_decode (const unsigned char *input,
+                                                  size_t input_len,
+                                                  int prefix_bits,
+                                                  uint64_t *value,
+                                                  size_t *consumed);
+
+/* ============================================================================
+ * String Encoding/Decoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode string with optional Huffman compression.
+ *
+ * @param str         String to encode
+ * @param len         String length
+ * @param prefix_bits Number of prefix bits for length (5 or 7)
+ * @param use_huffman Enable Huffman compression
+ * @param output      Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t SocketQPACK_string_encode (const char *str,
+                                          size_t len,
+                                          int prefix_bits,
+                                          int use_huffman,
+                                          unsigned char *output,
+                                          size_t output_size);
+
+/**
+ * @brief Decode string (with optional Huffman).
+ *
+ * @param input       Input buffer
+ * @param input_len   Input buffer length
+ * @param prefix_bits Number of prefix bits for length
+ * @param str_out     Output string (allocated from arena)
+ * @param str_len_out Output string length
+ * @param consumed    Bytes consumed
+ * @param arena       Memory arena for allocation
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result SocketQPACK_string_decode (const unsigned char *input,
+                                                     size_t input_len,
+                                                     int prefix_bits,
+                                                     char **str_out,
+                                                     size_t *str_len_out,
+                                                     size_t *consumed,
+                                                     Arena_T arena);
+
+/* ============================================================================
+ * Encoder Stream Instructions (RFC 9204 Section 4.3)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode "Insert with Literal Name" instruction (RFC 9204 Section
+ * 4.3.3).
+ *
+ * Wire format:
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 0 | 1 | H | Name Length (5+)  |
+ * +---+---+---+---+---+---+---+---+
+ * |  Name String (Length bytes)   |
+ * +---+---------------------------+
+ * | H |     Value Length (7+)     |
+ * +---+---------------------------+
+ * |  Value String (Length bytes)  |
+ * +-------------------------------+
+ *
+ * @param instr       Instruction parameters
+ * @param output      Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t SocketQPACK_encode_insert_literal_name (
+    const SocketQPACK_InsertLiteralInstruction *instr,
+    unsigned char *output,
+    size_t output_size);
+
+/**
+ * @brief Decode "Insert with Literal Name" instruction.
+ *
+ * @param input       Input buffer (starting at instruction)
+ * @param input_len   Input buffer length
+ * @param name_out    Output name string
+ * @param name_len    Output name length
+ * @param value_out   Output value string
+ * @param value_len   Output value length
+ * @param consumed    Bytes consumed
+ * @param arena       Memory arena for string allocation
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result
+SocketQPACK_decode_insert_literal_name (const unsigned char *input,
+                                        size_t input_len,
+                                        char **name_out,
+                                        size_t *name_len,
+                                        char **value_out,
+                                        size_t *value_len,
+                                        size_t *consumed,
+                                        Arena_T arena);
+
+/**
+ * @brief Process "Insert with Literal Name" and add to dynamic table.
+ *
+ * This is a convenience function that decodes the instruction and
+ * inserts the result into the dynamic table.
+ *
+ * @param table       Dynamic table
+ * @param input       Input buffer
+ * @param input_len   Input buffer length
+ * @param consumed    Bytes consumed
+ * @param arena       Memory arena
+ * @return QPACK_OK on success, error code otherwise
+ */
+extern SocketQPACK_Result
+SocketQPACK_process_insert_literal_name (SocketQPACK_DynamicTable_T table,
+                                         const unsigned char *input,
+                                         size_t input_len,
+                                         size_t *consumed,
+                                         Arena_T arena);
+
+/* ============================================================================
+ * Static Table (RFC 9204 Appendix A)
+ * ============================================================================
+ */
+
+/**
+ * @brief Get entry from static table by index (0-98).
+ *
+ * @param index  Static table index (0-based)
+ * @param header Output header structure
+ * @return QPACK_OK on success, QPACK_ERROR_INVALID_INDEX if out of range
+ */
+extern SocketQPACK_Result
+SocketQPACK_static_get (size_t index, SocketQPACK_Header *header);
+
+/**
+ * @brief Find entry in static table.
+ *
+ * @param name      Header name
+ * @param name_len  Name length
+ * @param value     Header value (NULL for name-only match)
+ * @param value_len Value length
+ * @return Positive index for exact match, negative index for name-only match,
+ *         0 if not found
+ */
+extern int SocketQPACK_static_find (const char *name,
+                                    size_t name_len,
+                                    const char *value,
+                                    size_t value_len);
+
+/* ============================================================================
+ * Huffman Encoding/Decoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Huffman encode string.
+ *
+ * Uses the same Huffman table as HPACK (RFC 7541 Appendix B).
+ *
+ * @param input       Input string
+ * @param input_len   Input length
+ * @param output      Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t SocketQPACK_huffman_encode (const unsigned char *input,
+                                           size_t input_len,
+                                           unsigned char *output,
+                                           size_t output_size);
+
+/**
+ * @brief Huffman decode string.
+ *
+ * @param input       Input (Huffman-encoded)
+ * @param input_len   Input length
+ * @param output      Output buffer
+ * @param output_size Output buffer size
+ * @return Bytes written, or -1 on error
+ */
+extern ssize_t SocketQPACK_huffman_decode (const unsigned char *input,
+                                           size_t input_len,
+                                           unsigned char *output,
+                                           size_t output_size);
+
+/**
+ * @brief Calculate Huffman-encoded size for a string.
+ *
+ * @param input     Input string
+ * @param input_len Input length
+ * @return Encoded size in bytes
+ */
+extern size_t
+SocketQPACK_huffman_encoded_size (const unsigned char *input, size_t input_len);
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Get string description of result code.
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK-encoder.c
+++ b/src/http/qpack/SocketQPACK-encoder.c
@@ -1,0 +1,630 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK-encoder.c - QPACK Encoder Stream Instructions (RFC 9204 Section
+ * 4.3)
+ *
+ * Implements encoding of encoder stream instructions, including:
+ * - Insert with Literal Name (Section 4.3.3)
+ * - Integer and string encoding primitives
+ */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include "core/SocketSecurity.h"
+#include "core/SocketUtil.h"
+
+/* ============================================================================
+ * Exception Definition
+ * ============================================================================
+ */
+
+const Except_T SocketQPACK_Error
+    = { &SocketQPACK_Error, "QPACK compression error" };
+
+SOCKET_DECLARE_MODULE_EXCEPTION (SocketQPACK);
+
+#undef SOCKET_LOG_COMPONENT
+#define SOCKET_LOG_COMPONENT "QPACK"
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_ERROR_INVALID_INDEX] = "Invalid table index",
+  [QPACK_ERROR_HUFFMAN] = "Huffman decoding error",
+  [QPACK_ERROR_INTEGER] = "Integer overflow",
+  [QPACK_ERROR_TABLE_SIZE] = "Invalid dynamic table size update",
+  [QPACK_ERROR_HEADER_SIZE] = "Header too large",
+  [QPACK_ERROR_LIST_SIZE] = "Header list too large",
+  [QPACK_ERROR_BOMB] = "QPACK bomb detected",
+  [QPACK_ERROR_DECOMPRESSION_FAILED] = "Decompression failed",
+};
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if (result < 0 || result > QPACK_ERROR_DECOMPRESSION_FAILED)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Validation Helpers
+ * ============================================================================
+ */
+
+static inline bool
+valid_prefix_bits (int prefix_bits)
+{
+  return prefix_bits >= 1 && prefix_bits <= 8;
+}
+
+/* ============================================================================
+ * Integer Encoding (RFC 9204 Section 4.1.1)
+ *
+ * Same algorithm as HPACK (RFC 7541 Section 5.1)
+ * ============================================================================
+ */
+
+static size_t
+encode_int_continuation (uint64_t value,
+                         unsigned char *output,
+                         size_t pos,
+                         size_t output_size)
+{
+  while (value >= 128 && pos < output_size)
+    {
+      output[pos++] = (unsigned char)(0x80 | (value & 0x7F));
+      value >>= 7;
+    }
+
+  if (pos >= output_size)
+    return 0;
+
+  output[pos++] = (unsigned char)value;
+  return pos;
+}
+
+size_t
+SocketQPACK_int_encode (uint64_t value,
+                        int prefix_bits,
+                        unsigned char *output,
+                        size_t output_size)
+{
+  uint64_t max_prefix;
+
+  if (output == NULL || output_size == 0 || !valid_prefix_bits (prefix_bits))
+    return 0;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  if (value < max_prefix)
+    {
+      output[0] = (unsigned char)value;
+      return 1;
+    }
+
+  output[0] = (unsigned char)max_prefix;
+  return encode_int_continuation (value - max_prefix, output, 1, output_size);
+}
+
+/* ============================================================================
+ * Integer Decoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+static SocketQPACK_Result
+decode_int_continuation (const unsigned char *input,
+                         size_t input_len,
+                         size_t *pos,
+                         uint64_t *result,
+                         unsigned int *shift)
+{
+  uint64_t byte_val;
+  unsigned int continuation_count = 0;
+
+  do
+    {
+      if (*pos >= input_len)
+        return QPACK_INCOMPLETE;
+
+      continuation_count++;
+      if (continuation_count > QPACK_MAX_INT_CONTINUATION_BYTES)
+        return QPACK_ERROR_INTEGER;
+
+      byte_val = input[(*pos)++];
+
+      if (*shift > QPACK_MAX_SAFE_SHIFT)
+        return QPACK_ERROR_INTEGER;
+
+      uint64_t add_val = (byte_val & 0x7F) << *shift;
+      if (*result > UINT64_MAX - add_val)
+        return QPACK_ERROR_INTEGER;
+
+      *result += add_val;
+      *shift += 7;
+    }
+  while (byte_val & 0x80);
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_int_decode (const unsigned char *input,
+                        size_t input_len,
+                        int prefix_bits,
+                        uint64_t *value,
+                        size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t max_prefix;
+  uint64_t result;
+  unsigned int shift = 0;
+
+  if (input == NULL || value == NULL || consumed == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+  result = input[pos++] & max_prefix;
+
+  if (result < max_prefix)
+    {
+      *value = result;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  SocketQPACK_Result cont_result
+      = decode_int_continuation (input, input_len, &pos, &result, &shift);
+  if (cont_result != QPACK_OK)
+    return cont_result;
+
+  *value = result;
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * String Encoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+static ssize_t
+qpack_encode_int_with_flag (uint64_t value,
+                            int prefix_bits,
+                            unsigned char flag,
+                            unsigned char *output,
+                            size_t output_size)
+{
+  unsigned char int_buf[QPACK_INT_BUF_SIZE];
+  size_t int_len;
+
+  int_len
+      = SocketQPACK_int_encode (value, prefix_bits, int_buf, sizeof (int_buf));
+  if (int_len == 0 || int_len > output_size)
+    return -1;
+
+  output[0] = flag | int_buf[0];
+  for (size_t i = 1; i < int_len; i++)
+    output[i] = int_buf[i];
+
+  return (ssize_t)int_len;
+}
+
+ssize_t
+SocketQPACK_string_encode (const char *str,
+                           size_t len,
+                           int prefix_bits,
+                           int use_huffman,
+                           unsigned char *output,
+                           size_t output_size)
+{
+  size_t pos = 0;
+  ssize_t encoded;
+  size_t data_len = len;
+  unsigned char flag = QPACK_STRING_LITERAL_FLAG;
+  int use_huffman_actual = 0;
+
+  if (str == NULL && len > 0)
+    return -1;
+  if (output == NULL && output_size > 0)
+    return -1;
+  if (!valid_prefix_bits (prefix_bits))
+    return -1;
+
+  /* Check if Huffman encoding would be smaller */
+  if (use_huffman && len > 0)
+    {
+      size_t huffman_size
+          = SocketQPACK_huffman_encoded_size ((const unsigned char *)str, len);
+      if (huffman_size < len)
+        {
+          data_len = huffman_size;
+          flag = QPACK_STRING_HUFFMAN_FLAG;
+          use_huffman_actual = 1;
+        }
+    }
+
+  /* Encode length with H flag */
+  encoded = qpack_encode_int_with_flag (
+      data_len, prefix_bits, flag, output, output_size);
+  if (encoded < 0)
+    return -1;
+  pos = (size_t)encoded;
+
+  /* Encode string data */
+  if (use_huffman_actual)
+    {
+      encoded = SocketQPACK_huffman_encode (
+          (const unsigned char *)str, len, output + pos, output_size - pos);
+      if (encoded < 0)
+        return -1;
+    }
+  else
+    {
+      if (pos + len > output_size)
+        return -1;
+      if (len > 0)
+        memcpy (output + pos, str, len);
+      encoded = (ssize_t)len;
+    }
+  pos += (size_t)encoded;
+
+  return (ssize_t)pos;
+}
+
+/* ============================================================================
+ * String Decoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+static SocketQPACK_Result
+allocate_string_buffer (Arena_T arena, size_t buf_size, char **buf_out)
+{
+  size_t alloc_size = buf_size + 1;
+  if (!SocketSecurity_check_size (alloc_size))
+    return QPACK_ERROR_BOMB;
+
+  *buf_out = ALLOC (arena, alloc_size);
+  if (*buf_out == NULL)
+    return QPACK_ERROR;
+
+  return QPACK_OK;
+}
+
+static SocketQPACK_Result
+decode_string_data_literal (const unsigned char *input,
+                            size_t str_len,
+                            size_t pos,
+                            char **str_out,
+                            size_t *str_len_out,
+                            Arena_T arena)
+{
+  SocketQPACK_Result result = allocate_string_buffer (arena, str_len, str_out);
+  if (result != QPACK_OK)
+    return result;
+
+  assert (input != NULL);
+  memcpy (*str_out, input + pos, str_len);
+  (*str_out)[str_len] = '\0';
+  *str_len_out = str_len;
+  return QPACK_OK;
+}
+
+static SocketQPACK_Result
+decode_string_data_huffman (const unsigned char *input,
+                            size_t encoded_len,
+                            size_t pos,
+                            char **str_out,
+                            size_t *str_len_out,
+                            Arena_T arena)
+{
+  size_t max_decoded;
+  if (!SocketSecurity_check_multiply (
+          encoded_len, QPACK_HUFFMAN_RATIO, &max_decoded))
+    return QPACK_ERROR_BOMB;
+
+  SocketQPACK_Result result
+      = allocate_string_buffer (arena, max_decoded, str_out);
+  if (result != QPACK_OK)
+    return result;
+
+  ssize_t decoded = SocketQPACK_huffman_decode (
+      input + pos, encoded_len, (unsigned char *)*str_out, max_decoded);
+  if (decoded < 0)
+    return QPACK_ERROR_HUFFMAN;
+
+  (*str_out)[decoded] = '\0';
+  *str_len_out = (size_t)decoded;
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_string_decode (const unsigned char *input,
+                           size_t input_len,
+                           int prefix_bits,
+                           char **str_out,
+                           size_t *str_len_out,
+                           size_t *consumed,
+                           Arena_T arena)
+{
+  size_t pos = 0;
+  int huffman;
+  uint64_t str_len;
+  SocketQPACK_Result result;
+
+  if (input == NULL || str_out == NULL || str_len_out == NULL
+      || consumed == NULL || arena == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR;
+
+  /* Check H bit - located at bit position (prefix_bits) in the first byte
+   * For 7-bit prefix: H is bit 7 (0x80)
+   * For 5-bit prefix: H is bit 5 (0x20)
+   * RFC 9204 Section 4.1.2: "The most significant bit of the first byte
+   * indicates whether the string is Huffman-encoded." */
+  unsigned char h_bit_mask = (unsigned char)(1 << prefix_bits);
+  huffman = (input[0] & h_bit_mask) != 0;
+
+  /* Decode length */
+  result
+      = SocketQPACK_int_decode (input, input_len, prefix_bits, &str_len, &pos);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Validate length */
+  if (str_len > SIZE_MAX || pos + str_len > input_len)
+    return (str_len > SIZE_MAX) ? QPACK_ERROR_INTEGER : QPACK_INCOMPLETE;
+
+  size_t len = (size_t)str_len;
+
+  /* Decode string data */
+  if (huffman)
+    result = decode_string_data_huffman (
+        input, len, pos, str_out, str_len_out, arena);
+  else
+    result = decode_string_data_literal (
+        input, len, pos, str_out, str_len_out, arena);
+
+  if (result != QPACK_OK)
+    return result;
+
+  *consumed = pos + len;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Insert with Literal Name (RFC 9204 Section 4.3.3)
+ *
+ * Wire format:
+ *      0   1   2   3   4   5   6   7
+ *    +---+---+---+---+---+---+---+---+
+ *    | 0 | 1 | H | Name Length (5+)  |
+ *    +---+---+---+---+---+---+---+---+
+ *    |  Name String (Length bytes)   |
+ *    +---+---------------------------+
+ *    | H |     Value Length (7+)     |
+ *    +---+---------------------------+
+ *    |  Value String (Length bytes)  |
+ *    +-------------------------------+
+ * ============================================================================
+ */
+
+ssize_t
+SocketQPACK_encode_insert_literal_name (
+    const SocketQPACK_InsertLiteralInstruction *instr,
+    unsigned char *output,
+    size_t output_size)
+{
+  size_t pos = 0;
+  ssize_t encoded;
+
+  if (instr == NULL || output == NULL)
+    return -1;
+
+  if (instr->name == NULL && instr->name_len > 0)
+    return -1;
+  if (instr->value == NULL && instr->value_len > 0)
+    return -1;
+
+  /* Check maximum string lengths */
+  if (instr->name_len > SOCKETQPACK_MAX_HEADER_SIZE
+      || instr->value_len > SOCKETQPACK_MAX_HEADER_SIZE)
+    return -1;
+
+  /* Encode name string with 5-bit prefix
+   * First byte: 01 | H | length[4:0]
+   * H bit is 0x20 (bit 5) when using Huffman */
+  unsigned char name_flag
+      = QPACK_INSERT_LITERAL_NAME_PATTERN; /* 0x40 = pattern 01 */
+  if (instr->name_huffman)
+    {
+      /* Check if Huffman would actually be smaller */
+      size_t huffman_size
+          = SocketQPACK_huffman_encoded_size (instr->name, instr->name_len);
+      if (huffman_size < instr->name_len)
+        name_flag |= 0x20; /* Set H bit */
+    }
+
+  /* Encode name */
+  if (output_size == 0)
+    return -1;
+
+  /* First, compute the actual data we'll encode */
+  int name_use_huffman
+      = instr->name_huffman
+        && (SocketQPACK_huffman_encoded_size (instr->name, instr->name_len)
+            < instr->name_len);
+  size_t name_data_len
+      = name_use_huffman
+            ? SocketQPACK_huffman_encoded_size (instr->name, instr->name_len)
+            : instr->name_len;
+
+  /* Encode length with pattern and H flag */
+  unsigned char int_buf[QPACK_INT_BUF_SIZE];
+  size_t int_len = SocketQPACK_int_encode (name_data_len,
+                                           QPACK_INSERT_LITERAL_NAME_PREFIX,
+                                           int_buf,
+                                           sizeof (int_buf));
+  if (int_len == 0 || int_len > output_size)
+    return -1;
+
+  /* Set pattern bits (01) and H flag */
+  output[0] = QPACK_INSERT_LITERAL_NAME_PATTERN | int_buf[0];
+  if (name_use_huffman)
+    output[0] |= 0x20; /* H bit */
+
+  for (size_t i = 1; i < int_len; i++)
+    output[i] = int_buf[i];
+  pos = int_len;
+
+  /* Encode name string data */
+  if (name_use_huffman)
+    {
+      encoded = SocketQPACK_huffman_encode (
+          instr->name, instr->name_len, output + pos, output_size - pos);
+      if (encoded < 0)
+        return -1;
+    }
+  else
+    {
+      if (pos + instr->name_len > output_size)
+        return -1;
+      if (instr->name_len > 0)
+        memcpy (output + pos, instr->name, instr->name_len);
+      encoded = (ssize_t)instr->name_len;
+    }
+  pos += (size_t)encoded;
+
+  /* Encode value string with 7-bit prefix */
+  encoded = SocketQPACK_string_encode ((const char *)instr->value,
+                                       instr->value_len,
+                                       QPACK_INSERT_LITERAL_VALUE_PREFIX,
+                                       instr->value_huffman,
+                                       output + pos,
+                                       output_size - pos);
+  if (encoded < 0)
+    return -1;
+  pos += (size_t)encoded;
+
+  return (ssize_t)pos;
+}
+
+/* ============================================================================
+ * Decode Insert with Literal Name (RFC 9204 Section 4.3.3)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_decode_insert_literal_name (const unsigned char *input,
+                                        size_t input_len,
+                                        char **name_out,
+                                        size_t *name_len,
+                                        char **value_out,
+                                        size_t *value_len,
+                                        size_t *consumed,
+                                        Arena_T arena)
+{
+  size_t pos = 0;
+  size_t name_consumed, value_consumed;
+  SocketQPACK_Result result;
+
+  if (input == NULL || name_out == NULL || name_len == NULL || value_out == NULL
+      || value_len == NULL || consumed == NULL || arena == NULL)
+    return QPACK_ERROR;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Verify instruction pattern (bits 7-6 = 01) */
+  if ((input[0] & QPACK_INSERT_LITERAL_NAME_MASK)
+      != QPACK_INSERT_LITERAL_NAME_PATTERN)
+    return QPACK_ERROR;
+
+  /* Decode name string (5-bit prefix) */
+  result = SocketQPACK_string_decode (input + pos,
+                                      input_len - pos,
+                                      QPACK_INSERT_LITERAL_NAME_PREFIX,
+                                      name_out,
+                                      name_len,
+                                      &name_consumed,
+                                      arena);
+  if (result != QPACK_OK)
+    return result;
+  pos += name_consumed;
+
+  /* Decode value string (7-bit prefix) */
+  result = SocketQPACK_string_decode (input + pos,
+                                      input_len - pos,
+                                      QPACK_INSERT_LITERAL_VALUE_PREFIX,
+                                      value_out,
+                                      value_len,
+                                      &value_consumed,
+                                      arena);
+  if (result != QPACK_OK)
+    return result;
+  pos += value_consumed;
+
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Process Insert with Literal Name and Add to Dynamic Table
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_process_insert_literal_name (SocketQPACK_DynamicTable_T table,
+                                         const unsigned char *input,
+                                         size_t input_len,
+                                         size_t *consumed,
+                                         Arena_T arena)
+{
+  char *name = NULL;
+  size_t name_len = 0;
+  char *value = NULL;
+  size_t value_len = 0;
+  SocketQPACK_Result result;
+
+  if (table == NULL)
+    return QPACK_ERROR;
+
+  /* Decode the instruction */
+  result = SocketQPACK_decode_insert_literal_name (
+      input, input_len, &name, &name_len, &value, &value_len, consumed, arena);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Insert into dynamic table */
+  result = SocketQPACK_DynamicTable_insert (
+      table, name, name_len, value, value_len);
+
+  return result;
+}

--- a/src/http/qpack/SocketQPACK-huffman.c
+++ b/src/http/qpack/SocketQPACK-huffman.c
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK-huffman.c - QPACK Huffman Encoding/Decoding (RFC 9204 Section
+ * 4.1.2)
+ *
+ * QPACK uses the same Huffman table as HPACK (RFC 7541 Appendix B).
+ * This file wraps the HPACK Huffman implementation for QPACK use.
+ */
+
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * Huffman Encoding (wraps HPACK implementation)
+ * ============================================================================
+ */
+
+ssize_t
+SocketQPACK_huffman_encode (const unsigned char *input,
+                            size_t input_len,
+                            unsigned char *output,
+                            size_t output_size)
+{
+  return SocketHPACK_huffman_encode (input, input_len, output, output_size);
+}
+
+ssize_t
+SocketQPACK_huffman_decode (const unsigned char *input,
+                            size_t input_len,
+                            unsigned char *output,
+                            size_t output_size)
+{
+  return SocketHPACK_huffman_decode (input, input_len, output, output_size);
+}
+
+size_t
+SocketQPACK_huffman_encoded_size (const unsigned char *input, size_t input_len)
+{
+  return SocketHPACK_huffman_encoded_size (input, input_len);
+}
+
+/* ============================================================================
+ * Export Huffman tables for QPACK internal use
+ *
+ * Note: These aliases point to the HPACK tables since QPACK uses identical
+ * Huffman encoding (RFC 9204 Section 4.1.2 references RFC 7541 Appendix B).
+ * ============================================================================
+ */
+
+/* The QPACK private header declares these as extern, but we don't need
+ * separate copies since we delegate to HPACK. The tables are accessed
+ * through the SocketHPACK_huffman_* functions above. */

--- a/src/http/qpack/SocketQPACK-table.c
+++ b/src/http/qpack/SocketQPACK-table.c
@@ -1,0 +1,761 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK-table.c - QPACK Static and Dynamic Table (RFC 9204)
+ *
+ * Static table with 99 pre-defined entries (Appendix A), dynamic table with
+ * circular buffer and absolute indexing.
+ */
+
+#include <assert.h>
+#include <string.h>
+
+#include "core/SocketUtil.h"
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#define T SocketQPACK_DynamicTable_T
+
+SOCKET_DECLARE_MODULE_EXCEPTION (SocketQPACK);
+
+#undef SOCKET_LOG_COMPONENT
+#define SOCKET_LOG_COMPONENT "QPACK"
+
+/* ============================================================================
+ * Static Table (RFC 9204 Appendix A)
+ *
+ * QPACK uses 0-based indexing (unlike HPACK's 1-based).
+ * ============================================================================
+ */
+
+/* clang-format off */
+const QPACK_StaticEntry qpack_static_table[SOCKETQPACK_STATIC_TABLE_SIZE] = {
+  /* Index 0: :authority */
+  { ":authority", "", 10, 0 },
+  /* Index 1: :path / */
+  { ":path", "/", 5, 1 },
+  /* Index 2: age 0 */
+  { "age", "0", 3, 1 },
+  /* Index 3: content-disposition */
+  { "content-disposition", "", 19, 0 },
+  /* Index 4: content-length 0 */
+  { "content-length", "0", 14, 1 },
+  /* Index 5: cookie */
+  { "cookie", "", 6, 0 },
+  /* Index 6: date */
+  { "date", "", 4, 0 },
+  /* Index 7: etag */
+  { "etag", "", 4, 0 },
+  /* Index 8: if-modified-since */
+  { "if-modified-since", "", 17, 0 },
+  /* Index 9: if-none-match */
+  { "if-none-match", "", 13, 0 },
+  /* Index 10: last-modified */
+  { "last-modified", "", 13, 0 },
+  /* Index 11: link */
+  { "link", "", 4, 0 },
+  /* Index 12: location */
+  { "location", "", 8, 0 },
+  /* Index 13: referer */
+  { "referer", "", 7, 0 },
+  /* Index 14: set-cookie */
+  { "set-cookie", "", 10, 0 },
+  /* Index 15: :method CONNECT */
+  { ":method", "CONNECT", 7, 7 },
+  /* Index 16: :method DELETE */
+  { ":method", "DELETE", 7, 6 },
+  /* Index 17: :method GET */
+  { ":method", "GET", 7, 3 },
+  /* Index 18: :method HEAD */
+  { ":method", "HEAD", 7, 4 },
+  /* Index 19: :method OPTIONS */
+  { ":method", "OPTIONS", 7, 7 },
+  /* Index 20: :method POST */
+  { ":method", "POST", 7, 4 },
+  /* Index 21: :method PUT */
+  { ":method", "PUT", 7, 3 },
+  /* Index 22: :scheme http */
+  { ":scheme", "http", 7, 4 },
+  /* Index 23: :scheme https */
+  { ":scheme", "https", 7, 5 },
+  /* Index 24: :status 103 */
+  { ":status", "103", 7, 3 },
+  /* Index 25: :status 200 */
+  { ":status", "200", 7, 3 },
+  /* Index 26: :status 304 */
+  { ":status", "304", 7, 3 },
+  /* Index 27: :status 404 */
+  { ":status", "404", 7, 3 },
+  /* Index 28: :status 503 */
+  { ":status", "503", 7, 3 },
+  /* Index 29: accept (wildcard) */
+  { "accept", "*/*", 6, 3 },
+  /* Index 30: accept application/dns-message */
+  { "accept", "application/dns-message", 6, 23 },
+  /* Index 31: accept-encoding gzip, deflate, br */
+  { "accept-encoding", "gzip, deflate, br", 15, 17 },
+  /* Index 32: accept-ranges bytes */
+  { "accept-ranges", "bytes", 13, 5 },
+  /* Index 33: access-control-allow-headers cache-control */
+  { "access-control-allow-headers", "cache-control", 28, 13 },
+  /* Index 34: access-control-allow-headers content-type */
+  { "access-control-allow-headers", "content-type", 28, 12 },
+  /* Index 35: access-control-allow-origin * */
+  { "access-control-allow-origin", "*", 27, 1 },
+  /* Index 36: cache-control max-age=0 */
+  { "cache-control", "max-age=0", 13, 9 },
+  /* Index 37: cache-control max-age=2592000 */
+  { "cache-control", "max-age=2592000", 13, 15 },
+  /* Index 38: cache-control max-age=604800 */
+  { "cache-control", "max-age=604800", 13, 14 },
+  /* Index 39: cache-control no-cache */
+  { "cache-control", "no-cache", 13, 8 },
+  /* Index 40: cache-control no-store */
+  { "cache-control", "no-store", 13, 8 },
+  /* Index 41: cache-control public, max-age=31536000 */
+  { "cache-control", "public, max-age=31536000", 13, 24 },
+  /* Index 42: content-encoding br */
+  { "content-encoding", "br", 16, 2 },
+  /* Index 43: content-encoding gzip */
+  { "content-encoding", "gzip", 16, 4 },
+  /* Index 44: content-type application/dns-message */
+  { "content-type", "application/dns-message", 12, 23 },
+  /* Index 45: content-type application/javascript */
+  { "content-type", "application/javascript", 12, 22 },
+  /* Index 46: content-type application/json */
+  { "content-type", "application/json", 12, 16 },
+  /* Index 47: content-type application/x-www-form-urlencoded */
+  { "content-type", "application/x-www-form-urlencoded", 12, 33 },
+  /* Index 48: content-type image/gif */
+  { "content-type", "image/gif", 12, 9 },
+  /* Index 49: content-type image/jpeg */
+  { "content-type", "image/jpeg", 12, 10 },
+  /* Index 50: content-type image/png */
+  { "content-type", "image/png", 12, 9 },
+  /* Index 51: content-type text/css */
+  { "content-type", "text/css", 12, 8 },
+  /* Index 52: content-type text/html; charset=utf-8 */
+  { "content-type", "text/html; charset=utf-8", 12, 24 },
+  /* Index 53: content-type text/plain */
+  { "content-type", "text/plain", 12, 10 },
+  /* Index 54: content-type text/plain;charset=utf-8 */
+  { "content-type", "text/plain;charset=utf-8", 12, 24 },
+  /* Index 55: range bytes=0- */
+  { "range", "bytes=0-", 5, 8 },
+  /* Index 56: strict-transport-security max-age=31536000 */
+  { "strict-transport-security", "max-age=31536000", 25, 16 },
+  /* Index 57: strict-transport-security max-age=31536000; includesubdomains */
+  { "strict-transport-security", "max-age=31536000; includesubdomains", 25, 35 },
+  /* Index 58: strict-transport-security max-age=31536000; includesubdomains; preload */
+  { "strict-transport-security", "max-age=31536000; includesubdomains; preload", 25, 44 },
+  /* Index 59: vary accept-encoding */
+  { "vary", "accept-encoding", 4, 15 },
+  /* Index 60: vary origin */
+  { "vary", "origin", 4, 6 },
+  /* Index 61: x-content-type-options nosniff */
+  { "x-content-type-options", "nosniff", 22, 7 },
+  /* Index 62: x-xss-protection 1; mode=block */
+  { "x-xss-protection", "1; mode=block", 16, 13 },
+  /* Index 63: :status 100 */
+  { ":status", "100", 7, 3 },
+  /* Index 64: :status 204 */
+  { ":status", "204", 7, 3 },
+  /* Index 65: :status 206 */
+  { ":status", "206", 7, 3 },
+  /* Index 66: :status 302 */
+  { ":status", "302", 7, 3 },
+  /* Index 67: :status 400 */
+  { ":status", "400", 7, 3 },
+  /* Index 68: :status 403 */
+  { ":status", "403", 7, 3 },
+  /* Index 69: :status 421 */
+  { ":status", "421", 7, 3 },
+  /* Index 70: :status 425 */
+  { ":status", "425", 7, 3 },
+  /* Index 71: :status 500 */
+  { ":status", "500", 7, 3 },
+  /* Index 72: accept-language */
+  { "accept-language", "", 15, 0 },
+  /* Index 73: access-control-allow-credentials FALSE */
+  { "access-control-allow-credentials", "FALSE", 32, 5 },
+  /* Index 74: access-control-allow-credentials TRUE */
+  { "access-control-allow-credentials", "TRUE", 32, 4 },
+  /* Index 75: access-control-allow-headers * */
+  { "access-control-allow-headers", "*", 28, 1 },
+  /* Index 76: access-control-allow-methods get */
+  { "access-control-allow-methods", "get", 28, 3 },
+  /* Index 77: access-control-allow-methods get, post, options */
+  { "access-control-allow-methods", "get, post, options", 28, 18 },
+  /* Index 78: access-control-allow-methods options */
+  { "access-control-allow-methods", "options", 28, 7 },
+  /* Index 79: access-control-expose-headers content-length */
+  { "access-control-expose-headers", "content-length", 29, 14 },
+  /* Index 80: access-control-request-headers content-type */
+  { "access-control-request-headers", "content-type", 30, 12 },
+  /* Index 81: access-control-request-method get */
+  { "access-control-request-method", "get", 29, 3 },
+  /* Index 82: access-control-request-method post */
+  { "access-control-request-method", "post", 29, 4 },
+  /* Index 83: alt-svc clear */
+  { "alt-svc", "clear", 7, 5 },
+  /* Index 84: authorization */
+  { "authorization", "", 13, 0 },
+  /* Index 85: content-security-policy script-src 'none'; object-src 'none'; base-uri 'none' */
+  { "content-security-policy", "script-src 'none'; object-src 'none'; base-uri 'none'", 23, 52 },
+  /* Index 86: early-data 1 */
+  { "early-data", "1", 10, 1 },
+  /* Index 87: expect-ct */
+  { "expect-ct", "", 9, 0 },
+  /* Index 88: forwarded */
+  { "forwarded", "", 9, 0 },
+  /* Index 89: if-range */
+  { "if-range", "", 8, 0 },
+  /* Index 90: origin */
+  { "origin", "", 6, 0 },
+  /* Index 91: purpose prefetch */
+  { "purpose", "prefetch", 7, 8 },
+  /* Index 92: server */
+  { "server", "", 6, 0 },
+  /* Index 93: timing-allow-origin * */
+  { "timing-allow-origin", "*", 19, 1 },
+  /* Index 94: upgrade-insecure-requests 1 */
+  { "upgrade-insecure-requests", "1", 25, 1 },
+  /* Index 95: user-agent */
+  { "user-agent", "", 10, 0 },
+  /* Index 96: x-forwarded-for */
+  { "x-forwarded-for", "", 15, 0 },
+  /* Index 97: x-frame-options deny */
+  { "x-frame-options", "deny", 15, 4 },
+  /* Index 98: x-frame-options sameorigin */
+  { "x-frame-options", "sameorigin", 15, 10 },
+};
+/* clang-format on */
+
+/* ============================================================================
+ * Internal Helpers
+ * ============================================================================
+ */
+
+static int
+qpack_validate_table (const SocketQPACK_DynamicTable_T table, const char *func)
+{
+  if (table == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK %s: NULL table pointer", func);
+      return 0;
+    }
+  return 1;
+}
+
+static SocketQPACK_Result
+qpack_validate_table_strict (const SocketQPACK_DynamicTable_T table,
+                             const char *func)
+{
+  if (table == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG ("SocketQPACK %s: NULL table pointer", func);
+      return QPACK_ERROR;
+    }
+  return QPACK_OK;
+}
+
+static int
+qpack_validate_search_params (const char *name, size_t name_len)
+{
+  if (name == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK find: NULL name pointer");
+      return 0;
+    }
+  if (name_len == 0)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK find: zero name length");
+      return 0;
+    }
+  return 1;
+}
+
+static SocketQPACK_Result
+qpack_validate_header_ptr (SocketQPACK_Header *header, const char *func)
+{
+  if (header == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG ("SocketQPACK %s: NULL output header pointer", func);
+      return QPACK_ERROR;
+    }
+  return QPACK_OK;
+}
+
+/* Case-insensitive comparison with explicit lengths (ASCII, for HTTP headers)
+ */
+static int
+qpack_strcasecmp (const char *a, size_t a_len, const char *b, size_t b_len)
+{
+  size_t min_len = (a_len < b_len) ? a_len : b_len;
+  int cmp = strncasecmp (a, b, min_len);
+
+  if (cmp != 0)
+    return cmp;
+
+  if (a_len < b_len)
+    return -1;
+  if (a_len > b_len)
+    return 1;
+  return 0;
+}
+
+/* Match entry against name and optionally value.
+ * Returns: 1=exact match, 0=name-only match, -1=no match */
+static int
+qpack_match_entry (const char *entry_name,
+                   size_t entry_name_len,
+                   const char *entry_value,
+                   size_t entry_value_len,
+                   const char *name,
+                   size_t name_len,
+                   const char *value,
+                   size_t value_len)
+{
+  if (entry_name_len != name_len)
+    return -1;
+
+  if (qpack_strcasecmp (entry_name, entry_name_len, name, name_len) != 0)
+    return -1;
+
+  if (value != NULL && entry_value_len == value_len
+      && (value_len == 0 || memcmp (entry_value, value, value_len) == 0))
+    {
+      return 1;
+    }
+
+  return 0;
+}
+
+static SocketQPACK_Result
+qpack_duplicate_header_strings (Arena_T arena,
+                                const char *name,
+                                size_t name_len,
+                                const char *value,
+                                size_t value_len,
+                                char **name_out,
+                                char **value_out)
+{
+  assert (arena != NULL);
+  assert (name_out != NULL);
+  assert (value_out != NULL);
+
+  *name_out = arena_strndup (arena, name, name_len);
+  if (*name_out == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG (
+          "SocketQPACK: failed to allocate header name copy (length=%zu)",
+          name_len);
+      return QPACK_ERROR;
+    }
+
+  *value_out = arena_strndup (arena, value, value_len);
+  if (*value_out == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG (
+          "SocketQPACK: failed to allocate header value copy (length=%zu)",
+          value_len);
+      return QPACK_ERROR;
+    }
+
+  return QPACK_OK;
+}
+
+/* Calculate initial capacity (power-of-2) based on max_size */
+static size_t
+qpack_dynamic_initial_capacity (size_t max_size)
+{
+  size_t est_entries;
+
+  if (max_size == 0)
+    return QPACK_MIN_DYNAMIC_TABLE_CAPACITY;
+
+  est_entries = max_size / QPACK_AVERAGE_DYNAMIC_ENTRY_SIZE;
+  if (est_entries < QPACK_MIN_DYNAMIC_TABLE_CAPACITY)
+    est_entries = QPACK_MIN_DYNAMIC_TABLE_CAPACITY;
+
+  return socket_util_round_up_pow2 (est_entries);
+}
+
+static void
+qpack_table_clear (SocketQPACK_DynamicTable_T table)
+{
+  assert (table != NULL);
+  table->head = 0;
+  table->tail = 0;
+  table->count = 0;
+  table->size = 0;
+  /* Note: insert_count and dropped_count are NOT reset */
+}
+
+static SocketQPACK_Result
+qpack_dynamic_entry_init (Arena_T arena,
+                          const char *name,
+                          size_t name_len,
+                          const char *value,
+                          size_t value_len,
+                          QPACK_DynamicEntry *entry)
+{
+  SocketQPACK_Result res;
+
+  assert (arena != NULL);
+  assert (entry != NULL);
+
+  res = qpack_duplicate_header_strings (
+      arena, name, name_len, value, value_len, &entry->name, &entry->value);
+  if (res != QPACK_OK)
+    {
+      SOCKET_LOG_ERROR_MSG ("SocketQPACK: qpack_dynamic_entry_init failed - "
+                            "%s (name_len=%zu, value_len=%zu)",
+                            SocketQPACK_result_string (res),
+                            name_len,
+                            value_len);
+      return res;
+    }
+
+  entry->name_len = name_len;
+  entry->value_len = value_len;
+  return QPACK_OK;
+}
+
+static void
+qpack_table_prepare_insertion (SocketQPACK_DynamicTable_T table,
+                               size_t entry_size)
+{
+  assert (table != NULL);
+
+  if (entry_size > table->max_size)
+    {
+      qpack_table_clear (table);
+      return;
+    }
+
+  qpack_table_evict (table, entry_size);
+}
+
+/* ============================================================================
+ * Dynamic Table Eviction
+ * ============================================================================
+ */
+
+size_t
+qpack_table_evict (SocketQPACK_DynamicTable_T table, size_t required_space)
+{
+  size_t evicted = 0;
+
+  while (table->count > 0 && table->size + required_space > table->max_size)
+    {
+      QPACK_DynamicEntry *entry = &table->entries[table->head];
+      size_t entry_size = qpack_entry_size (entry->name_len, entry->value_len);
+
+      if (entry_size > table->size)
+        {
+          SOCKET_LOG_ERROR_MSG (
+              "SocketQPACK: table corruption detected (entry_size=%zu > "
+              "table_size=%zu), resetting table",
+              entry_size,
+              table->size);
+          table->size = 0;
+          table->count = 0;
+          return evicted;
+        }
+
+      table->size -= entry_size;
+      table->head = RINGBUF_WRAP (table->head + 1, table->capacity);
+      table->count--;
+      table->dropped_count++;
+      evicted++;
+    }
+
+  return evicted;
+}
+
+/* ============================================================================
+ * Static Table Lookup
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_static_get (size_t index, SocketQPACK_Header *header)
+{
+  const QPACK_StaticEntry *entry;
+  SocketQPACK_Result res;
+
+  res = qpack_validate_header_ptr (header, "static_get");
+  if (res != QPACK_OK)
+    return res;
+
+  /* QPACK uses 0-based indexing */
+  if (index >= SOCKETQPACK_STATIC_TABLE_SIZE)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK static_get: invalid index %zu (valid range 0-%zu)",
+          index,
+          (size_t)SOCKETQPACK_STATIC_TABLE_SIZE - 1);
+      return QPACK_ERROR_INVALID_INDEX;
+    }
+
+  entry = &qpack_static_table[index];
+  header->name = entry->name;
+  header->name_len = entry->name_len;
+  header->value = entry->value;
+  header->value_len = entry->value_len;
+  header->never_index = 0;
+
+  return QPACK_OK;
+}
+
+int
+SocketQPACK_static_find (const char *name,
+                         size_t name_len,
+                         const char *value,
+                         size_t value_len)
+{
+  int name_match = 0;
+  size_t i;
+
+  if (!qpack_validate_search_params (name, name_len))
+    return 0;
+
+  for (i = 0; i < SOCKETQPACK_STATIC_TABLE_SIZE; i++)
+    {
+      const QPACK_StaticEntry *entry = &qpack_static_table[i];
+      int match = qpack_match_entry (entry->name,
+                                     entry->name_len,
+                                     entry->value,
+                                     entry->value_len,
+                                     name,
+                                     name_len,
+                                     value,
+                                     value_len);
+
+      if (match == 1)
+        return (int)(i + 1); /* Return positive for exact match */
+
+      if (match == 0 && name_match == 0)
+        name_match = -(int)(i + 1); /* Return negative for name-only match */
+    }
+
+  return name_match;
+}
+
+/* ============================================================================
+ * Dynamic Table Implementation
+ *
+ * QPACK uses absolute indexing: entries are referenced by their insertion
+ * order, starting from 0. This differs from HPACK's relative indexing.
+ * ============================================================================
+ */
+
+SocketQPACK_DynamicTable_T
+SocketQPACK_DynamicTable_new (size_t max_size, Arena_T arena)
+{
+  SocketQPACK_DynamicTable_T table;
+  size_t initial_capacity;
+
+  assert (arena != NULL);
+
+  table = ALLOC (arena, sizeof (*table));
+  if (table == NULL)
+    SOCKET_RAISE_MSG (SocketQPACK,
+                      SocketQPACK_Error,
+                      "failed to allocate SocketQPACK_DynamicTable structure");
+
+  initial_capacity = qpack_dynamic_initial_capacity (max_size);
+
+  table->entries
+      = CALLOC (arena, initial_capacity, sizeof (QPACK_DynamicEntry));
+  if (table->entries == NULL)
+    SOCKET_RAISE_MSG (
+        SocketQPACK,
+        SocketQPACK_Error,
+        "failed to allocate SocketQPACK_DynamicTable entries array "
+        "(capacity=%zu)",
+        initial_capacity);
+
+  table->capacity = initial_capacity;
+  table->head = 0;
+  table->tail = 0;
+  table->count = 0;
+  table->size = 0;
+  table->max_size = max_size;
+  table->insert_count = 0;
+  table->dropped_count = 0;
+  table->arena = arena;
+
+  return table;
+}
+
+void
+SocketQPACK_DynamicTable_free (SocketQPACK_DynamicTable_T *table)
+{
+  if (table == NULL || *table == NULL)
+    return;
+
+  *table = NULL;
+}
+
+size_t
+SocketQPACK_DynamicTable_size (SocketQPACK_DynamicTable_T table)
+{
+  if (!qpack_validate_table (table, "DynamicTable_size"))
+    return 0;
+  return table->size;
+}
+
+size_t
+SocketQPACK_DynamicTable_count (SocketQPACK_DynamicTable_T table)
+{
+  if (!qpack_validate_table (table, "DynamicTable_count"))
+    return 0;
+  return table->count;
+}
+
+size_t
+SocketQPACK_DynamicTable_max_size (SocketQPACK_DynamicTable_T table)
+{
+  if (!qpack_validate_table (table, "DynamicTable_max_size"))
+    return 0;
+  return table->max_size;
+}
+
+size_t
+SocketQPACK_DynamicTable_insert_count (SocketQPACK_DynamicTable_T table)
+{
+  if (!qpack_validate_table (table, "DynamicTable_insert_count"))
+    return 0;
+  return table->insert_count;
+}
+
+void
+SocketQPACK_DynamicTable_set_max_size (SocketQPACK_DynamicTable_T table,
+                                       size_t max_size)
+{
+  if (!qpack_validate_table (table, "DynamicTable_set_max_size"))
+    return;
+
+  if (max_size > SOCKETQPACK_MAX_TABLE_SIZE)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK DynamicTable_set_max_size: clamping max_size from %zu "
+          "to %zu",
+          max_size,
+          (size_t)SOCKETQPACK_MAX_TABLE_SIZE);
+      max_size = SOCKETQPACK_MAX_TABLE_SIZE;
+    }
+
+  table->max_size = max_size;
+
+  if (max_size == 0)
+    qpack_table_clear (table);
+  else
+    qpack_table_evict (table, 0);
+}
+
+SocketQPACK_Result
+SocketQPACK_DynamicTable_insert (SocketQPACK_DynamicTable_T table,
+                                 const char *name,
+                                 size_t name_len,
+                                 const char *value,
+                                 size_t value_len)
+{
+  size_t entry_size;
+  QPACK_DynamicEntry *entry_ptr;
+  SocketQPACK_Result res;
+
+  res = qpack_validate_table_strict (table, "DynamicTable_insert");
+  if (res != QPACK_OK)
+    return res;
+
+  if ((name == NULL && name_len != 0) || (value == NULL && value_len != 0))
+    {
+      SOCKET_LOG_ERROR_MSG (
+          "SocketQPACK DynamicTable_insert: invalid NULL string with non-zero "
+          "length");
+      return QPACK_ERROR;
+    }
+
+  entry_size = qpack_entry_size (name_len, value_len);
+  qpack_table_prepare_insertion (table, entry_size);
+
+  /* If entry is too large, it's already been handled (table cleared) */
+  if (entry_size > table->max_size)
+    {
+      /* Entry too large - don't insert, but count it for absolute indexing */
+      table->insert_count++;
+      return QPACK_OK;
+    }
+
+  entry_ptr = &table->entries[table->tail];
+
+  res = qpack_dynamic_entry_init (
+      table->arena, name, name_len, value, value_len, entry_ptr);
+  if (res != QPACK_OK)
+    return res;
+
+  table->tail = RINGBUF_WRAP (table->tail + 1, table->capacity);
+  table->count++;
+  table->size += entry_size;
+  table->insert_count++;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_DynamicTable_get (SocketQPACK_DynamicTable_T table,
+                              size_t index,
+                              SocketQPACK_Header *header)
+{
+  SocketQPACK_Result res;
+
+  res = qpack_validate_table_strict (table, "DynamicTable_get");
+  if (res != QPACK_OK)
+    return res;
+
+  res = qpack_validate_header_ptr (header, "DynamicTable_get");
+  if (res != QPACK_OK)
+    return res;
+
+  /* QPACK uses absolute indexing: index is the absolute insertion number.
+   * We need to convert to relative position in the ring buffer.
+   *
+   * Valid range: [dropped_count, insert_count)
+   * where dropped_count is the number of evicted entries.
+   */
+  if (index < table->dropped_count || index >= table->insert_count)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK DynamicTable_get: invalid absolute index %zu "
+          "(valid range %zu-%zu)",
+          index,
+          table->dropped_count,
+          table->insert_count > 0 ? table->insert_count - 1 : 0);
+      return QPACK_ERROR_INVALID_INDEX;
+    }
+
+  /* Convert absolute index to ring buffer slot */
+  size_t relative_index = index - table->dropped_count;
+  if (relative_index >= table->count)
+    return QPACK_ERROR_INVALID_INDEX;
+
+  size_t slot = RINGBUF_WRAP (table->head + relative_index, table->capacity);
+
+  QPACK_DynamicEntry *entry = &table->entries[slot];
+  header->name = entry->name;
+  header->name_len = entry->name_len;
+  header->value = entry->value;
+  header->value_len = entry->value_len;
+  header->never_index = 0;
+
+  return QPACK_OK;
+}
+
+#undef T

--- a/src/test/test_qpack.c
+++ b/src/test/test_qpack.c
@@ -1,0 +1,793 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_qpack.c - Unit tests for QPACK Header Compression (RFC 9204)
+ *
+ * Tests QPACK implementation including:
+ * - Integer encoding/decoding (Section 4.1.1)
+ * - String encoding/decoding with Huffman (Section 4.1.2)
+ * - Static table lookup (Appendix A)
+ * - Dynamic table operations (Section 3.2)
+ * - Insert with Literal Name instruction (Section 4.3.3)
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Simple test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * Test Helpers
+ * ============================================================================
+ */
+
+/**
+ * Convert hex string to bytes
+ */
+static int
+hex_to_bytes (const char *hex, unsigned char *out, size_t max_len)
+{
+  size_t len = strlen (hex);
+  size_t out_len = 0;
+
+  if (len % 2 != 0)
+    return -1;
+
+  for (size_t i = 0; i < len; i += 2)
+    {
+      if (out_len >= max_len)
+        return -1;
+
+      int hi, lo;
+      char c;
+
+      c = hex[i];
+      if (c >= '0' && c <= '9')
+        hi = c - '0';
+      else if (c >= 'a' && c <= 'f')
+        hi = c - 'a' + 10;
+      else if (c >= 'A' && c <= 'F')
+        hi = c - 'A' + 10;
+      else
+        return -1;
+
+      c = hex[i + 1];
+      if (c >= '0' && c <= '9')
+        lo = c - '0';
+      else if (c >= 'a' && c <= 'f')
+        lo = c - 'a' + 10;
+      else if (c >= 'A' && c <= 'F')
+        lo = c - 'A' + 10;
+      else
+        return -1;
+
+      out[out_len++] = (unsigned char)((hi << 4) | lo);
+    }
+
+  return (int)out_len;
+}
+
+/* ============================================================================
+ * Integer Encoding Tests (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Test integer encoding with 5-bit prefix
+ */
+static void
+test_int_encode_5bit_small (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 10 with 5-bit prefix... ");
+
+  len = SocketQPACK_int_encode (10, 5, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Expected 1 byte");
+  TEST_ASSERT (buf[0] == 0x0A, "Expected 0x0A (10)");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer encoding requiring multi-byte
+ */
+static void
+test_int_encode_5bit_large (void)
+{
+  unsigned char buf[16];
+  size_t len;
+
+  printf ("  Integer encode 1337 with 5-bit prefix... ");
+
+  len = SocketQPACK_int_encode (1337, 5, buf, sizeof (buf));
+  TEST_ASSERT (len == 3, "Expected 3 bytes");
+  TEST_ASSERT (buf[0] == 0x1F, "First byte should be 31 (2^5 - 1)");
+  TEST_ASSERT (buf[1] == 0x9A, "Second byte should be 0x9A");
+  TEST_ASSERT (buf[2] == 0x0A, "Third byte should be 0x0A");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test integer decoding
+ */
+static void
+test_int_decode_small (void)
+{
+  unsigned char data[] = { 0x0A };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode 10... ");
+
+  result = SocketQPACK_int_decode (data, sizeof (data), 5, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == 10, "Value should be 10");
+  TEST_ASSERT (consumed == 1, "Should consume 1 byte");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test multi-byte integer decoding
+ */
+static void
+test_int_decode_large (void)
+{
+  unsigned char data[] = { 0x1F, 0x9A, 0x0A };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Integer decode 1337... ");
+
+  result = SocketQPACK_int_decode (data, sizeof (data), 5, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == 1337, "Value should be 1337");
+  TEST_ASSERT (consumed == 3, "Should consume 3 bytes");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * String Encoding Tests (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+static void
+test_string_encode_literal (void)
+{
+  Arena_T arena = Arena_new ();
+  unsigned char buf[256];
+  ssize_t len;
+
+  printf ("  String encode literal 'hello'... ");
+
+  /* Encode without Huffman */
+  len = SocketQPACK_string_encode ("hello", 5, 7, 0, buf, sizeof (buf));
+  TEST_ASSERT (len > 0, "Should encode successfully");
+  TEST_ASSERT ((buf[0] & 0x80) == 0, "H bit should be 0 for literal");
+  TEST_ASSERT ((buf[0] & 0x7F) == 5, "Length should be 5");
+  TEST_ASSERT (memcmp (buf + 1, "hello", 5) == 0, "Data should be 'hello'");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_string_encode_huffman (void)
+{
+  unsigned char buf[256];
+  ssize_t len;
+
+  printf ("  String encode Huffman 'www.example.com'... ");
+
+  /* Encode with Huffman (should be smaller for this string) */
+  len = SocketQPACK_string_encode (
+      "www.example.com", 15, 7, 1, buf, sizeof (buf));
+  TEST_ASSERT (len > 0, "Should encode successfully");
+  /* Huffman encoding of www.example.com should be shorter than 15 bytes */
+  TEST_ASSERT ((buf[0] & 0x80) != 0, "H bit should be 1 for Huffman (shorter)");
+
+  printf ("PASS\n");
+}
+
+static void
+test_string_decode_literal (void)
+{
+  Arena_T arena = Arena_new ();
+  unsigned char data[] = { 0x05, 'h', 'e', 'l', 'l', 'o' };
+  char *str;
+  size_t str_len, consumed;
+  SocketQPACK_Result result;
+
+  printf ("  String decode literal... ");
+
+  result = SocketQPACK_string_decode (
+      data, sizeof (data), 7, &str, &str_len, &consumed, arena);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (str_len == 5, "Length should be 5");
+  TEST_ASSERT (memcmp (str, "hello", 5) == 0, "Should be 'hello'");
+  TEST_ASSERT (consumed == 6, "Should consume 6 bytes");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Static Table Tests (RFC 9204 Appendix A)
+ * ============================================================================
+ */
+
+static void
+test_static_table_get (void)
+{
+  SocketQPACK_Header header;
+  SocketQPACK_Result result;
+
+  printf ("  Static table get index 0 (:authority)... ");
+
+  result = SocketQPACK_static_get (0, &header);
+  TEST_ASSERT (result == QPACK_OK, "Should get OK");
+  TEST_ASSERT (header.name_len == 10, "Name length should be 10");
+  TEST_ASSERT (memcmp (header.name, ":authority", 10) == 0,
+               "Name should be ':authority'");
+  TEST_ASSERT (header.value_len == 0, "Value should be empty");
+
+  printf ("PASS\n");
+}
+
+static void
+test_static_table_get_method_get (void)
+{
+  SocketQPACK_Header header;
+  SocketQPACK_Result result;
+
+  printf ("  Static table get index 17 (:method GET)... ");
+
+  result = SocketQPACK_static_get (17, &header);
+  TEST_ASSERT (result == QPACK_OK, "Should get OK");
+  TEST_ASSERT (header.name_len == 7, "Name length should be 7");
+  TEST_ASSERT (memcmp (header.name, ":method", 7) == 0,
+               "Name should be ':method'");
+  TEST_ASSERT (header.value_len == 3, "Value length should be 3");
+  TEST_ASSERT (memcmp (header.value, "GET", 3) == 0, "Value should be 'GET'");
+
+  printf ("PASS\n");
+}
+
+static void
+test_static_table_invalid_index (void)
+{
+  SocketQPACK_Header header;
+  SocketQPACK_Result result;
+
+  printf ("  Static table invalid index... ");
+
+  result = SocketQPACK_static_get (99, &header);
+  TEST_ASSERT (result == QPACK_ERROR_INVALID_INDEX, "Should return error");
+
+  printf ("PASS\n");
+}
+
+static void
+test_static_table_find (void)
+{
+  int idx;
+
+  printf ("  Static table find ':method' 'GET'... ");
+
+  idx = SocketQPACK_static_find (":method", 7, "GET", 3);
+  TEST_ASSERT (idx > 0, "Should find exact match");
+  TEST_ASSERT (idx == 18, "Index should be 18 (1-based for exact)");
+
+  printf ("PASS\n");
+}
+
+static void
+test_static_table_find_name_only (void)
+{
+  int idx;
+
+  printf ("  Static table find ':method' (name only)... ");
+
+  idx = SocketQPACK_static_find (":method", 7, NULL, 0);
+  TEST_ASSERT (idx < 0, "Should find name-only match (negative)");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Dynamic Table Tests (RFC 9204 Section 3.2)
+ * ============================================================================
+ */
+
+static void
+test_dynamic_table_create (void)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_DynamicTable_T table;
+
+  printf ("  Dynamic table create... ");
+
+  table = SocketQPACK_DynamicTable_new (4096, arena);
+  TEST_ASSERT (table != NULL, "Should create table");
+  TEST_ASSERT (SocketQPACK_DynamicTable_size (table) == 0, "Size should be 0");
+  TEST_ASSERT (SocketQPACK_DynamicTable_count (table) == 0,
+               "Count should be 0");
+  TEST_ASSERT (SocketQPACK_DynamicTable_max_size (table) == 4096,
+               "Max size should be 4096");
+
+  SocketQPACK_DynamicTable_free (&table);
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_dynamic_table_insert (void)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_DynamicTable_T table;
+  SocketQPACK_Result result;
+
+  printf ("  Dynamic table insert... ");
+
+  table = SocketQPACK_DynamicTable_new (4096, arena);
+  result = SocketQPACK_DynamicTable_insert (
+      table, "custom-header", 13, "custom-value", 12);
+  TEST_ASSERT (result == QPACK_OK, "Should insert OK");
+  TEST_ASSERT (SocketQPACK_DynamicTable_count (table) == 1,
+               "Count should be 1");
+  /* Entry size = 13 + 12 + 32 = 57 */
+  TEST_ASSERT (SocketQPACK_DynamicTable_size (table) == 57,
+               "Size should be 57");
+  TEST_ASSERT (SocketQPACK_DynamicTable_insert_count (table) == 1,
+               "Insert count should be 1");
+
+  SocketQPACK_DynamicTable_free (&table);
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_dynamic_table_get (void)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_DynamicTable_T table;
+  SocketQPACK_Header header;
+  SocketQPACK_Result result;
+
+  printf ("  Dynamic table get... ");
+
+  table = SocketQPACK_DynamicTable_new (4096, arena);
+  SocketQPACK_DynamicTable_insert (
+      table, "custom-header", 13, "custom-value", 12);
+
+  /* QPACK uses absolute indexing - first entry is index 0 */
+  result = SocketQPACK_DynamicTable_get (table, 0, &header);
+  TEST_ASSERT (result == QPACK_OK, "Should get OK");
+  TEST_ASSERT (header.name_len == 13, "Name length should be 13");
+  TEST_ASSERT (memcmp (header.name, "custom-header", 13) == 0,
+               "Name should match");
+  TEST_ASSERT (header.value_len == 12, "Value length should be 12");
+  TEST_ASSERT (memcmp (header.value, "custom-value", 12) == 0,
+               "Value should match");
+
+  SocketQPACK_DynamicTable_free (&table);
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_dynamic_table_eviction (void)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_DynamicTable_T table;
+  SocketQPACK_Result result;
+
+  printf ("  Dynamic table eviction... ");
+
+  /* Small table to force eviction */
+  table = SocketQPACK_DynamicTable_new (100, arena);
+
+  /* First entry: 10 + 10 + 32 = 52 bytes */
+  result = SocketQPACK_DynamicTable_insert (
+      table, "header-one", 10, "value-one", 9); /* 10+9+32=51 */
+  TEST_ASSERT (result == QPACK_OK, "Should insert first");
+  TEST_ASSERT (SocketQPACK_DynamicTable_count (table) == 1,
+               "Count should be 1");
+
+  /* Second entry: 10 + 10 + 32 = 52 bytes - should evict first */
+  result = SocketQPACK_DynamicTable_insert (
+      table, "header-two", 10, "value-two", 9); /* 10+9+32=51 */
+  TEST_ASSERT (result == QPACK_OK, "Should insert second");
+  /* Both entries = 102 bytes, max is 100, so first should be evicted */
+  TEST_ASSERT (SocketQPACK_DynamicTable_count (table) == 1,
+               "Count should still be 1 after eviction");
+
+  /* Verify we can access the second entry (absolute index 1) */
+  SocketQPACK_Header header;
+  result = SocketQPACK_DynamicTable_get (table, 1, &header);
+  TEST_ASSERT (result == QPACK_OK, "Should get second entry");
+  TEST_ASSERT (memcmp (header.name, "header-two", 10) == 0,
+               "Should be second entry");
+
+  /* First entry should be inaccessible (evicted) */
+  result = SocketQPACK_DynamicTable_get (table, 0, &header);
+  TEST_ASSERT (result == QPACK_ERROR_INVALID_INDEX,
+               "First entry should be evicted");
+
+  SocketQPACK_DynamicTable_free (&table);
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Insert with Literal Name Tests (RFC 9204 Section 4.3.3)
+ * ============================================================================
+ */
+
+static void
+test_insert_literal_name_encode (void)
+{
+  unsigned char buf[256];
+  ssize_t len;
+  SocketQPACK_InsertLiteralInstruction instr;
+
+  printf ("  Insert literal name encode... ");
+
+  instr.name = (const unsigned char *)"custom-key";
+  instr.name_len = 10;
+  instr.value = (const unsigned char *)"custom-value";
+  instr.value_len = 12;
+  instr.name_huffman = 0;
+  instr.value_huffman = 0;
+
+  len = SocketQPACK_encode_insert_literal_name (&instr, buf, sizeof (buf));
+  TEST_ASSERT (len > 0, "Should encode successfully");
+
+  /* Verify pattern: first byte should have pattern 01 (bits 7-6) */
+  TEST_ASSERT ((buf[0] & 0xC0) == 0x40, "Should have pattern 01");
+  /* H bit should be 0 (bit 5) */
+  TEST_ASSERT ((buf[0] & 0x20) == 0, "H bit should be 0 for literal name");
+
+  printf ("PASS\n");
+}
+
+static void
+test_insert_literal_name_encode_huffman (void)
+{
+  unsigned char buf[256];
+  ssize_t len;
+  SocketQPACK_InsertLiteralInstruction instr;
+
+  printf ("  Insert literal name encode with Huffman... ");
+
+  instr.name = (const unsigned char *)"www.example.com";
+  instr.name_len = 15;
+  instr.value = (const unsigned char *)"no-cache";
+  instr.value_len = 8;
+  instr.name_huffman = 1;
+  instr.value_huffman = 1;
+
+  len = SocketQPACK_encode_insert_literal_name (&instr, buf, sizeof (buf));
+  TEST_ASSERT (len > 0, "Should encode successfully");
+
+  /* Verify pattern 01 */
+  TEST_ASSERT ((buf[0] & 0xC0) == 0x40, "Should have pattern 01");
+  /* H bit should be 1 (bit 5) for Huffman name */
+  TEST_ASSERT ((buf[0] & 0x20) != 0, "H bit should be 1 for Huffman name");
+
+  printf ("PASS\n");
+}
+
+static void
+test_insert_literal_name_decode (void)
+{
+  Arena_T arena = Arena_new ();
+  unsigned char buf[256];
+  ssize_t encoded_len;
+  SocketQPACK_InsertLiteralInstruction instr;
+  char *name, *value;
+  size_t name_len, value_len, consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Insert literal name decode... ");
+
+  /* First encode */
+  instr.name = (const unsigned char *)"test-header";
+  instr.name_len = 11;
+  instr.value = (const unsigned char *)"test-value";
+  instr.value_len = 10;
+  instr.name_huffman = 0;
+  instr.value_huffman = 0;
+
+  encoded_len
+      = SocketQPACK_encode_insert_literal_name (&instr, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Should encode");
+
+  /* Then decode */
+  result = SocketQPACK_decode_insert_literal_name (buf,
+                                                   (size_t)encoded_len,
+                                                   &name,
+                                                   &name_len,
+                                                   &value,
+                                                   &value_len,
+                                                   &consumed,
+                                                   arena);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (name_len == 11, "Name length should be 11");
+  TEST_ASSERT (memcmp (name, "test-header", 11) == 0, "Name should match");
+  TEST_ASSERT (value_len == 10, "Value length should be 10");
+  TEST_ASSERT (memcmp (value, "test-value", 10) == 0, "Value should match");
+  TEST_ASSERT (consumed == (size_t)encoded_len, "Should consume all bytes");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_insert_literal_name_roundtrip_huffman (void)
+{
+  Arena_T arena = Arena_new ();
+  unsigned char buf[256];
+  ssize_t encoded_len;
+  SocketQPACK_InsertLiteralInstruction instr;
+  char *name, *value;
+  size_t name_len, value_len, consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Insert literal name roundtrip with Huffman... ");
+
+  /* Encode with Huffman */
+  instr.name = (const unsigned char *)"content-type";
+  instr.name_len = 12;
+  instr.value = (const unsigned char *)"text/html";
+  instr.value_len = 9;
+  instr.name_huffman = 1;
+  instr.value_huffman = 1;
+
+  encoded_len
+      = SocketQPACK_encode_insert_literal_name (&instr, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Should encode");
+
+  /* Decode */
+  result = SocketQPACK_decode_insert_literal_name (buf,
+                                                   (size_t)encoded_len,
+                                                   &name,
+                                                   &name_len,
+                                                   &value,
+                                                   &value_len,
+                                                   &consumed,
+                                                   arena);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (name_len == 12, "Name length should be 12");
+  TEST_ASSERT (memcmp (name, "content-type", 12) == 0, "Name should match");
+  TEST_ASSERT (value_len == 9, "Value length should be 9");
+  TEST_ASSERT (memcmp (value, "text/html", 9) == 0, "Value should match");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_process_insert_literal_name (void)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_DynamicTable_T table;
+  unsigned char buf[256];
+  ssize_t encoded_len;
+  SocketQPACK_InsertLiteralInstruction instr;
+  size_t consumed;
+  SocketQPACK_Result result;
+  SocketQPACK_Header header;
+
+  printf ("  Process insert literal name into table... ");
+
+  table = SocketQPACK_DynamicTable_new (4096, arena);
+
+  /* Encode instruction */
+  instr.name = (const unsigned char *)"x-custom";
+  instr.name_len = 8;
+  instr.value = (const unsigned char *)"custom123";
+  instr.value_len = 9;
+  instr.name_huffman = 0;
+  instr.value_huffman = 0;
+
+  encoded_len
+      = SocketQPACK_encode_insert_literal_name (&instr, buf, sizeof (buf));
+  TEST_ASSERT (encoded_len > 0, "Should encode");
+
+  /* Process (decode and insert into table) */
+  result = SocketQPACK_process_insert_literal_name (
+      table, buf, (size_t)encoded_len, &consumed, arena);
+  TEST_ASSERT (result == QPACK_OK, "Should process OK");
+  TEST_ASSERT (consumed == (size_t)encoded_len, "Should consume all bytes");
+
+  /* Verify entry was added to table */
+  TEST_ASSERT (SocketQPACK_DynamicTable_count (table) == 1,
+               "Count should be 1");
+
+  /* Retrieve and verify */
+  result = SocketQPACK_DynamicTable_get (table, 0, &header);
+  TEST_ASSERT (result == QPACK_OK, "Should get entry");
+  TEST_ASSERT (header.name_len == 8, "Name length should be 8");
+  TEST_ASSERT (memcmp (header.name, "x-custom", 8) == 0, "Name should match");
+  TEST_ASSERT (header.value_len == 9, "Value length should be 9");
+  TEST_ASSERT (memcmp (header.value, "custom123", 9) == 0,
+               "Value should match");
+
+  SocketQPACK_DynamicTable_free (&table);
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Edge Case Tests
+ * ============================================================================
+ */
+
+static void
+test_empty_string_encode (void)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  printf ("  Empty string encode... ");
+
+  len = SocketQPACK_string_encode ("", 0, 7, 0, buf, sizeof (buf));
+  TEST_ASSERT (len == 1, "Should be 1 byte");
+  TEST_ASSERT (buf[0] == 0, "Length byte should be 0");
+
+  printf ("PASS\n");
+}
+
+static void
+test_empty_name_value (void)
+{
+  Arena_T arena = Arena_new ();
+  SocketQPACK_DynamicTable_T table;
+  SocketQPACK_Result result;
+  SocketQPACK_Header header;
+
+  printf ("  Empty name/value insert... ");
+
+  table = SocketQPACK_DynamicTable_new (4096, arena);
+
+  /* Insert with empty value */
+  result = SocketQPACK_DynamicTable_insert (table, "empty-value", 11, "", 0);
+  TEST_ASSERT (result == QPACK_OK, "Should insert with empty value");
+
+  result = SocketQPACK_DynamicTable_get (table, 0, &header);
+  TEST_ASSERT (result == QPACK_OK, "Should get entry");
+  TEST_ASSERT (header.value_len == 0, "Value should be empty");
+
+  SocketQPACK_DynamicTable_free (&table);
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+static void
+test_large_integer (void)
+{
+  unsigned char buf[16];
+  size_t len;
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result result;
+
+  printf ("  Large integer encode/decode... ");
+
+  /* Encode large value */
+  uint64_t large_val = 1000000;
+  len = SocketQPACK_int_encode (large_val, 5, buf, sizeof (buf));
+  TEST_ASSERT (len > 0, "Should encode");
+
+  /* Decode */
+  result = SocketQPACK_int_decode (buf, len, 5, &value, &consumed);
+  TEST_ASSERT (result == QPACK_OK, "Should decode OK");
+  TEST_ASSERT (value == large_val, "Value should match");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Test Groups
+ * ============================================================================
+ */
+
+static void
+run_integer_tests (void)
+{
+  printf ("\nInteger Encoding/Decoding Tests:\n");
+  test_int_encode_5bit_small ();
+  test_int_encode_5bit_large ();
+  test_int_decode_small ();
+  test_int_decode_large ();
+  test_large_integer ();
+}
+
+static void
+run_string_tests (void)
+{
+  printf ("\nString Encoding/Decoding Tests:\n");
+  test_string_encode_literal ();
+  test_string_encode_huffman ();
+  test_string_decode_literal ();
+  test_empty_string_encode ();
+}
+
+static void
+run_static_table_tests (void)
+{
+  printf ("\nStatic Table Tests:\n");
+  test_static_table_get ();
+  test_static_table_get_method_get ();
+  test_static_table_invalid_index ();
+  test_static_table_find ();
+  test_static_table_find_name_only ();
+}
+
+static void
+run_dynamic_table_tests (void)
+{
+  printf ("\nDynamic Table Tests:\n");
+  test_dynamic_table_create ();
+  test_dynamic_table_insert ();
+  test_dynamic_table_get ();
+  test_dynamic_table_eviction ();
+  test_empty_name_value ();
+}
+
+static void
+run_insert_literal_name_tests (void)
+{
+  printf ("\nInsert with Literal Name Tests (RFC 9204 Section 4.3.3):\n");
+  test_insert_literal_name_encode ();
+  test_insert_literal_name_encode_huffman ();
+  test_insert_literal_name_decode ();
+  test_insert_literal_name_roundtrip_huffman ();
+  test_process_insert_literal_name ();
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("=== QPACK Header Compression Tests (RFC 9204) ===\n");
+
+  run_integer_tests ();
+  run_string_tests ();
+  run_static_table_tests ();
+  run_dynamic_table_tests ();
+  run_insert_literal_name_tests ();
+
+  printf ("\n=== All QPACK tests passed! ===\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.3.3 - Insert with Literal Name instruction for the QPACK encoder stream.

- Add QPACK module with static table (99 entries), dynamic table, and encoder stream support
- Implement Insert with Literal Name instruction encoding and decoding
- Add integer/string encoding with variable-length prefix and Huffman compression
- Create comprehensive test suite covering all functionality

## Changes

- `include/http/qpack/SocketQPACK.h` - Public API header with types and functions
- `include/http/qpack/SocketQPACK-private.h` - Internal structures and constants
- `src/http/qpack/SocketQPACK-encoder.c` - Integer/string encoding, Insert with Literal Name
- `src/http/qpack/SocketQPACK-table.c` - Static table (99 entries) and dynamic table
- `src/http/qpack/SocketQPACK-huffman.c` - Huffman encoding wrapper (reuses HPACK tables)
- `src/test/test_qpack.c` - Unit tests for all QPACK functionality
- `CMakeLists.txt` - Build system integration

## Test Plan

- [x] All integer encoding/decoding tests pass
- [x] All string encoding/decoding tests pass (literal and Huffman)
- [x] Static table lookup tests pass (0-98 indices)
- [x] Dynamic table operations pass (insert, get, eviction)
- [x] Insert with Literal Name encode/decode roundtrip passes
- [x] Tests pass with sanitizers enabled (ASan + UBSan)
- [x] All 140 existing tests still pass

Closes #3280