### PR TITLE
feat(qpack): implement QPACK configuration (RFC 9204 Section 5)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-config.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -780,6 +783,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack_config
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/SocketQPACK.h
+++ b/include/http/SocketQPACK.h
@@ -1,0 +1,428 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression configuration for HTTP/3 (RFC 9204).
+ *
+ * Implements RFC 9204 Section 5 - Configuration. QPACK is the header
+ * compression format used by HTTP/3, evolved from HPACK (RFC 7541) to work
+ * with QUIC's out-of-order delivery.
+ *
+ * Configuration Settings (RFC 9204 Section 5):
+ *   - SETTINGS_QPACK_MAX_TABLE_CAPACITY (0x01): Maximum dynamic table size
+ *   - SETTINGS_QPACK_BLOCKED_STREAMS (0x07): Maximum blocked streams
+ *
+ * Both settings default to 0 per RFC 9204:
+ *   - 0 capacity means no dynamic table entries allowed
+ *   - 0 blocked streams means decoder cannot block waiting for table updates
+ *
+ * Thread Safety: Configuration instances are NOT thread-safe. One instance
+ * per connection/thread recommended. Static functions are thread-safe.
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/* ============================================================================
+ * QPACK SETTINGS IDENTIFIERS (RFC 9204 Section 5)
+ * ============================================================================
+ */
+
+/**
+ * @brief SETTINGS_QPACK_MAX_TABLE_CAPACITY identifier (0x01).
+ *
+ * RFC 9204 Section 5: "An integer with a maximum value of 2^30 - 1.
+ * The default value is zero."
+ *
+ * This setting specifies the maximum size (in bytes) of the dynamic table
+ * that the encoder can use. The decoder MUST NOT allocate more than this
+ * amount of memory for the dynamic table.
+ */
+#define SETTINGS_QPACK_MAX_TABLE_CAPACITY 0x01
+
+/**
+ * @brief SETTINGS_QPACK_BLOCKED_STREAMS identifier (0x07).
+ *
+ * RFC 9204 Section 5: "An integer with a maximum value of 2^16 - 1.
+ * The default value is zero."
+ *
+ * This setting specifies the maximum number of streams that can be blocked
+ * waiting for dynamic table entries. If the decoder has this many streams
+ * blocked, it MUST NOT reference any new dynamic table entries.
+ */
+#define SETTINGS_QPACK_BLOCKED_STREAMS 0x07
+
+/* ============================================================================
+ * QPACK LIMITS (RFC 9204 Section 5)
+ * ============================================================================
+ */
+
+/**
+ * @brief Maximum value for SETTINGS_QPACK_MAX_TABLE_CAPACITY.
+ *
+ * RFC 9204 Section 5: "An integer with a maximum value of 2^30 - 1."
+ */
+#define QPACK_MAX_TABLE_CAPACITY_LIMIT ((size_t)(1U << 30) - 1)
+
+/**
+ * @brief Maximum value for SETTINGS_QPACK_BLOCKED_STREAMS.
+ *
+ * RFC 9204 Section 5: "An integer with a maximum value of 2^16 - 1."
+ */
+#define QPACK_MAX_BLOCKED_STREAMS_LIMIT ((size_t)(1U << 16) - 1)
+
+/**
+ * @brief Warning threshold for table capacity (100 MB).
+ *
+ * Settings exceeding this value trigger a log warning but are still valid.
+ */
+#define QPACK_CAPACITY_WARNING_THRESHOLD (100 * 1024 * 1024)
+
+/* ============================================================================
+ * QPACK RESULT CODES
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK configuration operation result codes.
+ *
+ * These codes indicate the success or failure of configuration operations.
+ */
+typedef enum
+{
+  /** Operation completed successfully. */
+  QPACK_CONFIG_OK = 0,
+
+  /** Settings validation failed - value exceeds protocol limit. */
+  QPACK_CONFIG_ERROR_INVALID_VALUE,
+
+  /** Null parameter passed to function. */
+  QPACK_CONFIG_ERROR_NULL_PARAM,
+
+  /** Configuration already applied - cannot modify. */
+  QPACK_CONFIG_ERROR_ALREADY_APPLIED,
+
+  /** Memory allocation failed. */
+  QPACK_CONFIG_ERROR_ALLOC,
+
+  /** Configuration is not yet ready (waiting for peer settings). */
+  QPACK_CONFIG_ERROR_NOT_READY
+
+} SocketQPACK_ConfigResult;
+
+/* ============================================================================
+ * QPACK SETTINGS STRUCTURE (RFC 9204 Section 5)
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK settings from HTTP/3 SETTINGS frame.
+ *
+ * Represents the QPACK-specific settings exchanged between peers during
+ * HTTP/3 connection establishment. Both values default to 0 per RFC 9204.
+ *
+ * When max_table_capacity is 0:
+ *   - Encoder MUST NOT insert entries into dynamic table
+ *   - Encoder MUST use literal encoding for all headers
+ *
+ * When blocked_streams is 0:
+ *   - Decoder MUST NOT block waiting for dynamic table entries
+ *   - Encoder MUST NOT reference entries the decoder doesn't have
+ */
+typedef struct
+{
+  /**
+   * Maximum dynamic table capacity in bytes.
+   * RFC 9204 Section 5: "The default value is zero."
+   * Maximum: 2^30 - 1 (QPACK_MAX_TABLE_CAPACITY_LIMIT)
+   */
+  size_t max_table_capacity;
+
+  /**
+   * Maximum number of blocked streams.
+   * RFC 9204 Section 5: "The default value is zero."
+   * Maximum: 2^16 - 1 (QPACK_MAX_BLOCKED_STREAMS_LIMIT)
+   */
+  size_t blocked_streams;
+
+} SocketQPACK_Settings;
+
+/* ============================================================================
+ * QPACK CONFIGURATION STRUCTURE
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK connection configuration.
+ *
+ * Tracks both local and peer settings for a QPACK connection. The effective
+ * configuration depends on both sides:
+ *
+ *   - Encoder uses peer's settings to know what the decoder can handle
+ *   - Decoder uses local settings to allocate resources
+ *
+ * For 0-RTT (RFC 9204 Section 3.2.3):
+ *   - Encoder uses previous connection's settings for early data
+ *   - After handshake, switches to newly negotiated settings
+ */
+struct SocketQPACK_Config
+{
+  /** Our settings (sent to peer). */
+  SocketQPACK_Settings local;
+
+  /** Peer's settings (received from peer). */
+  SocketQPACK_Settings peer;
+
+  /** Previous settings for 0-RTT resumption (NULL if not resuming). */
+  SocketQPACK_Settings *previous;
+
+  /** Settings have been validated and applied. */
+  int validated;
+
+  /** Peer settings have been received. */
+  int peer_received;
+
+  /** Currently using 0-RTT settings. */
+  int using_0rtt;
+};
+
+/** Opaque type for QPACK configuration. */
+typedef struct SocketQPACK_Config *SocketQPACK_Config_T;
+
+/* ============================================================================
+ * EXCEPTION TYPE
+ * ============================================================================
+ */
+
+/**
+ * @brief Exception raised on QPACK configuration errors.
+ *
+ * This exception is raised when QPACK configuration operations encounter
+ * fatal errors that cannot be recovered.
+ */
+extern const Except_T SocketQPACK_ConfigError;
+
+/* ============================================================================
+ * SETTINGS FUNCTIONS (RFC 9204 Section 5)
+ * ============================================================================
+ */
+
+/**
+ * @brief Initialize settings to RFC 9204 defaults.
+ *
+ * Sets both max_table_capacity and blocked_streams to 0 per RFC 9204 Section 5:
+ * "The default value is zero."
+ *
+ * @param settings Settings structure to initialize (must not be NULL).
+ * @return QPACK_CONFIG_OK on success, QPACK_CONFIG_ERROR_NULL_PARAM if NULL.
+ *
+ * @note Thread-safe: Does not access global state.
+ */
+extern SocketQPACK_ConfigResult
+SocketQPACK_settings_defaults (SocketQPACK_Settings *settings);
+
+/**
+ * @brief Validate settings against RFC 9204 limits.
+ *
+ * Checks that:
+ *   - max_table_capacity <= 2^30 - 1 (QPACK_MAX_TABLE_CAPACITY_LIMIT)
+ *   - blocked_streams <= 2^16 - 1 (QPACK_MAX_BLOCKED_STREAMS_LIMIT)
+ *
+ * Values exceeding QPACK_CAPACITY_WARNING_THRESHOLD trigger a log warning
+ * but are still considered valid if within protocol limits.
+ *
+ * @param settings Settings to validate (must not be NULL).
+ * @return QPACK_CONFIG_OK if valid, error code otherwise.
+ *
+ * @note Thread-safe: Does not modify settings.
+ */
+extern SocketQPACK_ConfigResult
+SocketQPACK_settings_validate (const SocketQPACK_Settings *settings);
+
+/**
+ * @brief Check if settings enable dynamic table usage.
+ *
+ * RFC 9204 Section 5: When max_table_capacity is 0, the dynamic table
+ * cannot be used and all headers must be encoded as literals.
+ *
+ * @param settings Settings to check (must not be NULL).
+ * @return Non-zero if dynamic table is enabled, 0 if disabled or NULL.
+ */
+extern int
+SocketQPACK_settings_has_dynamic_table (const SocketQPACK_Settings *settings);
+
+/**
+ * @brief Check if settings allow blocking.
+ *
+ * RFC 9204 Section 5: When blocked_streams is 0, the decoder cannot block
+ * waiting for dynamic table entries.
+ *
+ * @param settings Settings to check (must not be NULL).
+ * @return Non-zero if blocking is allowed, 0 if not or NULL.
+ */
+extern int
+SocketQPACK_settings_allows_blocking (const SocketQPACK_Settings *settings);
+
+/* ============================================================================
+ * CONFIGURATION FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Create new QPACK configuration with defaults.
+ *
+ * Allocates a new configuration with both local and peer settings
+ * initialized to RFC 9204 defaults (0, 0).
+ *
+ * @param arena Memory arena for allocations.
+ * @return New configuration, or NULL on allocation failure.
+ *
+ * @throws SocketQPACK_ConfigError on allocation failure.
+ */
+extern SocketQPACK_Config_T SocketQPACK_config_new (Arena_T arena);
+
+/**
+ * @brief Set local settings (to be sent to peer).
+ *
+ * The local settings are advertised to the peer in the HTTP/3 SETTINGS frame.
+ * They specify our capabilities (how much memory we can allocate for the
+ * dynamic table, how many blocked streams we allow).
+ *
+ * @param config Configuration to modify.
+ * @param settings Settings to copy as local settings.
+ * @return QPACK_CONFIG_OK on success, error code on failure.
+ */
+extern SocketQPACK_ConfigResult
+SocketQPACK_config_set_local (SocketQPACK_Config_T config,
+                               const SocketQPACK_Settings *settings);
+
+/**
+ * @brief Apply peer settings (received from peer).
+ *
+ * Called when we receive the peer's SETTINGS frame containing
+ * SETTINGS_QPACK_MAX_TABLE_CAPACITY and SETTINGS_QPACK_BLOCKED_STREAMS.
+ *
+ * RFC 9204 Section 5.2: "QPACK implementations MUST handle SETTINGS
+ * received after the first SETTINGS frame."
+ *
+ * @param config Configuration to modify.
+ * @param settings Peer's settings from SETTINGS frame.
+ * @return QPACK_CONFIG_OK on success, error code on failure.
+ */
+extern SocketQPACK_ConfigResult
+SocketQPACK_config_apply_peer (SocketQPACK_Config_T config,
+                                const SocketQPACK_Settings *settings);
+
+/**
+ * @brief Get effective encoder settings.
+ *
+ * Returns the settings the encoder should use. The encoder is constrained
+ * by the peer's advertised settings (what the decoder can handle).
+ *
+ * @param config Configuration to query.
+ * @return Pointer to peer settings, or NULL if peer settings not received.
+ */
+extern const SocketQPACK_Settings *
+SocketQPACK_config_encoder_settings (const SocketQPACK_Config_T config);
+
+/**
+ * @brief Get effective decoder settings.
+ *
+ * Returns the settings the decoder should use. The decoder uses local
+ * settings (what we advertised we can handle).
+ *
+ * @param config Configuration to query.
+ * @return Pointer to local settings, or NULL if config is NULL.
+ */
+extern const SocketQPACK_Settings *
+SocketQPACK_config_decoder_settings (const SocketQPACK_Config_T config);
+
+/**
+ * @brief Check if configuration is ready for use.
+ *
+ * Returns true when both local settings are configured and peer settings
+ * have been received and validated.
+ *
+ * @param config Configuration to check.
+ * @return Non-zero if ready, 0 if not ready or NULL.
+ */
+extern int SocketQPACK_config_is_ready (const SocketQPACK_Config_T config);
+
+/* ============================================================================
+ * 0-RTT SUPPORT (RFC 9204 Section 3.2.3)
+ * ============================================================================
+ */
+
+/**
+ * @brief Set previous settings for 0-RTT resumption.
+ *
+ * RFC 9204 Section 3.2.3: "When 0-RTT is used, the encoder and decoder
+ * MUST use the settings from the previous connection."
+ *
+ * Call this before encoding early data to restore the previous connection's
+ * settings. The encoder will use these settings until the handshake completes
+ * and new settings are negotiated.
+ *
+ * @param config Configuration to modify.
+ * @param previous Previous connection's settings.
+ * @param arena Arena for allocating copy of settings.
+ * @return QPACK_CONFIG_OK on success, error code on failure.
+ */
+extern SocketQPACK_ConfigResult
+SocketQPACK_config_set_0rtt (SocketQPACK_Config_T config,
+                              const SocketQPACK_Settings *previous,
+                              Arena_T arena);
+
+/**
+ * @brief Switch from 0-RTT settings to negotiated settings.
+ *
+ * Called after the TLS handshake completes to transition from using
+ * the previous connection's settings to the newly negotiated settings.
+ *
+ * @param config Configuration to modify.
+ * @return QPACK_CONFIG_OK on success, error code on failure.
+ */
+extern SocketQPACK_ConfigResult
+SocketQPACK_config_complete_0rtt (SocketQPACK_Config_T config);
+
+/**
+ * @brief Check if using 0-RTT settings.
+ *
+ * @param config Configuration to check.
+ * @return Non-zero if using 0-RTT settings, 0 otherwise.
+ */
+extern int SocketQPACK_config_is_0rtt (const SocketQPACK_Config_T config);
+
+/* ============================================================================
+ * UTILITY FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Get human-readable string for configuration result code.
+ *
+ * @param result Result code to describe.
+ * @return Static string describing the result (never NULL).
+ *
+ * @note Thread-safe: Returns pointer to static read-only string.
+ */
+extern const char *
+SocketQPACK_config_result_string (SocketQPACK_ConfigResult result);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK-config.c
+++ b/src/http/qpack/SocketQPACK-config.c
@@ -1,0 +1,403 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-config.c
+ * @brief QPACK Configuration implementation (RFC 9204 Section 5).
+ *
+ * Implements QPACK settings handling including:
+ * - SETTINGS_QPACK_MAX_TABLE_CAPACITY (0x01)
+ * - SETTINGS_QPACK_BLOCKED_STREAMS (0x07)
+ * - 0-RTT early data settings handling (Section 3.2.3)
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-5
+ */
+
+#include "http/SocketQPACK.h"
+
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "core/SocketLog.h"
+
+#undef SOCKET_LOG_COMPONENT
+#define SOCKET_LOG_COMPONENT "QPACK"
+
+/* ============================================================================
+ * Exception Definition
+ * ============================================================================
+ */
+
+const Except_T SocketQPACK_ConfigError
+    = { &SocketQPACK_ConfigError, "QPACK configuration error" };
+
+/* ============================================================================
+ * Result String Table
+ * ============================================================================
+ */
+
+static const char *config_result_strings[] = {
+  [QPACK_CONFIG_OK] = "OK",
+  [QPACK_CONFIG_ERROR_INVALID_VALUE] = "Invalid settings value",
+  [QPACK_CONFIG_ERROR_NULL_PARAM] = "NULL parameter",
+  [QPACK_CONFIG_ERROR_ALREADY_APPLIED] = "Settings already applied",
+  [QPACK_CONFIG_ERROR_ALLOC] = "Allocation failed",
+  [QPACK_CONFIG_ERROR_NOT_READY] = "Configuration not ready",
+};
+
+const char *
+SocketQPACK_config_result_string (SocketQPACK_ConfigResult result)
+{
+  if (result < 0
+      || result >= (int)(sizeof (config_result_strings)
+                         / sizeof (config_result_strings[0])))
+    return "Unknown error";
+
+  const char *str = config_result_strings[result];
+  return str ? str : "Unknown error";
+}
+
+/* ============================================================================
+ * Settings Functions (RFC 9204 Section 5)
+ * ============================================================================
+ */
+
+SocketQPACK_ConfigResult
+SocketQPACK_settings_defaults (SocketQPACK_Settings *settings)
+{
+  if (settings == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG (
+          "SocketQPACK_settings_defaults: NULL settings pointer");
+      return QPACK_CONFIG_ERROR_NULL_PARAM;
+    }
+
+  /* RFC 9204 Section 5: "The default value is zero." */
+  settings->max_table_capacity = 0;
+  settings->blocked_streams = 0;
+
+  SOCKET_LOG_DEBUG_MSG ("SocketQPACK: initialized settings to RFC defaults "
+                        "(capacity=0, blocked=0)");
+
+  return QPACK_CONFIG_OK;
+}
+
+SocketQPACK_ConfigResult
+SocketQPACK_settings_validate (const SocketQPACK_Settings *settings)
+{
+  if (settings == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG (
+          "SocketQPACK_settings_validate: NULL settings pointer");
+      return QPACK_CONFIG_ERROR_NULL_PARAM;
+    }
+
+  /* RFC 9204 Section 5: max_table_capacity max is 2^30 - 1 */
+  if (settings->max_table_capacity > QPACK_MAX_TABLE_CAPACITY_LIMIT)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK: max_table_capacity (%zu) exceeds limit (%zu)",
+          settings->max_table_capacity,
+          QPACK_MAX_TABLE_CAPACITY_LIMIT);
+      return QPACK_CONFIG_ERROR_INVALID_VALUE;
+    }
+
+  /* RFC 9204 Section 5: blocked_streams max is 2^16 - 1 */
+  if (settings->blocked_streams > QPACK_MAX_BLOCKED_STREAMS_LIMIT)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK: blocked_streams (%zu) exceeds limit (%zu)",
+          settings->blocked_streams,
+          QPACK_MAX_BLOCKED_STREAMS_LIMIT);
+      return QPACK_CONFIG_ERROR_INVALID_VALUE;
+    }
+
+  /* Warn on very large capacity values (potential resource exhaustion) */
+  if (settings->max_table_capacity > QPACK_CAPACITY_WARNING_THRESHOLD)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK: max_table_capacity (%zu) exceeds 100 MB warning "
+          "threshold - ensure sufficient memory available",
+          settings->max_table_capacity);
+    }
+
+  SOCKET_LOG_DEBUG_MSG ("SocketQPACK: settings validated (capacity=%zu, "
+                        "blocked=%zu)",
+                        settings->max_table_capacity,
+                        settings->blocked_streams);
+
+  return QPACK_CONFIG_OK;
+}
+
+int
+SocketQPACK_settings_has_dynamic_table (const SocketQPACK_Settings *settings)
+{
+  if (settings == NULL)
+    return 0;
+
+  /* RFC 9204 Section 5: 0 capacity means no dynamic table */
+  return settings->max_table_capacity > 0;
+}
+
+int
+SocketQPACK_settings_allows_blocking (const SocketQPACK_Settings *settings)
+{
+  if (settings == NULL)
+    return 0;
+
+  /* RFC 9204 Section 5: 0 blocked_streams means no blocking allowed */
+  return settings->blocked_streams > 0;
+}
+
+/* ============================================================================
+ * Configuration Functions
+ * ============================================================================
+ */
+
+SocketQPACK_Config_T
+SocketQPACK_config_new (Arena_T arena)
+{
+  SocketQPACK_Config_T config;
+
+  if (arena == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG ("SocketQPACK_config_new: NULL arena");
+      RAISE (SocketQPACK_ConfigError);
+    }
+
+  config = ALLOC (arena, sizeof (*config));
+  if (config == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG (
+          "SocketQPACK_config_new: failed to allocate config");
+      RAISE (SocketQPACK_ConfigError);
+    }
+
+  /* Initialize both local and peer settings to RFC defaults */
+  SocketQPACK_settings_defaults (&config->local);
+  SocketQPACK_settings_defaults (&config->peer);
+
+  config->previous = NULL;
+  config->validated = 0;
+  config->peer_received = 0;
+  config->using_0rtt = 0;
+
+  SOCKET_LOG_DEBUG_MSG ("SocketQPACK: created new configuration");
+
+  return config;
+}
+
+SocketQPACK_ConfigResult
+SocketQPACK_config_set_local (SocketQPACK_Config_T config,
+                               const SocketQPACK_Settings *settings)
+{
+  SocketQPACK_ConfigResult result;
+
+  if (config == NULL || settings == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK_config_set_local: NULL parameter");
+      return QPACK_CONFIG_ERROR_NULL_PARAM;
+    }
+
+  /* Validate settings before applying */
+  result = SocketQPACK_settings_validate (settings);
+  if (result != QPACK_CONFIG_OK)
+    return result;
+
+  /* Copy settings */
+  config->local.max_table_capacity = settings->max_table_capacity;
+  config->local.blocked_streams = settings->blocked_streams;
+
+  SOCKET_LOG_DEBUG_MSG ("SocketQPACK: set local settings (capacity=%zu, "
+                        "blocked=%zu)",
+                        config->local.max_table_capacity,
+                        config->local.blocked_streams);
+
+  return QPACK_CONFIG_OK;
+}
+
+SocketQPACK_ConfigResult
+SocketQPACK_config_apply_peer (SocketQPACK_Config_T config,
+                                const SocketQPACK_Settings *settings)
+{
+  SocketQPACK_ConfigResult result;
+
+  if (config == NULL || settings == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK_config_apply_peer: NULL parameter");
+      return QPACK_CONFIG_ERROR_NULL_PARAM;
+    }
+
+  /* Validate settings before applying */
+  result = SocketQPACK_settings_validate (settings);
+  if (result != QPACK_CONFIG_OK)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK: rejecting invalid peer settings: %s",
+          SocketQPACK_config_result_string (result));
+      return result;
+    }
+
+  /* Copy settings */
+  config->peer.max_table_capacity = settings->max_table_capacity;
+  config->peer.blocked_streams = settings->blocked_streams;
+  config->peer_received = 1;
+  config->validated = 1;
+
+  SOCKET_LOG_DEBUG_MSG (
+      "SocketQPACK: applied peer settings (capacity=%zu, blocked=%zu)",
+      config->peer.max_table_capacity,
+      config->peer.blocked_streams);
+
+  /* Log dynamic table status */
+  if (config->peer.max_table_capacity == 0)
+    {
+      SOCKET_LOG_DEBUG_MSG (
+          "SocketQPACK: peer disabled dynamic table - using literal encoding");
+    }
+
+  if (config->peer.blocked_streams == 0)
+    {
+      SOCKET_LOG_DEBUG_MSG (
+          "SocketQPACK: peer disabled blocking - encoder cannot block decoder");
+    }
+
+  return QPACK_CONFIG_OK;
+}
+
+const SocketQPACK_Settings *
+SocketQPACK_config_encoder_settings (const SocketQPACK_Config_T config)
+{
+  if (config == NULL)
+    return NULL;
+
+  /* If using 0-RTT and handshake not complete, use previous settings */
+  if (config->using_0rtt && config->previous != NULL)
+    return config->previous;
+
+  /* Encoder uses peer's settings (what the decoder can handle) */
+  if (!config->peer_received)
+    {
+      SOCKET_LOG_DEBUG_MSG (
+          "SocketQPACK: encoder settings requested but peer not received");
+      return NULL;
+    }
+
+  return &config->peer;
+}
+
+const SocketQPACK_Settings *
+SocketQPACK_config_decoder_settings (const SocketQPACK_Config_T config)
+{
+  if (config == NULL)
+    return NULL;
+
+  /* Decoder uses local settings (what we advertised) */
+  return &config->local;
+}
+
+int
+SocketQPACK_config_is_ready (const SocketQPACK_Config_T config)
+{
+  if (config == NULL)
+    return 0;
+
+  /* Ready when peer settings received and validated */
+  return config->validated && config->peer_received;
+}
+
+/* ============================================================================
+ * 0-RTT Support (RFC 9204 Section 3.2.3)
+ * ============================================================================
+ */
+
+SocketQPACK_ConfigResult
+SocketQPACK_config_set_0rtt (SocketQPACK_Config_T config,
+                              const SocketQPACK_Settings *previous,
+                              Arena_T arena)
+{
+  SocketQPACK_ConfigResult result;
+
+  if (config == NULL || previous == NULL || arena == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK_config_set_0rtt: NULL parameter");
+      return QPACK_CONFIG_ERROR_NULL_PARAM;
+    }
+
+  /* Validate previous settings */
+  result = SocketQPACK_settings_validate (previous);
+  if (result != QPACK_CONFIG_OK)
+    {
+      SOCKET_LOG_WARN_MSG ("SocketQPACK: invalid 0-RTT settings: %s",
+                           SocketQPACK_config_result_string (result));
+      return result;
+    }
+
+  /* Allocate and copy previous settings */
+  config->previous = ALLOC (arena, sizeof (*config->previous));
+  if (config->previous == NULL)
+    {
+      SOCKET_LOG_ERROR_MSG (
+          "SocketQPACK: failed to allocate 0-RTT settings");
+      return QPACK_CONFIG_ERROR_ALLOC;
+    }
+
+  config->previous->max_table_capacity = previous->max_table_capacity;
+  config->previous->blocked_streams = previous->blocked_streams;
+  config->using_0rtt = 1;
+
+  SOCKET_LOG_DEBUG_MSG (
+      "SocketQPACK: set 0-RTT settings (capacity=%zu, blocked=%zu)",
+      previous->max_table_capacity,
+      previous->blocked_streams);
+
+  return QPACK_CONFIG_OK;
+}
+
+SocketQPACK_ConfigResult
+SocketQPACK_config_complete_0rtt (SocketQPACK_Config_T config)
+{
+  if (config == NULL)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK_config_complete_0rtt: NULL config");
+      return QPACK_CONFIG_ERROR_NULL_PARAM;
+    }
+
+  if (!config->using_0rtt)
+    {
+      SOCKET_LOG_DEBUG_MSG ("SocketQPACK: complete_0rtt called but not using "
+                            "0-RTT - no action needed");
+      return QPACK_CONFIG_OK;
+    }
+
+  if (!config->peer_received)
+    {
+      SOCKET_LOG_WARN_MSG (
+          "SocketQPACK: complete_0rtt called but peer settings not received");
+      return QPACK_CONFIG_ERROR_NOT_READY;
+    }
+
+  /* Switch from 0-RTT to negotiated settings */
+  config->using_0rtt = 0;
+
+  SOCKET_LOG_DEBUG_MSG (
+      "SocketQPACK: completed 0-RTT, now using negotiated settings "
+      "(capacity=%zu, blocked=%zu)",
+      config->peer.max_table_capacity,
+      config->peer.blocked_streams);
+
+  return QPACK_CONFIG_OK;
+}
+
+int
+SocketQPACK_config_is_0rtt (const SocketQPACK_Config_T config)
+{
+  if (config == NULL)
+    return 0;
+
+  return config->using_0rtt;
+}

