### PR TITLE
fix(qpack): address review feedback for PR #3343

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICAck.c
     src/quic/SocketQUICLoss.c
     src/quic/SocketQUICTLS.c
+    src/quic/SocketQPACK.c
 
 )
 
@@ -653,6 +654,7 @@ set(QUIC_HEADERS
     include/quic/SocketQUICAck.h
     include/quic/SocketQUICLoss.h
     include/quic/SocketQUICTLS.h
+    include/quic/SocketQPACK.h
 )
 
 set(SIMPLE_HEADERS
@@ -837,6 +839,7 @@ set(TEST_SOURCES
     test_quic_loss
     test_quic_key_discard
     test_quic_0rtt
+    test_qpack
 )
 
 # TLS tests (only built when TLS is enabled)

--- a/include/quic/SocketQPACK.h
+++ b/include/quic/SocketQPACK.h
@@ -1,0 +1,273 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK Primitives for HTTP/3 header compression (RFC 9204 Section 4.1).
+ *
+ * Implements the primitive encoding/decoding functions for QPACK:
+ * - Integer encoding/decoding with variable prefix sizes (3-8 bits)
+ * - String literal encoding/decoding with optional Huffman compression
+ *
+ * QPACK uses the same Huffman table as HPACK (RFC 7541 Appendix B) but
+ * supports additional prefix sizes for various instruction types.
+ *
+ * Thread Safety: All functions are thread-safe (no shared state).
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.1
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/**
+ * @brief Maximum integer value representable in QPACK (RFC 9204).
+ *
+ * QPACK integers can represent values up to 2^62-1 (4,611,686,018,427,387,903).
+ */
+#define SOCKETQPACK_INT_MAX ((uint64_t)4611686018427387903ULL)
+
+/**
+ * @brief Minimum valid prefix size for QPACK integers.
+ */
+#define SOCKETQPACK_PREFIX_MIN 3
+
+/**
+ * @brief Maximum valid prefix size for QPACK integers.
+ */
+#define SOCKETQPACK_PREFIX_MAX 8
+
+/**
+ * @brief Result codes for QPACK primitive operations.
+ */
+typedef enum
+{
+  QPACK_OK = 0,        /**< Operation succeeded */
+  QPACK_ERROR,         /**< Generic error */
+  QPACK_INCOMPLETE,    /**< Need more input data */
+  QPACK_ERROR_INTEGER, /**< Integer overflow or invalid encoding */
+  QPACK_ERROR_HUFFMAN, /**< Huffman encoding/decoding error */
+  QPACK_ERROR_BUFFER,  /**< Output buffer too small */
+  QPACK_ERROR_PREFIX,  /**< Invalid prefix bits (must be 3-8) */
+  QPACK_ERROR_NULL     /**< NULL pointer argument */
+} SocketQPACK_Result;
+
+/**
+ * @brief Huffman encoding mode for string literals.
+ */
+typedef enum
+{
+  QPACK_HUFFMAN_PLAIN = 0,  /**< Plain text encoding (no compression) */
+  QPACK_HUFFMAN_ENCODED = 1 /**< Huffman-compressed encoding */
+} SocketQPACK_Huffman_T;
+
+/**
+ * @brief Encode a prefixed integer (RFC 9204 Section 4.1.1).
+ *
+ * Encodes an integer value using the QPACK/HPACK integer encoding scheme.
+ * The prefix_bits parameter specifies how many bits of the first byte are
+ * available for the integer value.
+ *
+ * QPACK-specific prefix sizes by instruction type:
+ * - 8 bits: Required Insert Count
+ * - 7 bits: Section Ack, Delta Base
+ * - 6 bits: Insert Name Reference, Stream Cancel, Insert Count Increment,
+ *           Indexed Field Line
+ * - 5 bits: Set Dynamic Table Capacity, Insert Literal Name, Duplicate
+ * - 4 bits: Post-Base Indexed, Literal Name Reference
+ * - 3 bits: Post-Base Name Reference, Literal Name
+ *
+ * @param value       Integer value to encode (0 to 2^62-1).
+ * @param prefix_bits Number of bits available in first byte (3-8).
+ * @param output      Output buffer for encoded bytes.
+ * @param output_size Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, -1 on error.
+ *
+ * @note The first byte's high bits (above prefix_bits) are preserved
+ *       and should be set by the caller for instruction type flags.
+ *
+ * Example:
+ * @code
+ * unsigned char buf[16];
+ * // Encode value 1337 with 5-bit prefix
+ * ssize_t len = SocketQPACK_int_encode(1337, 5, buf, sizeof(buf));
+ * // len = 3, buf = {0x1f, 0x9a, 0x0a}
+ * @endcode
+ */
+extern ssize_t SocketQPACK_int_encode (uint64_t value,
+                                       int prefix_bits,
+                                       unsigned char *output,
+                                       size_t output_size);
+
+/**
+ * @brief Decode a prefixed integer (RFC 9204 Section 4.1.1).
+ *
+ * Decodes an integer value from QPACK/HPACK encoding. The prefix_bits
+ * parameter specifies how many bits of the first byte contain the
+ * integer value (the rest are instruction flags).
+ *
+ * @param input       Input buffer containing encoded integer.
+ * @param input_len   Size of input buffer in bytes.
+ * @param prefix_bits Number of bits used for integer in first byte (3-8).
+ * @param value       Output: decoded integer value.
+ * @param consumed    Output: number of bytes consumed from input.
+ *
+ * @return QPACK_OK on success, error code otherwise.
+ *
+ * @retval QPACK_OK           Successfully decoded.
+ * @retval QPACK_INCOMPLETE   Input truncated (need more bytes).
+ * @retval QPACK_ERROR_PREFIX Invalid prefix_bits (must be 3-8).
+ * @retval QPACK_ERROR_INTEGER Integer overflow (value > 2^62-1).
+ * @retval QPACK_ERROR_NULL   NULL pointer argument.
+ *
+ * Example:
+ * @code
+ * const unsigned char data[] = {0x1f, 0x9a, 0x0a};
+ * uint64_t value;
+ * size_t consumed;
+ * SocketQPACK_Result res = SocketQPACK_int_decode(data, 3, 5, &value,
+ * &consumed);
+ * // value = 1337, consumed = 3
+ * @endcode
+ */
+extern SocketQPACK_Result SocketQPACK_int_decode (const unsigned char *input,
+                                                  size_t input_len,
+                                                  int prefix_bits,
+                                                  uint64_t *value,
+                                                  size_t *consumed);
+
+/**
+ * @brief Encode a string literal (RFC 9204 Section 4.1.2).
+ *
+ * Encodes a string using optional Huffman compression (RFC 7541 Appendix B).
+ * The first byte contains:
+ * - Bit 7 (in position prefix_bits-1): Huffman flag (1=compressed, 0=plain)
+ * - Remaining bits: length prefix
+ *
+ * QPACK string prefix sizes depend on the instruction context:
+ * - 7 bits: Most common (same as HPACK)
+ * - Other sizes: Used in specific QPACK instructions
+ *
+ * @param input       Input string data.
+ * @param input_len   Length of input string in bytes.
+ * @param use_huffman 1 to enable Huffman compression, 0 for plain text.
+ * @param prefix_bits Number of bits for length prefix (3-8).
+ * @param output      Output buffer for encoded bytes.
+ * @param output_size Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, -1 on error.
+ *
+ * @note When use_huffman is 1, the function will encode using Huffman
+ *       only if it reduces the size; otherwise plain encoding is used.
+ *
+ * Example:
+ * @code
+ * unsigned char buf[256];
+ * const char *str = "www.example.org";
+ * ssize_t len = SocketQPACK_string_encode(
+ *     (const unsigned char *)str, strlen(str), 1, 7, buf, sizeof(buf));
+ * // Returns encoded length with Huffman compression
+ * @endcode
+ */
+extern ssize_t SocketQPACK_string_encode (const unsigned char *input,
+                                          size_t input_len,
+                                          int use_huffman,
+                                          int prefix_bits,
+                                          unsigned char *output,
+                                          size_t output_size);
+
+/**
+ * @brief Decode a string literal (RFC 9204 Section 4.1.2).
+ *
+ * Decodes a string from QPACK encoding, handling both plain and
+ * Huffman-compressed representations.
+ *
+ * @param input       Input buffer containing encoded string.
+ * @param input_len   Size of input buffer in bytes.
+ * @param prefix_bits Number of bits for length prefix (3-8).
+ * @param output      Output buffer for decoded string.
+ * @param output_size Size of output buffer in bytes.
+ * @param decoded_len Output: actual length of decoded string.
+ * @param consumed    Output: number of bytes consumed from input.
+ *
+ * @return QPACK_OK on success, error code otherwise.
+ *
+ * @retval QPACK_OK           Successfully decoded.
+ * @retval QPACK_INCOMPLETE   Input truncated (need more bytes).
+ * @retval QPACK_ERROR_PREFIX Invalid prefix_bits (must be 3-8).
+ * @retval QPACK_ERROR_HUFFMAN Huffman decoding failed.
+ * @retval QPACK_ERROR_BUFFER Output buffer too small.
+ * @retval QPACK_ERROR_NULL   NULL pointer argument.
+ *
+ * Example:
+ * @code
+ * const unsigned char encoded[] = {...};
+ * unsigned char decoded[256];
+ * size_t decoded_len, consumed;
+ * SocketQPACK_Result res = SocketQPACK_string_decode(
+ *     encoded, sizeof(encoded), 7, decoded, sizeof(decoded),
+ *     &decoded_len, &consumed);
+ * @endcode
+ */
+extern SocketQPACK_Result SocketQPACK_string_decode (const unsigned char *input,
+                                                     size_t input_len,
+                                                     int prefix_bits,
+                                                     unsigned char *output,
+                                                     size_t output_size,
+                                                     size_t *decoded_len,
+                                                     size_t *consumed);
+
+/**
+ * @brief Get string representation of result code.
+ *
+ * @param result Result code to convert.
+ *
+ * @return Human-readable string describing the result.
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/**
+ * @brief Calculate encoded size for an integer value.
+ *
+ * Returns the number of bytes needed to encode the given value
+ * with the specified prefix size.
+ *
+ * @param value       Value to calculate size for.
+ * @param prefix_bits Number of bits in prefix (3-8).
+ *
+ * @return Number of bytes needed, or 0 if value exceeds maximum
+ *         or prefix_bits is invalid.
+ */
+extern size_t SocketQPACK_int_size (uint64_t value, int prefix_bits);
+
+/**
+ * @brief Calculate encoded size for a string.
+ *
+ * Returns the number of bytes needed to encode the string
+ * with the specified settings.
+ *
+ * @param input       Input string data.
+ * @param input_len   Length of input string.
+ * @param use_huffman 1 for Huffman encoding, 0 for plain.
+ * @param prefix_bits Number of bits for length prefix (3-8).
+ *
+ * @return Number of bytes needed, or 0 on error.
+ */
+extern size_t SocketQPACK_string_size (const unsigned char *input,
+                                       size_t input_len,
+                                       int use_huffman,
+                                       int prefix_bits);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/quic/SocketQPACK.c
+++ b/src/quic/SocketQPACK.c
@@ -1,0 +1,496 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK.c - QPACK Primitives (RFC 9204 Section 4.1)
+ *
+ * Integer and string encoding/decoding for QPACK header compression.
+ * Reuses HPACK Huffman encoding (RFC 7541 Appendix B) but adds support
+ * for QPACK-specific prefix sizes.
+ */
+
+#include <string.h>
+
+#include "quic/SocketQPACK.h"
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/* Maximum continuation bytes for integer encoding.
+ * Each continuation byte carries 7 bits.
+ * For 62-bit values: ceil(62/7) = 9 continuation bytes max.
+ * We use 10 for safety margin. */
+#define QPACK_MAX_INT_CONTINUATION_BYTES 10
+
+/* Bit masks for integer encoding */
+#define QPACK_INT_CONTINUATION_MASK 0x80
+#define QPACK_INT_PAYLOAD_MASK 0x7F
+#define QPACK_INT_CONTINUATION_VAL 128
+
+/* Maximum safe shift to avoid overflow during decoding.
+ * 64 bits - 8 bits for last byte = 56 bits. */
+#define QPACK_MAX_SAFE_SHIFT 56
+
+/* Huffman flag position (highest bit in prefix) */
+#define QPACK_STRING_HUFFMAN_FLAG 0x80
+
+/* Conservative Huffman decode buffer ratio (worst-case is ~1.6x) */
+#define QPACK_HUFFMAN_DECODE_RATIO 2
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR_INTEGER] = "Integer overflow or invalid encoding",
+  [QPACK_ERROR_HUFFMAN] = "Huffman encoding/decoding error",
+  [QPACK_ERROR_BUFFER] = "Output buffer too small",
+  [QPACK_ERROR_PREFIX] = "Invalid prefix bits (must be 3-8)",
+  [QPACK_ERROR_NULL] = "NULL pointer argument",
+};
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if ((unsigned)result > QPACK_ERROR_NULL)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Validation Helpers
+ * ============================================================================
+ */
+
+static inline int
+valid_prefix_bits (int prefix_bits)
+{
+  return prefix_bits >= SOCKETQPACK_PREFIX_MIN
+         && prefix_bits <= SOCKETQPACK_PREFIX_MAX;
+}
+
+/* ============================================================================
+ * Integer Encoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Encode continuation bytes for values that exceed prefix capacity.
+ */
+static size_t
+encode_int_continuation (uint64_t value,
+                         unsigned char *output,
+                         size_t pos,
+                         size_t output_size)
+{
+  while (value >= QPACK_INT_CONTINUATION_VAL && pos < output_size)
+    {
+      output[pos++] = (unsigned char)(QPACK_INT_CONTINUATION_MASK
+                                      | (value & QPACK_INT_PAYLOAD_MASK));
+      value >>= 7;
+    }
+
+  if (pos >= output_size)
+    return 0;
+
+  output[pos++] = (unsigned char)value;
+  return pos;
+}
+
+ssize_t
+SocketQPACK_int_encode (uint64_t value,
+                        int prefix_bits,
+                        unsigned char *output,
+                        size_t output_size)
+{
+  uint64_t max_prefix;
+
+  if (output == NULL)
+    return -1;
+
+  if (output_size == 0)
+    return -1;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return -1;
+
+  /* Check maximum representable value */
+  if (value > SOCKETQPACK_INT_MAX)
+    return -1;
+
+  /* Calculate maximum value that fits in prefix */
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  /* Value fits in prefix - single byte encoding */
+  if (value < max_prefix)
+    {
+      output[0] = (unsigned char)value;
+      return 1;
+    }
+
+  /* Value exceeds prefix - use continuation bytes */
+  output[0] = (unsigned char)max_prefix;
+  size_t result
+      = encode_int_continuation (value - max_prefix, output, 1, output_size);
+  if (result == 0)
+    return -1;
+
+  return (ssize_t)result;
+}
+
+/* ============================================================================
+ * Integer Decoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Decode continuation bytes for multi-byte integers.
+ */
+static SocketQPACK_Result
+decode_int_continuation (const unsigned char *input,
+                         size_t input_len,
+                         size_t *pos,
+                         uint64_t *result,
+                         unsigned int *shift)
+{
+  uint64_t byte_val;
+  unsigned int continuation_count = 0;
+
+  do
+    {
+      if (*pos >= input_len)
+        return QPACK_INCOMPLETE;
+
+      continuation_count++;
+      if (continuation_count > QPACK_MAX_INT_CONTINUATION_BYTES)
+        return QPACK_ERROR_INTEGER;
+
+      byte_val = input[(*pos)++];
+
+      /* Check for overflow before shifting */
+      if (*shift > QPACK_MAX_SAFE_SHIFT)
+        return QPACK_ERROR_INTEGER;
+
+      uint64_t add_val = (byte_val & QPACK_INT_PAYLOAD_MASK) << *shift;
+      if (*result > UINT64_MAX - add_val)
+        return QPACK_ERROR_INTEGER;
+
+      *result += add_val;
+      *shift += 7;
+    }
+  while (byte_val & QPACK_INT_CONTINUATION_MASK);
+
+  /* Final overflow check against QPACK maximum */
+  if (*result > SOCKETQPACK_INT_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_int_decode (const unsigned char *input,
+                        size_t input_len,
+                        int prefix_bits,
+                        uint64_t *value,
+                        size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t max_prefix;
+  uint64_t result;
+  unsigned int shift = 0;
+
+  if (input == NULL || value == NULL || consumed == NULL)
+    return QPACK_ERROR_NULL;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR_PREFIX;
+
+  /* Extract prefix mask and initial value */
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+  result = input[pos++] & max_prefix;
+
+  /* Single-byte encoding: value fits in prefix */
+  if (result < max_prefix)
+    {
+      *value = result;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  /* Multi-byte encoding: decode continuation bytes */
+  SocketQPACK_Result cont_result
+      = decode_int_continuation (input, input_len, &pos, &result, &shift);
+  if (cont_result != QPACK_OK)
+    return cont_result;
+
+  *value = result;
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Integer Size Calculation
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_int_size (uint64_t value, int prefix_bits)
+{
+  uint64_t max_prefix;
+  size_t size;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return 0;
+
+  if (value > SOCKETQPACK_INT_MAX)
+    return 0;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  /* Value fits in prefix */
+  if (value < max_prefix)
+    return 1;
+
+  /* Count continuation bytes needed */
+  size = 1; /* prefix byte */
+  value -= max_prefix;
+  while (value >= QPACK_INT_CONTINUATION_VAL)
+    {
+      size++;
+      value >>= 7;
+    }
+  size++; /* final byte */
+
+  return size;
+}
+
+/* ============================================================================
+ * String Encoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+/**
+ * Encode integer with flag bit in the appropriate position.
+ * The flag is placed at position (8 - prefix_bits) in the first byte.
+ */
+static ssize_t
+encode_int_with_flag (uint64_t value,
+                      int prefix_bits,
+                      unsigned char flag,
+                      unsigned char *output,
+                      size_t output_size)
+{
+  ssize_t int_len
+      = SocketQPACK_int_encode (value, prefix_bits, output, output_size);
+  if (int_len <= 0)
+    return -1;
+
+  /* Set flag bit in the position determined by prefix_bits.
+   * For prefix_bits=7, the Huffman flag is at bit 7 (0x80).
+   * For prefix_bits=6, it's at bit 6 (0x40), etc. */
+  unsigned char flag_mask = (unsigned char)(1 << (prefix_bits));
+  if (flag)
+    output[0] |= flag_mask;
+
+  return int_len;
+}
+
+ssize_t
+SocketQPACK_string_encode (const unsigned char *input,
+                           size_t input_len,
+                           int use_huffman,
+                           int prefix_bits,
+                           unsigned char *output,
+                           size_t output_size)
+{
+  size_t pos = 0;
+  ssize_t encoded;
+  size_t data_len = input_len;
+  int use_huffman_actual = 0;
+
+  if (output == NULL)
+    return -1;
+
+  if (output_size == 0)
+    return -1;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return -1;
+
+  /* For non-empty strings, check if Huffman compression helps */
+  if (use_huffman && input != NULL && input_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (input, input_len);
+      if (huffman_size < input_len)
+        {
+          data_len = huffman_size;
+          use_huffman_actual = 1;
+        }
+    }
+
+  /* Encode length with Huffman flag */
+  encoded = encode_int_with_flag (data_len,
+                                  prefix_bits,
+                                  (unsigned char)use_huffman_actual,
+                                  output,
+                                  output_size);
+  if (encoded < 0)
+    return -1;
+  pos = (size_t)encoded;
+
+  /* Encode string data */
+  if (input_len > 0)
+    {
+      if (input == NULL)
+        return -1;
+
+      if (use_huffman_actual)
+        {
+          encoded = SocketHPACK_huffman_encode (
+              input, input_len, output + pos, output_size - pos);
+          if (encoded < 0)
+            return -1;
+        }
+      else
+        {
+          if (pos + input_len > output_size)
+            return -1;
+          memcpy (output + pos, input, input_len);
+          encoded = (ssize_t)input_len;
+        }
+      pos += (size_t)encoded;
+    }
+
+  return (ssize_t)pos;
+}
+
+/* ============================================================================
+ * String Decoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_string_decode (const unsigned char *input,
+                           size_t input_len,
+                           int prefix_bits,
+                           unsigned char *output,
+                           size_t output_size,
+                           size_t *decoded_len,
+                           size_t *consumed)
+{
+  size_t pos = 0;
+  int huffman;
+  uint64_t str_len;
+  SocketQPACK_Result result;
+
+  if (input == NULL || decoded_len == NULL || consumed == NULL)
+    return QPACK_ERROR_NULL;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR_PREFIX;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Extract Huffman flag from first byte */
+  unsigned char flag_mask = (unsigned char)(1 << prefix_bits);
+  huffman = (input[0] & flag_mask) != 0;
+
+  /* Decode string length */
+  result
+      = SocketQPACK_int_decode (input, input_len, prefix_bits, &str_len, &pos);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Validate string length */
+  if (str_len > SIZE_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  size_t len = (size_t)str_len;
+
+  /* Check if we have enough input data */
+  if (pos + len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Handle empty string */
+  if (len == 0)
+    {
+      *decoded_len = 0;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  /* Output buffer is required for non-empty strings */
+  if (output == NULL)
+    return QPACK_ERROR_NULL;
+
+  /* Decode string data */
+  if (huffman)
+    {
+      /* Huffman-decode the string */
+      ssize_t decoded
+          = SocketHPACK_huffman_decode (input + pos, len, output, output_size);
+      if (decoded < 0)
+        return QPACK_ERROR_HUFFMAN;
+
+      *decoded_len = (size_t)decoded;
+    }
+  else
+    {
+      /* Plain text - just copy */
+      if (len > output_size)
+        return QPACK_ERROR_BUFFER;
+
+      memcpy (output, input + pos, len);
+      *decoded_len = len;
+    }
+
+  *consumed = pos + len;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * String Size Calculation
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_string_size (const unsigned char *input,
+                         size_t input_len,
+                         int use_huffman,
+                         int prefix_bits)
+{
+  size_t data_len = input_len;
+  size_t header_len;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return 0;
+
+  /* Check if Huffman compression reduces size */
+  if (use_huffman && input != NULL && input_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (input, input_len);
+      if (huffman_size < input_len)
+        data_len = huffman_size;
+    }
+
+  /* Calculate header (length prefix) size */
+  header_len = SocketQPACK_int_size (data_len, prefix_bits);
+  if (header_len == 0)
+    return 0;
+
+  return header_len + data_len;
+}

--- a/src/test/test_qpack.c
+++ b/src/test/test_qpack.c
@@ -1,0 +1,888 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_qpack.c - Tests for QPACK Primitives (RFC 9204 Section 4.1)
+ *
+ * Tests integer encoding/decoding with various prefix sizes and
+ * string literal encoding/decoding with optional Huffman compression.
+ */
+
+#include <string.h>
+
+#include "quic/SocketQPACK.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Integer Encoding Tests
+ * ============================================================================
+ */
+
+TEST (qpack_int_encode_small_value_prefix5)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 10 with 5-bit prefix should fit in single byte */
+  len = SocketQPACK_int_encode (10, 5, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (10, buf[0] & 0x1f); /* Only check prefix bits */
+}
+
+TEST (qpack_int_encode_small_value_prefix6)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 30 with 6-bit prefix should fit in single byte */
+  len = SocketQPACK_int_encode (30, 6, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (30, buf[0] & 0x3f);
+}
+
+TEST (qpack_int_encode_small_value_prefix7)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 100 with 7-bit prefix should fit in single byte */
+  len = SocketQPACK_int_encode (100, 7, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (100, buf[0] & 0x7f);
+}
+
+TEST (qpack_int_encode_small_value_prefix8)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 200 with 8-bit prefix should fit in single byte */
+  len = SocketQPACK_int_encode (200, 8, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (200, buf[0]);
+}
+
+TEST (qpack_int_encode_value_exceeds_prefix5)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 1337 with 5-bit prefix (max prefix = 31) needs continuation */
+  len = SocketQPACK_int_encode (1337, 5, buf, sizeof (buf));
+  ASSERT (len >= 2);
+  ASSERT_EQ (0x1f, buf[0] & 0x1f); /* Prefix maxed out */
+  ASSERT (buf[1] & 0x80);          /* Continuation bit set */
+}
+
+TEST (qpack_int_encode_value_exceeds_prefix3)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 10 with 3-bit prefix (max prefix = 7) needs continuation */
+  len = SocketQPACK_int_encode (10, 3, buf, sizeof (buf));
+  ASSERT_EQ (2, len);
+  ASSERT_EQ (0x07, buf[0] & 0x07); /* Prefix maxed out (7) */
+  ASSERT_EQ (0x03, buf[1]);        /* 10 - 7 = 3, no continuation */
+}
+
+TEST (qpack_int_encode_max_62bit)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Maximum 62-bit value */
+  uint64_t max_val = SOCKETQPACK_INT_MAX;
+  len = SocketQPACK_int_encode (max_val, 8, buf, sizeof (buf));
+  ASSERT (len > 0);
+  ASSERT (len <= 10); /* Should fit in at most 10 bytes */
+}
+
+TEST (qpack_int_encode_zero)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Zero should always encode in 1 byte */
+  for (int prefix = 3; prefix <= 8; prefix++)
+    {
+      len = SocketQPACK_int_encode (0, prefix, buf, sizeof (buf));
+      ASSERT_EQ (1, len);
+      ASSERT_EQ (0, buf[0] & ((1 << prefix) - 1));
+    }
+}
+
+TEST (qpack_int_encode_invalid_prefix)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Prefix too small */
+  len = SocketQPACK_int_encode (10, 2, buf, sizeof (buf));
+  ASSERT_EQ (-1, len);
+
+  /* Prefix too large */
+  len = SocketQPACK_int_encode (10, 9, buf, sizeof (buf));
+  ASSERT_EQ (-1, len);
+}
+
+TEST (qpack_int_encode_buffer_too_small)
+{
+  unsigned char buf[1];
+  ssize_t len;
+
+  /* Large value needs more than 1 byte */
+  len = SocketQPACK_int_encode (1000000, 5, buf, sizeof (buf));
+  ASSERT_EQ (-1, len);
+}
+
+TEST (qpack_int_encode_null_buffer)
+{
+  ssize_t len = SocketQPACK_int_encode (10, 5, NULL, 16);
+  ASSERT_EQ (-1, len);
+}
+
+/* ============================================================================
+ * Integer Decoding Tests
+ * ============================================================================
+ */
+
+TEST (qpack_int_decode_small_value)
+{
+  unsigned char data[] = { 10 };
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result res;
+
+  res = SocketQPACK_int_decode (data, sizeof (data), 5, &value, &consumed);
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (10, value);
+  ASSERT_EQ (1, consumed);
+}
+
+TEST (qpack_int_decode_multi_byte)
+{
+  /* Encode 1337 with 5-bit prefix, then decode */
+  unsigned char buf[16];
+  ssize_t len = SocketQPACK_int_encode (1337, 5, buf, sizeof (buf));
+  ASSERT (len > 0);
+
+  uint64_t value;
+  size_t consumed;
+  SocketQPACK_Result res;
+
+  res = SocketQPACK_int_decode (buf, (size_t)len, 5, &value, &consumed);
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (1337, value);
+  ASSERT_EQ ((size_t)len, consumed);
+}
+
+TEST (qpack_int_decode_roundtrip_all_prefixes)
+{
+  unsigned char buf[16];
+  uint64_t test_values[] = { 0,
+                             1,
+                             10,
+                             31,
+                             63,
+                             100,
+                             127,
+                             255,
+                             1337,
+                             16383,
+                             65535,
+                             1000000,
+                             4611686018427387903ULL };
+
+  for (int prefix = 3; prefix <= 8; prefix++)
+    {
+      for (size_t i = 0; i < sizeof (test_values) / sizeof (test_values[0]);
+           i++)
+        {
+          uint64_t orig = test_values[i];
+          ssize_t len
+              = SocketQPACK_int_encode (orig, prefix, buf, sizeof (buf));
+          ASSERT (len > 0);
+
+          uint64_t decoded;
+          size_t consumed;
+          SocketQPACK_Result res;
+
+          res = SocketQPACK_int_decode (
+              buf, (size_t)len, prefix, &decoded, &consumed);
+          ASSERT_EQ (QPACK_OK, res);
+          ASSERT_EQ (orig, decoded);
+          ASSERT_EQ ((size_t)len, consumed);
+        }
+    }
+}
+
+TEST (qpack_int_decode_incomplete)
+{
+  /* Multi-byte encoding truncated */
+  unsigned char data[] = { 0x1f, 0x9a }; /* Missing final byte */
+  uint64_t value;
+  size_t consumed;
+
+  /* Set continuation bit on second byte to simulate incomplete */
+  data[1] |= 0x80;
+
+  SocketQPACK_Result res
+      = SocketQPACK_int_decode (data, sizeof (data), 5, &value, &consumed);
+  ASSERT_EQ (QPACK_INCOMPLETE, res);
+}
+
+TEST (qpack_int_decode_empty_input)
+{
+  uint64_t value;
+  size_t consumed;
+
+  SocketQPACK_Result res
+      = SocketQPACK_int_decode (NULL, 0, 5, &value, &consumed);
+  ASSERT_NE (QPACK_OK, res);
+}
+
+TEST (qpack_int_decode_invalid_prefix)
+{
+  unsigned char data[] = { 10 };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQPACK_Result res
+      = SocketQPACK_int_decode (data, sizeof (data), 2, &value, &consumed);
+  ASSERT_EQ (QPACK_ERROR_PREFIX, res);
+
+  res = SocketQPACK_int_decode (data, sizeof (data), 9, &value, &consumed);
+  ASSERT_EQ (QPACK_ERROR_PREFIX, res);
+}
+
+TEST (qpack_int_decode_null_pointers)
+{
+  unsigned char data[] = { 10 };
+  uint64_t value;
+  size_t consumed;
+
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_int_decode (NULL, 1, 5, &value, &consumed));
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_int_decode (data, 1, 5, NULL, &consumed));
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_int_decode (data, 1, 5, &value, NULL));
+}
+
+/* ============================================================================
+ * Integer Size Calculation Tests
+ * ============================================================================
+ */
+
+TEST (qpack_int_size_small_values)
+{
+  /* Values that fit in prefix should return 1 */
+  ASSERT_EQ (1, SocketQPACK_int_size (10, 5));  /* 10 < 31 */
+  ASSERT_EQ (1, SocketQPACK_int_size (30, 5));  /* 30 < 31 */
+  ASSERT_EQ (1, SocketQPACK_int_size (63, 7));  /* 63 < 127 */
+  ASSERT_EQ (1, SocketQPACK_int_size (254, 8)); /* 254 < 255 */
+}
+
+TEST (qpack_int_size_large_values)
+{
+  /* Values exceeding prefix need continuation bytes */
+  size_t size = SocketQPACK_int_size (1337, 5);
+  ASSERT (size > 1);
+
+  /* Verify size matches actual encoding */
+  unsigned char buf[16];
+  ssize_t len = SocketQPACK_int_encode (1337, 5, buf, sizeof (buf));
+  ASSERT_EQ ((size_t)len, size);
+}
+
+TEST (qpack_int_size_max_value)
+{
+  size_t size = SocketQPACK_int_size (SOCKETQPACK_INT_MAX, 8);
+  ASSERT (size > 0);
+  ASSERT (size <= 10);
+}
+
+TEST (qpack_int_size_invalid_prefix)
+{
+  ASSERT_EQ (0, SocketQPACK_int_size (10, 2));
+  ASSERT_EQ (0, SocketQPACK_int_size (10, 9));
+}
+
+/* ============================================================================
+ * String Encoding Tests
+ * ============================================================================
+ */
+
+TEST (qpack_string_encode_plain)
+{
+  unsigned char buf[256];
+  const char *str = "hello";
+  size_t str_len = strlen (str);
+
+  ssize_t len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 0, 7, buf, sizeof (buf));
+  ASSERT (len > 0);
+
+  /* First byte should have Huffman bit clear and length in lower 7 bits */
+  ASSERT_EQ (0, buf[0] & 0x80); /* Huffman flag off */
+  ASSERT_EQ (5, buf[0] & 0x7f); /* Length = 5 */
+
+  /* Remaining bytes should be the string itself */
+  ASSERT (memcmp (buf + 1, str, str_len) == 0);
+}
+
+TEST (qpack_string_encode_huffman)
+{
+  unsigned char buf[256];
+  const char *str = "www.example.org";
+  size_t str_len = strlen (str);
+
+  ssize_t len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 1, 7, buf, sizeof (buf));
+  ASSERT (len > 0);
+
+  /* If Huffman helps, the flag should be set */
+  /* Note: may or may not use Huffman depending on compression ratio */
+}
+
+TEST (qpack_string_encode_empty)
+{
+  unsigned char buf[16];
+
+  ssize_t len = SocketQPACK_string_encode (NULL, 0, 0, 7, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0, buf[0] & 0x7f); /* Length = 0 */
+}
+
+TEST (qpack_string_encode_prefix3)
+{
+  unsigned char buf[256];
+  const char *str = "test";
+  size_t str_len = strlen (str);
+
+  ssize_t len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 0, 3, buf, sizeof (buf));
+  ASSERT (len > 0);
+
+  /* With 3-bit prefix, length 4 should fit but Huffman flag at bit 3 */
+  ASSERT_EQ (4, buf[0] & 0x07); /* Length in lower 3 bits */
+}
+
+TEST (qpack_string_encode_large)
+{
+  unsigned char buf[8192];
+  unsigned char input[4096];
+  memset (input, 'a', sizeof (input));
+
+  ssize_t len = SocketQPACK_string_encode (
+      input, sizeof (input), 0, 7, buf, sizeof (buf));
+  ASSERT (len > 0);
+}
+
+TEST (qpack_string_encode_invalid_prefix)
+{
+  unsigned char buf[16];
+  const char *str = "test";
+
+  ASSERT_EQ (-1,
+             SocketQPACK_string_encode (
+                 (const unsigned char *)str, 4, 0, 2, buf, sizeof (buf)));
+  ASSERT_EQ (-1,
+             SocketQPACK_string_encode (
+                 (const unsigned char *)str, 4, 0, 9, buf, sizeof (buf)));
+}
+
+TEST (qpack_string_encode_buffer_too_small)
+{
+  unsigned char buf[2];
+  const char *str = "hello world";
+
+  ssize_t len = SocketQPACK_string_encode (
+      (const unsigned char *)str, strlen (str), 0, 7, buf, sizeof (buf));
+  ASSERT_EQ (-1, len);
+}
+
+/* ============================================================================
+ * String Decoding Tests
+ * ============================================================================
+ */
+
+TEST (qpack_string_decode_plain)
+{
+  /* Encode then decode */
+  unsigned char encoded[256];
+  unsigned char decoded[256];
+  const char *str = "hello";
+  size_t str_len = strlen (str);
+
+  ssize_t enc_len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 0, 7, encoded, sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  size_t decoded_len, consumed;
+  SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                      (size_t)enc_len,
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (str_len, decoded_len);
+  ASSERT_EQ ((size_t)enc_len, consumed);
+  ASSERT (memcmp (decoded, str, str_len) == 0);
+}
+
+TEST (qpack_string_decode_huffman_roundtrip)
+{
+  unsigned char encoded[256];
+  unsigned char decoded[256];
+  const char *str = "www.example.org";
+  size_t str_len = strlen (str);
+
+  ssize_t enc_len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 1, 7, encoded, sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  size_t decoded_len, consumed;
+  SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                      (size_t)enc_len,
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (str_len, decoded_len);
+  ASSERT (memcmp (decoded, str, str_len) == 0);
+}
+
+TEST (qpack_string_decode_empty)
+{
+  unsigned char encoded[16];
+  unsigned char decoded[16];
+
+  ssize_t enc_len
+      = SocketQPACK_string_encode (NULL, 0, 0, 7, encoded, sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  size_t decoded_len, consumed;
+  SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                      (size_t)enc_len,
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (0, decoded_len);
+}
+
+TEST (qpack_string_decode_all_prefixes)
+{
+  for (int prefix = 3; prefix <= 8; prefix++)
+    {
+      unsigned char encoded[256];
+      unsigned char decoded[256];
+      const char *str = "test string";
+      size_t str_len = strlen (str);
+
+      ssize_t enc_len = SocketQPACK_string_encode ((const unsigned char *)str,
+                                                   str_len,
+                                                   0,
+                                                   prefix,
+                                                   encoded,
+                                                   sizeof (encoded));
+      ASSERT (enc_len > 0);
+
+      size_t decoded_len, consumed;
+      SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                          (size_t)enc_len,
+                                                          prefix,
+                                                          decoded,
+                                                          sizeof (decoded),
+                                                          &decoded_len,
+                                                          &consumed);
+      ASSERT_EQ (QPACK_OK, res);
+      ASSERT_EQ (str_len, decoded_len);
+      ASSERT (memcmp (decoded, str, str_len) == 0);
+    }
+}
+
+TEST (qpack_string_decode_incomplete)
+{
+  unsigned char data[] = { 0x05 }; /* Length 5, but no data */
+  unsigned char decoded[256];
+  size_t decoded_len, consumed;
+
+  SocketQPACK_Result res = SocketQPACK_string_decode (data,
+                                                      sizeof (data),
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+  ASSERT_EQ (QPACK_INCOMPLETE, res);
+}
+
+TEST (qpack_string_decode_buffer_too_small)
+{
+  unsigned char encoded[256];
+  unsigned char decoded[2];
+  const char *str = "hello world this is a long string";
+
+  ssize_t enc_len = SocketQPACK_string_encode ((const unsigned char *)str,
+                                               strlen (str),
+                                               0,
+                                               7,
+                                               encoded,
+                                               sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  size_t decoded_len, consumed;
+  SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                      (size_t)enc_len,
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+  ASSERT_EQ (QPACK_ERROR_BUFFER, res);
+}
+
+TEST (qpack_string_decode_invalid_prefix)
+{
+  unsigned char data[] = { 0x05, 'h', 'e', 'l', 'l', 'o' };
+  unsigned char decoded[256];
+  size_t decoded_len, consumed;
+
+  ASSERT_EQ (QPACK_ERROR_PREFIX,
+             SocketQPACK_string_decode (data,
+                                        sizeof (data),
+                                        2,
+                                        decoded,
+                                        sizeof (decoded),
+                                        &decoded_len,
+                                        &consumed));
+}
+
+TEST (qpack_string_decode_null_pointers)
+{
+  unsigned char data[] = { 0x05, 'h', 'e', 'l', 'l', 'o' };
+  unsigned char decoded[256];
+  size_t decoded_len, consumed;
+
+  ASSERT_EQ (
+      QPACK_ERROR_NULL,
+      SocketQPACK_string_decode (
+          NULL, 6, 7, decoded, sizeof (decoded), &decoded_len, &consumed));
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_string_decode (
+                 data, 6, 7, decoded, sizeof (decoded), NULL, &consumed));
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_string_decode (
+                 data, 6, 7, decoded, sizeof (decoded), &decoded_len, NULL));
+}
+
+/* ============================================================================
+ * String Size Calculation Tests
+ * ============================================================================
+ */
+
+TEST (qpack_string_size_plain)
+{
+  const char *str = "hello";
+  size_t str_len = strlen (str);
+
+  size_t size
+      = SocketQPACK_string_size ((const unsigned char *)str, str_len, 0, 7);
+  ASSERT (size > 0);
+
+  /* Verify against actual encoding */
+  unsigned char buf[256];
+  ssize_t enc_len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 0, 7, buf, sizeof (buf));
+  ASSERT_EQ (size, (size_t)enc_len);
+}
+
+TEST (qpack_string_size_huffman)
+{
+  const char *str = "www.example.org";
+  size_t str_len = strlen (str);
+
+  size_t size
+      = SocketQPACK_string_size ((const unsigned char *)str, str_len, 1, 7);
+  ASSERT (size > 0);
+
+  unsigned char buf[256];
+  ssize_t enc_len = SocketQPACK_string_encode (
+      (const unsigned char *)str, str_len, 1, 7, buf, sizeof (buf));
+  ASSERT_EQ (size, (size_t)enc_len);
+}
+
+TEST (qpack_string_size_empty)
+{
+  size_t size = SocketQPACK_string_size (NULL, 0, 0, 7);
+  ASSERT_EQ (1, size); /* Just the length byte */
+}
+
+TEST (qpack_string_size_invalid_prefix)
+{
+  ASSERT_EQ (0,
+             SocketQPACK_string_size ((const unsigned char *)"test", 4, 0, 2));
+}
+
+/* ============================================================================
+ * Result String Tests
+ * ============================================================================
+ */
+
+TEST (qpack_result_string)
+{
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_OK));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_INCOMPLETE));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_INTEGER));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_HUFFMAN));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_BUFFER));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_PREFIX));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_NULL));
+
+  /* Invalid result code should return something */
+  ASSERT_NOT_NULL (SocketQPACK_result_string ((SocketQPACK_Result)999));
+}
+
+/* ============================================================================
+ * Edge Case Tests
+ * ============================================================================
+ */
+
+TEST (qpack_int_boundary_values)
+{
+  unsigned char buf[16];
+  uint64_t value;
+  size_t consumed;
+  ssize_t len;
+
+  /* Test boundary values for each prefix size */
+  for (int prefix = 3; prefix <= 8; prefix++)
+    {
+      uint64_t max_prefix = ((uint64_t)1 << prefix) - 1;
+
+      /* Value exactly at prefix maximum - 1 (fits in prefix) */
+      len = SocketQPACK_int_encode (max_prefix - 1, prefix, buf, sizeof (buf));
+      ASSERT_EQ (1, len);
+      ASSERT_EQ (
+          QPACK_OK,
+          SocketQPACK_int_decode (buf, (size_t)len, prefix, &value, &consumed));
+      ASSERT_EQ (max_prefix - 1, value);
+
+      /* Value exactly at prefix maximum (triggers continuation) */
+      len = SocketQPACK_int_encode (max_prefix, prefix, buf, sizeof (buf));
+      ASSERT (len >= 2);
+      ASSERT_EQ (
+          QPACK_OK,
+          SocketQPACK_int_decode (buf, (size_t)len, prefix, &value, &consumed));
+      ASSERT_EQ (max_prefix, value);
+
+      /* Value at prefix maximum + 1 */
+      len = SocketQPACK_int_encode (max_prefix + 1, prefix, buf, sizeof (buf));
+      ASSERT (len >= 2);
+      ASSERT_EQ (
+          QPACK_OK,
+          SocketQPACK_int_decode (buf, (size_t)len, prefix, &value, &consumed));
+      ASSERT_EQ (max_prefix + 1, value);
+    }
+}
+
+TEST (qpack_string_binary_data)
+{
+  unsigned char encoded[256];
+  unsigned char decoded[256];
+  unsigned char binary_data[] = { 0x00, 0x01, 0x02, 0xff, 0xfe, 0x80, 0x7f };
+
+  ssize_t enc_len = SocketQPACK_string_encode (
+      binary_data, sizeof (binary_data), 0, 7, encoded, sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  size_t decoded_len, consumed;
+  SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                      (size_t)enc_len,
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (sizeof (binary_data), decoded_len);
+  ASSERT (memcmp (decoded, binary_data, sizeof (binary_data)) == 0);
+}
+
+TEST (qpack_int_encode_values_0_to_100)
+{
+  unsigned char buf[16];
+
+  for (int prefix = 3; prefix <= 8; prefix++)
+    {
+      for (uint64_t i = 0; i <= 100; i++)
+        {
+          ssize_t len = SocketQPACK_int_encode (i, prefix, buf, sizeof (buf));
+          ASSERT (len > 0);
+
+          uint64_t decoded;
+          size_t consumed;
+          SocketQPACK_Result res = SocketQPACK_int_decode (
+              buf, (size_t)len, prefix, &decoded, &consumed);
+          ASSERT_EQ (QPACK_OK, res);
+          ASSERT_EQ (i, decoded);
+        }
+    }
+}
+
+/* ============================================================================
+ * Security/Overflow Tests
+ * ============================================================================
+ */
+
+/**
+ * Test too many continuation bytes (attack vector).
+ * Malicious encoder could send indefinite continuation bytes.
+ * Implementation must reject after QPACK_MAX_INT_CONTINUATION_BYTES (10).
+ */
+TEST (qpack_int_decode_too_many_continuation_bytes)
+{
+  /* Build malicious sequence: prefix maxed + 12 continuation bytes */
+  unsigned char malicious[16];
+  uint64_t value;
+  size_t consumed;
+
+  malicious[0] = 0x1f; /* 5-bit prefix maxed out (31) */
+  for (int i = 1; i <= 12; i++)
+    malicious[i] = 0x80; /* Continuation bit set, payload 0 */
+  malicious[13] = 0x00; /* Final byte (no continuation) */
+
+  SocketQPACK_Result res = SocketQPACK_int_decode (
+      malicious, sizeof (malicious), 5, &value, &consumed);
+
+  /* Must reject - too many continuation bytes */
+  ASSERT_EQ (QPACK_ERROR_INTEGER, res);
+}
+
+/**
+ * Test shift overflow protection.
+ * After 8 continuation bytes, shift would exceed 56 bits.
+ * Implementation must reject before allowing dangerous shifts.
+ */
+TEST (qpack_int_decode_shift_overflow)
+{
+  /* Create input that requires shifts > 56 bits.
+   * 9 continuation bytes = 63-bit shift (7*9=63 > 56). */
+  unsigned char overflow_input[12];
+  uint64_t value;
+  size_t consumed;
+
+  /* First byte fills prefix */
+  overflow_input[0] = 0x1F;
+
+  /* 9 continuation bytes - would shift by 63 bits */
+  for (int i = 1; i < 10; i++)
+    overflow_input[i] = 0x81; /* continuation + value 1 */
+
+  /* Final byte */
+  overflow_input[10] = 0x01;
+
+  SocketQPACK_Result res = SocketQPACK_int_decode (
+      overflow_input, 11, 5, &value, &consumed);
+  ASSERT_EQ (QPACK_ERROR_INTEGER, res);
+}
+
+/**
+ * Test value exceeding SOCKETQPACK_INT_MAX (2^62-1).
+ * Encoder must reject values that overflow 62-bit QPACK limit.
+ */
+TEST (qpack_int_encode_exceeds_max)
+{
+  unsigned char buf[16];
+
+  /* SOCKETQPACK_INT_MAX + 1 should be rejected */
+  uint64_t over_max = SOCKETQPACK_INT_MAX + 1;
+  ssize_t len = SocketQPACK_int_encode (over_max, 8, buf, sizeof (buf));
+  ASSERT_EQ (-1, len);
+
+  /* SOCKETQPACK_INT_MAX should succeed */
+  len = SocketQPACK_int_encode (SOCKETQPACK_INT_MAX, 8, buf, sizeof (buf));
+  ASSERT (len > 0);
+}
+
+/**
+ * Test int_size with value exceeding maximum.
+ */
+TEST (qpack_int_size_exceeds_max)
+{
+  uint64_t over_max = SOCKETQPACK_INT_MAX + 1;
+  size_t size = SocketQPACK_int_size (over_max, 8);
+  ASSERT_EQ (0, size);
+}
+
+/**
+ * Test string encode with non-null input but zero length.
+ * Edge case: pointer is valid but length is 0.
+ */
+TEST (qpack_string_encode_non_null_zero_len)
+{
+  unsigned char buf[16];
+  const char *str = "hello";
+
+  /* Non-NULL input with 0 length should work like empty string */
+  ssize_t len = SocketQPACK_string_encode (
+      (const unsigned char *)str, 0, 0, 7, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (0, buf[0] & 0x7f); /* Length = 0 */
+}
+
+/**
+ * Test decoding crafted input that could trigger integer overflow.
+ * Accumulating large values in continuation bytes.
+ */
+TEST (qpack_int_decode_accumulation_overflow)
+{
+  /* Craft bytes that would overflow uint64_t during addition:
+   * Each continuation byte adds (value & 0x7F) << shift to result.
+   * With 8 continuation bytes maxing payload, we can test overflow. */
+  unsigned char overflow_input[] = {
+    0xFF, /* 8-bit prefix maxed out (255) */
+    0xFF, /* 127 << 0 */
+    0xFF, /* 127 << 7 */
+    0xFF, /* 127 << 14 */
+    0xFF, /* 127 << 21 */
+    0xFF, /* 127 << 28 */
+    0xFF, /* 127 << 35 */
+    0xFF, /* 127 << 42 */
+    0xFF, /* 127 << 49 */
+    0x7F, /* 127 << 56 - would exceed QPACK max */
+  };
+  uint64_t value;
+  size_t consumed;
+
+  SocketQPACK_Result res = SocketQPACK_int_decode (
+      overflow_input, sizeof (overflow_input), 8, &value, &consumed);
+
+  /* Should return error - value exceeds SOCKETQPACK_INT_MAX */
+  ASSERT_EQ (QPACK_ERROR_INTEGER, res);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
Addresses review feedback for PR #3343 (QPACK Primitives RFC 9204 §4.1):

**Code Fix:**
- Remove redundant `result < 0` check in `SocketQPACK_result_string()` - enum is unsigned starting at 0, so this check is always false. Changed to `(unsigned)result > QPACK_ERROR_NULL`

**Security Tests Added:**
1. `qpack_int_decode_too_many_continuation_bytes` - Reject malicious inputs with >10 continuation bytes
2. `qpack_int_decode_shift_overflow` - Prevent shifts exceeding 56 bits
3. `qpack_int_encode_exceeds_max` - Reject values >SOCKETQPACK_INT_MAX
4. `qpack_int_size_exceeds_max` - Return 0 for overflow values
5. `qpack_string_encode_non_null_zero_len` - Handle edge case
6. `qpack_int_decode_accumulation_overflow` - Detect overflow during value accumulation

All 51 tests pass with ASan/UBSan enabled.

## Test plan
- [x] Build with sanitizers: `cmake -DENABLE_SANITIZERS=ON`
- [x] Run tests: `./test_qpack` - 51/51 pass