### PR TITLE
feat(qpack): implement Known Received Count tracking (RFC 9204 Section 2.1.4)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,9 @@ set(LIB_SOURCES
     src/http/h2/SocketHTTP2-validate.c
     src/http/h2/SocketHTTP2-priority.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-encoder.c
+
     # HTTP Client API
     src/http/SocketHTTPClient.c
     src/http/client/SocketHTTPClient-pool.c
@@ -837,6 +840,8 @@ set(TEST_SOURCES
     test_quic_loss
     test_quic_key_discard
     test_quic_0rtt
+    # QPACK tests (RFC 9204)
+    test_qpack_krc
 )
 
 # TLS tests (only built when TLS is enabled)

--- a/include/http/qpack/SocketQPACK-private.h
+++ b/include/http/qpack/SocketQPACK-private.h
@@ -1,0 +1,137 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-private.h
+ * @brief Internal QPACK structures and constants.
+ * @internal
+ *
+ * Private implementation for QPACK (RFC 9204). Use SocketQPACK.h for public
+ * API.
+ *
+ * @since 1.0.0
+ */
+
+#ifndef SOCKETQPACK_PRIVATE_INCLUDED
+#define SOCKETQPACK_PRIVATE_INCLUDED
+
+#include "http/qpack/SocketQPACK.h"
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "core/SocketSecurity.h"
+
+/* ============================================================================
+ * INTERNAL CONSTANTS
+ * ============================================================================
+ */
+
+/** Average entry size estimate for capacity calculation */
+#define QPACK_AVERAGE_ENTRY_SIZE 50
+
+/** Minimum dynamic table capacity (entries, power of 2) */
+#define QPACK_MIN_TABLE_CAPACITY 16
+
+/* ============================================================================
+ * DYNAMIC TABLE ENTRY
+ * ============================================================================
+ */
+
+/**
+ * @brief Dynamic table entry structure.
+ * @internal
+ *
+ * Each entry stores a header field (name/value pair) with its absolute index.
+ * Entries form a doubly-linked list for FIFO eviction order.
+ *
+ * @since 1.0.0
+ */
+typedef struct QPACK_Entry
+{
+  char *name;               /**< Field name (arena-allocated) */
+  size_t name_len;          /**< Name length in bytes */
+  char *value;              /**< Field value (arena-allocated) */
+  size_t value_len;         /**< Value length in bytes */
+  size_t abs_index;         /**< Absolute index (0 = first ever inserted) */
+  struct QPACK_Entry *prev; /**< Previous entry (towards tail/oldest) */
+  struct QPACK_Entry *next; /**< Next entry (towards head/newest) */
+} QPACK_Entry;
+
+/* ============================================================================
+ * ENCODER STRUCTURE - RFC 9204 Section 2.1.4
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK encoder state.
+ * @internal
+ *
+ * Implements the encoder side of RFC 9204. Key fields:
+ * - known_received_count: KRC per Section 2.1.4, tracks decoder acknowledgment
+ * - insert_count: Total insertions, next absolute index to assign
+ *
+ * The relationship between KRC and insert_count:
+ * - KRC <= insert_count always (cannot acknowledge what wasn't sent)
+ * - Entries with abs_index < KRC are safe to reference without blocking
+ * - Entries with abs_index >= KRC may cause decoder to block
+ *
+ * @since 1.0.0
+ */
+struct SocketQPACK_Encoder
+{
+  Arena_T arena; /**< Memory arena for allocations */
+
+  /* Dynamic table state */
+  QPACK_Entry *head;     /**< Most recently inserted entry */
+  QPACK_Entry *tail;     /**< Oldest entry (evicted first) */
+  size_t entry_count;    /**< Current number of entries in table */
+  size_t table_size;     /**< Current table size in bytes */
+  size_t max_table_size; /**< Maximum allowed table size */
+  size_t insert_count;   /**< Total entries ever inserted (monotonic) */
+
+  /* RFC 9204 Section 2.1.4: Known Received Count */
+  size_t known_received_count; /**< Highest acknowledged absolute index + 1 */
+
+  /* Note: The KRC represents the number of insertions the decoder has
+   * acknowledged receiving. Entries with absolute index < KRC are guaranteed
+   * to be in the decoder's table and can be safely referenced.
+   *
+   * KRC is updated by:
+   * 1. Section Acknowledgment (Section 4.4.1): KRC = max(KRC, RIC)
+   * 2. Insert Count Increment (Section 4.4.3): KRC += increment
+   */
+};
+
+/* ============================================================================
+ * INTERNAL HELPERS
+ * ============================================================================
+ */
+
+/**
+ * @brief Calculate entry size per RFC 9204 Section 3.2.1.
+ * @internal
+ *
+ * Entry size = name length + value length + 32 bytes overhead.
+ *
+ * @param name_len  Name length in bytes
+ * @param value_len Value length in bytes
+ * @return Entry size in bytes, or SIZE_MAX on overflow
+ *
+ * @since 1.0.0
+ */
+static inline size_t
+qpack_entry_size (size_t name_len, size_t value_len)
+{
+  size_t temp;
+  if (SocketSecurity_check_add (name_len, value_len, &temp)
+      && SocketSecurity_check_add (temp, SOCKETQPACK_ENTRY_OVERHEAD, &temp))
+    {
+      return temp;
+    }
+  return SIZE_MAX;
+}
+
+#endif /* SOCKETQPACK_PRIVATE_INCLUDED */

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -1,0 +1,292 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression/decompression for HTTP/3 (RFC 9204).
+ *
+ * Implements QPACK algorithm with static table (99 entries), dynamic table
+ * with absolute indexing, and three index conversion schemes as per RFC 9204
+ * Sections 3.2.4-3.2.6.
+ *
+ * Known Received Count (KRC) - RFC 9204 Section 2.1.4:
+ * The encoder tracks which dynamic table entries have been acknowledged by
+ * the decoder. Only entries with absolute index < KRC can be safely referenced
+ * in non-blocking representations.
+ *
+ * Thread Safety: Encoder/decoder instances are NOT thread-safe. One instance
+ * per connection/thread recommended. Static functions are thread-safe.
+ *
+ * @since 1.0.0
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/* ============================================================================
+ * COMPILER ATTRIBUTES
+ * ============================================================================
+ */
+
+#if defined(__GNUC__) || defined(__clang__)
+#define QPACK_NONNULL(...) __attribute__ ((nonnull (__VA_ARGS__)))
+#define QPACK_WARN_UNUSED __attribute__ ((warn_unused_result))
+#else
+#define QPACK_NONNULL(...)
+#define QPACK_WARN_UNUSED
+#endif
+
+/* ============================================================================
+ * CONFIGURATION CONSTANTS
+ * ============================================================================
+ */
+
+#ifndef SOCKETQPACK_DEFAULT_TABLE_SIZE
+#define SOCKETQPACK_DEFAULT_TABLE_SIZE 4096
+#endif
+
+#ifndef SOCKETQPACK_MAX_TABLE_SIZE
+#define SOCKETQPACK_MAX_TABLE_SIZE (64 * 1024)
+#endif
+
+#ifndef SOCKETQPACK_MAX_BLOCKED_STREAMS
+#define SOCKETQPACK_MAX_BLOCKED_STREAMS 100
+#endif
+
+/** RFC 9204 Section 3.2.1: Entry overhead is 32 bytes (same as HPACK) */
+#define SOCKETQPACK_ENTRY_OVERHEAD 32
+
+/** RFC 9204 Appendix A: Static table has 99 entries (0-indexed) */
+#define SOCKETQPACK_STATIC_TABLE_SIZE 99
+
+/* ============================================================================
+ * ERROR CODES
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK operation result codes.
+ *
+ * RFC 9204 Section 2.2.3 specifies error handling requirements.
+ *
+ * @since 1.0.0
+ */
+typedef enum
+{
+  QPACK_OK = 0,            /**< Operation successful */
+  QPACK_INCOMPLETE,        /**< Need more data to complete operation */
+  QPACK_ERR_INVALID_INDEX, /**< Index out of valid range */
+  QPACK_ERR_EVICTED_INDEX, /**< Referenced entry has been evicted */
+  QPACK_ERR_FUTURE_INDEX,  /**< Index references not-yet-inserted entry */
+  QPACK_ERR_BASE_OVERFLOW, /**< Base would exceed Insert Count */
+  QPACK_ERR_TABLE_SIZE,    /**< Dynamic table size limit exceeded */
+  QPACK_ERR_HEADER_SIZE,   /**< Individual header size limit exceeded */
+  QPACK_ERR_HUFFMAN,       /**< Huffman decoding error */
+  QPACK_ERR_INTEGER,       /**< Integer decoding error */
+  QPACK_ERR_DECOMPRESSION, /**< Decompression failed (bomb protection) */
+  QPACK_ERR_NULL_PARAM,    /**< NULL parameter passed to function */
+  QPACK_ERR_INTERNAL       /**< Internal error */
+} SocketQPACK_Result;
+
+/* ============================================================================
+ * OPAQUE TYPES
+ * ============================================================================
+ */
+
+/**
+ * @brief Opaque type for QPACK encoder.
+ *
+ * Manages header compression state including the dynamic table, Known Received
+ * Count (KRC), and blocked stream tracking as per RFC 9204.
+ *
+ * @since 1.0.0
+ */
+typedef struct SocketQPACK_Encoder *SocketQPACK_Encoder_T;
+
+/* ============================================================================
+ * ENCODER CREATION/DESTRUCTION
+ * ============================================================================
+ */
+
+/**
+ * @brief Create a new QPACK encoder.
+ *
+ * Creates an encoder with the specified maximum dynamic table size. The
+ * encoder's Known Received Count (KRC) is initialized to 0.
+ *
+ * @param arena      Memory arena for allocations
+ * @param max_table_size Maximum dynamic table size in bytes (0 = disable)
+ * @return New encoder instance, never NULL
+ * @throws Mem_Failed on allocation failure
+ *
+ * @note The encoder is not thread-safe. Use one encoder per QUIC connection.
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED QPACK_NONNULL (1) SocketQPACK_Encoder_T
+    SocketQPACK_Encoder_new (Arena_T arena, size_t max_table_size);
+
+/**
+ * @brief Free encoder resources.
+ *
+ * Sets the encoder pointer to NULL after cleanup. Safe to call with NULL.
+ *
+ * @param encoder Pointer to encoder (will be set to NULL)
+ *
+ * @since 1.0.0
+ */
+extern void SocketQPACK_Encoder_free (SocketQPACK_Encoder_T *encoder);
+
+/* ============================================================================
+ * KNOWN RECEIVED COUNT (KRC) - RFC 9204 Section 2.1.4
+ *
+ * The KRC tracks the highest absolute index that the decoder has confirmed
+ * receiving. Entries with index < KRC can be safely referenced without
+ * blocking the decoder.
+ * ============================================================================
+ */
+
+/**
+ * @brief Get the current Known Received Count.
+ *
+ * RFC 9204 Section 2.1.4: The Known Received Count is the highest absolute
+ * index that has been acknowledged by the decoder. The encoder can safely
+ * reference entries with absolute index < KRC without causing the decoder
+ * to block.
+ *
+ * @param encoder QPACK encoder instance
+ * @return Current Known Received Count, or 0 if encoder is NULL
+ *
+ * @since 1.0.0
+ */
+extern size_t
+SocketQPACK_Encoder_known_received_count (SocketQPACK_Encoder_T encoder);
+
+/**
+ * @brief Check if an absolute index is acknowledged (safe to reference).
+ *
+ * RFC 9204 Section 2.1.4: An entry is considered acknowledged if its absolute
+ * index is less than the Known Received Count. Acknowledged entries can be
+ * referenced in non-blocking representations.
+ *
+ * @param encoder   QPACK encoder instance
+ * @param abs_index Absolute index to check
+ * @return true if index < KRC (acknowledged), false otherwise
+ *
+ * @note This is the primary function for determining whether to use a
+ *       blocking or non-blocking representation when encoding headers.
+ *
+ * @since 1.0.0
+ */
+extern bool SocketQPACK_Encoder_is_acknowledged (SocketQPACK_Encoder_T encoder,
+                                                 size_t abs_index);
+
+/**
+ * @brief Process a Section Acknowledgment decoder instruction.
+ *
+ * RFC 9204 Section 4.4.1 / Section 2.1.4: When the decoder acknowledges a
+ * field section, it sends the Required Insert Count (RIC) of that section.
+ * The encoder updates KRC to max(KRC, RIC) because any entry referenced by
+ * the acknowledged section must have been received.
+ *
+ * @param encoder QPACK encoder instance
+ * @param ric     Required Insert Count from the Section Acknowledgment
+ * @return QPACK_OK on success
+ *
+ * @note KRC never decreases. If ric <= current KRC, this is a no-op.
+ * @note ric is clamped to insert_count if it exceeds the current value.
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACK_Result
+SocketQPACK_Encoder_on_section_ack (SocketQPACK_Encoder_T encoder, size_t ric);
+
+/**
+ * @brief Process an Insert Count Increment decoder instruction.
+ *
+ * RFC 9204 Section 4.4.3 / Section 2.1.4: The decoder sends an Insert Count
+ * Increment instruction to inform the encoder that it has processed additional
+ * dynamic table insertions. This increments the KRC by the specified amount.
+ *
+ * @param encoder   QPACK encoder instance
+ * @param increment Number of entries to add to KRC (must be > 0)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_INVALID_INDEX if increment is 0 or would overflow
+ *
+ * @note The resulting KRC is clamped to insert_count if it would exceed it.
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACK_Result
+SocketQPACK_Encoder_on_insert_count_inc (SocketQPACK_Encoder_T encoder,
+                                         size_t increment);
+
+/* ============================================================================
+ * ENCODER STATE QUERIES
+ * ============================================================================
+ */
+
+/**
+ * @brief Get the total number of insertions ever made.
+ *
+ * The insert count is a monotonically increasing counter that represents
+ * the absolute index that will be assigned to the next inserted entry.
+ *
+ * @param encoder QPACK encoder instance
+ * @return Total insertions (next absolute index), or 0 if encoder is NULL
+ *
+ * @since 1.0.0
+ */
+extern size_t SocketQPACK_Encoder_insert_count (SocketQPACK_Encoder_T encoder);
+
+/**
+ * @brief Get the current dynamic table size in bytes.
+ *
+ * @param encoder QPACK encoder instance
+ * @return Current size in bytes, or 0 if encoder is NULL
+ *
+ * @since 1.0.0
+ */
+extern size_t SocketQPACK_Encoder_table_size (SocketQPACK_Encoder_T encoder);
+
+/**
+ * @brief Get the number of entries in the dynamic table.
+ *
+ * @param encoder QPACK encoder instance
+ * @return Number of entries, or 0 if encoder is NULL
+ *
+ * @since 1.0.0
+ */
+extern size_t SocketQPACK_Encoder_entry_count (SocketQPACK_Encoder_T encoder);
+
+/* ============================================================================
+ * UTILITY FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Get human-readable string for QPACK result code.
+ *
+ * @param result Result code to describe
+ * @return Static string describing the result (never NULL)
+ *
+ * @since 1.0.0
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK-encoder.c
+++ b/src/http/qpack/SocketQPACK-encoder.c
@@ -1,0 +1,233 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-encoder.c
+ * @brief QPACK Encoder implementation (RFC 9204).
+ *
+ * Implements the QPACK encoder with Known Received Count (KRC) tracking
+ * per RFC 9204 Section 2.1.4. The encoder tracks which dynamic table entries
+ * have been acknowledged by the decoder to determine safe references.
+ *
+ * Key concepts:
+ * - Known Received Count (KRC): Number of insertions acknowledged by decoder
+ * - Insert Count: Total entries ever inserted (monotonically increasing)
+ * - Safe reference: Entry with absolute index < KRC (decoder has it)
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-2.1.4
+ * @since 1.0.0
+ */
+
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include <assert.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/SocketSecurity.h"
+
+#define T SocketQPACK_Encoder_T
+
+/* ============================================================================
+ * Result String Table
+ * ============================================================================
+ */
+
+static const char *const result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete data",
+  [QPACK_ERR_INVALID_INDEX] = "Invalid index",
+  [QPACK_ERR_EVICTED_INDEX] = "Entry has been evicted",
+  [QPACK_ERR_FUTURE_INDEX] = "Reference to not-yet-inserted entry",
+  [QPACK_ERR_BASE_OVERFLOW] = "Base exceeds Insert Count",
+  [QPACK_ERR_TABLE_SIZE] = "Table size limit exceeded",
+  [QPACK_ERR_HEADER_SIZE] = "Header size limit exceeded",
+  [QPACK_ERR_HUFFMAN] = "Huffman decoding error",
+  [QPACK_ERR_INTEGER] = "Integer decoding error",
+  [QPACK_ERR_DECOMPRESSION] = "Decompression failed",
+  [QPACK_ERR_NULL_PARAM] = "NULL parameter",
+  [QPACK_ERR_INTERNAL] = "Internal error",
+};
+
+#define RESULT_STRING_COUNT \
+  (sizeof (result_strings) / sizeof (result_strings[0]))
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if (result >= 0 && (size_t)result < RESULT_STRING_COUNT
+      && result_strings[result] != NULL)
+    {
+      return result_strings[result];
+    }
+
+  return "Unknown error";
+}
+
+/* ============================================================================
+ * Encoder Creation/Destruction
+ * ============================================================================
+ */
+
+SocketQPACK_Encoder_T
+SocketQPACK_Encoder_new (Arena_T arena, size_t max_table_size)
+{
+  T encoder;
+
+  assert (arena != NULL);
+
+  encoder = ALLOC (arena, sizeof (*encoder));
+
+  encoder->arena = arena;
+  encoder->head = NULL;
+  encoder->tail = NULL;
+  encoder->entry_count = 0;
+  encoder->table_size = 0;
+  encoder->max_table_size = max_table_size;
+  encoder->insert_count = 0;
+  encoder->known_received_count = 0;
+
+  return encoder;
+}
+
+void
+SocketQPACK_Encoder_free (SocketQPACK_Encoder_T *encoder)
+{
+  if (encoder == NULL || *encoder == NULL)
+    return;
+
+  /* Memory is arena-managed, just clear pointer */
+  *encoder = NULL;
+}
+
+/* ============================================================================
+ * Known Received Count (KRC) - RFC 9204 Section 2.1.4
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_Encoder_known_received_count (SocketQPACK_Encoder_T encoder)
+{
+  if (encoder == NULL)
+    return 0;
+
+  return encoder->known_received_count;
+}
+
+bool
+SocketQPACK_Encoder_is_acknowledged (SocketQPACK_Encoder_T encoder,
+                                     size_t abs_index)
+{
+  if (encoder == NULL)
+    return false;
+
+  /*
+   * RFC 9204 Section 2.1.4:
+   * "The encoder tracks the decoder's Known Received Count, which is the
+   * highest absolute index that can be acknowledged."
+   *
+   * An entry is acknowledged (safe to reference without blocking) if its
+   * absolute index is strictly less than the Known Received Count.
+   */
+  return abs_index < encoder->known_received_count;
+}
+
+SocketQPACK_Result
+SocketQPACK_Encoder_on_section_ack (SocketQPACK_Encoder_T encoder, size_t ric)
+{
+  if (encoder == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /*
+   * RFC 9204 Section 4.4.1 / Section 2.1.4:
+   * "When a field section is acknowledged, the encoder knows that the
+   * decoder has received all dynamic table entries with an absolute index
+   * less than the Required Insert Count."
+   *
+   * Update KRC to max(KRC, RIC). KRC never decreases.
+   */
+
+  /* Clamp RIC to insert_count - cannot acknowledge what wasn't sent */
+  if (ric > encoder->insert_count)
+    ric = encoder->insert_count;
+
+  /* Update KRC if RIC is higher (KRC never decreases) */
+  if (ric > encoder->known_received_count)
+    encoder->known_received_count = ric;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_Encoder_on_insert_count_inc (SocketQPACK_Encoder_T encoder,
+                                         size_t increment)
+{
+  size_t new_krc;
+
+  if (encoder == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /*
+   * RFC 9204 Section 4.4.3:
+   * "The Insert Count Increment instruction informs the encoder that the
+   * decoder has received and processed additional dynamic table entries."
+   *
+   * The increment must be > 0 per the RFC (an increment of 0 is meaningless).
+   */
+  if (increment == 0)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Check for overflow */
+  if (!SocketSecurity_check_add (
+          encoder->known_received_count, increment, &new_krc))
+    {
+      /* On overflow, clamp to insert_count */
+      new_krc = encoder->insert_count;
+    }
+
+  /* Clamp to insert_count - cannot exceed what was actually sent */
+  if (new_krc > encoder->insert_count)
+    new_krc = encoder->insert_count;
+
+  encoder->known_received_count = new_krc;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Encoder State Queries
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_Encoder_insert_count (SocketQPACK_Encoder_T encoder)
+{
+  if (encoder == NULL)
+    return 0;
+
+  return encoder->insert_count;
+}
+
+size_t
+SocketQPACK_Encoder_table_size (SocketQPACK_Encoder_T encoder)
+{
+  if (encoder == NULL)
+    return 0;
+
+  return encoder->table_size;
+}
+
+size_t
+SocketQPACK_Encoder_entry_count (SocketQPACK_Encoder_T encoder)
+{
+  if (encoder == NULL)
+    return 0;
+
+  return encoder->entry_count;
+}
+
+#undef T

--- a/src/test/test_qpack_krc.c
+++ b/src/test/test_qpack_krc.c
@@ -1,0 +1,527 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_krc.c
+ * @brief Unit tests for QPACK Known Received Count (RFC 9204 Section 2.1.4).
+ *
+ * Tests cover:
+ * - KRC initialization to 0
+ * - KRC update via Section Acknowledgment
+ * - KRC update via Insert Count Increment
+ * - KRC never decreases
+ * - is_acknowledged() returns correct values
+ * - KRC remains <= insert_count
+ * - Edge cases (overflow, zero increment, NULL parameters)
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "http/qpack/SocketQPACK.h"
+
+/* Simple test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * KRC Initialization Tests
+ * ============================================================================
+ */
+
+static void
+test_krc_initialized_to_zero (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+
+  printf ("  KRC initialized to 0... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  TEST_ASSERT (encoder != NULL, "Encoder should be created");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 0,
+               "KRC should be 0 initially");
+  TEST_ASSERT (SocketQPACK_Encoder_insert_count (encoder) == 0,
+               "Insert count should be 0 initially");
+
+  SocketQPACK_Encoder_free (&encoder);
+  TEST_ASSERT (encoder == NULL, "Encoder should be NULL after free");
+
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Section Acknowledgment Tests
+ * ============================================================================
+ */
+
+static void
+test_section_ack_updates_krc (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  Section Ack updates KRC... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Simulate that insert_count is 10 (entries 0-9 exist) */
+  /* We need to manually set insert_count for testing since we haven't
+   * implemented the insert function yet. Access the struct directly. */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 10;
+
+  /* Section Ack with RIC=5 should update KRC to 5 */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 5);
+  TEST_ASSERT (result == QPACK_OK, "Section ack should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 5,
+               "KRC should be 5");
+
+  /* Section Ack with RIC=8 should update KRC to 8 */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 8);
+  TEST_ASSERT (result == QPACK_OK, "Section ack should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 8,
+               "KRC should be 8");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_krc_never_decreases (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  KRC never decreases... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Set insert_count to 20 */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 20;
+
+  /* Set KRC to 10 via section ack */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 10);
+  TEST_ASSERT (result == QPACK_OK, "Section ack should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 10,
+               "KRC should be 10");
+
+  /* Try to set KRC to 5 - should remain at 10 (never decreases) */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 5);
+  TEST_ASSERT (result == QPACK_OK, "Section ack with lower RIC should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 10,
+               "KRC should remain 10 (not decrease)");
+
+  /* Set KRC to same value - should remain unchanged */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 10);
+  TEST_ASSERT (result == QPACK_OK, "Section ack with same RIC should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 10,
+               "KRC should remain 10");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_krc_clamped_to_insert_count (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  KRC clamped to insert_count... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Set insert_count to 10 */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 10;
+
+  /* Try to set KRC to 100 (exceeds insert_count) - should clamp to 10 */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 100);
+  TEST_ASSERT (result == QPACK_OK, "Section ack should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 10,
+               "KRC should be clamped to 10");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Insert Count Increment Tests
+ * ============================================================================
+ */
+
+static void
+test_insert_count_increment (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  Insert Count Increment updates KRC... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Set insert_count to 20 */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 20;
+
+  /* KRC starts at 0, increment by 5 -> KRC = 5 */
+  result = SocketQPACK_Encoder_on_insert_count_inc (encoder, 5);
+  TEST_ASSERT (result == QPACK_OK, "Insert count inc should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 5,
+               "KRC should be 5");
+
+  /* Increment by 3 more -> KRC = 8 */
+  result = SocketQPACK_Encoder_on_insert_count_inc (encoder, 3);
+  TEST_ASSERT (result == QPACK_OK, "Insert count inc should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 8,
+               "KRC should be 8");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_insert_count_increment_zero_fails (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  Insert Count Increment with 0 fails... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Increment of 0 is invalid per RFC 9204 */
+  result = SocketQPACK_Encoder_on_insert_count_inc (encoder, 0);
+  TEST_ASSERT (result == QPACK_ERR_INVALID_INDEX, "Zero increment should fail");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 0,
+               "KRC should remain 0");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+static void
+test_insert_count_increment_clamped (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  Insert Count Increment clamped to insert_count... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Set insert_count to 10 */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 10;
+
+  /* Set KRC to 5 first */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 5);
+  TEST_ASSERT (result == QPACK_OK, "Section ack should succeed");
+
+  /* Try to increment by 100 - should clamp to insert_count (10) */
+  result = SocketQPACK_Encoder_on_insert_count_inc (encoder, 100);
+  TEST_ASSERT (result == QPACK_OK, "Insert count inc should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 10,
+               "KRC should be clamped to 10");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * is_acknowledged Tests
+ * ============================================================================
+ */
+
+static void
+test_is_acknowledged_basic (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  is_acknowledged returns correct values... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Set insert_count to 10 */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 10;
+
+  /* KRC = 0 initially - nothing is acknowledged */
+  TEST_ASSERT (!SocketQPACK_Encoder_is_acknowledged (encoder, 0),
+               "Index 0 should not be acknowledged when KRC=0");
+  TEST_ASSERT (!SocketQPACK_Encoder_is_acknowledged (encoder, 5),
+               "Index 5 should not be acknowledged when KRC=0");
+
+  /* Set KRC to 5 */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 5);
+  TEST_ASSERT (result == QPACK_OK, "Section ack should succeed");
+
+  /* Indices 0-4 should be acknowledged (index < KRC) */
+  TEST_ASSERT (SocketQPACK_Encoder_is_acknowledged (encoder, 0),
+               "Index 0 should be acknowledged when KRC=5");
+  TEST_ASSERT (SocketQPACK_Encoder_is_acknowledged (encoder, 4),
+               "Index 4 should be acknowledged when KRC=5");
+
+  /* Index 5 and above should NOT be acknowledged (index >= KRC) */
+  TEST_ASSERT (!SocketQPACK_Encoder_is_acknowledged (encoder, 5),
+               "Index 5 should NOT be acknowledged when KRC=5");
+  TEST_ASSERT (!SocketQPACK_Encoder_is_acknowledged (encoder, 9),
+               "Index 9 should NOT be acknowledged when KRC=5");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Edge Case Tests
+ * ============================================================================
+ */
+
+static void
+test_null_encoder_handling (void)
+{
+  printf ("  NULL encoder handling... ");
+
+  /* All functions should handle NULL gracefully */
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (NULL) == 0,
+               "KRC should be 0 for NULL encoder");
+  TEST_ASSERT (SocketQPACK_Encoder_insert_count (NULL) == 0,
+               "Insert count should be 0 for NULL encoder");
+  TEST_ASSERT (SocketQPACK_Encoder_table_size (NULL) == 0,
+               "Table size should be 0 for NULL encoder");
+  TEST_ASSERT (SocketQPACK_Encoder_entry_count (NULL) == 0,
+               "Entry count should be 0 for NULL encoder");
+  TEST_ASSERT (!SocketQPACK_Encoder_is_acknowledged (NULL, 0),
+               "is_acknowledged should return false for NULL encoder");
+  TEST_ASSERT (SocketQPACK_Encoder_on_section_ack (NULL, 5)
+                   == QPACK_ERR_NULL_PARAM,
+               "Section ack should return error for NULL encoder");
+  TEST_ASSERT (SocketQPACK_Encoder_on_insert_count_inc (NULL, 5)
+                   == QPACK_ERR_NULL_PARAM,
+               "Insert count inc should return error for NULL encoder");
+
+  /* Free with NULL should not crash */
+  SocketQPACK_Encoder_free (NULL);
+  SocketQPACK_Encoder_T enc = NULL;
+  SocketQPACK_Encoder_free (&enc);
+
+  printf ("PASS\n");
+}
+
+static void
+test_result_string (void)
+{
+  printf ("  Result string lookup... ");
+
+  TEST_ASSERT (strcmp (SocketQPACK_result_string (QPACK_OK), "OK") == 0,
+               "OK string");
+  TEST_ASSERT (SocketQPACK_result_string (QPACK_ERR_INVALID_INDEX) != NULL,
+               "Invalid index string should not be NULL");
+  TEST_ASSERT (SocketQPACK_result_string (QPACK_ERR_NULL_PARAM) != NULL,
+               "NULL param string should not be NULL");
+  TEST_ASSERT (SocketQPACK_result_string ((SocketQPACK_Result)999) != NULL,
+               "Unknown error string should not be NULL");
+
+  printf ("PASS\n");
+}
+
+static void
+test_multiple_acks_with_increasing_ric (void)
+{
+  Arena_T arena;
+  SocketQPACK_Encoder_T encoder;
+  SocketQPACK_Result result;
+
+  printf ("  Multiple Section Acks with increasing RIC... ");
+
+  arena = Arena_new ();
+  encoder = SocketQPACK_Encoder_new (arena, 4096);
+
+  /* Set insert_count to 100 */
+  struct SocketQPACK_Encoder
+  {
+    Arena_T arena;
+    void *head;
+    void *tail;
+    size_t entry_count;
+    size_t table_size;
+    size_t max_table_size;
+    size_t insert_count;
+    size_t known_received_count;
+  };
+  ((struct SocketQPACK_Encoder *)encoder)->insert_count = 100;
+
+  /* Simulate multiple field sections being acknowledged in order */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 10);
+  TEST_ASSERT (result == QPACK_OK, "Section ack 10 should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 10,
+               "KRC should be 10");
+
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 25);
+  TEST_ASSERT (result == QPACK_OK, "Section ack 25 should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 25,
+               "KRC should be 25");
+
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 50);
+  TEST_ASSERT (result == QPACK_OK, "Section ack 50 should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 50,
+               "KRC should be 50");
+
+  /* Out of order ack (lower RIC) should not decrease KRC */
+  result = SocketQPACK_Encoder_on_section_ack (encoder, 30);
+  TEST_ASSERT (result == QPACK_OK, "Out of order ack should succeed");
+  TEST_ASSERT (SocketQPACK_Encoder_known_received_count (encoder) == 50,
+               "KRC should remain 50");
+
+  SocketQPACK_Encoder_free (&encoder);
+  Arena_dispose (&arena);
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * Main Test Runner
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("QPACK Known Received Count Unit Tests (RFC 9204 Section 2.1.4)\n");
+  printf ("==============================================================\n\n");
+
+  printf ("KRC Initialization Tests:\n");
+  test_krc_initialized_to_zero ();
+
+  printf ("\nSection Acknowledgment Tests:\n");
+  test_section_ack_updates_krc ();
+  test_krc_never_decreases ();
+  test_krc_clamped_to_insert_count ();
+
+  printf ("\nInsert Count Increment Tests:\n");
+  test_insert_count_increment ();
+  test_insert_count_increment_zero_fails ();
+  test_insert_count_increment_clamped ();
+
+  printf ("\nis_acknowledged Tests:\n");
+  test_is_acknowledged_basic ();
+
+  printf ("\nEdge Case Tests:\n");
+  test_null_encoder_handling ();
+  test_result_string ();
+  test_multiple_acks_with_increasing_ric ();
+
+  printf ("\n==============================================================\n");
+  printf ("All QPACK Known Received Count tests passed!\n");
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements QPACK Encoder's Known Received Count (KRC) tracking as specified in RFC 9204 Section 2.1.4.

- Adds `SocketQPACK_Encoder_known_received_count()` to get current KRC
- Adds `SocketQPACK_Encoder_is_acknowledged()` to check if an entry is safe to reference
- Adds `SocketQPACK_Encoder_on_section_ack()` to process Section Acknowledgment (Section 4.4.1)
- Adds `SocketQPACK_Encoder_on_insert_count_inc()` to process Insert Count Increment (Section 4.4.3)

## Test Plan

- [x] All KRC tests pass with sanitizers enabled
- [x] Related HTTP/2 and HPACK tests still pass
- [x] KRC never decreases invariant enforced
- [x] KRC <= insert_count invariant enforced
- [x] NULL parameter handling tested

Closes #3307