### PR TITLE
fix(qpack): harden index functions with defensive NULL checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -425,6 +425,9 @@ set(LIB_SOURCES
     src/quic/SocketQUICLoss.c
     src/quic/SocketQUICTLS.c
 
+    # QPACK Header Compression (RFC 9204)
+    src/http/qpack/SocketQPACK-index.c
+
 )
 
 # Add TLS sources if enabled (split for maintainability)
@@ -837,6 +840,8 @@ set(TEST_SOURCES
     test_quic_loss
     test_quic_key_discard
     test_quic_0rtt
+    # QPACK tests (RFC 9204)
+    test_qpack_index
 )
 
 # TLS tests (only built when TLS is enabled)

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -1,0 +1,370 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK.h
+ * @brief QPACK header compression/decompression for HTTP/3 (RFC 9204).
+ *
+ * Implements QPACK algorithm with static table (99 entries), dynamic table
+ * with absolute indexing, and three index conversion schemes as per RFC 9204
+ * Sections 3.2.4-3.2.6.
+ *
+ * Index Schemes (RFC 9204 Section 3.2):
+ * - Absolute Indexing: Global, monotonically increasing (0 = first insertion)
+ * - Encoder Relative Indexing: Relative to Insert Count (encoder stream)
+ * - Field Section Indexing: Relative to Base (field sections), includes
+ *   post-base for entries inserted during encoding
+ *
+ * Thread Safety: Encoder/decoder instances are NOT thread-safe. One instance
+ * per connection/thread recommended. Static functions are thread-safe.
+ *
+ * @since 1.0.0
+ * @defgroup qpack QPACK Header Compression Module
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204
+ */
+
+#ifndef SOCKETQPACK_INCLUDED
+#define SOCKETQPACK_INCLUDED
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+
+/* ============================================================================
+ * COMPILER ATTRIBUTES
+ * ============================================================================
+ */
+
+#if defined(__GNUC__) || defined(__clang__)
+#define QPACK_NONNULL(...) __attribute__((nonnull(__VA_ARGS__)))
+#define QPACK_WARN_UNUSED __attribute__((warn_unused_result))
+#else
+#define QPACK_NONNULL(...)
+#define QPACK_WARN_UNUSED
+#endif
+
+/* ============================================================================
+ * CONFIGURATION CONSTANTS
+ * ============================================================================
+ */
+
+#ifndef SOCKETQPACK_DEFAULT_TABLE_SIZE
+#define SOCKETQPACK_DEFAULT_TABLE_SIZE 4096
+#endif
+
+#ifndef SOCKETQPACK_MAX_TABLE_SIZE
+#define SOCKETQPACK_MAX_TABLE_SIZE (64 * 1024)
+#endif
+
+#ifndef SOCKETQPACK_MAX_BLOCKED_STREAMS
+#define SOCKETQPACK_MAX_BLOCKED_STREAMS 100
+#endif
+
+/** RFC 9204 Section 3.2.1: Entry overhead is 32 bytes (same as HPACK) */
+#define SOCKETQPACK_ENTRY_OVERHEAD 32
+
+/** RFC 9204 Appendix A: Static table has 99 entries (0-indexed) */
+#define SOCKETQPACK_STATIC_TABLE_SIZE 99
+
+/* ============================================================================
+ * ERROR CODES
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK operation result codes.
+ *
+ * RFC 9204 Section 2.2.3 specifies error handling requirements.
+ *
+ * @since 1.0.0
+ */
+typedef enum
+{
+  QPACK_OK = 0,            /**< Operation successful */
+  QPACK_INCOMPLETE,        /**< Need more data to complete operation */
+  QPACK_ERR_INVALID_INDEX, /**< Index out of valid range */
+  QPACK_ERR_EVICTED_INDEX, /**< Referenced entry has been evicted */
+  QPACK_ERR_FUTURE_INDEX,  /**< Index references not-yet-inserted entry */
+  QPACK_ERR_BASE_OVERFLOW, /**< Base would exceed Insert Count */
+  QPACK_ERR_TABLE_SIZE,    /**< Dynamic table size limit exceeded */
+  QPACK_ERR_HEADER_SIZE,   /**< Individual header size limit exceeded */
+  QPACK_ERR_HUFFMAN,       /**< Huffman decoding error */
+  QPACK_ERR_INTEGER,       /**< Integer decoding error */
+  QPACK_ERR_DECOMPRESSION, /**< Decompression failed (bomb protection) */
+  QPACK_ERR_NULL_PARAM,    /**< NULL parameter passed to function */
+  QPACK_ERR_INTERNAL       /**< Internal error */
+} SocketQPACK_Result;
+
+/* ============================================================================
+ * OPAQUE TYPES
+ * ============================================================================
+ */
+
+/**
+ * @brief Opaque type for QPACK dynamic table.
+ *
+ * Manages entries with absolute indexing as per RFC 9204 Section 3.2.1-3.2.3.
+ *
+ * @since 1.0.0
+ */
+typedef struct SocketQPACK_Table *SocketQPACK_Table_T;
+
+/* ============================================================================
+ * INDEX CONVERSION FUNCTIONS (RFC 9204 Sections 3.2.4-3.2.6)
+ * ============================================================================
+ */
+
+/**
+ * @brief Convert absolute index to encoder-relative index.
+ *
+ * RFC 9204 Section 3.2.5: Encoder instructions reference dynamic table entries
+ * using a relative index. The relative index starts at 0 for the most recently
+ * inserted entry.
+ *
+ * Formula: relative = insert_count - abs_index - 1
+ *
+ * @param insert_count Current Insert Count (total entries ever inserted)
+ * @param abs_index    Absolute index to convert
+ * @param[out] rel_out Output: resulting relative index (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if rel_out is NULL,
+ *         QPACK_ERR_INVALID_INDEX if abs_index >= insert_count
+ *
+ * @note abs_index must be < insert_count (cannot reference future entries)
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+    SocketQPACK_abs_to_relative_encoder (uint64_t insert_count,
+                                         uint64_t abs_index,
+                                         uint64_t *rel_out);
+
+/**
+ * @brief Convert encoder-relative index to absolute index.
+ *
+ * RFC 9204 Section 3.2.5: Converts from encoder stream relative indexing
+ * to the canonical absolute index.
+ *
+ * Formula: absolute = insert_count - relative - 1
+ *
+ * @param insert_count Current Insert Count
+ * @param rel_index    Relative index to convert
+ * @param[out] abs_out Output: resulting absolute index (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if abs_out is NULL,
+ *         QPACK_ERR_INVALID_INDEX if rel_index >= insert_count
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+    SocketQPACK_relative_to_abs_encoder (uint64_t insert_count,
+                                         uint64_t rel_index,
+                                         uint64_t *abs_out);
+
+/**
+ * @brief Convert absolute index to field-relative index.
+ *
+ * RFC 9204 Section 3.2.5: Field section references use a relative index
+ * computed from the Base value. Relative index 0 references the entry
+ * at Base - 1.
+ *
+ * Formula: relative = base - abs_index - 1
+ *
+ * @param base      Base value for the field section
+ * @param abs_index Absolute index to convert (must be < base)
+ * @param[out] rel_out Output: resulting relative index (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if rel_out is NULL,
+ *         QPACK_ERR_INVALID_INDEX if abs_index >= base or base == 0
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+    SocketQPACK_abs_to_relative_field (uint64_t base,
+                                       uint64_t abs_index,
+                                       uint64_t *rel_out);
+
+/**
+ * @brief Convert field-relative index to absolute index.
+ *
+ * RFC 9204 Section 3.2.5: Converts from field section relative indexing
+ * to the canonical absolute index.
+ *
+ * Formula: absolute = base - relative - 1
+ *
+ * @param base      Base value for the field section
+ * @param rel_index Relative index to convert (must be < base)
+ * @param[out] abs_out Output: resulting absolute index (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if abs_out is NULL,
+ *         QPACK_ERR_INVALID_INDEX if rel_index >= base or base == 0
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+    SocketQPACK_relative_to_abs_field (uint64_t base,
+                                       uint64_t rel_index,
+                                       uint64_t *abs_out);
+
+/**
+ * @brief Convert absolute index to post-base index.
+ *
+ * RFC 9204 Section 3.2.6: Post-base indexing allows field sections to
+ * reference entries inserted during encoding (abs_index >= base).
+ * Post-base index 0 references the entry at Base.
+ *
+ * Formula: post_base = abs_index - base
+ *
+ * @param base      Base value for the field section
+ * @param abs_index Absolute index to convert (must be >= base)
+ * @param[out] pb_out Output: resulting post-base index (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if pb_out is NULL,
+ *         QPACK_ERR_INVALID_INDEX if abs_index < base
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+    SocketQPACK_abs_to_postbase (uint64_t base,
+                                 uint64_t abs_index,
+                                 uint64_t *pb_out);
+
+/**
+ * @brief Convert post-base index to absolute index.
+ *
+ * RFC 9204 Section 3.2.6: Converts from post-base indexing to the canonical
+ * absolute index.
+ *
+ * Formula: absolute = base + post_base
+ *
+ * @param base     Base value for the field section
+ * @param pb_index Post-base index to convert
+ * @param[out] abs_out Output: resulting absolute index (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if abs_out is NULL,
+ *         QPACK_ERR_INVALID_INDEX if overflow would occur
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+    SocketQPACK_postbase_to_abs (uint64_t base,
+                                 uint64_t pb_index,
+                                 uint64_t *abs_out);
+
+/* ============================================================================
+ * INDEX VALIDATION FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Validate encoder-relative index against eviction bounds.
+ *
+ * RFC 9204 Section 3.2.5: An encoder-relative index is valid if:
+ * 1. rel_index < insert_count (not a future reference)
+ * 2. The corresponding absolute index >= dropped_count (not evicted)
+ *
+ * @param insert_count  Current Insert Count
+ * @param dropped_count Number of entries evicted (absolute index of oldest
+ * valid)
+ * @param rel_index     Relative index to validate
+ * @return QPACK_OK if valid, appropriate error code otherwise
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+SocketQPACK_is_valid_relative_encoder (uint64_t insert_count,
+                                       uint64_t dropped_count,
+                                       uint64_t rel_index);
+
+/**
+ * @brief Validate field-relative index against Base and eviction bounds.
+ *
+ * RFC 9204 Section 3.2.5: A field-relative index is valid if:
+ * 1. rel_index < base (in valid range)
+ * 2. The corresponding absolute index >= dropped_count (not evicted)
+ *
+ * @param base          Base value for the field section
+ * @param dropped_count Number of entries evicted
+ * @param rel_index     Relative index to validate
+ * @return QPACK_OK if valid, appropriate error code otherwise
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+SocketQPACK_is_valid_relative_field (uint64_t base,
+                                     uint64_t dropped_count,
+                                     uint64_t rel_index);
+
+/**
+ * @brief Validate post-base index against Insert Count bounds.
+ *
+ * RFC 9204 Section 3.2.6: A post-base index is valid if:
+ * 1. base + pb_index < insert_count (not a future reference)
+ *
+ * @param base         Base value for the field section
+ * @param insert_count Current Insert Count
+ * @param pb_index     Post-base index to validate
+ * @return QPACK_OK if valid, QPACK_ERR_FUTURE_INDEX otherwise
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+SocketQPACK_is_valid_postbase (uint64_t base,
+                               uint64_t insert_count,
+                               uint64_t pb_index);
+
+/**
+ * @brief Validate absolute index against table bounds.
+ *
+ * Checks that an absolute index is within the valid range [dropped_count,
+ * insert_count).
+ *
+ * @param insert_count  Current Insert Count
+ * @param dropped_count Number of entries evicted
+ * @param abs_index     Absolute index to validate
+ * @return QPACK_OK if valid, appropriate error code otherwise
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+SocketQPACK_is_valid_absolute (uint64_t insert_count,
+                               uint64_t dropped_count,
+                               uint64_t abs_index);
+
+/* ============================================================================
+ * UTILITY FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Get human-readable string for QPACK result code.
+ *
+ * @param result Result code to describe
+ * @return Static string describing the result (never NULL)
+ *
+ * @since 1.0.0
+ */
+extern const char *SocketQPACK_result_string (SocketQPACK_Result result);
+
+/**
+ * @brief Calculate required table capacity for a given max size.
+ *
+ * Estimates the number of entries based on average entry size
+ * and rounds up to a power of 2 for efficient ring buffer operations.
+ *
+ * @param max_size Maximum table size in bytes
+ * @return Recommended capacity (power of 2, minimum 16)
+ *
+ * @since 1.0.0
+ */
+extern size_t SocketQPACK_estimate_capacity (size_t max_size);
+
+/** @} */
+
+#endif /* SOCKETQPACK_INCLUDED */

