### PR TITLE
feat(qpack): implement decoder stream infrastructure (RFC 9204 Section 4.2)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -362,6 +362,7 @@ set(LIB_SOURCES
     # QPACK Header Compression (RFC 9204)
     src/http/qpack/SocketQPACK-index.c
     src/http/qpack/SocketQPACK-encoder-stream.c
+    src/http/qpack/SocketQPACK-decoder-stream.c
 
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
@@ -641,6 +642,7 @@ set(QPACK_HEADERS
     include/http/qpack/SocketQPACK.h
     include/http/qpack/SocketQPACK-private.h
     include/http/qpack/SocketQPACKEncoderStream.h
+    include/http/qpack/SocketQPACKDecoderStream.h
 )
 
 set(TEST_HEADERS
@@ -801,6 +803,7 @@ set(TEST_SOURCES
     # QPACK tests (RFC 9204)
     test_qpack_index
     test_qpack_encoder_stream
+    test_qpack_decoder_stream
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/qpack/SocketQPACKDecoderStream.h
+++ b/include/http/qpack/SocketQPACKDecoderStream.h
@@ -1,0 +1,325 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACKDecoderStream.h
+ * @brief QPACK Decoder Stream Infrastructure (RFC 9204 Section 4.2).
+ *
+ * Implements the decoder stream for QPACK, which carries decoder instructions
+ * from decoder to encoder. The decoder stream is a unidirectional stream of
+ * type 0x03 that carries an unframed sequence of decoder instructions.
+ *
+ * Decoder Instructions (RFC 9204 Section 4.4):
+ * - Section Acknowledgment (Section 4.4.1)
+ * - Stream Cancellation (Section 4.4.2)
+ * - Insert Count Increment (Section 4.4.3)
+ *
+ * Thread Safety: Decoder stream instances are NOT thread-safe. One instance
+ * per connection recommended.
+ *
+ * @defgroup qpack_decoder_stream QPACK Decoder Stream
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.2
+ */
+
+#ifndef SOCKETQPACK_DECODER_STREAM_INCLUDED
+#define SOCKETQPACK_DECODER_STREAM_INCLUDED
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "http/qpack/SocketQPACK.h"
+#include "http/qpack/SocketQPACKEncoderStream.h" /* For SocketQPACKStream_Result */
+
+/* ============================================================================
+ * DECODER INSTRUCTION BIT PATTERNS (RFC 9204 Section 4.4)
+ * ============================================================================
+ */
+
+/**
+ * @brief Section Acknowledgment instruction prefix.
+ *
+ * RFC 9204 Section 4.4.1: Bit pattern 1xxxxxxx (1-bit prefix, 7-bit stream ID).
+ */
+#define QPACK_DINSTR_SECTION_ACK_MASK 0x80
+#define QPACK_DINSTR_SECTION_ACK_PREFIX 7
+
+/**
+ * @brief Stream Cancellation instruction prefix.
+ *
+ * RFC 9204 Section 4.4.2: Bit pattern 01xxxxxx (2-bit prefix, 6-bit stream ID).
+ */
+#define QPACK_DINSTR_STREAM_CANCEL_MASK 0x40
+#define QPACK_DINSTR_STREAM_CANCEL_PREFIX 6
+
+/**
+ * @brief Insert Count Increment instruction prefix.
+ *
+ * RFC 9204 Section 4.4.3: Bit pattern 00xxxxxx (2-bit prefix, 6-bit increment).
+ */
+#define QPACK_DINSTR_INSERT_COUNT_INC_MASK 0x00
+#define QPACK_DINSTR_INSERT_COUNT_INC_PREFIX 6
+
+/* ============================================================================
+ * CONFIGURATION CONSTANTS
+ * ============================================================================
+ */
+
+/**
+ * @brief Default decoder stream buffer size.
+ *
+ * Pre-allocated buffer for decoder instructions. Grows as needed.
+ */
+#ifndef QPACK_DECODER_STREAM_DEFAULT_BUFSIZE
+#define QPACK_DECODER_STREAM_DEFAULT_BUFSIZE 256
+#endif
+
+/**
+ * @brief Maximum decoder stream buffer size.
+ *
+ * Limit to prevent unbounded memory growth.
+ */
+#ifndef QPACK_DECODER_STREAM_MAX_BUFSIZE
+#define QPACK_DECODER_STREAM_MAX_BUFSIZE (64 * 1024)
+#endif
+
+/* ============================================================================
+ * OPAQUE TYPE
+ * ============================================================================
+ */
+
+/**
+ * @brief Opaque type for QPACK decoder stream.
+ *
+ * Manages decoder stream state and instruction buffer.
+ */
+typedef struct SocketQPACK_DecoderStream *SocketQPACK_DecoderStream_T;
+
+/* ============================================================================
+ * LIFECYCLE FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Create a new QPACK decoder stream.
+ *
+ * Creates a decoder stream with the specified stream ID. The stream is
+ * initially in an uninitialized state and must be initialized before use.
+ *
+ * @param arena     Memory arena for allocations (must not be NULL)
+ * @param stream_id QUIC unidirectional stream ID for this decoder stream
+ * @return New decoder stream instance, or NULL on allocation failure
+ *
+ * @note The stream_id should be a client-initiated unidirectional stream
+ *       (4*N+2 for client, 4*N+3 for server in QUIC terminology).
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACK_DecoderStream_T
+SocketQPACK_DecoderStream_new (Arena_T arena, uint64_t stream_id);
+
+/**
+ * @brief Initialize decoder stream for sending.
+ *
+ * Marks the stream as initialized and ready to send decoder instructions.
+ * Each endpoint MUST initiate at most one decoder stream per direction.
+ *
+ * @param stream Decoder stream to initialize
+ * @return QPACK_STREAM_OK on success,
+ *         QPACK_STREAM_ERR_NULL_PARAM if stream is NULL,
+ *         QPACK_STREAM_ERR_ALREADY_INIT if already initialized
+ *
+ * @note RFC 9204 Section 4.2: The decoder stream SHOULD be established
+ *       early in the connection.
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result
+SocketQPACK_DecoderStream_init (SocketQPACK_DecoderStream_T stream);
+
+/**
+ * @brief Check if stream type matches decoder stream.
+ *
+ * Validates that a received stream type byte equals QPACK_DECODER_STREAM_TYPE.
+ *
+ * @param type_byte Stream type byte received from peer
+ * @return QPACK_STREAM_OK if type is 0x03,
+ *         QPACK_STREAM_ERR_INVALID_TYPE otherwise
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result
+SocketQPACK_DecoderStream_validate_type (uint8_t type_byte);
+
+/**
+ * @brief Validate that a stream ID represents the decoder stream.
+ *
+ * Verifies that a stream ID matches this decoder stream's ID.
+ * Used to validate incoming stream data.
+ *
+ * @param stream    Decoder stream
+ * @param stream_id Stream ID to validate
+ * @return QPACK_STREAM_OK if stream_id matches,
+ *         QPACK_STREAM_ERR_NULL_PARAM if stream is NULL,
+ *         QPACK_STREAM_ERR_INVALID_TYPE if stream_id doesn't match
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result
+SocketQPACK_DecoderStream_validate_id (SocketQPACK_DecoderStream_T stream,
+                                       uint64_t stream_id);
+
+/**
+ * @brief Check if decoder stream is initialized.
+ *
+ * @param stream Decoder stream to check
+ * @return true if initialized and ready for instructions, false otherwise
+ *
+ * @since 1.0.0
+ */
+extern bool
+SocketQPACK_DecoderStream_is_open (SocketQPACK_DecoderStream_T stream);
+
+/**
+ * @brief Get the stream ID.
+ *
+ * @param stream Decoder stream
+ * @return Stream ID, or 0 if stream is NULL
+ *
+ * @since 1.0.0
+ */
+extern uint64_t
+SocketQPACK_DecoderStream_get_id (SocketQPACK_DecoderStream_T stream);
+
+/* ============================================================================
+ * DECODER INSTRUCTIONS (RFC 9204 Section 4.4)
+ * ============================================================================
+ */
+
+/**
+ * @brief Write Section Acknowledgment instruction.
+ *
+ * RFC 9204 Section 4.4.1: After processing an encoded field section whose
+ * Required Insert Count is not zero, the decoder emits a Section Acknowledgment
+ * instruction. This signals that all dynamic table references in the field
+ * section have been processed.
+ *
+ * @param stream    Decoder stream
+ * @param stream_id Stream ID of the field section being acknowledged
+ * @return QPACK_STREAM_OK on success,
+ *         QPACK_STREAM_ERR_NULL_PARAM if stream is NULL,
+ *         QPACK_STREAM_ERR_NOT_INIT if stream not initialized,
+ *         QPACK_STREAM_ERR_BUFFER_FULL if buffer cannot be grown
+ *
+ * @note This allows the encoder to safely evict entries from the dynamic table.
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result
+SocketQPACK_DecoderStream_write_section_ack (SocketQPACK_DecoderStream_T stream,
+                                             uint64_t stream_id);
+
+/**
+ * @brief Write Stream Cancellation instruction.
+ *
+ * RFC 9204 Section 4.4.2: When a stream is reset or reading is abandoned,
+ * the decoder emits a Stream Cancellation instruction. This indicates that
+ * the field section(s) on that stream will not be processed.
+ *
+ * @param stream    Decoder stream
+ * @param stream_id Stream ID being cancelled
+ * @return QPACK_STREAM_OK on success,
+ *         QPACK_STREAM_ERR_NULL_PARAM if stream is NULL,
+ *         QPACK_STREAM_ERR_NOT_INIT if stream not initialized,
+ *         QPACK_STREAM_ERR_BUFFER_FULL if buffer cannot be grown
+ *
+ * @note This allows the encoder to know that pending references will never
+ *       be acknowledged.
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result SocketQPACK_DecoderStream_write_stream_cancel (
+    SocketQPACK_DecoderStream_T stream, uint64_t stream_id);
+
+/**
+ * @brief Write Insert Count Increment instruction.
+ *
+ * RFC 9204 Section 4.4.3: The decoder informs the encoder that it has
+ * received and processed entries added to the dynamic table. This increases
+ * the Known Received Count at the encoder.
+ *
+ * @param stream    Decoder stream
+ * @param increment Number of entries to increment (must be > 0)
+ * @return QPACK_STREAM_OK on success,
+ *         QPACK_STREAM_ERR_NULL_PARAM if stream is NULL,
+ *         QPACK_STREAM_ERR_NOT_INIT if stream not initialized,
+ *         QPACK_STREAM_ERR_INVALID_INDEX if increment is 0,
+ *         QPACK_STREAM_ERR_BUFFER_FULL if buffer cannot be grown
+ *
+ * @note An increment of 0 is an error per RFC 9204 Section 4.4.3.
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result
+SocketQPACK_DecoderStream_write_insert_count_inc (
+    SocketQPACK_DecoderStream_T stream, uint64_t increment);
+
+/* ============================================================================
+ * BUFFER MANAGEMENT
+ * ============================================================================
+ */
+
+/**
+ * @brief Get accumulated instruction buffer for transmission.
+ *
+ * Returns a pointer to the internal buffer containing decoder instructions
+ * ready to be sent on the QUIC stream. The buffer contains an unframed
+ * sequence of decoder instructions.
+ *
+ * @param stream  Decoder stream
+ * @param[out] len Output: buffer length in bytes (set to 0 if stream is NULL)
+ * @return Pointer to instruction buffer, or NULL if empty or error
+ *
+ * @warning The returned pointer is only valid until the next write operation
+ *          or reset_buffer call.
+ *
+ * @since 1.0.0
+ */
+extern const unsigned char *
+SocketQPACK_DecoderStream_get_buffer (SocketQPACK_DecoderStream_T stream,
+                                      size_t *len);
+
+/**
+ * @brief Reset instruction buffer after transmission.
+ *
+ * Clears the instruction buffer after successful transmission. Call this
+ * after the QUIC stream has acknowledged the data.
+ *
+ * @param stream Decoder stream
+ * @return QPACK_STREAM_OK on success,
+ *         QPACK_STREAM_ERR_NULL_PARAM if stream is NULL
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACKStream_Result
+SocketQPACK_DecoderStream_reset_buffer (SocketQPACK_DecoderStream_T stream);
+
+/**
+ * @brief Get current buffer usage.
+ *
+ * @param stream Decoder stream
+ * @return Number of bytes currently in the instruction buffer
+ *
+ * @since 1.0.0
+ */
+extern size_t
+SocketQPACK_DecoderStream_buffer_size (SocketQPACK_DecoderStream_T stream);
+
+/** @} */
+
+#endif /* SOCKETQPACK_DECODER_STREAM_INCLUDED */

--- a/src/http/qpack/SocketQPACK-decoder-stream.c
+++ b/src/http/qpack/SocketQPACK-decoder-stream.c
@@ -1,0 +1,409 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-decoder-stream.c
+ * @brief QPACK Decoder Stream Infrastructure (RFC 9204 Section 4.2)
+ *
+ * Implements the decoder stream for QPACK, which carries decoder instructions
+ * from decoder to encoder. The decoder stream is a unidirectional stream of
+ * type 0x03.
+ *
+ * Decoder Instructions (RFC 9204 Section 4.4):
+ * - Section Acknowledgment (Section 4.4.1)
+ * - Stream Cancellation (Section 4.4.2)
+ * - Insert Count Increment (Section 4.4.3)
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.2
+ */
+
+#include <string.h>
+
+#include "http/qpack/SocketQPACKDecoderStream.h"
+
+#include "core/SocketSecurity.h"
+#include "core/SocketUtil.h"
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * INTERNAL CONSTANTS
+ * ============================================================================
+ */
+
+/** Maximum integer encoding buffer size (1 prefix + 10 continuation bytes) */
+#define QPACK_INT_ENCODE_BUF_SIZE 16
+
+/** Growth factor for buffer expansion */
+#define QPACK_BUFFER_GROWTH_FACTOR 2
+
+/* ============================================================================
+ * INTERNAL STRUCTURE
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK decoder stream internal structure.
+ */
+struct SocketQPACK_DecoderStream
+{
+  Arena_T arena;         /**< Memory arena for allocations */
+  uint64_t stream_id;    /**< QUIC unidirectional stream ID */
+  unsigned char *buffer; /**< Instruction buffer */
+  size_t buffer_len;     /**< Current data length in buffer */
+  size_t buffer_cap;     /**< Buffer capacity */
+  int initialized;       /**< Has stream been initialized? */
+};
+
+/* ============================================================================
+ * BUFFER MANAGEMENT (INTERNAL)
+ * ============================================================================
+ */
+
+/**
+ * @brief Ensure buffer has at least required_space additional bytes.
+ *
+ * @param stream  Decoder stream
+ * @param required_space Additional bytes needed
+ * @return QPACK_STREAM_OK on success, error code on failure
+ */
+static SocketQPACKStream_Result
+ensure_buffer_space (SocketQPACK_DecoderStream_T stream, size_t required_space)
+{
+  size_t needed;
+  size_t new_cap;
+  unsigned char *new_buf;
+
+  /* Check for overflow in needed calculation */
+  if (!SocketSecurity_check_add (stream->buffer_len, required_space, &needed))
+    return QPACK_STREAM_ERR_BUFFER_FULL;
+
+  /* Already have enough space */
+  if (needed <= stream->buffer_cap)
+    return QPACK_STREAM_OK;
+
+  /* Calculate new capacity (double until sufficient or hit max) */
+  new_cap = stream->buffer_cap;
+  while (new_cap < needed)
+    {
+      size_t doubled;
+      if (!SocketSecurity_check_multiply (
+              new_cap, QPACK_BUFFER_GROWTH_FACTOR, &doubled))
+        {
+          /* Overflow - try exact fit instead */
+          new_cap = needed;
+          break;
+        }
+      new_cap = doubled;
+    }
+
+  /* Enforce maximum buffer size */
+  if (new_cap > QPACK_DECODER_STREAM_MAX_BUFSIZE)
+    {
+      /* Try exact fit if growth exceeds max */
+      if (needed > QPACK_DECODER_STREAM_MAX_BUFSIZE)
+        return QPACK_STREAM_ERR_BUFFER_FULL;
+      new_cap = needed;
+    }
+
+  /* Allocate new buffer and copy existing data */
+  new_buf = ALLOC (stream->arena, new_cap);
+  if (new_buf == NULL)
+    return QPACK_STREAM_ERR_INTERNAL;
+
+  if (stream->buffer_len > 0)
+    memcpy (new_buf, stream->buffer, stream->buffer_len);
+
+  stream->buffer = new_buf;
+  stream->buffer_cap = new_cap;
+
+  return QPACK_STREAM_OK;
+}
+
+/**
+ * @brief Append bytes to the instruction buffer.
+ *
+ * @param stream Decoder stream
+ * @param data   Data to append
+ * @param len    Length of data
+ * @return QPACK_STREAM_OK on success, error code on failure
+ */
+static SocketQPACKStream_Result
+append_to_buffer (SocketQPACK_DecoderStream_T stream,
+                  const unsigned char *data,
+                  size_t len)
+{
+  SocketQPACKStream_Result result;
+
+  if (len == 0)
+    return QPACK_STREAM_OK;
+
+  result = ensure_buffer_space (stream, len);
+  if (result != QPACK_STREAM_OK)
+    return result;
+
+  memcpy (stream->buffer + stream->buffer_len, data, len);
+  stream->buffer_len += len;
+
+  return QPACK_STREAM_OK;
+}
+
+/* ============================================================================
+ * INTEGER ENCODING (INTERNAL)
+ *
+ * Uses HPACK integer encoding (RFC 7541 Section 5.1) which is the same
+ * encoding used by QPACK primitives (RFC 9204 Section 4.1.1).
+ * ============================================================================
+ */
+
+/**
+ * @brief Encode an integer with prefix and append to buffer.
+ *
+ * @param stream      Decoder stream
+ * @param value       Integer value to encode
+ * @param prefix_bits Number of prefix bits (1-8)
+ * @param first_byte  First byte with flags already set (integer fills lower
+ * bits)
+ * @return QPACK_STREAM_OK on success, error code on failure
+ */
+static SocketQPACKStream_Result
+encode_and_append_int (SocketQPACK_DecoderStream_T stream,
+                       uint64_t value,
+                       int prefix_bits,
+                       unsigned char first_byte)
+{
+  unsigned char int_buf[QPACK_INT_ENCODE_BUF_SIZE];
+  size_t int_len;
+
+  /* Encode the integer */
+  int_len
+      = SocketHPACK_int_encode (value, prefix_bits, int_buf, sizeof (int_buf));
+  if (int_len == 0)
+    return QPACK_STREAM_ERR_INTERNAL;
+
+  /* Merge first byte flags with integer encoding */
+  int_buf[0] |= first_byte;
+
+  return append_to_buffer (stream, int_buf, int_len);
+}
+
+/* ============================================================================
+ * LIFECYCLE FUNCTIONS
+ * ============================================================================
+ */
+
+SocketQPACK_DecoderStream_T
+SocketQPACK_DecoderStream_new (Arena_T arena, uint64_t stream_id)
+{
+  SocketQPACK_DecoderStream_T stream;
+
+  if (arena == NULL)
+    return NULL;
+
+  stream = CALLOC (arena, 1, sizeof (*stream));
+  if (stream == NULL)
+    return NULL;
+
+  stream->arena = arena;
+  stream->stream_id = stream_id;
+  stream->initialized = 0;
+  stream->buffer_len = 0;
+
+  /* Pre-allocate initial buffer */
+  stream->buffer_cap = QPACK_DECODER_STREAM_DEFAULT_BUFSIZE;
+  stream->buffer = ALLOC (arena, stream->buffer_cap);
+  if (stream->buffer == NULL)
+    return NULL;
+
+  return stream;
+}
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_init (SocketQPACK_DecoderStream_T stream)
+{
+  if (stream == NULL)
+    return QPACK_STREAM_ERR_NULL_PARAM;
+
+  if (stream->initialized)
+    return QPACK_STREAM_ERR_ALREADY_INIT;
+
+  stream->initialized = 1;
+  return QPACK_STREAM_OK;
+}
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_validate_type (uint8_t type_byte)
+{
+  if (type_byte == QPACK_DECODER_STREAM_TYPE)
+    return QPACK_STREAM_OK;
+
+  return QPACK_STREAM_ERR_INVALID_TYPE;
+}
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_validate_id (SocketQPACK_DecoderStream_T stream,
+                                       uint64_t stream_id)
+{
+  if (stream == NULL)
+    return QPACK_STREAM_ERR_NULL_PARAM;
+
+  if (stream->stream_id == stream_id)
+    return QPACK_STREAM_OK;
+
+  return QPACK_STREAM_ERR_INVALID_TYPE;
+}
+
+bool
+SocketQPACK_DecoderStream_is_open (SocketQPACK_DecoderStream_T stream)
+{
+  if (stream == NULL)
+    return false;
+
+  return stream->initialized != 0;
+}
+
+uint64_t
+SocketQPACK_DecoderStream_get_id (SocketQPACK_DecoderStream_T stream)
+{
+  if (stream == NULL)
+    return 0;
+
+  return stream->stream_id;
+}
+
+/* ============================================================================
+ * DECODER INSTRUCTIONS (RFC 9204 Section 4.4)
+ * ============================================================================
+ */
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_write_section_ack (SocketQPACK_DecoderStream_T stream,
+                                             uint64_t stream_id)
+{
+  /*
+   * RFC 9204 Section 4.4.1: Section Acknowledgment
+   *
+   *   0   1   2   3   4   5   6   7
+   * +---+---+---+---+---+---+---+---+
+   * | 1 |      Stream ID (7+)       |
+   * +---+---------------------------+
+   *
+   * Bit pattern: 1xxxxxxx (0x80 mask)
+   * The 7-bit prefix encodes the stream ID of the acknowledged field section.
+   */
+  if (stream == NULL)
+    return QPACK_STREAM_ERR_NULL_PARAM;
+
+  if (!stream->initialized)
+    return QPACK_STREAM_ERR_NOT_INIT;
+
+  return encode_and_append_int (stream,
+                                stream_id,
+                                QPACK_DINSTR_SECTION_ACK_PREFIX,
+                                QPACK_DINSTR_SECTION_ACK_MASK);
+}
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_write_stream_cancel (
+    SocketQPACK_DecoderStream_T stream, uint64_t stream_id)
+{
+  /*
+   * RFC 9204 Section 4.4.2: Stream Cancellation
+   *
+   *   0   1   2   3   4   5   6   7
+   * +---+---+---+---+---+---+---+---+
+   * | 0 | 1 |     Stream ID (6+)    |
+   * +---+---+-----------------------+
+   *
+   * Bit pattern: 01xxxxxx (0x40 mask)
+   * The 6-bit prefix encodes the stream ID being cancelled.
+   */
+  if (stream == NULL)
+    return QPACK_STREAM_ERR_NULL_PARAM;
+
+  if (!stream->initialized)
+    return QPACK_STREAM_ERR_NOT_INIT;
+
+  return encode_and_append_int (stream,
+                                stream_id,
+                                QPACK_DINSTR_STREAM_CANCEL_PREFIX,
+                                QPACK_DINSTR_STREAM_CANCEL_MASK);
+}
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_write_insert_count_inc (
+    SocketQPACK_DecoderStream_T stream, uint64_t increment)
+{
+  /*
+   * RFC 9204 Section 4.4.3: Insert Count Increment
+   *
+   *   0   1   2   3   4   5   6   7
+   * +---+---+---+---+---+---+---+---+
+   * | 0 | 0 |     Increment (6+)    |
+   * +---+---+-----------------------+
+   *
+   * Bit pattern: 00xxxxxx (0x00 mask)
+   * The 6-bit prefix encodes the increment value.
+   *
+   * Note: An increment of 0 is an error (QPACK_DECOMPRESSION_FAILED).
+   */
+  if (stream == NULL)
+    return QPACK_STREAM_ERR_NULL_PARAM;
+
+  if (!stream->initialized)
+    return QPACK_STREAM_ERR_NOT_INIT;
+
+  /* RFC 9204 Section 4.4.3: increment of 0 is an error */
+  if (increment == 0)
+    return QPACK_STREAM_ERR_INVALID_INDEX;
+
+  return encode_and_append_int (stream,
+                                increment,
+                                QPACK_DINSTR_INSERT_COUNT_INC_PREFIX,
+                                QPACK_DINSTR_INSERT_COUNT_INC_MASK);
+}
+
+/* ============================================================================
+ * BUFFER MANAGEMENT
+ * ============================================================================
+ */
+
+const unsigned char *
+SocketQPACK_DecoderStream_get_buffer (SocketQPACK_DecoderStream_T stream,
+                                      size_t *len)
+{
+  if (len != NULL)
+    *len = 0;
+
+  if (stream == NULL)
+    return NULL;
+
+  if (len != NULL)
+    *len = stream->buffer_len;
+
+  if (stream->buffer_len == 0)
+    return NULL;
+
+  return stream->buffer;
+}
+
+SocketQPACKStream_Result
+SocketQPACK_DecoderStream_reset_buffer (SocketQPACK_DecoderStream_T stream)
+{
+  if (stream == NULL)
+    return QPACK_STREAM_ERR_NULL_PARAM;
+
+  stream->buffer_len = 0;
+  return QPACK_STREAM_OK;
+}
+
+size_t
+SocketQPACK_DecoderStream_buffer_size (SocketQPACK_DecoderStream_T stream)
+{
+  if (stream == NULL)
+    return 0;
+
+  return stream->buffer_len;
+}

--- a/src/test/test_qpack_decoder_stream.c
+++ b/src/test/test_qpack_decoder_stream.c
@@ -1,0 +1,827 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_decoder_stream.c
+ * @brief Unit tests for QPACK Decoder Stream Infrastructure (RFC 9204
+ * Section 4.2)
+ *
+ * Tests the decoder stream implementation including:
+ * - Stream lifecycle (creation, initialization, state)
+ * - Stream type and ID validation (Section 4.2)
+ * - Decoder instructions (Section 4.4):
+ *   - Section Acknowledgment (4.4.1)
+ *   - Stream Cancellation (4.4.2)
+ *   - Insert Count Increment (4.4.3)
+ * - Buffer management
+ * - Error handling and security
+ */
+
+#include "core/Arena.h"
+#include "http/qpack/SocketQPACK.h"
+#include "http/qpack/SocketQPACKDecoderStream.h"
+#include "http/qpack/SocketQPACKEncoderStream.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * STREAM TYPE VALIDATION TESTS (RFC 9204 Section 4.2)
+ * ============================================================================
+ */
+
+/**
+ * Test decoder stream type validation.
+ *
+ * RFC 9204 Section 4.2: Decoder stream has type 0x03.
+ */
+static void
+test_stream_type_validation (void)
+{
+  SocketQPACKStream_Result result;
+
+  printf ("  Stream type validation... ");
+
+  /* Valid decoder stream type (0x03) */
+  result = SocketQPACK_DecoderStream_validate_type (QPACK_DECODER_STREAM_TYPE);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "type 0x03 should be valid");
+
+  /* Invalid types */
+  result = SocketQPACK_DecoderStream_validate_type (0x00);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_TYPE, "type 0x00 invalid");
+
+  result = SocketQPACK_DecoderStream_validate_type (0x01);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_TYPE, "type 0x01 invalid");
+
+  result = SocketQPACK_DecoderStream_validate_type (QPACK_ENCODER_STREAM_TYPE);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_TYPE,
+               "type 0x02 (encoder) invalid for decoder");
+
+  result = SocketQPACK_DecoderStream_validate_type (0xFF);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_TYPE, "type 0xFF invalid");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * STREAM LIFECYCLE TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test decoder stream creation.
+ */
+static void
+test_stream_creation (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+
+  printf ("  Stream creation... ");
+
+  arena = Arena_new ();
+  TEST_ASSERT (arena != NULL, "arena creation");
+
+  /* Create stream with typical parameters */
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  TEST_ASSERT (stream != NULL, "stream creation");
+
+  /* Verify initial state */
+  TEST_ASSERT (!SocketQPACK_DecoderStream_is_open (stream),
+               "stream not initialized");
+  TEST_ASSERT (SocketQPACK_DecoderStream_get_id (stream) == 3, "stream_id=3");
+  TEST_ASSERT (SocketQPACK_DecoderStream_buffer_size (stream) == 0,
+               "buffer empty");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoder stream creation with NULL arena.
+ */
+static void
+test_stream_creation_null_arena (void)
+{
+  SocketQPACK_DecoderStream_T stream;
+
+  printf ("  Stream creation NULL arena... ");
+
+  stream = SocketQPACK_DecoderStream_new (NULL, 3);
+  TEST_ASSERT (stream == NULL, "NULL arena should fail");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoder stream initialization.
+ */
+static void
+test_stream_initialization (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Stream initialization... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  TEST_ASSERT (stream != NULL, "stream creation");
+
+  /* Not initialized yet */
+  TEST_ASSERT (!SocketQPACK_DecoderStream_is_open (stream), "not open yet");
+
+  /* Initialize */
+  result = SocketQPACK_DecoderStream_init (stream);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "init should succeed");
+  TEST_ASSERT (SocketQPACK_DecoderStream_is_open (stream), "now open");
+
+  /* Double init should fail */
+  result = SocketQPACK_DecoderStream_init (stream);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_ALREADY_INIT, "double init fails");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoder stream ID validation.
+ */
+static void
+test_stream_id_validation (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Stream ID validation... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 7);
+  TEST_ASSERT (stream != NULL, "stream creation");
+
+  /* Correct stream ID */
+  result = SocketQPACK_DecoderStream_validate_id (stream, 7);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "matching ID should be valid");
+
+  /* Wrong stream ID */
+  result = SocketQPACK_DecoderStream_validate_id (stream, 3);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_TYPE,
+               "non-matching ID invalid");
+
+  result = SocketQPACK_DecoderStream_validate_id (stream, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_TYPE, "ID 0 invalid");
+
+  /* NULL stream */
+  result = SocketQPACK_DecoderStream_validate_id (NULL, 7);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL stream fails");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoder stream NULL parameter handling for lifecycle functions.
+ */
+static void
+test_stream_lifecycle_null_params (void)
+{
+  SocketQPACKStream_Result result;
+  size_t len;
+
+  printf ("  Lifecycle NULL parameters... ");
+
+  /* init with NULL */
+  result = SocketQPACK_DecoderStream_init (NULL);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "init NULL fails");
+
+  /* is_open with NULL */
+  TEST_ASSERT (!SocketQPACK_DecoderStream_is_open (NULL), "is_open NULL=false");
+
+  /* get_id with NULL */
+  TEST_ASSERT (SocketQPACK_DecoderStream_get_id (NULL) == 0, "get_id NULL=0");
+
+  /* buffer_size with NULL */
+  TEST_ASSERT (SocketQPACK_DecoderStream_buffer_size (NULL) == 0,
+               "buffer_size NULL=0");
+
+  /* get_buffer with NULL */
+  TEST_ASSERT (SocketQPACK_DecoderStream_get_buffer (NULL, &len) == NULL,
+               "get_buffer NULL=NULL");
+  TEST_ASSERT (len == 0, "get_buffer NULL len=0");
+
+  /* reset_buffer with NULL */
+  result = SocketQPACK_DecoderStream_reset_buffer (NULL);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "reset NULL fails");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * SECTION ACKNOWLEDGMENT TESTS (RFC 9204 Section 4.4.1)
+ * ============================================================================
+ */
+
+/**
+ * Test Section Acknowledgment instruction encoding.
+ *
+ * RFC 9204 Section 4.4.1: Bit pattern 1xxxxxxx with 7-bit prefix.
+ */
+static void
+test_write_section_ack_basic (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+  const unsigned char *buf;
+  size_t len;
+
+  printf ("  Section acknowledgment basic... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Acknowledge stream 0 */
+  result = SocketQPACK_DecoderStream_write_section_ack (stream, 0);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "section_ack stream=0 should succeed");
+
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf != NULL, "buffer not NULL");
+  TEST_ASSERT (len == 1, "single byte for stream_id=0");
+  TEST_ASSERT (buf[0] == 0x80, "1 0000000 = 0x80 for stream_id=0");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Acknowledge stream 126 (fits in 7 bits: 126 < 127) */
+  result = SocketQPACK_DecoderStream_write_section_ack (stream, 126);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "section_ack stream=126 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (len == 1, "single byte for stream_id=126");
+  TEST_ASSERT (buf[0] == (0x80 | 126), "1 1111110 for stream_id=126");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Acknowledge stream 127 (needs continuation: 2^7 - 1 = 127) */
+  result = SocketQPACK_DecoderStream_write_section_ack (stream, 127);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "section_ack stream=127 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (len == 2, "two bytes for stream_id=127");
+  TEST_ASSERT (buf[0] == 0xFF, "1 1111111 prefix full");
+  TEST_ASSERT (buf[1] == 0x00, "continuation 0");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test Section Acknowledgment with large stream IDs.
+ */
+static void
+test_write_section_ack_large_id (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+  const unsigned char *buf;
+  size_t len;
+
+  printf ("  Section acknowledgment large IDs... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Large stream ID that requires multiple continuation bytes */
+  result = SocketQPACK_DecoderStream_write_section_ack (stream, 1000);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "section_ack stream=1000 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf != NULL && len >= 2, "multi-byte encoding");
+  TEST_ASSERT ((buf[0] & 0x80) == 0x80, "high bit set for section ack");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test Section Acknowledgment on uninitialized stream.
+ */
+static void
+test_write_section_ack_not_init (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Section acknowledgment uninitialized... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  /* Don't init */
+
+  result = SocketQPACK_DecoderStream_write_section_ack (stream, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NOT_INIT, "uninitialized fails");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * STREAM CANCELLATION TESTS (RFC 9204 Section 4.4.2)
+ * ============================================================================
+ */
+
+/**
+ * Test Stream Cancellation instruction encoding.
+ *
+ * RFC 9204 Section 4.4.2: Bit pattern 01xxxxxx with 6-bit prefix.
+ */
+static void
+test_write_stream_cancel_basic (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+  const unsigned char *buf;
+  size_t len;
+
+  printf ("  Stream cancellation basic... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Cancel stream 0 */
+  result = SocketQPACK_DecoderStream_write_stream_cancel (stream, 0);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "stream_cancel stream=0 should succeed");
+
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf != NULL, "buffer not NULL");
+  TEST_ASSERT (len == 1, "single byte for stream_id=0");
+  TEST_ASSERT (buf[0] == 0x40, "01 000000 = 0x40 for stream_id=0");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Cancel stream 62 (fits in 6 bits: 62 < 63) */
+  result = SocketQPACK_DecoderStream_write_stream_cancel (stream, 62);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "stream_cancel stream=62 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (len == 1, "single byte for stream_id=62");
+  TEST_ASSERT (buf[0] == (0x40 | 62), "01 111110 for stream_id=62");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Cancel stream 63 (needs continuation: 2^6 - 1 = 63) */
+  result = SocketQPACK_DecoderStream_write_stream_cancel (stream, 63);
+  TEST_ASSERT (result == QPACK_STREAM_OK,
+               "stream_cancel stream=63 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (len == 2, "two bytes for stream_id=63");
+  TEST_ASSERT (buf[0] == 0x7F, "01 111111 prefix full");
+  TEST_ASSERT (buf[1] == 0x00, "continuation 0");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test Stream Cancellation on uninitialized stream.
+ */
+static void
+test_write_stream_cancel_not_init (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Stream cancellation uninitialized... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  /* Don't init */
+
+  result = SocketQPACK_DecoderStream_write_stream_cancel (stream, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NOT_INIT, "uninitialized fails");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * INSERT COUNT INCREMENT TESTS (RFC 9204 Section 4.4.3)
+ * ============================================================================
+ */
+
+/**
+ * Test Insert Count Increment instruction encoding.
+ *
+ * RFC 9204 Section 4.4.3: Bit pattern 00xxxxxx with 6-bit prefix.
+ */
+static void
+test_write_insert_count_inc_basic (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+  const unsigned char *buf;
+  size_t len;
+
+  printf ("  Insert count increment basic... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Increment by 1 */
+  result = SocketQPACK_DecoderStream_write_insert_count_inc (stream, 1);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "insert_count_inc=1 should succeed");
+
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf != NULL, "buffer not NULL");
+  TEST_ASSERT (len == 1, "single byte for increment=1");
+  TEST_ASSERT (buf[0] == 0x01, "00 000001 = 0x01 for increment=1");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Increment by 62 (fits in 6 bits: 62 < 63) */
+  result = SocketQPACK_DecoderStream_write_insert_count_inc (stream, 62);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "insert_count_inc=62 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (len == 1, "single byte for increment=62");
+  TEST_ASSERT (buf[0] == 62, "00 111110 for increment=62");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Increment by 63 (needs continuation: 2^6 - 1 = 63) */
+  result = SocketQPACK_DecoderStream_write_insert_count_inc (stream, 63);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "insert_count_inc=63 should succeed");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (len == 2, "two bytes for increment=63");
+  TEST_ASSERT (buf[0] == 0x3F, "00 111111 prefix full");
+  TEST_ASSERT (buf[1] == 0x00, "continuation 0");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test Insert Count Increment with 0 (error case).
+ *
+ * RFC 9204 Section 4.4.3: increment of 0 is an error.
+ */
+static void
+test_write_insert_count_inc_zero (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Insert count increment zero (error)... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Increment of 0 is an error per RFC 9204 Section 4.4.3 */
+  result = SocketQPACK_DecoderStream_write_insert_count_inc (stream, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX,
+               "increment=0 should fail");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test Insert Count Increment on uninitialized stream.
+ */
+static void
+test_write_insert_count_inc_not_init (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Insert count increment uninitialized... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  /* Don't init */
+
+  result = SocketQPACK_DecoderStream_write_insert_count_inc (stream, 5);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NOT_INIT, "uninitialized fails");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * BUFFER MANAGEMENT TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test buffer management - get, reset, size.
+ */
+static void
+test_buffer_management (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  const unsigned char *buf;
+  size_t len;
+
+  printf ("  Buffer management... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Empty buffer */
+  TEST_ASSERT (SocketQPACK_DecoderStream_buffer_size (stream) == 0,
+               "initially empty");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf == NULL && len == 0, "empty returns NULL");
+
+  /* Write something */
+  SocketQPACK_DecoderStream_write_section_ack (stream, 5);
+  TEST_ASSERT (SocketQPACK_DecoderStream_buffer_size (stream) > 0, "has data");
+
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf != NULL && len > 0, "get_buffer returns data");
+  TEST_ASSERT (len == SocketQPACK_DecoderStream_buffer_size (stream),
+               "len matches size");
+
+  /* Reset */
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+  TEST_ASSERT (SocketQPACK_DecoderStream_buffer_size (stream) == 0,
+               "reset clears");
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT (buf == NULL && len == 0, "empty after reset");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test buffer accumulation across multiple instructions.
+ */
+static void
+test_buffer_accumulation (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  size_t len1, len2, len3;
+
+  printf ("  Buffer accumulation... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Write multiple instructions */
+  SocketQPACK_DecoderStream_write_section_ack (stream, 4);
+  len1 = SocketQPACK_DecoderStream_buffer_size (stream);
+  TEST_ASSERT (len1 > 0, "first instruction written");
+
+  SocketQPACK_DecoderStream_write_stream_cancel (stream, 8);
+  len2 = SocketQPACK_DecoderStream_buffer_size (stream);
+  TEST_ASSERT (len2 > len1, "second instruction accumulated");
+
+  SocketQPACK_DecoderStream_write_insert_count_inc (stream, 10);
+  len3 = SocketQPACK_DecoderStream_buffer_size (stream);
+  TEST_ASSERT (len3 > len2, "third instruction accumulated");
+
+  /* All instructions in one buffer */
+  const unsigned char *buf;
+  size_t total_len;
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &total_len);
+  TEST_ASSERT (buf != NULL, "buffer not NULL");
+  TEST_ASSERT (total_len == len3, "total matches");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * SECURITY TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test NULL parameter handling for instruction functions.
+ */
+static void
+test_instruction_null_params (void)
+{
+  SocketQPACKStream_Result result;
+
+  printf ("  Instruction NULL parameters... ");
+
+  /* All instruction functions with NULL stream */
+  result = SocketQPACK_DecoderStream_write_section_ack (NULL, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "section_ack NULL fails");
+
+  result = SocketQPACK_DecoderStream_write_stream_cancel (NULL, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM,
+               "stream_cancel NULL fails");
+
+  result = SocketQPACK_DecoderStream_write_insert_count_inc (NULL, 1);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM,
+               "insert_count_inc NULL fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test large values that could cause overflow.
+ */
+static void
+test_large_values (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  SocketQPACKStream_Result result;
+
+  printf ("  Large values... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Large stream ID (should encode correctly with HPACK integer) */
+  result = SocketQPACK_DecoderStream_write_section_ack (stream, (1ULL << 40));
+  TEST_ASSERT (result == QPACK_STREAM_OK, "large section_ack succeeds");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Large stream ID for cancellation */
+  result = SocketQPACK_DecoderStream_write_stream_cancel (stream, (1ULL << 40));
+  TEST_ASSERT (result == QPACK_STREAM_OK, "large stream_cancel succeeds");
+
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Large increment */
+  result
+      = SocketQPACK_DecoderStream_write_insert_count_inc (stream, (1ULL << 40));
+  TEST_ASSERT (result == QPACK_STREAM_OK, "large insert_count_inc succeeds");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/**
+ * Test instruction bit patterns are distinct.
+ */
+static void
+test_instruction_bit_patterns (void)
+{
+  Arena_T arena;
+  SocketQPACK_DecoderStream_T stream;
+  const unsigned char *buf;
+  size_t len;
+
+  printf ("  Instruction bit patterns... ");
+
+  arena = Arena_new ();
+  stream = SocketQPACK_DecoderStream_new (arena, 3);
+  SocketQPACK_DecoderStream_init (stream);
+
+  /* Section Ack: 1xxxxxxx */
+  SocketQPACK_DecoderStream_write_section_ack (stream, 0);
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT ((buf[0] & 0x80) == 0x80, "section_ack has bit 7 set");
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Stream Cancel: 01xxxxxx */
+  SocketQPACK_DecoderStream_write_stream_cancel (stream, 0);
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT ((buf[0] & 0xC0) == 0x40, "stream_cancel has bits 7-6 = 01");
+  SocketQPACK_DecoderStream_reset_buffer (stream);
+
+  /* Insert Count Inc: 00xxxxxx */
+  SocketQPACK_DecoderStream_write_insert_count_inc (stream, 1);
+  buf = SocketQPACK_DecoderStream_get_buffer (stream, &len);
+  TEST_ASSERT ((buf[0] & 0xC0) == 0x00, "insert_count_inc has bits 7-6 = 00");
+
+  Arena_dispose (&arena);
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * TEST SUITE
+ * ============================================================================
+ */
+
+static void
+run_stream_type_tests (void)
+{
+  printf ("Stream Type Validation Tests (RFC 9204 Section 4.2):\n");
+  test_stream_type_validation ();
+}
+
+static void
+run_lifecycle_tests (void)
+{
+  printf ("Stream Lifecycle Tests:\n");
+  test_stream_creation ();
+  test_stream_creation_null_arena ();
+  test_stream_initialization ();
+  test_stream_id_validation ();
+  test_stream_lifecycle_null_params ();
+}
+
+static void
+run_section_ack_tests (void)
+{
+  printf ("Section Acknowledgment Tests (RFC 9204 Section 4.4.1):\n");
+  test_write_section_ack_basic ();
+  test_write_section_ack_large_id ();
+  test_write_section_ack_not_init ();
+}
+
+static void
+run_stream_cancel_tests (void)
+{
+  printf ("Stream Cancellation Tests (RFC 9204 Section 4.4.2):\n");
+  test_write_stream_cancel_basic ();
+  test_write_stream_cancel_not_init ();
+}
+
+static void
+run_insert_count_inc_tests (void)
+{
+  printf ("Insert Count Increment Tests (RFC 9204 Section 4.4.3):\n");
+  test_write_insert_count_inc_basic ();
+  test_write_insert_count_inc_zero ();
+  test_write_insert_count_inc_not_init ();
+}
+
+static void
+run_buffer_tests (void)
+{
+  printf ("Buffer Management Tests:\n");
+  test_buffer_management ();
+  test_buffer_accumulation ();
+}
+
+static void
+run_security_tests (void)
+{
+  printf ("Security Tests:\n");
+  test_instruction_null_params ();
+  test_large_values ();
+  test_instruction_bit_patterns ();
+}
+
+int
+main (void)
+{
+  printf ("=== QPACK Decoder Stream Tests (RFC 9204 Section 4.2) ===\n\n");
+
+  run_stream_type_tests ();
+  printf ("\n");
+
+  run_lifecycle_tests ();
+  printf ("\n");
+
+  run_section_ack_tests ();
+  printf ("\n");
+
+  run_stream_cancel_tests ();
+  printf ("\n");
+
+  run_insert_count_inc_tests ();
+  printf ("\n");
+
+  run_buffer_tests ();
+  printf ("\n");
+
+  run_security_tests ();
+  printf ("\n");
+
+  printf ("=== All tests passed! ===\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements #3279 - QPACK Decoder Stream Infrastructure for HTTP/3 header compression.

- Decoder stream type 0x03 per RFC 9204 Section 4.2
- Section Acknowledgment instruction (Section 4.4.1)
- Stream Cancellation instruction (Section 4.4.2)
- Insert Count Increment instruction (Section 4.4.3)
- Stream ID validation for connection integrity

## Changes

- `include/http/qpack/SocketQPACKDecoderStream.h`: Public API header
- `src/http/qpack/SocketQPACK-decoder-stream.c`: Implementation
- `src/test/test_qpack_decoder_stream.c`: Comprehensive test suite
- `CMakeLists.txt`: Build integration

## Test Plan

- [x] All decoder stream unit tests pass
- [x] Tests pass with AddressSanitizer enabled
- [x] Tests pass with UndefinedBehaviorSanitizer enabled
- [x] Verified instruction bit patterns match RFC 9204

Closes #3279