--- a/src/test/test_qpack_config.c
+++ b/src/test/test_qpack_config.c
@@ -1,0 +1,705 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_config.c
+ * @brief Unit tests for QPACK Configuration (RFC 9204 Section 5).
+ *
+ * Tests cover:
+ * - Settings identifiers match RFC (0x01, 0x07)
+ * - Default settings are (0, 0) per RFC
+ * - Settings validation (capacity and blocked_streams limits)
+ * - Configuration creation and management
+ * - Peer settings application
+ * - 0-RTT settings handling
+ * - Dynamic table and blocking status queries
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/SocketQPACK.h"
+
+/* Simple test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * Settings Identifier Tests
+ * ============================================================================
+ */
+
+static void
+test_settings_identifiers (void)
+{
+  printf ("  Settings identifiers match RFC 9204... ");
+
+  /* RFC 9204 Section 5: SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0x01 */
+  TEST_ASSERT (SETTINGS_QPACK_MAX_TABLE_CAPACITY == 0x01,
+               "SETTINGS_QPACK_MAX_TABLE_CAPACITY should be 0x01");
+
+  /* RFC 9204 Section 5: SETTINGS_QPACK_BLOCKED_STREAMS = 0x07 */
+  TEST_ASSERT (SETTINGS_QPACK_BLOCKED_STREAMS == 0x07,
+               "SETTINGS_QPACK_BLOCKED_STREAMS should be 0x07");
+
+  printf ("PASS\n");
+}
+
+static void
+test_settings_limits (void)
+{
+  printf ("  Settings limits match RFC 9204... ");
+
+  /* RFC 9204 Section 5: max_table_capacity limit is 2^30 - 1 */
+  TEST_ASSERT (QPACK_MAX_TABLE_CAPACITY_LIMIT == ((size_t)(1U << 30) - 1),
+               "max_table_capacity limit should be 2^30 - 1");
+
+  /* RFC 9204 Section 5: blocked_streams limit is 2^16 - 1 */
+  TEST_ASSERT (QPACK_MAX_BLOCKED_STREAMS_LIMIT == ((size_t)(1U << 16) - 1),
+               "blocked_streams limit should be 2^16 - 1");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Settings Default Tests
+ * ============================================================================
+ */
+
+static void
+test_settings_defaults (void)
+{
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Default settings are (0, 0) per RFC... ");
+
+  /* Initialize with non-zero to ensure defaults overwrite */
+  settings.max_table_capacity = 9999;
+  settings.blocked_streams = 9999;
+
+  result = SocketQPACK_settings_defaults (&settings);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "defaults should succeed");
+
+  /* RFC 9204 Section 5: "The default value is zero." */
+  TEST_ASSERT (settings.max_table_capacity == 0,
+               "default max_table_capacity should be 0");
+  TEST_ASSERT (settings.blocked_streams == 0,
+               "default blocked_streams should be 0");
+
+  printf ("PASS\n");
+}
+
+static void
+test_settings_defaults_null (void)
+{
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Settings defaults handles NULL... ");
+
+  result = SocketQPACK_settings_defaults (NULL);
+  TEST_ASSERT (result == QPACK_CONFIG_ERROR_NULL_PARAM,
+               "NULL should return error");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Settings Validation Tests
+ * ============================================================================
+ */
+
+static void
+test_settings_validate_valid (void)
+{
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Validate accepts valid settings... ");
+
+  /* Test with defaults (0, 0) */
+  SocketQPACK_settings_defaults (&settings);
+  result = SocketQPACK_settings_validate (&settings);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "defaults should be valid");
+
+  /* Test with typical values */
+  settings.max_table_capacity = 4096;
+  settings.blocked_streams = 100;
+  result = SocketQPACK_settings_validate (&settings);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "typical values should be valid");
+
+  /* Test with maximum allowed values */
+  settings.max_table_capacity = QPACK_MAX_TABLE_CAPACITY_LIMIT;
+  settings.blocked_streams = QPACK_MAX_BLOCKED_STREAMS_LIMIT;
+  result = SocketQPACK_settings_validate (&settings);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "max values should be valid");
+
+  printf ("PASS\n");
+}
+
+static void
+test_settings_validate_invalid_capacity (void)
+{
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Validate rejects invalid capacity... ");
+
+  SocketQPACK_settings_defaults (&settings);
+
+  /* Exceed max capacity limit */
+  settings.max_table_capacity = QPACK_MAX_TABLE_CAPACITY_LIMIT + 1;
+  result = SocketQPACK_settings_validate (&settings);
+  TEST_ASSERT (result == QPACK_CONFIG_ERROR_INVALID_VALUE,
+               "exceeding capacity limit should fail");
+
+  printf ("PASS\n");
+}
+
+static void
+test_settings_validate_invalid_blocked (void)
+{
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Validate rejects invalid blocked_streams... ");
+
+  SocketQPACK_settings_defaults (&settings);
+
+  /* Exceed max blocked_streams limit */
+  settings.blocked_streams = QPACK_MAX_BLOCKED_STREAMS_LIMIT + 1;
+  result = SocketQPACK_settings_validate (&settings);
+  TEST_ASSERT (result == QPACK_CONFIG_ERROR_INVALID_VALUE,
+               "exceeding blocked_streams limit should fail");
+
+  printf ("PASS\n");
+}
+
+static void
+test_settings_validate_null (void)
+{
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Validate handles NULL... ");
+
+  result = SocketQPACK_settings_validate (NULL);
+  TEST_ASSERT (result == QPACK_CONFIG_ERROR_NULL_PARAM,
+               "NULL should return error");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Settings Query Tests
+ * ============================================================================
+ */
+
+static void
+test_settings_dynamic_table_check (void)
+{
+  SocketQPACK_Settings settings;
+  int result;
+
+  printf ("  Dynamic table check... ");
+
+  /* Zero capacity disables dynamic table */
+  SocketQPACK_settings_defaults (&settings);
+  result = SocketQPACK_settings_has_dynamic_table (&settings);
+  TEST_ASSERT (result == 0, "zero capacity should disable dynamic table");
+
+  /* Non-zero capacity enables dynamic table */
+  settings.max_table_capacity = 4096;
+  result = SocketQPACK_settings_has_dynamic_table (&settings);
+  TEST_ASSERT (result != 0, "non-zero capacity should enable dynamic table");
+
+  /* NULL check */
+  result = SocketQPACK_settings_has_dynamic_table (NULL);
+  TEST_ASSERT (result == 0, "NULL should return false");
+
+  printf ("PASS\n");
+}
+
+static void
+test_settings_blocking_check (void)
+{
+  SocketQPACK_Settings settings;
+  int result;
+
+  printf ("  Blocking allowed check... ");
+
+  /* Zero blocked_streams disallows blocking */
+  SocketQPACK_settings_defaults (&settings);
+  result = SocketQPACK_settings_allows_blocking (&settings);
+  TEST_ASSERT (result == 0, "zero blocked_streams should disallow blocking");
+
+  /* Non-zero blocked_streams allows blocking */
+  settings.blocked_streams = 100;
+  result = SocketQPACK_settings_allows_blocking (&settings);
+  TEST_ASSERT (result != 0, "non-zero blocked_streams should allow blocking");
+
+  /* NULL check */
+  result = SocketQPACK_settings_allows_blocking (NULL);
+  TEST_ASSERT (result == 0, "NULL should return false");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Configuration Tests
+ * ============================================================================
+ */
+
+static void
+test_config_new (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+
+  printf ("  Config new creates valid config... ");
+
+  arena = Arena_new ();
+  TEST_ASSERT (arena != NULL, "arena should be created");
+
+  config = SocketQPACK_config_new (arena);
+  TEST_ASSERT (config != NULL, "config should be created");
+
+  /* Should not be ready (no peer settings yet) */
+  TEST_ASSERT (SocketQPACK_config_is_ready (config) == 0,
+               "new config should not be ready");
+
+  /* Should not be using 0-RTT */
+  TEST_ASSERT (SocketQPACK_config_is_0rtt (config) == 0,
+               "new config should not be 0-RTT");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_set_local (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+  const SocketQPACK_Settings *decoder_settings;
+
+  printf ("  Config set local settings... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  settings.max_table_capacity = 8192;
+  settings.blocked_streams = 50;
+
+  result = SocketQPACK_config_set_local (config, &settings);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "set local should succeed");
+
+  /* Decoder uses local settings */
+  decoder_settings = SocketQPACK_config_decoder_settings (config);
+  TEST_ASSERT (decoder_settings != NULL, "decoder settings should exist");
+  TEST_ASSERT (decoder_settings->max_table_capacity == 8192,
+               "capacity should match");
+  TEST_ASSERT (decoder_settings->blocked_streams == 50,
+               "blocked_streams should match");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_apply_peer (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+  const SocketQPACK_Settings *encoder_settings;
+
+  printf ("  Config apply peer settings... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  settings.max_table_capacity = 16384;
+  settings.blocked_streams = 200;
+
+  result = SocketQPACK_config_apply_peer (config, &settings);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "apply peer should succeed");
+
+  /* Config should now be ready */
+  TEST_ASSERT (SocketQPACK_config_is_ready (config) != 0,
+               "config should be ready after peer settings");
+
+  /* Encoder uses peer settings */
+  encoder_settings = SocketQPACK_config_encoder_settings (config);
+  TEST_ASSERT (encoder_settings != NULL, "encoder settings should exist");
+  TEST_ASSERT (encoder_settings->max_table_capacity == 16384,
+               "capacity should match");
+  TEST_ASSERT (encoder_settings->blocked_streams == 200,
+               "blocked_streams should match");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_apply_peer_invalid (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings settings;
+  SocketQPACK_ConfigResult result;
+
+  printf ("  Config rejects invalid peer settings... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  /* Invalid capacity */
+  settings.max_table_capacity = QPACK_MAX_TABLE_CAPACITY_LIMIT + 1;
+  settings.blocked_streams = 0;
+
+  result = SocketQPACK_config_apply_peer (config, &settings);
+  TEST_ASSERT (result == QPACK_CONFIG_ERROR_INVALID_VALUE,
+               "invalid peer settings should fail");
+
+  /* Config should not be ready */
+  TEST_ASSERT (SocketQPACK_config_is_ready (config) == 0,
+               "config should not be ready after failed apply");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_encoder_settings_not_ready (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  const SocketQPACK_Settings *encoder_settings;
+
+  printf ("  Encoder settings NULL when peer not received... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  /* No peer settings applied */
+  encoder_settings = SocketQPACK_config_encoder_settings (config);
+  TEST_ASSERT (encoder_settings == NULL,
+               "encoder settings should be NULL before peer received");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * 0-RTT Tests
+ * ============================================================================
+ */
+
+static void
+test_config_0rtt_set (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings previous;
+  SocketQPACK_ConfigResult result;
+  const SocketQPACK_Settings *encoder_settings;
+
+  printf ("  0-RTT settings set... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  previous.max_table_capacity = 4096;
+  previous.blocked_streams = 100;
+
+  result = SocketQPACK_config_set_0rtt (config, &previous, arena);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "set 0-RTT should succeed");
+
+  /* Should be using 0-RTT */
+  TEST_ASSERT (SocketQPACK_config_is_0rtt (config) != 0,
+               "should be using 0-RTT");
+
+  /* Encoder should use 0-RTT settings */
+  encoder_settings = SocketQPACK_config_encoder_settings (config);
+  TEST_ASSERT (encoder_settings != NULL, "0-RTT encoder settings should exist");
+  TEST_ASSERT (encoder_settings->max_table_capacity == 4096,
+               "capacity should match 0-RTT");
+  TEST_ASSERT (encoder_settings->blocked_streams == 100,
+               "blocked_streams should match 0-RTT");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_0rtt_complete (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings previous, peer;
+  SocketQPACK_ConfigResult result;
+  const SocketQPACK_Settings *encoder_settings;
+
+  printf ("  0-RTT completion switches to negotiated... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  /* Set 0-RTT settings */
+  previous.max_table_capacity = 4096;
+  previous.blocked_streams = 100;
+  SocketQPACK_config_set_0rtt (config, &previous, arena);
+
+  /* Apply new peer settings */
+  peer.max_table_capacity = 8192;
+  peer.blocked_streams = 200;
+  SocketQPACK_config_apply_peer (config, &peer);
+
+  /* Complete 0-RTT */
+  result = SocketQPACK_config_complete_0rtt (config);
+  TEST_ASSERT (result == QPACK_CONFIG_OK, "complete 0-RTT should succeed");
+
+  /* Should no longer be using 0-RTT */
+  TEST_ASSERT (SocketQPACK_config_is_0rtt (config) == 0,
+               "should not be using 0-RTT after complete");
+
+  /* Encoder should now use negotiated settings */
+  encoder_settings = SocketQPACK_config_encoder_settings (config);
+  TEST_ASSERT (encoder_settings != NULL, "encoder settings should exist");
+  TEST_ASSERT (encoder_settings->max_table_capacity == 8192,
+               "capacity should match negotiated");
+  TEST_ASSERT (encoder_settings->blocked_streams == 200,
+               "blocked_streams should match negotiated");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_0rtt_complete_not_ready (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings previous;
+  SocketQPACK_ConfigResult result;
+
+  printf ("  0-RTT complete fails if peer not received... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  /* Set 0-RTT settings but don't apply peer settings */
+  previous.max_table_capacity = 4096;
+  previous.blocked_streams = 100;
+  SocketQPACK_config_set_0rtt (config, &previous, arena);
+
+  /* Complete 0-RTT should fail */
+  result = SocketQPACK_config_complete_0rtt (config);
+  TEST_ASSERT (result == QPACK_CONFIG_ERROR_NOT_READY,
+               "complete should fail without peer settings");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Edge Case Tests
+ * ============================================================================
+ */
+
+static void
+test_config_null_handling (void)
+{
+  SocketQPACK_Settings settings;
+
+  printf ("  NULL handling... ");
+
+  /* Set local with NULL config */
+  TEST_ASSERT (SocketQPACK_config_set_local (NULL, &settings)
+                   == QPACK_CONFIG_ERROR_NULL_PARAM,
+               "set_local NULL config should fail");
+
+  /* Apply peer with NULL config */
+  TEST_ASSERT (SocketQPACK_config_apply_peer (NULL, &settings)
+                   == QPACK_CONFIG_ERROR_NULL_PARAM,
+               "apply_peer NULL config should fail");
+
+  /* Set 0-RTT with NULL */
+  TEST_ASSERT (
+      SocketQPACK_config_set_0rtt (NULL, &settings, NULL)
+          == QPACK_CONFIG_ERROR_NULL_PARAM,
+      "set_0rtt NULL config should fail");
+
+  /* Complete 0-RTT with NULL */
+  TEST_ASSERT (SocketQPACK_config_complete_0rtt (NULL)
+                   == QPACK_CONFIG_ERROR_NULL_PARAM,
+               "complete_0rtt NULL should fail");
+
+  /* Query functions with NULL */
+  TEST_ASSERT (SocketQPACK_config_encoder_settings (NULL) == NULL,
+               "encoder_settings NULL should return NULL");
+  TEST_ASSERT (SocketQPACK_config_decoder_settings (NULL) == NULL,
+               "decoder_settings NULL should return NULL");
+  TEST_ASSERT (SocketQPACK_config_is_ready (NULL) == 0,
+               "is_ready NULL should return 0");
+  TEST_ASSERT (SocketQPACK_config_is_0rtt (NULL) == 0,
+               "is_0rtt NULL should return 0");
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_zero_capacity (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings settings;
+  const SocketQPACK_Settings *encoder_settings;
+
+  printf ("  Zero capacity disables dynamic table... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  settings.max_table_capacity = 0;
+  settings.blocked_streams = 100;
+
+  SocketQPACK_config_apply_peer (config, &settings);
+
+  encoder_settings = SocketQPACK_config_encoder_settings (config);
+  TEST_ASSERT (encoder_settings != NULL, "settings should exist");
+  TEST_ASSERT (SocketQPACK_settings_has_dynamic_table (encoder_settings) == 0,
+               "dynamic table should be disabled");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_config_zero_blocked (void)
+{
+  Arena_T arena;
+  SocketQPACK_Config_T config;
+  SocketQPACK_Settings settings;
+  const SocketQPACK_Settings *encoder_settings;
+
+  printf ("  Zero blocked_streams disallows blocking... ");
+
+  arena = Arena_new ();
+  config = SocketQPACK_config_new (arena);
+
+  settings.max_table_capacity = 4096;
+  settings.blocked_streams = 0;
+
+  SocketQPACK_config_apply_peer (config, &settings);
+
+  encoder_settings = SocketQPACK_config_encoder_settings (config);
+  TEST_ASSERT (encoder_settings != NULL, "settings should exist");
+  TEST_ASSERT (SocketQPACK_settings_allows_blocking (encoder_settings) == 0,
+               "blocking should be disallowed");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_result_string (void)
+{
+  printf ("  Result string lookup... ");
+
+  TEST_ASSERT (
+      strcmp (SocketQPACK_config_result_string (QPACK_CONFIG_OK), "OK") == 0,
+      "OK string");
+  TEST_ASSERT (
+      SocketQPACK_config_result_string (QPACK_CONFIG_ERROR_INVALID_VALUE)
+          != NULL,
+      "invalid value string");
+  TEST_ASSERT (
+      SocketQPACK_config_result_string (QPACK_CONFIG_ERROR_NULL_PARAM) != NULL,
+      "null param string");
+  TEST_ASSERT (SocketQPACK_config_result_string ((SocketQPACK_ConfigResult)999)
+                   != NULL,
+               "unknown error string");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Main Test Runner
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("QPACK Configuration Unit Tests (RFC 9204 Section 5)\n");
+  printf ("====================================================\n\n");
+
+  printf ("Settings Identifier Tests:\n");
+  test_settings_identifiers ();
+  test_settings_limits ();
+
+  printf ("\nSettings Default Tests:\n");
+  test_settings_defaults ();
+  test_settings_defaults_null ();
+
+  printf ("\nSettings Validation Tests:\n");
+  test_settings_validate_valid ();
+  test_settings_validate_invalid_capacity ();
+  test_settings_validate_invalid_blocked ();
+  test_settings_validate_null ();
+
+  printf ("\nSettings Query Tests:\n");
+  test_settings_dynamic_table_check ();
+  test_settings_blocking_check ();
+
+  printf ("\nConfiguration Tests:\n");
+  test_config_new ();
+  test_config_set_local ();
+  test_config_apply_peer ();
+  test_config_apply_peer_invalid ();
+  test_config_encoder_settings_not_ready ();
+
+  printf ("\n0-RTT Tests:\n");
+  test_config_0rtt_set ();
+  test_config_0rtt_complete ();
+  test_config_0rtt_complete_not_ready ();
+
+  printf ("\nEdge Case Tests:\n");
+  test_config_null_handling ();
+  test_config_zero_capacity ();
+  test_config_zero_blocked ();
+  test_result_string ();
+
+  printf ("\n====================================================\n");
+  printf ("All QPACK Configuration tests passed!\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 5 - Configuration for QPACK header compression in HTTP/3.

- Add SETTINGS_QPACK_MAX_TABLE_CAPACITY (0x01) and SETTINGS_QPACK_BLOCKED_STREAMS (0x07) identifiers
- Default values are (0, 0) per RFC 9204 specification
- Settings validation with protocol limits (capacity: 2^30-1, blocked_streams: 2^16-1)
- Configuration structure tracking local/peer settings for encoder/decoder
- 0-RTT early data settings support per RFC 9204 Section 3.2.3
- Helper functions to query dynamic table and blocking status

## Test Plan

- [x] All 22 QPACK configuration tests pass
- [x] Tests validate RFC compliance for settings identifiers and limits
- [x] Tests cover settings validation, configuration management, and 0-RTT
- [x] Tests pass with AddressSanitizer and UndefinedBehaviorSanitizer enabled
- [x] Related HTTP/HPACK tests unaffected

Closes #3311