### PR TITLE
feat(qpack): implement RFC 9204 Section 6 error handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,9 @@ set(LIB_SOURCES
     src/http/h2/SocketHTTP2-validate.c
     src/http/h2/SocketHTTP2-priority.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-error.c
+
     # HTTP Client API
     src/http/SocketHTTPClient.c
     src/http/client/SocketHTTPClient-pool.c
@@ -628,6 +631,7 @@ set(HTTP_HEADERS
     include/http/SocketHPACK-private.h
     include/http/SocketHTTP2.h
     include/http/SocketHTTP2-private.h
+    include/http/SocketQPACK.h
     include/http/SocketHTTPClient.h
     include/http/SocketHTTPClient-private.h
     include/http/SocketHTTPServer.h
@@ -780,6 +784,7 @@ set(TEST_SOURCES
     test_http_core
     test_http1_parser
     test_hpack
+    test_qpack_error
     test_http2
     test_http2_priority
     test_http2_rate_limit

--- a/include/http/SocketQPACK.h
+++ b/include/http/SocketQPACK.h
@@ -1,0 +1,333 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression/decompression for HTTP/3 (RFC 9204).
+ *
+ * Implements RFC 9204 Section 6 - Error Handling. QPACK is the header
+ * compression format used by HTTP/3, evolved from HPACK (RFC 7541) to work
+ * with QUIC's out-of-order delivery.
+ *
+ * QPACK-specific error codes (RFC 9204 §6):
+ *   - 0x0200: QPACK_DECOMPRESSION_FAILED - decoder cannot interpret field
+ *             section
+ *   - 0x0201: QPACK_ENCODER_STREAM_ERROR - invalid encoder stream instruction
+ *   - 0x0202: QPACK_DECODER_STREAM_ERROR - invalid decoder stream instruction
+ *
+ * HTTP/3 error codes used by QPACK (RFC 9114):
+ *   - 0x0101: H3_STREAM_CREATION_ERROR - duplicate encoder/decoder stream
+ *   - 0x0104: H3_CLOSED_CRITICAL_STREAM - encoder/decoder stream closed
+ *
+ * Thread Safety: Encoder/decoder instances are NOT thread-safe. One instance
+ * per connection/thread recommended. Static functions are thread-safe.
+ *
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Except.h"
+
+/* ============================================================================
+ * QPACK Result Codes (Internal Error Handling)
+ * ============================================================================
+ */
+
+/**
+ * @brief Internal QPACK operation result codes.
+ *
+ * These codes provide granular error information for internal API calls.
+ * They are mapped to HTTP/3 error codes when errors need to be communicated
+ * over the wire via QUIC CONNECTION_CLOSE frames.
+ */
+typedef enum
+{
+  /** Operation completed successfully. */
+  QPACK_OK = 0,
+
+  /** Need more data to complete operation. */
+  QPACK_INCOMPLETE,
+
+  /** Waiting for dynamic table state from encoder stream. */
+  QPACK_BLOCKED,
+
+  /** Generic error (unspecified). */
+  QPACK_ERROR,
+
+  /** Invalid static or dynamic table index. */
+  QPACK_ERROR_INVALID_INDEX,
+
+  /** Dynamic table capacity exceeds configured limit. */
+  QPACK_ERROR_INVALID_CAPACITY,
+
+  /** Huffman decoding error. */
+  QPACK_ERROR_HUFFMAN,
+
+  /** Integer decoding error (overflow or malformed). */
+  QPACK_ERROR_INTEGER,
+
+  /** String decoding error (length or encoding). */
+  QPACK_ERROR_STRING,
+
+  /** Individual header exceeds size limit. */
+  QPACK_ERROR_HEADER_SIZE,
+
+  /** Total header list exceeds size limit. */
+  QPACK_ERROR_LIST_SIZE,
+
+  /** Invalid Required Insert Count in encoded field section. */
+  QPACK_ERROR_REQUIRED_INSERT,
+
+  /** Invalid Base delta in encoded field section. */
+  QPACK_ERROR_BASE,
+
+  /**
+   * Duplicate encoder or decoder stream on connection.
+   * RFC 9204 §4.2: Maps to H3_STREAM_CREATION_ERROR (0x0101).
+   */
+  QPACK_ERROR_DUPLICATE_STREAM,
+
+  /**
+   * Critical unidirectional stream was closed.
+   * RFC 9204 §4.2: Maps to H3_CLOSED_CRITICAL_STREAM (0x0104).
+   */
+  QPACK_ERROR_STREAM_CLOSED,
+
+  /**
+   * Static table lookup: name not found.
+   * Used when searching static table for a header name that doesn't exist.
+   */
+  QPACK_ERROR_NOT_FOUND,
+
+  /**
+   * Dynamic table: referenced entry has been evicted.
+   * RFC 9204 Section 2.1.1: Entries are evicted when table capacity exceeded.
+   */
+  QPACK_ERROR_EVICTED_INDEX,
+
+  /**
+   * Dynamic table: index references not-yet-inserted entry.
+   * RFC 9204 Section 3.2.6: Post-base references must be valid.
+   */
+  QPACK_ERROR_FUTURE_INDEX,
+
+  /**
+   * Dynamic table: base would exceed Insert Count.
+   * RFC 9204 Section 4.5.1: Base must be within valid range.
+   */
+  QPACK_ERROR_BASE_OVERFLOW,
+
+  /** Count of result codes (for array bounds checking). */
+  QPACK_RESULT_COUNT
+
+} SocketQPACK_Result;
+
+/* ============================================================================
+ * HTTP/3 Error Codes (RFC 9204 Section 6)
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK decompression failed error code.
+ *
+ * RFC 9204 Section 6: "An error in the encoded data that indicates
+ * a violation of QPACK. This error is raised when the decoder cannot
+ * interpret an encoded field section."
+ *
+ * Used in CONNECTION_CLOSE frames (type 0x1d) to indicate that the
+ * decoder encountered malformed or invalid QPACK-encoded data.
+ */
+#define QPACK_DECOMPRESSION_FAILED 0x0200
+
+/**
+ * @brief QPACK encoder stream error code.
+ *
+ * RFC 9204 Section 6: "An error on the encoder stream. This error is
+ * raised when the decoder fails to interpret an instruction on the
+ * encoder stream."
+ *
+ * Used in CONNECTION_CLOSE frames (type 0x1d) when an invalid
+ * instruction is received on the encoder stream.
+ */
+#define QPACK_ENCODER_STREAM_ERROR 0x0201
+
+/**
+ * @brief QPACK decoder stream error code.
+ *
+ * RFC 9204 Section 6: "An error on the decoder stream. This error is
+ * raised when the encoder fails to interpret an instruction on the
+ * decoder stream."
+ *
+ * Used in CONNECTION_CLOSE frames (type 0x1d) when an invalid
+ * instruction is received on the decoder stream.
+ */
+#define QPACK_DECODER_STREAM_ERROR 0x0202
+
+/* ============================================================================
+ * HTTP/3 Error Codes Used by QPACK (RFC 9114, referenced by RFC 9204 §4.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Duplicate critical stream error code.
+ *
+ * RFC 9204 §4.2: "Receipt of a second instance of either stream type
+ * MUST be treated as a connection error of type H3_STREAM_CREATION_ERROR."
+ *
+ * This is an HTTP/3 error code (RFC 9114), not a QPACK error code, but
+ * is used for QPACK stream management violations.
+ */
+#define H3_STREAM_CREATION_ERROR 0x0101
+
+/**
+ * @brief Critical stream closed error code.
+ *
+ * RFC 9204 §4.2: "Closure of either unidirectional stream type MUST be
+ * treated as a connection error of type H3_CLOSED_CRITICAL_STREAM."
+ *
+ * This is an HTTP/3 error code (RFC 9114), not a QPACK error code, but
+ * is used when the encoder or decoder stream is prematurely closed.
+ */
+#define H3_CLOSED_CRITICAL_STREAM 0x0104
+
+/* ============================================================================
+ * Exception Type
+ * ============================================================================
+ */
+
+/**
+ * @brief Exception raised on QPACK encoding/decoding errors.
+ *
+ * This exception is raised when QPACK operations encounter fatal errors
+ * that cannot be recovered. The exception's reason field contains a
+ * human-readable description of the error.
+ *
+ * Example usage:
+ * @code
+ * TRY {
+ *     result = SocketQPACK_decode(...);
+ * } EXCEPT(SocketQPACK_Error) {
+ *     // Handle QPACK error
+ * } END_TRY;
+ * @endcode
+ */
+extern const Except_T SocketQPACK_Error;
+
+/* ============================================================================
+ * Error Handling Functions
+ * ============================================================================
+ */
+
+/**
+ * @brief Convert internal result code to human-readable string.
+ *
+ * Returns a static string describing the given result code. This function
+ * is useful for logging and debugging QPACK operations.
+ *
+ * @param result QPACK operation result code.
+ * @return Static string describing the result. Never returns NULL.
+ *
+ * @note Thread-safe: Returns pointer to static read-only string.
+ *
+ * Example:
+ * @code
+ * SocketQPACK_Result r = QPACK_ERROR_INVALID_INDEX;
+ * printf("Error: %s\n", SocketQPACK_result_string(r));
+ * // Output: "Error: Invalid table index"
+ * @endcode
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/**
+ * @brief Map internal result code to HTTP/3 error code.
+ *
+ * Converts an internal QPACK result code to the appropriate HTTP/3
+ * error code for use in QUIC CONNECTION_CLOSE frames. The mapping
+ * follows RFC 9204:
+ *
+ *   - Field section decoding errors -> QPACK_DECOMPRESSION_FAILED (0x0200)
+ *   - Encoder stream instruction errors -> QPACK_ENCODER_STREAM_ERROR (0x0201)
+ *   - Decoder stream instruction errors -> QPACK_DECODER_STREAM_ERROR (0x0202)
+ *   - Duplicate stream (§4.2) -> H3_STREAM_CREATION_ERROR (0x0101)
+ *   - Stream closed (§4.2) -> H3_CLOSED_CRITICAL_STREAM (0x0104)
+ *
+ * @param result Internal QPACK result code.
+ * @return HTTP/3 error code, or 0 if result is not an error.
+ *
+ * @note For QPACK_OK, QPACK_INCOMPLETE, and QPACK_BLOCKED, returns 0
+ *       since these are not error conditions requiring connection closure.
+ *
+ * Example:
+ * @code
+ * if (result != QPACK_OK) {
+ *     uint64_t http3_error = SocketQPACK_error_code(result);
+ *     SocketQUIC_send_connection_close(conn, http3_error, NULL, 0, buf, len);
+ * }
+ * @endcode
+ */
+extern uint64_t SocketQPACK_error_code (SocketQPACK_Result result);
+
+/**
+ * @brief Get human-readable string for HTTP/3 QPACK error code.
+ *
+ * Returns a static string describing the given HTTP/3 error code.
+ * Handles both QPACK-specific error codes (0x0200-0x0202) and
+ * HTTP/3 error codes used by QPACK (0x0101, 0x0104).
+ *
+ * @param code HTTP/3 error code.
+ * @return Static string for recognized errors, or NULL if code is not
+ *         a QPACK-related error.
+ *
+ * @note Thread-safe: Returns pointer to static read-only string.
+ */
+extern const char *SocketQPACK_http3_error_string (uint64_t code);
+
+/**
+ * @brief Check if HTTP/3 error code is a QPACK-specific error.
+ *
+ * Returns true only for QPACK error codes defined in RFC 9204 §6
+ * (0x0200-0x0202). Does NOT return true for HTTP/3 errors that
+ * QPACK uses (H3_STREAM_CREATION_ERROR, H3_CLOSED_CRITICAL_STREAM).
+ *
+ * @param code HTTP/3 error code to check.
+ * @return Non-zero if code is in QPACK error range (0x0200-0x0202),
+ *         0 otherwise.
+ */
+static inline int
+SocketQPACK_is_qpack_error (uint64_t code)
+{
+  return code >= QPACK_DECOMPRESSION_FAILED
+         && code <= QPACK_DECODER_STREAM_ERROR;
+}
+
+/**
+ * @brief Check if HTTP/3 error code is QPACK-related (including H3 errors).
+ *
+ * Returns true for any error code that can be generated by QPACK
+ * operations, including both RFC 9204 §6 errors and HTTP/3 errors
+ * referenced in RFC 9204 §4.2.
+ *
+ * @param code HTTP/3 error code to check.
+ * @return Non-zero if code is QPACK-related, 0 otherwise.
+ */
+static inline int
+SocketQPACK_is_qpack_related_error (uint64_t code)
+{
+  return SocketQPACK_is_qpack_error (code)
+         || code == H3_STREAM_CREATION_ERROR
+         || code == H3_CLOSED_CRITICAL_STREAM;
+}
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK-error.c
+++ b/src/http/qpack/SocketQPACK-error.c
@@ -1,0 +1,176 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * SocketQPACK.c - QPACK Error Handling (RFC 9204 Section 6)
+ *
+ * Implements error code definitions, result string conversion, and
+ * HTTP/3 error code mapping for QPACK header compression.
+ */
+
+#include "http/SocketQPACK.h"
+
+#include <stddef.h>
+
+/* ============================================================================
+ * Exception Definition
+ * ============================================================================
+ */
+
+const Except_T SocketQPACK_Error
+    = { &SocketQPACK_Error, "QPACK compression error" };
+
+/* ============================================================================
+ * Result String Mapping
+ * ============================================================================
+ */
+
+/**
+ * Static result string table indexed by SocketQPACK_Result.
+ * Provides human-readable descriptions for logging and debugging.
+ *
+ * Note: Array size is QPACK_RESULT_COUNT to ensure bounds safety.
+ * If new result codes are added, this array must be updated.
+ */
+static const char *result_strings[QPACK_RESULT_COUNT] = {
+  [QPACK_OK] = "OK",
+  [QPACK_INCOMPLETE] = "Incomplete - need more data",
+  [QPACK_BLOCKED] = "Blocked - waiting for dynamic table state",
+  [QPACK_ERROR] = "Generic error",
+  [QPACK_ERROR_INVALID_INDEX] = "Invalid table index",
+  [QPACK_ERROR_INVALID_CAPACITY] = "Capacity exceeds limit",
+  [QPACK_ERROR_HUFFMAN] = "Huffman decoding error",
+  [QPACK_ERROR_INTEGER] = "Integer decoding error",
+  [QPACK_ERROR_STRING] = "String decoding error",
+  [QPACK_ERROR_HEADER_SIZE] = "Header too large",
+  [QPACK_ERROR_LIST_SIZE] = "Header list too large",
+  [QPACK_ERROR_REQUIRED_INSERT] = "Invalid Required Insert Count",
+  [QPACK_ERROR_BASE] = "Invalid Base",
+  [QPACK_ERROR_DUPLICATE_STREAM] = "Duplicate encoder/decoder stream",
+  [QPACK_ERROR_STREAM_CLOSED] = "Critical stream closed",
+  [QPACK_ERROR_NOT_FOUND] = "Static table name not found",
+  [QPACK_ERROR_EVICTED_INDEX] = "Dynamic table entry evicted",
+  [QPACK_ERROR_FUTURE_INDEX] = "Dynamic table future index reference",
+  [QPACK_ERROR_BASE_OVERFLOW] = "Dynamic table base overflow",
+};
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  if (result < 0 || result >= QPACK_RESULT_COUNT)
+    return "Unknown error";
+
+  const char *str = result_strings[result];
+  return str ? str : "Unknown error";
+}
+
+/* ============================================================================
+ * HTTP/3 Error Code Mapping (RFC 9204 Section 6 and Section 4.2)
+ * ============================================================================
+ */
+
+/**
+ * Map internal QPACK result codes to HTTP/3 error codes.
+ *
+ * The mapping follows RFC 9204:
+ *
+ * QPACK_DECOMPRESSION_FAILED (0x0200) - RFC 9204 §6:
+ *   - Used when decoder cannot interpret encoded field section data
+ *   - Maps from: QPACK_ERROR_INVALID_INDEX, QPACK_ERROR_HUFFMAN,
+ *                QPACK_ERROR_INTEGER, QPACK_ERROR_STRING,
+ *                QPACK_ERROR_HEADER_SIZE, QPACK_ERROR_LIST_SIZE,
+ *                QPACK_ERROR_REQUIRED_INSERT, QPACK_ERROR_BASE,
+ *                QPACK_ERROR (generic)
+ *
+ * QPACK_ENCODER_STREAM_ERROR (0x0201) - RFC 9204 §6:
+ *   - Used when decoder fails to interpret encoder stream instruction
+ *   - Maps from: QPACK_ERROR_INVALID_CAPACITY (capacity update instruction)
+ *
+ * QPACK_DECODER_STREAM_ERROR (0x0202) - RFC 9204 §6:
+ *   - Used when encoder fails to interpret decoder stream instruction
+ *   - (No internal errors currently map to this)
+ *
+ * H3_STREAM_CREATION_ERROR (0x0101) - RFC 9204 §4.2:
+ *   - "Receipt of a second instance of either stream type MUST be
+ *      treated as a connection error of type H3_STREAM_CREATION_ERROR."
+ *   - Maps from: QPACK_ERROR_DUPLICATE_STREAM
+ *
+ * H3_CLOSED_CRITICAL_STREAM (0x0104) - RFC 9204 §4.2:
+ *   - "Closure of either unidirectional stream type MUST be treated
+ *      as a connection error of type H3_CLOSED_CRITICAL_STREAM."
+ *   - Maps from: QPACK_ERROR_STREAM_CLOSED
+ */
+uint64_t
+SocketQPACK_error_code (SocketQPACK_Result result)
+{
+  switch (result)
+    {
+    /* Non-error conditions - return 0 */
+    case QPACK_OK:
+    case QPACK_INCOMPLETE:
+    case QPACK_BLOCKED:
+      return 0;
+
+    /* Encoder stream errors (0x0201) - RFC 9204 §6 */
+    case QPACK_ERROR_INVALID_CAPACITY:
+      return QPACK_ENCODER_STREAM_ERROR;
+
+    /* HTTP/3 stream management errors - RFC 9204 §4.2 */
+    case QPACK_ERROR_DUPLICATE_STREAM:
+      return H3_STREAM_CREATION_ERROR;
+
+    case QPACK_ERROR_STREAM_CLOSED:
+      return H3_CLOSED_CRITICAL_STREAM;
+
+    /* Decompression failures (0x0200) - RFC 9204 §6 - all other errors */
+    case QPACK_ERROR:
+    case QPACK_ERROR_INVALID_INDEX:
+    case QPACK_ERROR_HUFFMAN:
+    case QPACK_ERROR_INTEGER:
+    case QPACK_ERROR_STRING:
+    case QPACK_ERROR_HEADER_SIZE:
+    case QPACK_ERROR_LIST_SIZE:
+    case QPACK_ERROR_REQUIRED_INSERT:
+    case QPACK_ERROR_BASE:
+    case QPACK_ERROR_NOT_FOUND:
+    case QPACK_ERROR_EVICTED_INDEX:
+    case QPACK_ERROR_FUTURE_INDEX:
+    case QPACK_ERROR_BASE_OVERFLOW:
+    default:
+      return QPACK_DECOMPRESSION_FAILED;
+
+    /* Note: QPACK_RESULT_COUNT is not a valid result, handled by default */
+    }
+}
+
+/* ============================================================================
+ * HTTP/3 Error String Conversion
+ * ============================================================================
+ */
+
+const char *
+SocketQPACK_http3_error_string (uint64_t code)
+{
+  switch (code)
+    {
+    /* QPACK-specific errors (RFC 9204 §6) */
+    case QPACK_DECOMPRESSION_FAILED:
+      return "QPACK_DECOMPRESSION_FAILED";
+    case QPACK_ENCODER_STREAM_ERROR:
+      return "QPACK_ENCODER_STREAM_ERROR";
+    case QPACK_DECODER_STREAM_ERROR:
+      return "QPACK_DECODER_STREAM_ERROR";
+
+    /* HTTP/3 errors used by QPACK (RFC 9204 §4.2) */
+    case H3_STREAM_CREATION_ERROR:
+      return "H3_STREAM_CREATION_ERROR";
+    case H3_CLOSED_CRITICAL_STREAM:
+      return "H3_CLOSED_CRITICAL_STREAM";
+
+    default:
+      return NULL;
+    }
+}

--- a/src/test/test_qpack_error.c
+++ b/src/test/test_qpack_error.c
@@ -1,0 +1,524 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_error.c
+ * @brief Unit tests for QPACK error handling (RFC 9204 Section 6).
+ *
+ * Tests error code definitions, result string conversion, HTTP/3
+ * error code mapping, and inline utility functions.
+ */
+
+#include "http/SocketQPACK.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * Error Code Constant Tests
+ * ============================================================================
+ */
+
+TEST (qpack_error_decompression_failed_value)
+{
+  ASSERT_EQ (0x0200, QPACK_DECOMPRESSION_FAILED);
+}
+
+TEST (qpack_error_encoder_stream_error_value)
+{
+  ASSERT_EQ (0x0201, QPACK_ENCODER_STREAM_ERROR);
+}
+
+TEST (qpack_error_decoder_stream_error_value)
+{
+  ASSERT_EQ (0x0202, QPACK_DECODER_STREAM_ERROR);
+}
+
+TEST (h3_stream_creation_error_value)
+{
+  ASSERT_EQ (0x0101, H3_STREAM_CREATION_ERROR);
+}
+
+TEST (h3_closed_critical_stream_value)
+{
+  ASSERT_EQ (0x0104, H3_CLOSED_CRITICAL_STREAM);
+}
+
+/* ============================================================================
+ * Result String Tests
+ * ============================================================================
+ */
+
+TEST (qpack_result_string_ok)
+{
+  const char *str = SocketQPACK_result_string (QPACK_OK);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strcmp (str, "OK") == 0);
+}
+
+TEST (qpack_result_string_incomplete)
+{
+  const char *str = SocketQPACK_result_string (QPACK_INCOMPLETE);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Incomplete") != NULL);
+}
+
+TEST (qpack_result_string_blocked)
+{
+  const char *str = SocketQPACK_result_string (QPACK_BLOCKED);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Blocked") != NULL);
+}
+
+TEST (qpack_result_string_generic_error)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "error") != NULL || strstr (str, "Error") != NULL);
+}
+
+TEST (qpack_result_string_invalid_index)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_INVALID_INDEX);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "index") != NULL || strstr (str, "Index") != NULL);
+}
+
+TEST (qpack_result_string_invalid_capacity)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_INVALID_CAPACITY);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "apacity") != NULL);
+}
+
+TEST (qpack_result_string_huffman)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_HUFFMAN);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Huffman") != NULL || strstr (str, "huffman") != NULL);
+}
+
+TEST (qpack_result_string_integer)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_INTEGER);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Integer") != NULL || strstr (str, "integer") != NULL);
+}
+
+TEST (qpack_result_string_string)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_STRING);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "String") != NULL || strstr (str, "string") != NULL);
+}
+
+TEST (qpack_result_string_header_size)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_HEADER_SIZE);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Header") != NULL || strstr (str, "header") != NULL);
+}
+
+TEST (qpack_result_string_list_size)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_LIST_SIZE);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "list") != NULL || strstr (str, "List") != NULL);
+}
+
+TEST (qpack_result_string_required_insert)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_REQUIRED_INSERT);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Insert") != NULL || strstr (str, "insert") != NULL);
+}
+
+TEST (qpack_result_string_base)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_BASE);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "Base") != NULL || strstr (str, "base") != NULL);
+}
+
+TEST (qpack_result_string_duplicate_stream)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_DUPLICATE_STREAM);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "uplicate") != NULL || strstr (str, "stream") != NULL);
+}
+
+TEST (qpack_result_string_stream_closed)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_STREAM_CLOSED);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "losed") != NULL || strstr (str, "stream") != NULL);
+}
+
+TEST (qpack_result_string_not_found)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_NOT_FOUND);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "ound") != NULL || strstr (str, "table") != NULL);
+}
+
+TEST (qpack_result_string_evicted_index)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_EVICTED_INDEX);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "victed") != NULL || strstr (str, "dynamic") != NULL);
+}
+
+TEST (qpack_result_string_future_index)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_FUTURE_INDEX);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "uture") != NULL || strstr (str, "index") != NULL);
+}
+
+TEST (qpack_result_string_base_overflow)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERROR_BASE_OVERFLOW);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "verflow") != NULL || strstr (str, "base") != NULL);
+}
+
+TEST (qpack_result_string_invalid_negative)
+{
+  const char *str = SocketQPACK_result_string ((SocketQPACK_Result) -1);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "nknown") != NULL);
+}
+
+TEST (qpack_result_string_invalid_large)
+{
+  const char *str = SocketQPACK_result_string ((SocketQPACK_Result) 999);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "nknown") != NULL);
+}
+
+TEST (qpack_result_string_at_count)
+{
+  const char *str = SocketQPACK_result_string (QPACK_RESULT_COUNT);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "nknown") != NULL);
+}
+
+/* ============================================================================
+ * HTTP/3 Error Code Mapping Tests
+ * ============================================================================
+ */
+
+TEST (qpack_error_code_ok)
+{
+  ASSERT_EQ (0, SocketQPACK_error_code (QPACK_OK));
+}
+
+TEST (qpack_error_code_incomplete)
+{
+  ASSERT_EQ (0, SocketQPACK_error_code (QPACK_INCOMPLETE));
+}
+
+TEST (qpack_error_code_blocked)
+{
+  ASSERT_EQ (0, SocketQPACK_error_code (QPACK_BLOCKED));
+}
+
+TEST (qpack_error_code_generic_error)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR));
+}
+
+TEST (qpack_error_code_invalid_index)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_INVALID_INDEX));
+}
+
+TEST (qpack_error_code_invalid_capacity)
+{
+  ASSERT_EQ (QPACK_ENCODER_STREAM_ERROR,
+             SocketQPACK_error_code (QPACK_ERROR_INVALID_CAPACITY));
+}
+
+TEST (qpack_error_code_huffman)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_HUFFMAN));
+}
+
+TEST (qpack_error_code_integer)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_INTEGER));
+}
+
+TEST (qpack_error_code_string)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_STRING));
+}
+
+TEST (qpack_error_code_header_size)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_HEADER_SIZE));
+}
+
+TEST (qpack_error_code_list_size)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_LIST_SIZE));
+}
+
+TEST (qpack_error_code_required_insert)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_REQUIRED_INSERT));
+}
+
+TEST (qpack_error_code_base)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_BASE));
+}
+
+TEST (qpack_error_code_not_found)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_NOT_FOUND));
+}
+
+TEST (qpack_error_code_evicted_index)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_EVICTED_INDEX));
+}
+
+TEST (qpack_error_code_future_index)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_FUTURE_INDEX));
+}
+
+TEST (qpack_error_code_base_overflow)
+{
+  ASSERT_EQ (QPACK_DECOMPRESSION_FAILED,
+             SocketQPACK_error_code (QPACK_ERROR_BASE_OVERFLOW));
+}
+
+/* RFC 9204 §4.2 compliance tests */
+TEST (qpack_error_code_duplicate_stream_rfc9204_section4_2)
+{
+  /* RFC 9204 §4.2: "Receipt of a second instance of either stream type
+   * MUST be treated as a connection error of type H3_STREAM_CREATION_ERROR." */
+  ASSERT_EQ (H3_STREAM_CREATION_ERROR,
+             SocketQPACK_error_code (QPACK_ERROR_DUPLICATE_STREAM));
+}
+
+TEST (qpack_error_code_stream_closed_rfc9204_section4_2)
+{
+  /* RFC 9204 §4.2: "Closure of either unidirectional stream type MUST be
+   * treated as a connection error of type H3_CLOSED_CRITICAL_STREAM." */
+  ASSERT_EQ (H3_CLOSED_CRITICAL_STREAM,
+             SocketQPACK_error_code (QPACK_ERROR_STREAM_CLOSED));
+}
+
+/* ============================================================================
+ * HTTP/3 Error String Tests
+ * ============================================================================
+ */
+
+TEST (qpack_http3_error_string_decompression_failed)
+{
+  const char *str = SocketQPACK_http3_error_string (QPACK_DECOMPRESSION_FAILED);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "DECOMPRESSION") != NULL);
+}
+
+TEST (qpack_http3_error_string_encoder_stream)
+{
+  const char *str = SocketQPACK_http3_error_string (QPACK_ENCODER_STREAM_ERROR);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "ENCODER") != NULL);
+}
+
+TEST (qpack_http3_error_string_decoder_stream)
+{
+  const char *str = SocketQPACK_http3_error_string (QPACK_DECODER_STREAM_ERROR);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "DECODER") != NULL);
+}
+
+TEST (qpack_http3_error_string_stream_creation)
+{
+  const char *str = SocketQPACK_http3_error_string (H3_STREAM_CREATION_ERROR);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "STREAM_CREATION") != NULL);
+}
+
+TEST (qpack_http3_error_string_closed_critical)
+{
+  const char *str = SocketQPACK_http3_error_string (H3_CLOSED_CRITICAL_STREAM);
+  ASSERT_NOT_NULL (str);
+  ASSERT (strstr (str, "CLOSED_CRITICAL") != NULL);
+}
+
+TEST (qpack_http3_error_string_unknown)
+{
+  const char *str = SocketQPACK_http3_error_string (0x9999);
+  ASSERT_NULL (str);
+}
+
+TEST (qpack_http3_error_string_zero)
+{
+  const char *str = SocketQPACK_http3_error_string (0);
+  ASSERT_NULL (str);
+}
+
+/* ============================================================================
+ * Inline Function Tests
+ * ============================================================================
+ */
+
+TEST (qpack_is_qpack_error_decompression)
+{
+  ASSERT (SocketQPACK_is_qpack_error (QPACK_DECOMPRESSION_FAILED));
+}
+
+TEST (qpack_is_qpack_error_encoder)
+{
+  ASSERT (SocketQPACK_is_qpack_error (QPACK_ENCODER_STREAM_ERROR));
+}
+
+TEST (qpack_is_qpack_error_decoder)
+{
+  ASSERT (SocketQPACK_is_qpack_error (QPACK_DECODER_STREAM_ERROR));
+}
+
+TEST (qpack_is_qpack_error_stream_creation_not)
+{
+  /* H3_STREAM_CREATION_ERROR is NOT a QPACK-specific error (RFC 9204 §6),
+   * it's an HTTP/3 error (RFC 9114) referenced by QPACK (RFC 9204 §4.2) */
+  ASSERT (!SocketQPACK_is_qpack_error (H3_STREAM_CREATION_ERROR));
+}
+
+TEST (qpack_is_qpack_error_closed_critical_not)
+{
+  /* H3_CLOSED_CRITICAL_STREAM is NOT a QPACK-specific error (RFC 9204 §6),
+   * it's an HTTP/3 error (RFC 9114) referenced by QPACK (RFC 9204 §4.2) */
+  ASSERT (!SocketQPACK_is_qpack_error (H3_CLOSED_CRITICAL_STREAM));
+}
+
+TEST (qpack_is_qpack_error_zero_not)
+{
+  ASSERT (!SocketQPACK_is_qpack_error (0));
+}
+
+TEST (qpack_is_qpack_error_below_range_not)
+{
+  ASSERT (!SocketQPACK_is_qpack_error (0x01FF));
+}
+
+TEST (qpack_is_qpack_error_above_range_not)
+{
+  ASSERT (!SocketQPACK_is_qpack_error (0x0203));
+}
+
+TEST (qpack_is_qpack_related_decompression)
+{
+  ASSERT (SocketQPACK_is_qpack_related_error (QPACK_DECOMPRESSION_FAILED));
+}
+
+TEST (qpack_is_qpack_related_encoder)
+{
+  ASSERT (SocketQPACK_is_qpack_related_error (QPACK_ENCODER_STREAM_ERROR));
+}
+
+TEST (qpack_is_qpack_related_decoder)
+{
+  ASSERT (SocketQPACK_is_qpack_related_error (QPACK_DECODER_STREAM_ERROR));
+}
+
+TEST (qpack_is_qpack_related_stream_creation)
+{
+  /* H3_STREAM_CREATION_ERROR IS a QPACK-related error (RFC 9204 §4.2) */
+  ASSERT (SocketQPACK_is_qpack_related_error (H3_STREAM_CREATION_ERROR));
+}
+
+TEST (qpack_is_qpack_related_closed_critical)
+{
+  /* H3_CLOSED_CRITICAL_STREAM IS a QPACK-related error (RFC 9204 §4.2) */
+  ASSERT (SocketQPACK_is_qpack_related_error (H3_CLOSED_CRITICAL_STREAM));
+}
+
+TEST (qpack_is_qpack_related_zero_not)
+{
+  ASSERT (!SocketQPACK_is_qpack_related_error (0));
+}
+
+TEST (qpack_is_qpack_related_unrelated_not)
+{
+  ASSERT (!SocketQPACK_is_qpack_related_error (0x0100));
+}
+
+/* ============================================================================
+ * Enum Value Tests
+ * ============================================================================
+ */
+
+TEST (qpack_result_enum_values_sequential)
+{
+  ASSERT_EQ (0, QPACK_OK);
+  ASSERT_EQ (1, QPACK_INCOMPLETE);
+  ASSERT_EQ (2, QPACK_BLOCKED);
+  ASSERT_EQ (3, QPACK_ERROR);
+  ASSERT_EQ (4, QPACK_ERROR_INVALID_INDEX);
+  ASSERT_EQ (5, QPACK_ERROR_INVALID_CAPACITY);
+  ASSERT_EQ (6, QPACK_ERROR_HUFFMAN);
+  ASSERT_EQ (7, QPACK_ERROR_INTEGER);
+  ASSERT_EQ (8, QPACK_ERROR_STRING);
+  ASSERT_EQ (9, QPACK_ERROR_HEADER_SIZE);
+  ASSERT_EQ (10, QPACK_ERROR_LIST_SIZE);
+  ASSERT_EQ (11, QPACK_ERROR_REQUIRED_INSERT);
+  ASSERT_EQ (12, QPACK_ERROR_BASE);
+  ASSERT_EQ (13, QPACK_ERROR_DUPLICATE_STREAM);
+  ASSERT_EQ (14, QPACK_ERROR_STREAM_CLOSED);
+  ASSERT_EQ (15, QPACK_ERROR_NOT_FOUND);
+  ASSERT_EQ (16, QPACK_ERROR_EVICTED_INDEX);
+  ASSERT_EQ (17, QPACK_ERROR_FUTURE_INDEX);
+  ASSERT_EQ (18, QPACK_ERROR_BASE_OVERFLOW);
+  ASSERT_EQ (19, QPACK_RESULT_COUNT);
+}
+
+TEST (qpack_result_count_matches_enum_size)
+{
+  /* QPACK_RESULT_COUNT should be the number of actual result codes */
+  ASSERT_EQ (19, QPACK_RESULT_COUNT);
+}
+
+/* ============================================================================
+ * Exception Definition Test
+ * ============================================================================
+ */
+
+TEST (qpack_exception_defined)
+{
+  ASSERT_NOT_NULL (&SocketQPACK_Error);
+  ASSERT_NOT_NULL (SocketQPACK_Error.reason);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary
- Implements QPACK error handling module for HTTP/3 header compression per RFC 9204
- Adds proper error code mapping from internal errors to HTTP/3 error codes
- Fixes RFC 9204 §4.2 compliance issues identified in PR #3342:
  - `QPACK_ERROR_DUPLICATE_STREAM` now correctly maps to `H3_STREAM_CREATION_ERROR` (0x0101)
  - `QPACK_ERROR_STREAM_CLOSED` now correctly maps to `H3_CLOSED_CRITICAL_STREAM` (0x0104)

Fixes #3361

## Test plan
- [x] 71 unit tests covering all 19 error codes and mappings
- [x] Tests pass with AddressSanitizer and UndefinedBehaviorSanitizer enabled
- [x] All RFC 9204 §4.2 and §6 compliance verified