--- a/src/http/qpack/SocketQPACK-index.c
+++ b/src/http/qpack/SocketQPACK-index.c
@@ -1,0 +1,282 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-index.c
+ * @brief QPACK index conversion and validation (RFC 9204 Sections 3.2.4-3.2.6).
+ *
+ * Implements the three index address spaces used in QPACK:
+ * - Absolute Indexing: Canonical, monotonically increasing (Section 3.2.4)
+ * - Relative Indexing: Used in encoder stream and field sections (Section 3.2.5)
+ * - Post-Base Indexing: References entries inserted during encoding (Section 3.2.6)
+ */
+
+#include "http/qpack/SocketQPACK.h"
+
+#include <stdint.h>
+
+/* ============================================================================
+ * ABSOLUTE <-> ENCODER RELATIVE CONVERSIONS (RFC 9204 Section 3.2.5)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_abs_to_relative_encoder (uint64_t insert_count,
+                                     uint64_t abs_index,
+                                     uint64_t *rel_out)
+{
+  /* Hardened NULL check - return error instead of crashing */
+  if (rel_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* RFC 9204 §3.2.5: Cannot reference entry not yet inserted */
+  if (abs_index >= insert_count)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Formula: relative = insert_count - abs_index - 1 */
+  *rel_out = insert_count - abs_index - 1;
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_relative_to_abs_encoder (uint64_t insert_count,
+                                     uint64_t rel_index,
+                                     uint64_t *abs_out)
+{
+  /* Hardened NULL check */
+  if (abs_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* RFC 9204 §3.2.5: Relative index must be < insert_count */
+  if (rel_index >= insert_count)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Formula: absolute = insert_count - relative - 1 */
+  *abs_out = insert_count - rel_index - 1;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * ABSOLUTE <-> FIELD RELATIVE CONVERSIONS (RFC 9204 Section 3.2.5)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_abs_to_relative_field (uint64_t base,
+                                   uint64_t abs_index,
+                                   uint64_t *rel_out)
+{
+  /* Hardened NULL check */
+  if (rel_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* Base of 0 means no entries available for relative indexing */
+  if (base == 0)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* RFC 9204 §3.2.5: abs_index must be < base for relative indexing */
+  if (abs_index >= base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Formula: relative = base - abs_index - 1 */
+  *rel_out = base - abs_index - 1;
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_relative_to_abs_field (uint64_t base,
+                                   uint64_t rel_index,
+                                   uint64_t *abs_out)
+{
+  /* Hardened NULL check */
+  if (abs_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* Base of 0 means no valid relative indices exist */
+  if (base == 0)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* RFC 9204 §3.2.5: rel_index must be < base */
+  if (rel_index >= base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Formula: absolute = base - relative - 1 */
+  *abs_out = base - rel_index - 1;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * ABSOLUTE <-> POST-BASE CONVERSIONS (RFC 9204 Section 3.2.6)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_abs_to_postbase (uint64_t base, uint64_t abs_index, uint64_t *pb_out)
+{
+  /* Hardened NULL check */
+  if (pb_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* RFC 9204 §3.2.6: Post-base indices reference entries >= base */
+  if (abs_index < base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Formula: post_base = abs_index - base */
+  *pb_out = abs_index - base;
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_postbase_to_abs (uint64_t base, uint64_t pb_index, uint64_t *abs_out)
+{
+  /* Hardened NULL check */
+  if (abs_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* Check for overflow before addition */
+  if (pb_index > UINT64_MAX - base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Formula: absolute = base + post_base */
+  *abs_out = base + pb_index;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * INDEX VALIDATION FUNCTIONS
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_is_valid_relative_encoder (uint64_t insert_count,
+                                       uint64_t dropped_count,
+                                       uint64_t rel_index)
+{
+  /* Defensive check: dropped_count should never exceed insert_count */
+  if (dropped_count > insert_count)
+    return QPACK_ERR_INTERNAL;
+
+  /* Check if relative index is in valid range */
+  if (rel_index >= insert_count)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Convert to absolute and check if evicted */
+  uint64_t abs_index = insert_count - rel_index - 1;
+
+  if (abs_index < dropped_count)
+    return QPACK_ERR_EVICTED_INDEX;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_is_valid_relative_field (uint64_t base,
+                                     uint64_t dropped_count,
+                                     uint64_t rel_index)
+{
+  /* Base of 0 means no valid relative indices */
+  if (base == 0)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Check if relative index is in valid range */
+  if (rel_index >= base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Convert to absolute and check if evicted */
+  uint64_t abs_index = base - rel_index - 1;
+
+  if (abs_index < dropped_count)
+    return QPACK_ERR_EVICTED_INDEX;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_is_valid_postbase (uint64_t base,
+                               uint64_t insert_count,
+                               uint64_t pb_index)
+{
+  /* Check for overflow */
+  if (pb_index > UINT64_MAX - base)
+    return QPACK_ERR_FUTURE_INDEX;
+
+  /* Post-base index must reference an inserted entry */
+  uint64_t abs_index = base + pb_index;
+
+  if (abs_index >= insert_count)
+    return QPACK_ERR_FUTURE_INDEX;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_is_valid_absolute (uint64_t insert_count,
+                               uint64_t dropped_count,
+                               uint64_t abs_index)
+{
+  /* Defensive check: dropped_count should never exceed insert_count */
+  if (dropped_count > insert_count)
+    return QPACK_ERR_INTERNAL;
+
+  /* Check if index references a future entry */
+  if (abs_index >= insert_count)
+    return QPACK_ERR_FUTURE_INDEX;
+
+  /* Check if index references an evicted entry */
+  if (abs_index < dropped_count)
+    return QPACK_ERR_EVICTED_INDEX;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * UTILITY FUNCTIONS
+ * ============================================================================
+ */
+
+const char *
+SocketQPACK_result_string (SocketQPACK_Result result)
+{
+  static const char *strings[] = {
+    [QPACK_OK] = "OK",
+    [QPACK_INCOMPLETE] = "Incomplete - need more data",
+    [QPACK_ERR_INVALID_INDEX] = "Invalid table index",
+    [QPACK_ERR_EVICTED_INDEX] = "Referenced entry has been evicted",
+    [QPACK_ERR_FUTURE_INDEX] = "Index references not-yet-inserted entry",
+    [QPACK_ERR_BASE_OVERFLOW] = "Base would exceed Insert Count",
+    [QPACK_ERR_TABLE_SIZE] = "Dynamic table size limit exceeded",
+    [QPACK_ERR_HEADER_SIZE] = "Header too large",
+    [QPACK_ERR_HUFFMAN] = "Huffman decoding error",
+    [QPACK_ERR_INTEGER] = "Integer decoding error",
+    [QPACK_ERR_DECOMPRESSION] = "Decompression failed",
+    [QPACK_ERR_NULL_PARAM] = "NULL parameter passed to function",
+    [QPACK_ERR_INTERNAL] = "Internal error",
+  };
+
+  if (result < 0 || result > QPACK_ERR_INTERNAL)
+    return "Unknown error";
+
+  return strings[result] ? strings[result] : "Unknown error";
+}
+
+size_t
+SocketQPACK_estimate_capacity (size_t max_size)
+{
+  /* Estimate entries based on average header size (64 bytes + 32 overhead) */
+  size_t avg_entry_size = 64 + SOCKETQPACK_ENTRY_OVERHEAD;
+  size_t estimated = max_size / avg_entry_size;
+
+  /* Minimum capacity of 16 */
+  if (estimated < 16)
+    return 16;
+
+  /* Round up to next power of 2 for efficient ring buffer operations */
+  size_t capacity = 16;
+  while (capacity < estimated && capacity < (SIZE_MAX / 2))
+    capacity *= 2;
+
+  return capacity;
+}

--- a/src/test/test_qpack_index.c
+++ b/src/test/test_qpack_index.c
@@ -1,0 +1,553 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_index.c
+ * @brief Unit tests for QPACK index conversion (RFC 9204 Sections 3.2.4-3.2.6).
+ *
+ * Tests cover:
+ * - NULL parameter handling (hardened security)
+ * - RFC 9204 Appendix B test vectors
+ * - RFC 9204 Figure 2, 3, 4 examples
+ * - Edge cases (empty table, invalid state)
+ * - Large index handling
+ */
+
+#include "http/qpack/SocketQPACK.h"
+#include "test/Test.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+/* ============================================================================
+ * NULL PARAMETER HANDLING TESTS (Security Hardening)
+ * ============================================================================
+ */
+
+TEST (qpack_null_param_abs_to_relative_encoder)
+{
+  SocketQPACK_Result result;
+
+  /* NULL output pointer should return QPACK_ERR_NULL_PARAM, not crash */
+  result = SocketQPACK_abs_to_relative_encoder (10, 5, NULL);
+  ASSERT_EQ (QPACK_ERR_NULL_PARAM, result);
+}
+
+TEST (qpack_null_param_relative_to_abs_encoder)
+{
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_relative_to_abs_encoder (10, 5, NULL);
+  ASSERT_EQ (QPACK_ERR_NULL_PARAM, result);
+}
+
+TEST (qpack_null_param_abs_to_relative_field)
+{
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_abs_to_relative_field (10, 5, NULL);
+  ASSERT_EQ (QPACK_ERR_NULL_PARAM, result);
+}
+
+TEST (qpack_null_param_relative_to_abs_field)
+{
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_relative_to_abs_field (10, 5, NULL);
+  ASSERT_EQ (QPACK_ERR_NULL_PARAM, result);
+}
+
+TEST (qpack_null_param_abs_to_postbase)
+{
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_abs_to_postbase (5, 10, NULL);
+  ASSERT_EQ (QPACK_ERR_NULL_PARAM, result);
+}
+
+TEST (qpack_null_param_postbase_to_abs)
+{
+  SocketQPACK_Result result;
+
+  result = SocketQPACK_postbase_to_abs (5, 5, NULL);
+  ASSERT_EQ (QPACK_ERR_NULL_PARAM, result);
+}
+
+/* ============================================================================
+ * RFC 9204 FIGURE 2 - ENCODER RELATIVE INDEXING EXAMPLES
+ * ============================================================================
+ *
+ * RFC 9204 Figure 2 shows encoder stream relative indexing with insert_count=4:
+ *
+ *      +-----+---------------+-------+
+ *      | n=4 |      foo      |   0   |  <-- Most recent (relative 0)
+ *      +-----+---------------+-------+
+ *      | n=3 |      bar      |   1   |
+ *      +-----+---------------+-------+
+ *      | n=2 |      baz      |   2   |
+ *      +-----+---------------+-------+
+ *      | n=1 |      qux      |   3   |  <-- Oldest (relative 3)
+ *      +-----+---------------+-------+
+ *            Absolute Index    Relative Index
+ *
+ * Note: The RFC uses 1-based absolute indices in examples, but implementation
+ * uses 0-based (entry 0 has absolute index 0).
+ */
+TEST (qpack_rfc_figure2_encoder_indexing)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* With insert_count=4:
+   * - Absolute 3 -> Relative 0 (most recent)
+   * - Absolute 2 -> Relative 1
+   * - Absolute 1 -> Relative 2
+   * - Absolute 0 -> Relative 3 (oldest)
+   */
+  result = SocketQPACK_abs_to_relative_encoder (4, 3, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output);
+
+  result = SocketQPACK_abs_to_relative_encoder (4, 2, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, output);
+
+  result = SocketQPACK_abs_to_relative_encoder (4, 1, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2, output);
+
+  result = SocketQPACK_abs_to_relative_encoder (4, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (3, output);
+
+  /* Reverse conversions */
+  result = SocketQPACK_relative_to_abs_encoder (4, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (3, output);
+
+  result = SocketQPACK_relative_to_abs_encoder (4, 3, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output);
+}
+
+/* ============================================================================
+ * RFC 9204 FIGURE 3 - FIELD SECTION RELATIVE INDEXING EXAMPLES
+ * ============================================================================
+ *
+ * RFC 9204 Figure 3 shows field section relative indexing with Base=2:
+ *
+ *      +-----+---------------+-------+
+ *      | n=4 |      foo      |  N/A  |  <-- Post-base (use post-base indexing)
+ *      +-----+---------------+-------+
+ *      | n=3 |      bar      |  N/A  |  <-- Post-base
+ *      +-----+---------------+-------+
+ *      | n=2 |      baz      |   0   |  <-- Base-1 (relative 0)
+ *      +-----+---------------+-------+
+ *      | n=1 |      qux      |   1   |  <-- Oldest visible (relative 1)
+ *      +-----+---------------+-------+
+ *            Absolute Index    Relative Index (Base=2)
+ */
+TEST (qpack_rfc_figure3_field_indexing)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* With base=2 (0-indexed, so entries 0 and 1 are visible):
+   * - Absolute 1 -> Relative 0
+   * - Absolute 0 -> Relative 1
+   */
+  result = SocketQPACK_abs_to_relative_field (2, 1, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output);
+
+  result = SocketQPACK_abs_to_relative_field (2, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, output);
+
+  /* Entries at or above base should fail */
+  result = SocketQPACK_abs_to_relative_field (2, 2, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  result = SocketQPACK_abs_to_relative_field (2, 3, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+}
+
+/* ============================================================================
+ * RFC 9204 FIGURE 4 - POST-BASE INDEXING EXAMPLES
+ * ============================================================================
+ *
+ * RFC 9204 Figure 4 shows post-base indexing with Base=2:
+ *
+ *      +-----+---------------+-------+
+ *      | n=4 |      foo      |   1   |  <-- Post-base 1
+ *      +-----+---------------+-------+
+ *      | n=3 |      bar      |   0   |  <-- Post-base 0 (at Base)
+ *      +-----+---------------+-------+
+ *      | n=2 |      baz      |  N/A  |  <-- Use relative indexing
+ *      +-----+---------------+-------+
+ *      | n=1 |      qux      |  N/A  |
+ *      +-----+---------------+-------+
+ *            Absolute Index    Post-Base Index (Base=2)
+ */
+TEST (qpack_rfc_figure4_postbase_indexing)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* With base=2:
+   * - Absolute 2 -> Post-base 0
+   * - Absolute 3 -> Post-base 1
+   * - Absolute 4 -> Post-base 2
+   */
+  result = SocketQPACK_abs_to_postbase (2, 2, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output);
+
+  result = SocketQPACK_abs_to_postbase (2, 3, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, output);
+
+  result = SocketQPACK_abs_to_postbase (2, 4, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2, output);
+
+  /* Entries below base should fail */
+  result = SocketQPACK_abs_to_postbase (2, 1, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  result = SocketQPACK_abs_to_postbase (2, 0, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  /* Reverse conversions */
+  result = SocketQPACK_postbase_to_abs (2, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2, output);
+
+  result = SocketQPACK_postbase_to_abs (2, 1, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (3, output);
+}
+
+/* ============================================================================
+ * RFC 9204 APPENDIX B - ENCODED STREAM TEST VECTORS
+ * ============================================================================
+ *
+ * These tests verify index conversions match the examples in RFC 9204 Appendix B.
+ */
+
+/**
+ * RFC 9204 Appendix B.2 - Post-base indexing in encoded field section.
+ */
+TEST (qpack_rfc_appendix_b2_postbase)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* Scenario: Base=0, encoder inserts entries during encoding.
+   * Entry at absolute 0 is referenced as post-base 0.
+   * Entry at absolute 1 is referenced as post-base 1.
+   */
+  result = SocketQPACK_abs_to_postbase (0, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output);
+
+  result = SocketQPACK_abs_to_postbase (0, 1, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (1, output);
+
+  /* Validation: with insert_count=2, post-base 0 and 1 are valid */
+  result = SocketQPACK_is_valid_postbase (0, 2, 0);
+  ASSERT_EQ (QPACK_OK, result);
+
+  result = SocketQPACK_is_valid_postbase (0, 2, 1);
+  ASSERT_EQ (QPACK_OK, result);
+
+  /* Post-base 2 would reference insert_count=2, which is future */
+  result = SocketQPACK_is_valid_postbase (0, 2, 2);
+  ASSERT_EQ (QPACK_ERR_FUTURE_INDEX, result);
+}
+
+/**
+ * RFC 9204 Appendix B.4 - Relative indexing after dynamic table updates.
+ */
+TEST (qpack_rfc_appendix_b4_relative)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* Scenario: After several insertions, insert_count=4.
+   * Encoder references recently inserted entries.
+   */
+  result = SocketQPACK_relative_to_abs_encoder (4, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (3, output); /* Most recent entry */
+
+  result = SocketQPACK_relative_to_abs_encoder (4, 1, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (2, output);
+
+  /* Field section with Base=4 uses relative indexing */
+  result = SocketQPACK_relative_to_abs_field (4, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (3, output);
+
+  result = SocketQPACK_relative_to_abs_field (4, 3, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output);
+}
+
+/* ============================================================================
+ * EDGE CASE TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test empty table edge case (insert_count=0).
+ */
+TEST (qpack_empty_table)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* Empty table: insert_count=0, dropped_count=0 */
+
+  /* Encoder relative: any index is invalid */
+  result = SocketQPACK_abs_to_relative_encoder (0, 0, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  result = SocketQPACK_relative_to_abs_encoder (0, 0, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  /* Field relative with base=0: invalid */
+  result = SocketQPACK_abs_to_relative_field (0, 0, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  result = SocketQPACK_relative_to_abs_field (0, 0, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result);
+
+  /* Post-base with base=0, insert_count=0: any index is future */
+  result = SocketQPACK_is_valid_postbase (0, 0, 0);
+  ASSERT_EQ (QPACK_ERR_FUTURE_INDEX, result);
+
+  /* Absolute validation: empty table has no valid indices */
+  result = SocketQPACK_is_valid_absolute (0, 0, 0);
+  ASSERT_EQ (QPACK_ERR_FUTURE_INDEX, result);
+}
+
+/**
+ * Test invalid state detection (dropped_count > insert_count).
+ */
+TEST (qpack_validate_invalid_state)
+{
+  SocketQPACK_Result result;
+
+  /* Invalid state: dropped_count=5, insert_count=3 */
+  result = SocketQPACK_is_valid_relative_encoder (3, 5, 0);
+  ASSERT_EQ (QPACK_ERR_INTERNAL, result);
+
+  result = SocketQPACK_is_valid_absolute (3, 5, 0);
+  ASSERT_EQ (QPACK_ERR_INTERNAL, result);
+}
+
+/**
+ * Test eviction detection in validation functions.
+ */
+TEST (qpack_eviction_detection)
+{
+  SocketQPACK_Result result;
+
+  /* Scenario: insert_count=10, dropped_count=5
+   * Valid absolute indices: 5, 6, 7, 8, 9
+   * Evicted: 0, 1, 2, 3, 4
+   * Future: 10+
+   */
+
+  /* Valid index */
+  result = SocketQPACK_is_valid_absolute (10, 5, 7);
+  ASSERT_EQ (QPACK_OK, result);
+
+  /* Boundary: oldest valid */
+  result = SocketQPACK_is_valid_absolute (10, 5, 5);
+  ASSERT_EQ (QPACK_OK, result);
+
+  /* Boundary: newest valid */
+  result = SocketQPACK_is_valid_absolute (10, 5, 9);
+  ASSERT_EQ (QPACK_OK, result);
+
+  /* Just evicted */
+  result = SocketQPACK_is_valid_absolute (10, 5, 4);
+  ASSERT_EQ (QPACK_ERR_EVICTED_INDEX, result);
+
+  /* Long evicted */
+  result = SocketQPACK_is_valid_absolute (10, 5, 0);
+  ASSERT_EQ (QPACK_ERR_EVICTED_INDEX, result);
+
+  /* Future entry */
+  result = SocketQPACK_is_valid_absolute (10, 5, 10);
+  ASSERT_EQ (QPACK_ERR_FUTURE_INDEX, result);
+
+  /* Far future */
+  result = SocketQPACK_is_valid_absolute (10, 5, 100);
+  ASSERT_EQ (QPACK_ERR_FUTURE_INDEX, result);
+
+  /* Encoder relative with eviction */
+  result = SocketQPACK_is_valid_relative_encoder (10, 5, 0); /* abs=9, valid */
+  ASSERT_EQ (QPACK_OK, result);
+
+  result = SocketQPACK_is_valid_relative_encoder (10, 5, 4); /* abs=5, valid */
+  ASSERT_EQ (QPACK_OK, result);
+
+  result = SocketQPACK_is_valid_relative_encoder (10, 5, 5); /* abs=4, evicted */
+  ASSERT_EQ (QPACK_ERR_EVICTED_INDEX, result);
+
+  /* Field relative with eviction */
+  result = SocketQPACK_is_valid_relative_field (10, 5, 0); /* abs=9, valid */
+  ASSERT_EQ (QPACK_OK, result);
+
+  result = SocketQPACK_is_valid_relative_field (10, 5, 5); /* abs=4, evicted */
+  ASSERT_EQ (QPACK_ERR_EVICTED_INDEX, result);
+}
+
+/**
+ * Test large index values (near UINT64_MAX).
+ */
+TEST (qpack_large_indices)
+{
+  SocketQPACK_Result result;
+  uint64_t output;
+
+  /* Large insert_count */
+  result
+      = SocketQPACK_abs_to_relative_encoder (UINT64_MAX, UINT64_MAX - 1, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (0, output); /* Most recent */
+
+  result = SocketQPACK_abs_to_relative_encoder (UINT64_MAX, 0, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (UINT64_MAX - 1, output); /* Oldest */
+
+  /* Post-base overflow protection */
+  result = SocketQPACK_postbase_to_abs (UINT64_MAX, 1, &output);
+  ASSERT_EQ (QPACK_ERR_INVALID_INDEX, result); /* Would overflow */
+
+  result = SocketQPACK_postbase_to_abs (UINT64_MAX - 10, 10, &output);
+  ASSERT_EQ (QPACK_OK, result);
+  ASSERT_EQ (UINT64_MAX, output);
+}
+
+/**
+ * Test round-trip conversions maintain consistency.
+ */
+TEST (qpack_roundtrip_conversions)
+{
+  SocketQPACK_Result result;
+  uint64_t relative, absolute;
+
+  /* Encoder relative round-trip */
+  for (uint64_t ic = 1; ic <= 100; ic++)
+    {
+      for (uint64_t abs = 0; abs < ic; abs++)
+        {
+          result = SocketQPACK_abs_to_relative_encoder (ic, abs, &relative);
+          ASSERT_EQ (QPACK_OK, result);
+
+          result = SocketQPACK_relative_to_abs_encoder (ic, relative, &absolute);
+          ASSERT_EQ (QPACK_OK, result);
+          ASSERT_EQ (abs, absolute);
+        }
+    }
+
+  /* Field relative round-trip */
+  for (uint64_t base = 1; base <= 100; base++)
+    {
+      for (uint64_t abs = 0; abs < base; abs++)
+        {
+          result = SocketQPACK_abs_to_relative_field (base, abs, &relative);
+          ASSERT_EQ (QPACK_OK, result);
+
+          result = SocketQPACK_relative_to_abs_field (base, relative, &absolute);
+          ASSERT_EQ (QPACK_OK, result);
+          ASSERT_EQ (abs, absolute);
+        }
+    }
+
+  /* Post-base round-trip */
+  for (uint64_t base = 0; base <= 50; base++)
+    {
+      for (uint64_t abs = base; abs < base + 50; abs++)
+        {
+          uint64_t postbase;
+          result = SocketQPACK_abs_to_postbase (base, abs, &postbase);
+          ASSERT_EQ (QPACK_OK, result);
+
+          result = SocketQPACK_postbase_to_abs (base, postbase, &absolute);
+          ASSERT_EQ (QPACK_OK, result);
+          ASSERT_EQ (abs, absolute);
+        }
+    }
+}
+
+/**
+ * Test result_string function.
+ */
+TEST (qpack_result_string)
+{
+  /* All result codes should have non-NULL strings */
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_OK));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_INCOMPLETE));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_INVALID_INDEX));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_EVICTED_INDEX));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_FUTURE_INDEX));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_BASE_OVERFLOW));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_TABLE_SIZE));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_HEADER_SIZE));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_HUFFMAN));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_INTEGER));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_DECOMPRESSION));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_NULL_PARAM));
+  ASSERT_NOT_NULL (SocketQPACK_result_string (QPACK_ERR_INTERNAL));
+
+  /* Invalid result codes should return "Unknown error" */
+  ASSERT_NOT_NULL (SocketQPACK_result_string ((SocketQPACK_Result) -1));
+  ASSERT_NOT_NULL (SocketQPACK_result_string ((SocketQPACK_Result) 999));
+}
+
+/**
+ * Test estimate_capacity function.
+ */
+TEST (qpack_estimate_capacity)
+{
+  size_t cap;
+
+  /* Minimum capacity is 16 */
+  cap = SocketQPACK_estimate_capacity (0);
+  ASSERT_EQ (16, cap);
+
+  cap = SocketQPACK_estimate_capacity (100);
+  ASSERT_EQ (16, cap);
+
+  /* Default 4096 bytes should give reasonable capacity */
+  cap = SocketQPACK_estimate_capacity (4096);
+  ASSERT (cap >= 16);
+  ASSERT ((cap & (cap - 1)) == 0); /* Power of 2 */
+
+  /* 64KB max should give larger capacity */
+  cap = SocketQPACK_estimate_capacity (65536);
+  ASSERT (cap > 16);
+  ASSERT ((cap & (cap - 1)) == 0); /* Power of 2 */
+}
+
+/* ============================================================================
+ * TEST RUNNER
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Addresses security review feedback on PR #3341:

- **Remove `nonnull` attributes in favor of explicit NULL checks** - Return `QPACK_ERR_NULL_PARAM` instead of relying on undefined behavior when NULL is passed
- **Add defensive state validation** - Detect impossible `dropped_count > insert_count` state and return `QPACK_ERR_INTERNAL`
- **Add `@since 1.0.0` tags** for API versioning
- **Add `QPACK_WARN_UNUSED` attribute** to encourage checking return values
- **Comprehensive test coverage** (18 tests):
  - NULL parameter handling for all 6 conversion functions
  - RFC 9204 Figure 2, 3, 4 diagram examples
  - RFC 9204 Appendix B test vectors
  - Edge cases: empty table (`insert_count=0`), invalid state
  - Overflow protection for large indices near UINT64_MAX
  - Round-trip conversion consistency

## Design Decision

Chose explicit NULL checks over `nonnull` attribute because:
1. Defense in depth - graceful error handling vs undefined behavior
2. Better debugging - clear error code instead of crash
3. Sanitizer-friendly - no false positives for intentional NULL tests

Fixes #3360