### PR TITLE
feat(qpack): implement Literal Field Line with Literal Name (RFC 9204 Section 4.5.6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,6 +359,9 @@ set(LIB_SOURCES
     src/http/hpack/SocketHPACK-huffman.c
     src/http/hpack/SocketHPACK-table.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -633,6 +636,10 @@ set(HTTP_HEADERS
     include/http/SocketHTTPServer.h
 )
 
+set(QPACK_HEADERS
+    include/http/qpack/SocketQPACK.h
+)
+
 set(TEST_HEADERS
     include/test/Test.h
 )
@@ -686,6 +693,7 @@ install(FILES ${POLL_HEADERS} DESTINATION include/poll)
 install(FILES ${POOL_HEADERS} DESTINATION include/pool)
 install(FILES ${TLS_HEADERS} DESTINATION include/tls)
 install(FILES ${HTTP_HEADERS} DESTINATION include/http)
+install(FILES ${QPACK_HEADERS} DESTINATION include/http/qpack)
 install(FILES ${TEST_HEADERS} DESTINATION include/test)
 install(FILES ${QUIC_HEADERS} DESTINATION include/quic)
 install(FILES ${SIMPLE_HEADERS} DESTINATION include/simple)
@@ -837,6 +845,8 @@ set(TEST_SOURCES
     test_quic_loss
     test_quic_key_discard
     test_quic_0rtt
+    # QPACK tests (RFC 9204)
+    test_qpack_literal
 )
 
 # TLS tests (only built when TLS is enabled)

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -1,0 +1,370 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression for HTTP/3 (RFC 9204).
+ *
+ * Implements QPACK encoding/decoding primitives (Section 4.1) and field line
+ * representations for HTTP/3 header compression.
+ *
+ * Key features:
+ * - Integer encoding/decoding with variable prefix sizes (3-8 bits)
+ * - String literal encoding/decoding with optional Huffman compression
+ * - Literal Field Line with Literal Name (Section 4.5.6)
+ *
+ * QPACK uses the same Huffman table as HPACK (RFC 7541 Appendix B) but
+ * supports additional prefix sizes for various instruction types.
+ *
+ * Thread Safety: All functions are thread-safe (no shared state).
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+/**
+ * @brief Maximum integer value representable in QPACK (RFC 9204).
+ *
+ * QPACK integers can represent values up to 2^62-1 (4,611,686,018,427,387,903).
+ */
+#define SOCKETQPACK_INT_MAX ((uint64_t)4611686018427387903ULL)
+
+/**
+ * @brief Minimum valid prefix size for QPACK integers.
+ */
+#define SOCKETQPACK_PREFIX_MIN 3
+
+/**
+ * @brief Maximum valid prefix size for QPACK integers.
+ */
+#define SOCKETQPACK_PREFIX_MAX 8
+
+/**
+ * @brief RFC 9204 Section 4.5.6: Pattern bits for Literal Field Line with
+ *        Literal Name.
+ *
+ * Wire format: 0 0 1 N H NameLen(3+) | NameString | H ValueLen(7+) |
+ * ValueString The first 3 bits are '001' (0x20 mask after shifting).
+ */
+#define SOCKETQPACK_LITERAL_LITERAL_PATTERN 0x20
+
+/**
+ * @brief Mask for pattern bits (top 3 bits).
+ */
+#define SOCKETQPACK_LITERAL_LITERAL_MASK 0xE0
+
+/**
+ * @brief Never-indexed bit position in Literal Field Line with Literal Name.
+ *
+ * RFC 9204 Section 4.5.6: The N bit (bit 4) indicates sensitive data that
+ * must not be added to the dynamic table.
+ */
+#define SOCKETQPACK_NEVER_INDEXED_BIT 0x10
+
+/**
+ * @brief Huffman flag bit for name in Literal Field Line with Literal Name.
+ *
+ * RFC 9204 Section 4.5.6: Bit 3 indicates if the name is Huffman-encoded.
+ */
+#define SOCKETQPACK_NAME_HUFFMAN_BIT 0x08
+
+/**
+ * @brief Name length prefix size for Literal Field Line with Literal Name.
+ *
+ * RFC 9204 Section 4.5.6: 3-bit prefix for name length encoding.
+ */
+#define SOCKETQPACK_LITERAL_NAME_PREFIX 3
+
+/**
+ * @brief Value length prefix size for Literal Field Line with Literal Name.
+ *
+ * RFC 9204 Section 4.5.6: 7-bit prefix for value length encoding.
+ */
+#define SOCKETQPACK_LITERAL_VALUE_PREFIX 7
+
+/**
+ * @brief Result codes for QPACK operations.
+ */
+typedef enum
+{
+  QPACK_OK = 0,        /**< Operation succeeded */
+  QPACK_ERROR,         /**< Generic error */
+  QPACK_INCOMPLETE,    /**< Need more input data */
+  QPACK_ERROR_INTEGER, /**< Integer overflow or invalid encoding */
+  QPACK_ERROR_HUFFMAN, /**< Huffman encoding/decoding error */
+  QPACK_ERROR_BUFFER,  /**< Output buffer too small */
+  QPACK_ERROR_PREFIX,  /**< Invalid prefix bits (must be 3-8) */
+  QPACK_ERROR_NULL,    /**< NULL pointer argument */
+  QPACK_ERROR_PATTERN  /**< Invalid pattern bits for field line type */
+} SocketQPACK_Result;
+
+/**
+ * @brief Decoded Literal Field Line with Literal Name structure.
+ *
+ * RFC 9204 Section 4.5.6: Contains the decoded field name and value
+ * along with metadata flags.
+ */
+typedef struct
+{
+  const unsigned char *name;  /**< Field name (not null-terminated) */
+  size_t name_len;            /**< Length of name in bytes */
+  const unsigned char *value; /**< Field value (not null-terminated) */
+  size_t value_len;           /**< Length of value in bytes */
+  int never_indexed;          /**< N bit: 1=sensitive, 0=can be indexed */
+} SocketQPACK_LiteralLiteral_T;
+
+/* ============================================================================
+ * Integer Encoding/Decoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode a prefixed integer (RFC 9204 Section 4.1.1).
+ *
+ * Encodes an integer value using the QPACK/HPACK integer encoding scheme.
+ * The prefix_bits parameter specifies how many bits of the first byte are
+ * available for the integer value.
+ *
+ * @param value       Integer value to encode (0 to 2^62-1).
+ * @param prefix_bits Number of bits available in first byte (3-8).
+ * @param output      Output buffer for encoded bytes.
+ * @param output_size Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, -1 on error.
+ */
+extern ssize_t SocketQPACK_int_encode (uint64_t value,
+                                       int prefix_bits,
+                                       unsigned char *output,
+                                       size_t output_size);
+
+/**
+ * @brief Decode a prefixed integer (RFC 9204 Section 4.1.1).
+ *
+ * Decodes an integer value from QPACK/HPACK encoding.
+ *
+ * @param input       Input buffer containing encoded integer.
+ * @param input_len   Size of input buffer in bytes.
+ * @param prefix_bits Number of bits used for integer in first byte (3-8).
+ * @param value       Output: decoded integer value.
+ * @param consumed    Output: number of bytes consumed from input.
+ *
+ * @return QPACK_OK on success, error code otherwise.
+ */
+extern SocketQPACK_Result SocketQPACK_int_decode (const unsigned char *input,
+                                                  size_t input_len,
+                                                  int prefix_bits,
+                                                  uint64_t *value,
+                                                  size_t *consumed);
+
+/**
+ * @brief Calculate encoded size for an integer value.
+ *
+ * @param value       Value to calculate size for.
+ * @param prefix_bits Number of bits in prefix (3-8).
+ *
+ * @return Number of bytes needed, or 0 if invalid.
+ */
+extern size_t SocketQPACK_int_size (uint64_t value, int prefix_bits);
+
+/* ============================================================================
+ * String Encoding/Decoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode a string literal (RFC 9204 Section 4.1.2).
+ *
+ * Encodes a string using optional Huffman compression (RFC 7541 Appendix B).
+ *
+ * @param input       Input string data.
+ * @param input_len   Length of input string in bytes.
+ * @param use_huffman 1 to enable Huffman compression, 0 for plain text.
+ * @param prefix_bits Number of bits for length prefix (3-8).
+ * @param output      Output buffer for encoded bytes.
+ * @param output_size Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, -1 on error.
+ */
+extern ssize_t SocketQPACK_string_encode (const unsigned char *input,
+                                          size_t input_len,
+                                          int use_huffman,
+                                          int prefix_bits,
+                                          unsigned char *output,
+                                          size_t output_size);
+
+/**
+ * @brief Decode a string literal (RFC 9204 Section 4.1.2).
+ *
+ * @param input       Input buffer containing encoded string.
+ * @param input_len   Size of input buffer in bytes.
+ * @param prefix_bits Number of bits for length prefix (3-8).
+ * @param output      Output buffer for decoded string.
+ * @param output_size Size of output buffer in bytes.
+ * @param decoded_len Output: actual length of decoded string.
+ * @param consumed    Output: number of bytes consumed from input.
+ *
+ * @return QPACK_OK on success, error code otherwise.
+ */
+extern SocketQPACK_Result SocketQPACK_string_decode (const unsigned char *input,
+                                                     size_t input_len,
+                                                     int prefix_bits,
+                                                     unsigned char *output,
+                                                     size_t output_size,
+                                                     size_t *decoded_len,
+                                                     size_t *consumed);
+
+/**
+ * @brief Calculate encoded size for a string.
+ *
+ * @param input       Input string data.
+ * @param input_len   Length of input string.
+ * @param use_huffman 1 for Huffman encoding, 0 for plain.
+ * @param prefix_bits Number of bits for length prefix (3-8).
+ *
+ * @return Number of bytes needed, or 0 on error.
+ */
+extern size_t SocketQPACK_string_size (const unsigned char *input,
+                                       size_t input_len,
+                                       int use_huffman,
+                                       int prefix_bits);
+
+/* ============================================================================
+ * Literal Field Line with Literal Name (RFC 9204 Section 4.5.6)
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode a Literal Field Line with Literal Name (RFC 9204
+ * Section 4.5.6).
+ *
+ * Encodes a header field where both name and value are literal strings.
+ * This is the most general encoding form in QPACK.
+ *
+ * Wire format:
+ *   0 0 1 N H NameLen(3+) | NameString | H ValueLen(7+) | ValueString
+ *
+ * @param name          Field name (case-sensitive, lowercase recommended).
+ * @param name_len      Length of field name in bytes.
+ * @param value         Field value.
+ * @param value_len     Length of field value in bytes.
+ * @param never_indexed 1 for sensitive data (N bit), 0 for normal.
+ * @param use_huffman   1 to enable Huffman compression, 0 for plain.
+ * @param output        Output buffer for encoded field line.
+ * @param output_size   Size of output buffer in bytes.
+ *
+ * @return Number of bytes written on success, -1 on error.
+ *
+ * Example:
+ * @code
+ * unsigned char buf[256];
+ * ssize_t len = SocketQPACK_literal_literal_encode(
+ *     (const unsigned char *)"content-type", 12,
+ *     (const unsigned char *)"application/json", 16,
+ *     0, 1, buf, sizeof(buf));
+ * @endcode
+ */
+extern ssize_t SocketQPACK_literal_literal_encode (const unsigned char *name,
+                                                   size_t name_len,
+                                                   const unsigned char *value,
+                                                   size_t value_len,
+                                                   int never_indexed,
+                                                   int use_huffman,
+                                                   unsigned char *output,
+                                                   size_t output_size);
+
+/**
+ * @brief Decode a Literal Field Line with Literal Name (RFC 9204
+ * Section 4.5.6).
+ *
+ * Decodes a header field where both name and value are literal strings.
+ * The caller must provide output buffers for name and value.
+ *
+ * @param input         Input buffer containing encoded field line.
+ * @param input_len     Size of input buffer in bytes.
+ * @param name_out      Output buffer for decoded name.
+ * @param name_out_size Size of name output buffer.
+ * @param value_out     Output buffer for decoded value.
+ * @param value_out_size Size of value output buffer.
+ * @param result        Output: decoded field line structure.
+ * @param consumed      Output: number of bytes consumed from input.
+ *
+ * @return QPACK_OK on success, error code otherwise.
+ *
+ * @retval QPACK_OK           Successfully decoded.
+ * @retval QPACK_INCOMPLETE   Input truncated.
+ * @retval QPACK_ERROR_PATTERN First byte does not have '001' pattern.
+ * @retval QPACK_ERROR_HUFFMAN Huffman decoding failed.
+ * @retval QPACK_ERROR_BUFFER Output buffer too small.
+ * @retval QPACK_ERROR_NULL   NULL pointer argument.
+ */
+extern SocketQPACK_Result
+SocketQPACK_literal_literal_decode (const unsigned char *input,
+                                    size_t input_len,
+                                    unsigned char *name_out,
+                                    size_t name_out_size,
+                                    unsigned char *value_out,
+                                    size_t value_out_size,
+                                    SocketQPACK_LiteralLiteral_T *result,
+                                    size_t *consumed);
+
+/**
+ * @brief Calculate encoded size for a Literal Field Line with Literal Name.
+ *
+ * @param name        Field name.
+ * @param name_len    Length of field name.
+ * @param value       Field value.
+ * @param value_len   Length of field value.
+ * @param use_huffman 1 for Huffman encoding, 0 for plain.
+ *
+ * @return Number of bytes needed, or 0 on error.
+ */
+extern size_t SocketQPACK_literal_literal_size (const unsigned char *name,
+                                                size_t name_len,
+                                                const unsigned char *value,
+                                                size_t value_len,
+                                                int use_huffman);
+
+/**
+ * @brief Validate pattern bits for Literal Field Line with Literal Name.
+ *
+ * RFC 9204 Section 4.5.6: Pattern bits must be '001' (bits 7-5).
+ *
+ * @param first_byte First byte of encoded field line.
+ *
+ * @return 1 if pattern is valid ('001'), 0 otherwise.
+ */
+static inline int
+SocketQPACK_is_literal_literal (unsigned char first_byte)
+{
+  return (first_byte & SOCKETQPACK_LITERAL_LITERAL_MASK)
+         == SOCKETQPACK_LITERAL_LITERAL_PATTERN;
+}
+
+/* ============================================================================
+ * Utility Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Get string representation of result code.
+ *
+ * @param result Result code to convert.
+ *
+ * @return Human-readable string describing the result.
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK.c
+++ b/src/http/qpack/SocketQPACK.c
@@ -1,0 +1,843 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK.c - QPACK Primitives and Field Line Encoding (RFC 9204)
+ *
+ * Implements:
+ * - Section 4.1: Integer and string encoding/decoding primitives
+ * - Section 4.5.6: Literal Field Line with Literal Name
+ *
+ * Reuses HPACK Huffman encoding (RFC 7541 Appendix B).
+ */
+
+#include <string.h>
+
+#include "http/qpack/SocketQPACK.h"
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+/* Maximum continuation bytes for integer encoding.
+ * Each continuation byte carries 7 bits.
+ * For 62-bit values: ceil(62/7) = 9 continuation bytes max. */
+#define QPACK_MAX_INT_CONTINUATION_BYTES 10
+
+/* Bit masks for integer encoding */
+#define QPACK_INT_CONTINUATION_MASK 0x80
+#define QPACK_INT_PAYLOAD_MASK 0x7F
+#define QPACK_INT_CONTINUATION_VAL 128
+
+/* Maximum safe shift to avoid overflow during decoding.
+ * 64 bits - 8 bits for last byte = 56 bits. */
+#define QPACK_MAX_SAFE_SHIFT 56
+
+/* Huffman flag for value string (highest bit in 7-bit prefix) */
+#define QPACK_VALUE_HUFFMAN_FLAG 0x80
+
+/* ============================================================================
+ * Result Strings
+ * ============================================================================
+ */
+
+static const char *result_strings[] = {
+  [QPACK_OK] = "OK",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_ERROR_INTEGER] = "Integer overflow or invalid encoding",
+  [QPACK_ERROR_HUFFMAN] = "Huffman encoding/decoding error",
+  [QPACK_ERROR_BUFFER] = "Output buffer too small",
+  [QPACK_ERROR_PREFIX] = "Invalid prefix bits (must be 3-8)",
+  [QPACK_ERROR_NULL] = "NULL pointer argument",
+  [QPACK_ERROR_PATTERN] = "Invalid pattern bits for field line type",
+};
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if ((unsigned)result > QPACK_ERROR_PATTERN)
+    return "Unknown error";
+  return result_strings[result];
+}
+
+/* ============================================================================
+ * Validation Helpers
+ * ============================================================================
+ */
+
+static inline int
+valid_prefix_bits (int prefix_bits)
+{
+  return prefix_bits >= SOCKETQPACK_PREFIX_MIN
+         && prefix_bits <= SOCKETQPACK_PREFIX_MAX;
+}
+
+/* ============================================================================
+ * Integer Encoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Encode continuation bytes for values that exceed prefix capacity.
+ */
+static size_t
+encode_int_continuation (uint64_t value,
+                         unsigned char *output,
+                         size_t pos,
+                         size_t output_size)
+{
+  while (value >= QPACK_INT_CONTINUATION_VAL && pos < output_size)
+    {
+      output[pos++] = (unsigned char)(QPACK_INT_CONTINUATION_MASK
+                                      | (value & QPACK_INT_PAYLOAD_MASK));
+      value >>= 7;
+    }
+
+  if (pos >= output_size)
+    return 0;
+
+  output[pos++] = (unsigned char)value;
+  return pos;
+}
+
+ssize_t
+SocketQPACK_int_encode (uint64_t value,
+                        int prefix_bits,
+                        unsigned char *output,
+                        size_t output_size)
+{
+  uint64_t max_prefix;
+
+  if (output == NULL)
+    return -1;
+
+  if (output_size == 0)
+    return -1;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return -1;
+
+  /* Check maximum representable value */
+  if (value > SOCKETQPACK_INT_MAX)
+    return -1;
+
+  /* Calculate maximum value that fits in prefix */
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  /* Value fits in prefix - single byte encoding */
+  if (value < max_prefix)
+    {
+      output[0] = (unsigned char)value;
+      return 1;
+    }
+
+  /* Value exceeds prefix - use continuation bytes */
+  output[0] = (unsigned char)max_prefix;
+  size_t result
+      = encode_int_continuation (value - max_prefix, output, 1, output_size);
+  if (result == 0)
+    return -1;
+
+  return (ssize_t)result;
+}
+
+/* ============================================================================
+ * Integer Decoding (RFC 9204 Section 4.1.1)
+ * ============================================================================
+ */
+
+/**
+ * Decode continuation bytes for multi-byte integers.
+ */
+static SocketQPACK_Result
+decode_int_continuation (const unsigned char *input,
+                         size_t input_len,
+                         size_t *pos,
+                         uint64_t *result,
+                         unsigned int *shift)
+{
+  uint64_t byte_val;
+  unsigned int continuation_count = 0;
+
+  do
+    {
+      if (*pos >= input_len)
+        return QPACK_INCOMPLETE;
+
+      continuation_count++;
+      if (continuation_count > QPACK_MAX_INT_CONTINUATION_BYTES)
+        return QPACK_ERROR_INTEGER;
+
+      byte_val = input[(*pos)++];
+
+      /* Check for overflow before shifting */
+      if (*shift > QPACK_MAX_SAFE_SHIFT)
+        return QPACK_ERROR_INTEGER;
+
+      uint64_t add_val = (byte_val & QPACK_INT_PAYLOAD_MASK) << *shift;
+      if (*result > UINT64_MAX - add_val)
+        return QPACK_ERROR_INTEGER;
+
+      *result += add_val;
+      *shift += 7;
+    }
+  while (byte_val & QPACK_INT_CONTINUATION_MASK);
+
+  /* Final overflow check against QPACK maximum */
+  if (*result > SOCKETQPACK_INT_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_int_decode (const unsigned char *input,
+                        size_t input_len,
+                        int prefix_bits,
+                        uint64_t *value,
+                        size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t max_prefix;
+  uint64_t result;
+  unsigned int shift = 0;
+
+  if (input == NULL || value == NULL || consumed == NULL)
+    return QPACK_ERROR_NULL;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR_PREFIX;
+
+  /* Extract prefix mask and initial value */
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+  result = input[pos++] & max_prefix;
+
+  /* Single-byte encoding: value fits in prefix */
+  if (result < max_prefix)
+    {
+      *value = result;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  /* Multi-byte encoding: decode continuation bytes */
+  SocketQPACK_Result cont_result
+      = decode_int_continuation (input, input_len, &pos, &result, &shift);
+  if (cont_result != QPACK_OK)
+    return cont_result;
+
+  *value = result;
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Integer Size Calculation
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_int_size (uint64_t value, int prefix_bits)
+{
+  uint64_t max_prefix;
+  size_t size;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return 0;
+
+  if (value > SOCKETQPACK_INT_MAX)
+    return 0;
+
+  max_prefix = ((uint64_t)1 << prefix_bits) - 1;
+
+  /* Value fits in prefix */
+  if (value < max_prefix)
+    return 1;
+
+  /* Count continuation bytes needed */
+  size = 1; /* prefix byte */
+  value -= max_prefix;
+  while (value >= QPACK_INT_CONTINUATION_VAL)
+    {
+      size++;
+      value >>= 7;
+    }
+  size++; /* final byte */
+
+  return size;
+}
+
+/* ============================================================================
+ * String Encoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+/**
+ * Encode integer with flag bit in the appropriate position.
+ * The flag is placed at position (prefix_bits) in the first byte.
+ */
+static ssize_t
+encode_int_with_flag (uint64_t value,
+                      int prefix_bits,
+                      unsigned char flag,
+                      unsigned char *output,
+                      size_t output_size)
+{
+  ssize_t int_len
+      = SocketQPACK_int_encode (value, prefix_bits, output, output_size);
+  if (int_len <= 0)
+    return -1;
+
+  /* Set flag bit in the position determined by prefix_bits. */
+  unsigned char flag_mask = (unsigned char)(1 << (prefix_bits));
+  if (flag)
+    output[0] |= flag_mask;
+
+  return int_len;
+}
+
+ssize_t
+SocketQPACK_string_encode (const unsigned char *input,
+                           size_t input_len,
+                           int use_huffman,
+                           int prefix_bits,
+                           unsigned char *output,
+                           size_t output_size)
+{
+  size_t pos = 0;
+  ssize_t encoded;
+  size_t data_len = input_len;
+  int use_huffman_actual = 0;
+
+  if (output == NULL)
+    return -1;
+
+  if (output_size == 0)
+    return -1;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return -1;
+
+  /* For non-empty strings, check if Huffman compression helps */
+  if (use_huffman && input != NULL && input_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (input, input_len);
+      if (huffman_size < input_len)
+        {
+          data_len = huffman_size;
+          use_huffman_actual = 1;
+        }
+    }
+
+  /* Encode length with Huffman flag */
+  encoded = encode_int_with_flag (data_len,
+                                  prefix_bits,
+                                  (unsigned char)use_huffman_actual,
+                                  output,
+                                  output_size);
+  if (encoded < 0)
+    return -1;
+  pos = (size_t)encoded;
+
+  /* Encode string data */
+  if (input_len > 0)
+    {
+      if (input == NULL)
+        return -1;
+
+      if (use_huffman_actual)
+        {
+          encoded = SocketHPACK_huffman_encode (
+              input, input_len, output + pos, output_size - pos);
+          if (encoded < 0)
+            return -1;
+        }
+      else
+        {
+          if (pos + input_len > output_size)
+            return -1;
+          memcpy (output + pos, input, input_len);
+          encoded = (ssize_t)input_len;
+        }
+      pos += (size_t)encoded;
+    }
+
+  return (ssize_t)pos;
+}
+
+/* ============================================================================
+ * String Decoding (RFC 9204 Section 4.1.2)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_string_decode (const unsigned char *input,
+                           size_t input_len,
+                           int prefix_bits,
+                           unsigned char *output,
+                           size_t output_size,
+                           size_t *decoded_len,
+                           size_t *consumed)
+{
+  size_t pos = 0;
+  int huffman;
+  uint64_t str_len;
+  SocketQPACK_Result result;
+
+  if (input == NULL || decoded_len == NULL || consumed == NULL)
+    return QPACK_ERROR_NULL;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return QPACK_ERROR_PREFIX;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Extract Huffman flag from first byte */
+  unsigned char flag_mask = (unsigned char)(1 << prefix_bits);
+  huffman = (input[0] & flag_mask) != 0;
+
+  /* Decode string length */
+  result
+      = SocketQPACK_int_decode (input, input_len, prefix_bits, &str_len, &pos);
+  if (result != QPACK_OK)
+    return result;
+
+  /* Validate string length */
+  if (str_len > SIZE_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  size_t len = (size_t)str_len;
+
+  /* Check if we have enough input data */
+  if (pos + len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Handle empty string */
+  if (len == 0)
+    {
+      *decoded_len = 0;
+      *consumed = pos;
+      return QPACK_OK;
+    }
+
+  /* Output buffer is required for non-empty strings */
+  if (output == NULL)
+    return QPACK_ERROR_NULL;
+
+  /* Decode string data */
+  if (huffman)
+    {
+      /* Huffman-decode the string */
+      ssize_t decoded
+          = SocketHPACK_huffman_decode (input + pos, len, output, output_size);
+      if (decoded < 0)
+        return QPACK_ERROR_HUFFMAN;
+
+      *decoded_len = (size_t)decoded;
+    }
+  else
+    {
+      /* Plain text - just copy */
+      if (len > output_size)
+        return QPACK_ERROR_BUFFER;
+
+      memcpy (output, input + pos, len);
+      *decoded_len = len;
+    }
+
+  *consumed = pos + len;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * String Size Calculation
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_string_size (const unsigned char *input,
+                         size_t input_len,
+                         int use_huffman,
+                         int prefix_bits)
+{
+  size_t data_len = input_len;
+  size_t header_len;
+
+  if (!valid_prefix_bits (prefix_bits))
+    return 0;
+
+  /* Check if Huffman compression reduces size */
+  if (use_huffman && input != NULL && input_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (input, input_len);
+      if (huffman_size < input_len)
+        data_len = huffman_size;
+    }
+
+  /* Calculate header (length prefix) size */
+  header_len = SocketQPACK_int_size (data_len, prefix_bits);
+  if (header_len == 0)
+    return 0;
+
+  return header_len + data_len;
+}
+
+/* ============================================================================
+ * Literal Field Line with Literal Name - Encoding (RFC 9204 Section 4.5.6)
+ *
+ * Wire format:
+ *   0 0 1 N H NameLen(3+) | NameString | H ValueLen(7+) | ValueString
+ *
+ * Bit layout of first byte:
+ *   [7:5] = 001 (pattern for literal literal)
+ *   [4]   = N (never-indexed flag)
+ *   [3]   = H (Huffman flag for name)
+ *   [2:0] = Name length prefix (3 bits)
+ * ============================================================================
+ */
+
+ssize_t
+SocketQPACK_literal_literal_encode (const unsigned char *name,
+                                    size_t name_len,
+                                    const unsigned char *value,
+                                    size_t value_len,
+                                    int never_indexed,
+                                    int use_huffman,
+                                    unsigned char *output,
+                                    size_t output_size)
+{
+  size_t pos = 0;
+  ssize_t encoded;
+  size_t name_data_len = name_len;
+  size_t value_data_len = value_len;
+  int name_huffman = 0;
+  int value_huffman = 0;
+
+  if (output == NULL)
+    return -1;
+
+  if (output_size == 0)
+    return -1;
+
+  /* Determine if Huffman helps for name */
+  if (use_huffman && name != NULL && name_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (name, name_len);
+      if (huffman_size < name_len)
+        {
+          name_data_len = huffman_size;
+          name_huffman = 1;
+        }
+    }
+
+  /* Determine if Huffman helps for value */
+  if (use_huffman && value != NULL && value_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (value, value_len);
+      if (huffman_size < value_len)
+        {
+          value_data_len = huffman_size;
+          value_huffman = 1;
+        }
+    }
+
+  /*
+   * Encode first byte with:
+   * - Pattern '001' (bits 7-5)
+   * - N bit (bit 4)
+   * - H bit for name (bit 3)
+   * - Name length (bits 2-0, with 3-bit prefix)
+   */
+
+  /* Start with pattern and flags */
+  unsigned char first_byte = SOCKETQPACK_LITERAL_LITERAL_PATTERN;
+  if (never_indexed)
+    first_byte |= SOCKETQPACK_NEVER_INDEXED_BIT;
+  if (name_huffman)
+    first_byte |= SOCKETQPACK_NAME_HUFFMAN_BIT;
+
+  /* Encode name length with 3-bit prefix */
+  encoded = SocketQPACK_int_encode (
+      name_data_len, SOCKETQPACK_LITERAL_NAME_PREFIX, output, output_size);
+  if (encoded < 0)
+    return -1;
+
+  /* Set pattern and flags in first byte (preserving length prefix bits) */
+  output[0] = (output[0] & 0x07) | first_byte;
+  pos = (size_t)encoded;
+
+  /* Encode name string */
+  if (name_len > 0)
+    {
+      if (name == NULL)
+        return -1;
+
+      if (name_huffman)
+        {
+          encoded = SocketHPACK_huffman_encode (
+              name, name_len, output + pos, output_size - pos);
+          if (encoded < 0)
+            return -1;
+        }
+      else
+        {
+          if (pos + name_len > output_size)
+            return -1;
+          memcpy (output + pos, name, name_len);
+          encoded = (ssize_t)name_len;
+        }
+      pos += (size_t)encoded;
+    }
+
+  /*
+   * Encode value with:
+   * - H bit for value (bit 7)
+   * - Value length (bits 6-0, with 7-bit prefix)
+   */
+  if (pos >= output_size)
+    return -1;
+
+  encoded = SocketQPACK_int_encode (value_data_len,
+                                    SOCKETQPACK_LITERAL_VALUE_PREFIX,
+                                    output + pos,
+                                    output_size - pos);
+  if (encoded < 0)
+    return -1;
+
+  /* Set Huffman flag for value */
+  if (value_huffman)
+    output[pos] |= QPACK_VALUE_HUFFMAN_FLAG;
+
+  pos += (size_t)encoded;
+
+  /* Encode value string */
+  if (value_len > 0)
+    {
+      if (value == NULL)
+        return -1;
+
+      if (value_huffman)
+        {
+          encoded = SocketHPACK_huffman_encode (
+              value, value_len, output + pos, output_size - pos);
+          if (encoded < 0)
+            return -1;
+        }
+      else
+        {
+          if (pos + value_len > output_size)
+            return -1;
+          memcpy (output + pos, value, value_len);
+          encoded = (ssize_t)value_len;
+        }
+      pos += (size_t)encoded;
+    }
+
+  return (ssize_t)pos;
+}
+
+/* ============================================================================
+ * Literal Field Line with Literal Name - Decoding (RFC 9204 Section 4.5.6)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_literal_literal_decode (const unsigned char *input,
+                                    size_t input_len,
+                                    unsigned char *name_out,
+                                    size_t name_out_size,
+                                    unsigned char *value_out,
+                                    size_t value_out_size,
+                                    SocketQPACK_LiteralLiteral_T *result,
+                                    size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t name_len;
+  uint64_t value_len;
+  size_t bytes_consumed;
+  SocketQPACK_Result res;
+
+  if (input == NULL || result == NULL || consumed == NULL)
+    return QPACK_ERROR_NULL;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  /* Validate pattern bits (must be '001') */
+  if (!SocketQPACK_is_literal_literal (input[0]))
+    return QPACK_ERROR_PATTERN;
+
+  /* Extract flags from first byte */
+  result->never_indexed = (input[0] & SOCKETQPACK_NEVER_INDEXED_BIT) != 0;
+  int name_huffman = (input[0] & SOCKETQPACK_NAME_HUFFMAN_BIT) != 0;
+
+  /* Decode name length with 3-bit prefix */
+  res = SocketQPACK_int_decode (input,
+                                input_len,
+                                SOCKETQPACK_LITERAL_NAME_PREFIX,
+                                &name_len,
+                                &bytes_consumed);
+  if (res != QPACK_OK)
+    return res;
+  pos = bytes_consumed;
+
+  /* Validate name length */
+  if (name_len > SIZE_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  size_t name_wire_len = (size_t)name_len;
+
+  /* Check if we have enough input for name */
+  if (pos + name_wire_len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Decode name string */
+  if (name_wire_len > 0)
+    {
+      if (name_out == NULL)
+        return QPACK_ERROR_NULL;
+
+      if (name_huffman)
+        {
+          ssize_t decoded = SocketHPACK_huffman_decode (
+              input + pos, name_wire_len, name_out, name_out_size);
+          if (decoded < 0)
+            return QPACK_ERROR_HUFFMAN;
+          result->name_len = (size_t)decoded;
+        }
+      else
+        {
+          if (name_wire_len > name_out_size)
+            return QPACK_ERROR_BUFFER;
+          memcpy (name_out, input + pos, name_wire_len);
+          result->name_len = name_wire_len;
+        }
+      result->name = name_out;
+      pos += name_wire_len;
+    }
+  else
+    {
+      result->name = name_out;
+      result->name_len = 0;
+    }
+
+  /* Check if we have at least one byte for value header */
+  if (pos >= input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Extract Huffman flag for value from value length byte */
+  int value_huffman = (input[pos] & QPACK_VALUE_HUFFMAN_FLAG) != 0;
+
+  /* Decode value length with 7-bit prefix */
+  res = SocketQPACK_int_decode (input + pos,
+                                input_len - pos,
+                                SOCKETQPACK_LITERAL_VALUE_PREFIX,
+                                &value_len,
+                                &bytes_consumed);
+  if (res != QPACK_OK)
+    return res;
+  pos += bytes_consumed;
+
+  /* Validate value length */
+  if (value_len > SIZE_MAX)
+    return QPACK_ERROR_INTEGER;
+
+  size_t value_wire_len = (size_t)value_len;
+
+  /* Check if we have enough input for value */
+  if (pos + value_wire_len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Decode value string */
+  if (value_wire_len > 0)
+    {
+      if (value_out == NULL)
+        return QPACK_ERROR_NULL;
+
+      if (value_huffman)
+        {
+          ssize_t decoded = SocketHPACK_huffman_decode (
+              input + pos, value_wire_len, value_out, value_out_size);
+          if (decoded < 0)
+            return QPACK_ERROR_HUFFMAN;
+          result->value_len = (size_t)decoded;
+        }
+      else
+        {
+          if (value_wire_len > value_out_size)
+            return QPACK_ERROR_BUFFER;
+          memcpy (value_out, input + pos, value_wire_len);
+          result->value_len = value_wire_len;
+        }
+      result->value = value_out;
+      pos += value_wire_len;
+    }
+  else
+    {
+      result->value = value_out;
+      result->value_len = 0;
+    }
+
+  *consumed = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * Literal Field Line with Literal Name - Size Calculation
+ * ============================================================================
+ */
+
+size_t
+SocketQPACK_literal_literal_size (const unsigned char *name,
+                                  size_t name_len,
+                                  const unsigned char *value,
+                                  size_t value_len,
+                                  int use_huffman)
+{
+  size_t name_data_len = name_len;
+  size_t value_data_len = value_len;
+  size_t total_size;
+
+  /* Check if Huffman helps for name */
+  if (use_huffman && name != NULL && name_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (name, name_len);
+      if (huffman_size < name_len)
+        name_data_len = huffman_size;
+    }
+
+  /* Check if Huffman helps for value */
+  if (use_huffman && value != NULL && value_len > 0)
+    {
+      size_t huffman_size = SocketHPACK_huffman_encoded_size (value, value_len);
+      if (huffman_size < value_len)
+        value_data_len = huffman_size;
+    }
+
+  /* Calculate name header size (3-bit prefix) */
+  size_t name_header
+      = SocketQPACK_int_size (name_data_len, SOCKETQPACK_LITERAL_NAME_PREFIX);
+  if (name_header == 0)
+    return 0;
+
+  /* Calculate value header size (7-bit prefix) */
+  size_t value_header
+      = SocketQPACK_int_size (value_data_len, SOCKETQPACK_LITERAL_VALUE_PREFIX);
+  if (value_header == 0)
+    return 0;
+
+  /* Total = name header + name data + value header + value data */
+  total_size = name_header + name_data_len + value_header + value_data_len;
+
+  return total_size;
+}

--- a/src/test/test_qpack_literal.c
+++ b/src/test/test_qpack_literal.c
@@ -1,0 +1,861 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_qpack_literal.c - Tests for QPACK Literal Field Line with Literal Name
+ *                        (RFC 9204 Section 4.5.6)
+ *
+ * Tests encoding/decoding of field lines where both name and value are
+ * literal strings, with various configurations of Huffman encoding and
+ * the never-indexed flag.
+ */
+
+#include <string.h>
+
+#include "http/qpack/SocketQPACK.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Pattern Validation Tests
+ * ============================================================================
+ */
+
+TEST (qpack_literal_literal_pattern_valid)
+{
+  /* Pattern '001' should match */
+  ASSERT (SocketQPACK_is_literal_literal (0x20)); /* 00100000 */
+  ASSERT (SocketQPACK_is_literal_literal (0x21)); /* 00100001 */
+  ASSERT (SocketQPACK_is_literal_literal (0x2F)); /* 00101111 */
+  ASSERT (SocketQPACK_is_literal_literal (0x30)); /* 00110000 */
+  ASSERT (SocketQPACK_is_literal_literal (0x3F)); /* 00111111 */
+}
+
+TEST (qpack_literal_literal_pattern_invalid)
+{
+  /* Pattern '000', '010', '011', '1xx' should not match */
+  ASSERT (!SocketQPACK_is_literal_literal (0x00)); /* 00000000 - indexed */
+  ASSERT (
+      !SocketQPACK_is_literal_literal (0x40)); /* 01000000 - literal indexed */
+  ASSERT (!SocketQPACK_is_literal_literal (0x60)); /* 01100000 */
+  ASSERT (!SocketQPACK_is_literal_literal (0x80)); /* 10000000 - indexed */
+  ASSERT (!SocketQPACK_is_literal_literal (0xC0)); /* 11000000 */
+}
+
+/* ============================================================================
+ * Encoding Tests - Basic
+ * ============================================================================
+ */
+
+TEST (qpack_literal_literal_encode_basic)
+{
+  unsigned char buf[256];
+  const char *name = "content-type";
+  const char *value = "text/plain";
+  ssize_t len;
+
+  len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)value,
+                                            strlen (value),
+                                            0,
+                                            0,
+                                            buf,
+                                            sizeof (buf));
+
+  ASSERT (len > 0);
+
+  /* Verify pattern bits are '001' */
+  ASSERT (SocketQPACK_is_literal_literal (buf[0]));
+
+  /* Verify N bit is 0 (not never-indexed) */
+  ASSERT_EQ (0, buf[0] & SOCKETQPACK_NEVER_INDEXED_BIT);
+
+  /* Verify H bit for name is 0 (plain text) */
+  ASSERT_EQ (0, buf[0] & SOCKETQPACK_NAME_HUFFMAN_BIT);
+}
+
+TEST (qpack_literal_literal_encode_never_indexed)
+{
+  unsigned char buf[256];
+  const char *name = "authorization";
+  const char *value = "Bearer secret-token";
+  ssize_t len;
+
+  len = SocketQPACK_literal_literal_encode (
+      (const unsigned char *)name,
+      strlen (name),
+      (const unsigned char *)value,
+      strlen (value),
+      1,
+      0,
+      buf,
+      sizeof (buf)); /* never_indexed = 1 */
+
+  ASSERT (len > 0);
+
+  /* Verify N bit is set */
+  ASSERT_NE (0, buf[0] & SOCKETQPACK_NEVER_INDEXED_BIT);
+}
+
+TEST (qpack_literal_literal_encode_huffman)
+{
+  unsigned char buf[256];
+  const char *name = "www-authenticate";
+  const char *value = "www.example.org";
+  ssize_t len;
+
+  len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)value,
+                                            strlen (value),
+                                            0,
+                                            1,
+                                            buf,
+                                            sizeof (buf)); /* use_huffman = 1 */
+
+  ASSERT (len > 0);
+
+  /* Huffman may or may not be used depending on whether it saves space */
+}
+
+TEST (qpack_literal_literal_encode_empty_value)
+{
+  unsigned char buf[256];
+  const char *name = "x-empty";
+  ssize_t len;
+
+  len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)"",
+                                            0,
+                                            0,
+                                            0,
+                                            buf,
+                                            sizeof (buf));
+
+  ASSERT (len > 0);
+}
+
+TEST (qpack_literal_literal_encode_buffer_too_small)
+{
+  unsigned char buf[2];
+  const char *name = "content-type";
+  const char *value = "application/json";
+  ssize_t len;
+
+  len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)value,
+                                            strlen (value),
+                                            0,
+                                            0,
+                                            buf,
+                                            sizeof (buf));
+
+  ASSERT_EQ (-1, len);
+}
+
+TEST (qpack_literal_literal_encode_null_buffer)
+{
+  ssize_t len
+      = SocketQPACK_literal_literal_encode ((const unsigned char *)"name",
+                                            4,
+                                            (const unsigned char *)"value",
+                                            5,
+                                            0,
+                                            0,
+                                            NULL,
+                                            256);
+
+  ASSERT_EQ (-1, len);
+}
+
+/* ============================================================================
+ * Decoding Tests - Basic
+ * ============================================================================
+ */
+
+TEST (qpack_literal_literal_decode_basic)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  const char *name = "content-type";
+  const char *value = "text/plain";
+  ssize_t enc_len;
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  /* Encode first */
+  enc_len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)value,
+                                                strlen (value),
+                                                0,
+                                                0,
+                                                encoded,
+                                                sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  /* Decode */
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (encoded,
+                                            (size_t)enc_len,
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ ((size_t)enc_len, consumed);
+  ASSERT_EQ (strlen (name), result.name_len);
+  ASSERT_EQ (strlen (value), result.value_len);
+  ASSERT_EQ (0, result.never_indexed);
+  ASSERT (memcmp (result.name, name, result.name_len) == 0);
+  ASSERT (memcmp (result.value, value, result.value_len) == 0);
+}
+
+TEST (qpack_literal_literal_decode_never_indexed)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  const char *name = "authorization";
+  const char *value = "Bearer token123";
+  ssize_t enc_len;
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  /* Encode with never_indexed = 1 */
+  enc_len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)value,
+                                                strlen (value),
+                                                1,
+                                                0,
+                                                encoded,
+                                                sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  /* Decode */
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (encoded,
+                                            (size_t)enc_len,
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (1, result.never_indexed);
+}
+
+TEST (qpack_literal_literal_decode_huffman)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  const char *name = "content-type";
+  const char *value = "application/json";
+  ssize_t enc_len;
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  /* Encode with Huffman */
+  enc_len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)value,
+                                                strlen (value),
+                                                0,
+                                                1,
+                                                encoded,
+                                                sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  /* Decode */
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (encoded,
+                                            (size_t)enc_len,
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (strlen (name), result.name_len);
+  ASSERT_EQ (strlen (value), result.value_len);
+  ASSERT (memcmp (result.name, name, result.name_len) == 0);
+  ASSERT (memcmp (result.value, value, result.value_len) == 0);
+}
+
+TEST (qpack_literal_literal_decode_empty_value)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  const char *name = "x-empty";
+  ssize_t enc_len;
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  enc_len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)"",
+                                                0,
+                                                0,
+                                                0,
+                                                encoded,
+                                                sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (encoded,
+                                            (size_t)enc_len,
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (strlen (name), result.name_len);
+  ASSERT_EQ (0, result.value_len);
+}
+
+TEST (qpack_literal_literal_decode_invalid_pattern)
+{
+  unsigned char data[]
+      = { 0x00, 0x05, 'h', 'e', 'l', 'l', 'o', 0x05, 'w', 'o', 'r', 'l', 'd' };
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  /* First byte has pattern '000', not '001' */
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (data,
+                                            sizeof (data),
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_ERROR_PATTERN, res);
+}
+
+TEST (qpack_literal_literal_decode_incomplete_name)
+{
+  unsigned char data[]
+      = { 0x25, 'h', 'e' }; /* Pattern 001, length 5, only 2 bytes */
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (data,
+                                            sizeof (data),
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_INCOMPLETE, res);
+}
+
+TEST (qpack_literal_literal_decode_incomplete_value)
+{
+  unsigned char data[]
+      = { 0x24, 't', 'e', 's', 't', 0x05, 'v' }; /* name OK, value truncated */
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (data,
+                                            sizeof (data),
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_INCOMPLETE, res);
+}
+
+TEST (qpack_literal_literal_decode_buffer_too_small)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[2]; /* Too small */
+  unsigned char value_buf[256];
+  const char *name = "content-type";
+  const char *value = "text/plain";
+  ssize_t enc_len;
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  enc_len = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)value,
+                                                strlen (value),
+                                                0,
+                                                0,
+                                                encoded,
+                                                sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (encoded,
+                                            (size_t)enc_len,
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_ERROR_BUFFER, res);
+}
+
+TEST (qpack_literal_literal_decode_null_pointers)
+{
+  unsigned char encoded[]
+      = { 0x24, 't', 'e', 's', 't', 0x05, 'v', 'a', 'l', 'u', 'e' };
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_literal_literal_decode (NULL,
+                                                 sizeof (encoded),
+                                                 name_buf,
+                                                 sizeof (name_buf),
+                                                 value_buf,
+                                                 sizeof (value_buf),
+                                                 &result,
+                                                 &consumed));
+
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_literal_literal_decode (encoded,
+                                                 sizeof (encoded),
+                                                 name_buf,
+                                                 sizeof (name_buf),
+                                                 value_buf,
+                                                 sizeof (value_buf),
+                                                 NULL,
+                                                 &consumed));
+
+  ASSERT_EQ (QPACK_ERROR_NULL,
+             SocketQPACK_literal_literal_decode (encoded,
+                                                 sizeof (encoded),
+                                                 name_buf,
+                                                 sizeof (name_buf),
+                                                 value_buf,
+                                                 sizeof (value_buf),
+                                                 &result,
+                                                 NULL));
+}
+
+/* ============================================================================
+ * Round-Trip Tests
+ * ============================================================================
+ */
+
+TEST (qpack_literal_literal_roundtrip_various_sizes)
+{
+  unsigned char encoded[4096];
+  unsigned char name_buf[256];
+  unsigned char value_buf[2048];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  /* Test various name/value size combinations */
+  struct
+  {
+    const char *name;
+    const char *value;
+  } test_cases[] = {
+    { "a", "b" },
+    { "content-type", "application/json" },
+    { "x-custom-header-with-longer-name", "short" },
+    { "short",
+      "a much longer value that should test multi-byte length encoding" },
+    { "cache-control", "no-cache, no-store, must-revalidate, max-age=0" },
+    { "set-cookie",
+      "session=abc123; Path=/; HttpOnly; Secure; SameSite=Strict" },
+  };
+
+  for (size_t i = 0; i < sizeof (test_cases) / sizeof (test_cases[0]); i++)
+    {
+      const char *name = test_cases[i].name;
+      const char *value = test_cases[i].value;
+
+      /* Test with plain encoding */
+      ssize_t enc_len
+          = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)value,
+                                                strlen (value),
+                                                0,
+                                                0,
+                                                encoded,
+                                                sizeof (encoded));
+      ASSERT (enc_len > 0);
+
+      SocketQPACK_Result res
+          = SocketQPACK_literal_literal_decode (encoded,
+                                                (size_t)enc_len,
+                                                name_buf,
+                                                sizeof (name_buf),
+                                                value_buf,
+                                                sizeof (value_buf),
+                                                &result,
+                                                &consumed);
+
+      ASSERT_EQ (QPACK_OK, res);
+      ASSERT_EQ ((size_t)enc_len, consumed);
+      ASSERT_EQ (strlen (name), result.name_len);
+      ASSERT_EQ (strlen (value), result.value_len);
+      ASSERT (memcmp (result.name, name, result.name_len) == 0);
+      ASSERT (memcmp (result.value, value, result.value_len) == 0);
+
+      /* Test with Huffman encoding */
+      enc_len
+          = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                                strlen (name),
+                                                (const unsigned char *)value,
+                                                strlen (value),
+                                                0,
+                                                1,
+                                                encoded,
+                                                sizeof (encoded));
+      ASSERT (enc_len > 0);
+
+      res = SocketQPACK_literal_literal_decode (encoded,
+                                                (size_t)enc_len,
+                                                name_buf,
+                                                sizeof (name_buf),
+                                                value_buf,
+                                                sizeof (value_buf),
+                                                &result,
+                                                &consumed);
+
+      ASSERT_EQ (QPACK_OK, res);
+      ASSERT_EQ (strlen (name), result.name_len);
+      ASSERT_EQ (strlen (value), result.value_len);
+      ASSERT (memcmp (result.name, name, result.name_len) == 0);
+      ASSERT (memcmp (result.value, value, result.value_len) == 0);
+    }
+}
+
+TEST (qpack_literal_literal_roundtrip_sensitive)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  const char *sensitive_headers[] = {
+    "authorization",
+    "cookie",
+    "set-cookie",
+    "proxy-authorization",
+  };
+
+  for (size_t i = 0;
+       i < sizeof (sensitive_headers) / sizeof (sensitive_headers[0]);
+       i++)
+    {
+      const char *name = sensitive_headers[i];
+      const char *value = "sensitive-value-that-should-not-be-indexed";
+
+      ssize_t enc_len = SocketQPACK_literal_literal_encode (
+          (const unsigned char *)name,
+          strlen (name),
+          (const unsigned char *)value,
+          strlen (value),
+          1,
+          0,
+          encoded,
+          sizeof (encoded)); /* never_indexed = 1 */
+      ASSERT (enc_len > 0);
+
+      SocketQPACK_Result res
+          = SocketQPACK_literal_literal_decode (encoded,
+                                                (size_t)enc_len,
+                                                name_buf,
+                                                sizeof (name_buf),
+                                                value_buf,
+                                                sizeof (value_buf),
+                                                &result,
+                                                &consumed);
+
+      ASSERT_EQ (QPACK_OK, res);
+      ASSERT_EQ (1, result.never_indexed);
+      ASSERT (memcmp (result.name, name, result.name_len) == 0);
+      ASSERT (memcmp (result.value, value, result.value_len) == 0);
+    }
+}
+
+TEST (qpack_literal_literal_roundtrip_binary_data)
+{
+  unsigned char encoded[256];
+  unsigned char name_buf[256];
+  unsigned char value_buf[256];
+  SocketQPACK_LiteralLiteral_T result;
+  size_t consumed;
+
+  unsigned char name[] = { 'x', '-', 'b', 'i', 'n' };
+  unsigned char value[] = { 0x00, 0x01, 0x02, 0xff, 0xfe, 0x80, 0x7f };
+
+  ssize_t enc_len = SocketQPACK_literal_literal_encode (name,
+                                                        sizeof (name),
+                                                        value,
+                                                        sizeof (value),
+                                                        0,
+                                                        0,
+                                                        encoded,
+                                                        sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  SocketQPACK_Result res
+      = SocketQPACK_literal_literal_decode (encoded,
+                                            (size_t)enc_len,
+                                            name_buf,
+                                            sizeof (name_buf),
+                                            value_buf,
+                                            sizeof (value_buf),
+                                            &result,
+                                            &consumed);
+
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (sizeof (name), result.name_len);
+  ASSERT_EQ (sizeof (value), result.value_len);
+  ASSERT (memcmp (result.name, name, result.name_len) == 0);
+  ASSERT (memcmp (result.value, value, result.value_len) == 0);
+}
+
+/* ============================================================================
+ * Size Calculation Tests
+ * ============================================================================
+ */
+
+TEST (qpack_literal_literal_size_basic)
+{
+  const char *name = "content-type";
+  const char *value = "text/plain";
+
+  size_t calc_size
+      = SocketQPACK_literal_literal_size ((const unsigned char *)name,
+                                          strlen (name),
+                                          (const unsigned char *)value,
+                                          strlen (value),
+                                          0);
+  ASSERT (calc_size > 0);
+
+  /* Verify against actual encoding */
+  unsigned char buf[256];
+  ssize_t enc_len
+      = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)value,
+                                            strlen (value),
+                                            0,
+                                            0,
+                                            buf,
+                                            sizeof (buf));
+
+  ASSERT_EQ (calc_size, (size_t)enc_len);
+}
+
+TEST (qpack_literal_literal_size_huffman)
+{
+  const char *name = "content-type";
+  const char *value = "application/json";
+
+  size_t calc_size
+      = SocketQPACK_literal_literal_size ((const unsigned char *)name,
+                                          strlen (name),
+                                          (const unsigned char *)value,
+                                          strlen (value),
+                                          1);
+  ASSERT (calc_size > 0);
+
+  unsigned char buf[256];
+  ssize_t enc_len
+      = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)value,
+                                            strlen (value),
+                                            0,
+                                            1,
+                                            buf,
+                                            sizeof (buf));
+
+  ASSERT_EQ (calc_size, (size_t)enc_len);
+}
+
+TEST (qpack_literal_literal_size_empty_value)
+{
+  const char *name = "x-empty";
+
+  size_t calc_size
+      = SocketQPACK_literal_literal_size ((const unsigned char *)name,
+                                          strlen (name),
+                                          (const unsigned char *)"",
+                                          0,
+                                          0);
+  ASSERT (calc_size > 0);
+
+  unsigned char buf[256];
+  ssize_t enc_len
+      = SocketQPACK_literal_literal_encode ((const unsigned char *)name,
+                                            strlen (name),
+                                            (const unsigned char *)"",
+                                            0,
+                                            0,
+                                            0,
+                                            buf,
+                                            sizeof (buf));
+
+  ASSERT_EQ (calc_size, (size_t)enc_len);
+}
+
+/* ============================================================================
+ * Integer Primitive Tests (from Section 4.1)
+ * ============================================================================
+ */
+
+TEST (qpack_int_encode_small_value)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 10 with 5-bit prefix should fit in single byte */
+  len = SocketQPACK_int_encode (10, 5, buf, sizeof (buf));
+  ASSERT_EQ (1, len);
+  ASSERT_EQ (10, buf[0] & 0x1f);
+}
+
+TEST (qpack_int_encode_multi_byte)
+{
+  unsigned char buf[16];
+  ssize_t len;
+
+  /* Value 1337 with 5-bit prefix needs continuation bytes */
+  len = SocketQPACK_int_encode (1337, 5, buf, sizeof (buf));
+  ASSERT (len >= 2);
+  ASSERT_EQ (0x1f, buf[0] & 0x1f);
+}
+
+TEST (qpack_int_decode_roundtrip)
+{
+  unsigned char buf[16];
+  uint64_t value;
+  size_t consumed;
+  ssize_t len;
+
+  for (int prefix = 3; prefix <= 8; prefix++)
+    {
+      len = SocketQPACK_int_encode (1337, prefix, buf, sizeof (buf));
+      ASSERT (len > 0);
+
+      SocketQPACK_Result res = SocketQPACK_int_decode (
+          buf, (size_t)len, prefix, &value, &consumed);
+      ASSERT_EQ (QPACK_OK, res);
+      ASSERT_EQ (1337, value);
+      ASSERT_EQ ((size_t)len, consumed);
+    }
+}
+
+/* ============================================================================
+ * String Primitive Tests (from Section 4.1)
+ * ============================================================================
+ */
+
+TEST (qpack_string_encode_plain)
+{
+  unsigned char buf[256];
+  const char *str = "hello";
+  ssize_t len;
+
+  len = SocketQPACK_string_encode (
+      (const unsigned char *)str, strlen (str), 0, 7, buf, sizeof (buf));
+  ASSERT (len > 0);
+  ASSERT_EQ (0, buf[0] & 0x80); /* Huffman flag off */
+}
+
+TEST (qpack_string_decode_roundtrip)
+{
+  unsigned char encoded[256];
+  unsigned char decoded[256];
+  const char *str = "www.example.org";
+  ssize_t enc_len;
+  size_t decoded_len, consumed;
+
+  enc_len = SocketQPACK_string_encode ((const unsigned char *)str,
+                                       strlen (str),
+                                       1,
+                                       7,
+                                       encoded,
+                                       sizeof (encoded));
+  ASSERT (enc_len > 0);
+
+  SocketQPACK_Result res = SocketQPACK_string_decode (encoded,
+                                                      (size_t)enc_len,
+                                                      7,
+                                                      decoded,
+                                                      sizeof (decoded),
+                                                      &decoded_len,
+                                                      &consumed);
+
+  ASSERT_EQ (QPACK_OK, res);
+  ASSERT_EQ (strlen (str), decoded_len);
+  ASSERT (memcmp (decoded, str, decoded_len) == 0);
+}
+
+/* ============================================================================
+ * Result String Tests
+ * ============================================================================
+ */
+
+TEST (qpack_result_string)
+{
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_OK));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_INCOMPLETE));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERROR_PATTERN));
+
+  /* Invalid result code should return something */
+  ASSERT_NOT_NULL (SocketQPACK_result_string ((SocketQPACK_Result)999));
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Implements QPACK Literal Field Line with Literal Name encoding/decoding per RFC 9204 Section 4.5.6, enabling HTTP/3 header compression where both field name and value are transmitted as literal strings.

- Add QPACK primitives: integer encode/decode, string encode/decode (Section 4.1)
- Implement Literal Field Line with Literal Name encode/decode/size (Section 4.5.6)
- Support for pattern validation ('001' prefix bits)
- Support for never-indexed flag (N bit) for sensitive headers
- Support for optional Huffman compression
- Comprehensive test suite with 29 tests

## Changes

- `include/http/qpack/SocketQPACK.h` - Public API header with documentation
- `src/http/qpack/SocketQPACK.c` - Implementation of primitives and field line encoding
- `src/test/test_qpack_literal.c` - Test suite covering encode/decode/roundtrip/edge cases
- `CMakeLists.txt` - Build system integration

## Test Plan

- [x] All 29 QPACK tests pass
- [x] Full test suite (140 tests) passes with sanitizers enabled
- [x] Code formatted with clang-format

Closes #3297