### PR TITLE
feat(qpack): implement RFC 9204 Section 4.4.3 - Insert Count Increment

### DIFF
--- a/src/test/test_qpack_decoder_stream.c
+++ b/src/test/test_qpack_decoder_stream.c
@@ -538,6 +538,444 @@ test_write_insert_count_inc_not_init (void)
 }
 
 /* ============================================================================
+ * INSERT COUNT INCREMENT PRIMITIVES TESTS (RFC 9204 Section 4.4.3)
+ * ============================================================================
+ */
+
+/**
+ * Test standalone encode function for Insert Count Increment.
+ */
+static void
+test_encode_insert_count_inc_basic (void)
+{
+  unsigned char buf[32];
+  size_t written;
+  SocketQPACKStream_Result result;
+
+  printf ("  Encode insert count inc basic... ");
+
+  /* Encode increment = 1 */
+  result = SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 1, &written);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "encode inc=1 succeeds");
+  TEST_ASSERT (written == 1, "single byte for inc=1");
+  TEST_ASSERT (buf[0] == 0x01, "00 000001 for inc=1");
+
+  /* Encode increment = 62 (fits in 6 bits) */
+  result
+      = SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 62, &written);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "encode inc=62 succeeds");
+  TEST_ASSERT (written == 1, "single byte for inc=62");
+  TEST_ASSERT (buf[0] == 62, "00 111110 for inc=62");
+
+  /* Encode increment = 63 (needs continuation) */
+  result
+      = SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 63, &written);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "encode inc=63 succeeds");
+  TEST_ASSERT (written == 2, "two bytes for inc=63");
+  TEST_ASSERT (buf[0] == 0x3F, "00 111111 prefix full");
+  TEST_ASSERT (buf[1] == 0x00, "continuation 0");
+
+  /* Encode increment = 1000 (multi-byte) */
+  result
+      = SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 1000, &written);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "encode inc=1000 succeeds");
+  TEST_ASSERT (written > 1, "multi-byte for inc=1000");
+  TEST_ASSERT ((buf[0] & 0xC0) == 0x00, "bits 7-6 are 00");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encode with 0 (error case).
+ */
+static void
+test_encode_insert_count_inc_zero (void)
+{
+  unsigned char buf[32];
+  size_t written;
+  SocketQPACKStream_Result result;
+
+  printf ("  Encode insert count inc zero (error)... ");
+
+  result = SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 0, &written);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX, "inc=0 fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encode NULL parameters.
+ */
+static void
+test_encode_insert_count_inc_null (void)
+{
+  unsigned char buf[32];
+  size_t written;
+  SocketQPACKStream_Result result;
+
+  printf ("  Encode insert count inc NULL params... ");
+
+  result = SocketQPACK_encode_insert_count_inc (NULL, 32, 1, &written);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL output fails");
+
+  result = SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 1, NULL);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL written fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encode with insufficient buffer.
+ */
+static void
+test_encode_insert_count_inc_buffer_full (void)
+{
+  unsigned char buf[1];
+  size_t written;
+  SocketQPACKStream_Result result;
+
+  printf ("  Encode insert count inc buffer full... ");
+
+  /* 63 needs 2 bytes, but buffer is only 1 */
+  result = SocketQPACK_encode_insert_count_inc (buf, 1, 63, &written);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_BUFFER_FULL, "insufficient buffer");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test standalone decode function for Insert Count Increment.
+ */
+static void
+test_decode_insert_count_inc_basic (void)
+{
+  unsigned char buf[32];
+  size_t written, consumed;
+  uint64_t increment;
+  SocketQPACKStream_Result result;
+
+  printf ("  Decode insert count inc basic... ");
+
+  /* Encode then decode increment = 1 */
+  SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 1, &written);
+  result = SocketQPACK_decode_insert_count_inc (
+      buf, written, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "decode inc=1 succeeds");
+  TEST_ASSERT (increment == 1, "decoded value is 1");
+  TEST_ASSERT (consumed == written, "consumed matches written");
+
+  /* Encode then decode increment = 62 */
+  SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 62, &written);
+  result = SocketQPACK_decode_insert_count_inc (
+      buf, written, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "decode inc=62 succeeds");
+  TEST_ASSERT (increment == 62, "decoded value is 62");
+  TEST_ASSERT (consumed == written, "consumed matches written");
+
+  /* Encode then decode increment = 63 */
+  SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 63, &written);
+  result = SocketQPACK_decode_insert_count_inc (
+      buf, written, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "decode inc=63 succeeds");
+  TEST_ASSERT (increment == 63, "decoded value is 63");
+  TEST_ASSERT (consumed == written, "consumed matches written");
+
+  /* Encode then decode increment = 1000 */
+  SocketQPACK_encode_insert_count_inc (buf, sizeof (buf), 1000, &written);
+  result = SocketQPACK_decode_insert_count_inc (
+      buf, written, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "decode inc=1000 succeeds");
+  TEST_ASSERT (increment == 1000, "decoded value is 1000");
+  TEST_ASSERT (consumed == written, "consumed matches written");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decode with 0 value (error case).
+ */
+static void
+test_decode_insert_count_inc_zero (void)
+{
+  unsigned char buf[1] = { 0x00 }; /* 00 000000 = increment 0 */
+  uint64_t increment;
+  size_t consumed;
+  SocketQPACKStream_Result result;
+
+  printf ("  Decode insert count inc zero (error)... ");
+
+  result = SocketQPACK_decode_insert_count_inc (buf, 1, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX, "inc=0 fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decode NULL parameters.
+ */
+static void
+test_decode_insert_count_inc_null (void)
+{
+  unsigned char buf[1] = { 0x01 };
+  uint64_t increment;
+  size_t consumed;
+  SocketQPACKStream_Result result;
+
+  printf ("  Decode insert count inc NULL params... ");
+
+  result = SocketQPACK_decode_insert_count_inc (NULL, 1, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL input fails");
+
+  result = SocketQPACK_decode_insert_count_inc (buf, 1, NULL, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL increment fails");
+
+  result = SocketQPACK_decode_insert_count_inc (buf, 1, &increment, NULL);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL consumed fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decode with incomplete data.
+ */
+static void
+test_decode_insert_count_inc_incomplete (void)
+{
+  unsigned char buf[1] = { 0x3F }; /* 00 111111 - needs continuation */
+  uint64_t increment;
+  size_t consumed;
+  SocketQPACKStream_Result result;
+
+  printf ("  Decode insert count inc incomplete... ");
+
+  /* Empty buffer */
+  result = SocketQPACK_decode_insert_count_inc (buf, 0, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_BUFFER_FULL, "empty buffer fails");
+
+  /* Prefix indicates continuation but no continuation byte */
+  result = SocketQPACK_decode_insert_count_inc (buf, 1, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_BUFFER_FULL, "truncated fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decode with wrong instruction pattern.
+ */
+static void
+test_decode_insert_count_inc_wrong_pattern (void)
+{
+  unsigned char buf[1];
+  uint64_t increment;
+  size_t consumed;
+  SocketQPACKStream_Result result;
+
+  printf ("  Decode insert count inc wrong pattern... ");
+
+  /* Section Ack pattern: 1xxxxxxx */
+  buf[0] = 0x80;
+  result = SocketQPACK_decode_insert_count_inc (buf, 1, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INTERNAL,
+               "section ack pattern fails");
+
+  /* Stream Cancel pattern: 01xxxxxx */
+  buf[0] = 0x40;
+  result = SocketQPACK_decode_insert_count_inc (buf, 1, &increment, &consumed);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INTERNAL,
+               "stream cancel pattern fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test apply increment function.
+ */
+static void
+test_apply_insert_count_inc_basic (void)
+{
+  uint64_t known_received = 0;
+  uint64_t insert_count = 10;
+  SocketQPACKStream_Result result;
+
+  printf ("  Apply insert count inc basic... ");
+
+  /* Apply increment of 5 */
+  result
+      = SocketQPACK_apply_insert_count_inc (&known_received, insert_count, 5);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "apply inc=5 succeeds");
+  TEST_ASSERT (known_received == 5, "known_received updated to 5");
+
+  /* Apply another increment of 3 */
+  result
+      = SocketQPACK_apply_insert_count_inc (&known_received, insert_count, 3);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "apply inc=3 succeeds");
+  TEST_ASSERT (known_received == 8, "known_received updated to 8");
+
+  /* Apply increment to reach exact insert_count */
+  result
+      = SocketQPACK_apply_insert_count_inc (&known_received, insert_count, 2);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "apply inc=2 succeeds");
+  TEST_ASSERT (known_received == 10, "known_received equals insert_count");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test apply increment with 0 (error case).
+ */
+static void
+test_apply_insert_count_inc_zero (void)
+{
+  uint64_t known_received = 0;
+  SocketQPACKStream_Result result;
+
+  printf ("  Apply insert count inc zero (error)... ");
+
+  result = SocketQPACK_apply_insert_count_inc (&known_received, 10, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX, "inc=0 fails");
+  TEST_ASSERT (known_received == 0, "known_received unchanged");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test apply increment exceeding insert_count (error case).
+ */
+static void
+test_apply_insert_count_inc_exceed (void)
+{
+  uint64_t known_received = 5;
+  SocketQPACKStream_Result result;
+
+  printf ("  Apply insert count inc exceed (error)... ");
+
+  /* Try to increment beyond insert_count */
+  result = SocketQPACK_apply_insert_count_inc (&known_received, 10, 6);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX,
+               "exceeding insert_count fails");
+  TEST_ASSERT (known_received == 5, "known_received unchanged");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test apply increment with NULL parameter.
+ */
+static void
+test_apply_insert_count_inc_null (void)
+{
+  SocketQPACKStream_Result result;
+
+  printf ("  Apply insert count inc NULL... ");
+
+  result = SocketQPACK_apply_insert_count_inc (NULL, 10, 1);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_NULL_PARAM, "NULL param fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test validate increment function.
+ */
+static void
+test_validate_insert_count_inc (void)
+{
+  SocketQPACKStream_Result result;
+
+  printf ("  Validate insert count inc... ");
+
+  /* Valid increments */
+  result = SocketQPACK_validate_insert_count_inc (0, 10, 5);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "valid 0+5<=10");
+
+  result = SocketQPACK_validate_insert_count_inc (5, 10, 5);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "valid 5+5=10");
+
+  result = SocketQPACK_validate_insert_count_inc (0, 100, 100);
+  TEST_ASSERT (result == QPACK_STREAM_OK, "valid 0+100=100");
+
+  /* Invalid: increment = 0 */
+  result = SocketQPACK_validate_insert_count_inc (0, 10, 0);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX, "inc=0 invalid");
+
+  /* Invalid: exceeds insert_count */
+  result = SocketQPACK_validate_insert_count_inc (5, 10, 6);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX, "5+6>10 invalid");
+
+  result = SocketQPACK_validate_insert_count_inc (0, 10, 11);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX, "0+11>10 invalid");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encode/decode round-trip with large values.
+ */
+static void
+test_insert_count_inc_roundtrip_large (void)
+{
+  unsigned char buf[32];
+  size_t written, consumed;
+  uint64_t increment, decoded;
+  SocketQPACKStream_Result result;
+
+  printf ("  Insert count inc roundtrip large... ");
+
+  /* Test various large values */
+  uint64_t test_values[]
+      = { 100,     1000,         10000,        100000,
+          1000000, (1ULL << 20), (1ULL << 30), (1ULL << 40) };
+
+  for (size_t i = 0; i < sizeof (test_values) / sizeof (test_values[0]); i++)
+    {
+      increment = test_values[i];
+
+      result = SocketQPACK_encode_insert_count_inc (
+          buf, sizeof (buf), increment, &written);
+      TEST_ASSERT (result == QPACK_STREAM_OK, "encode large value succeeds");
+
+      result = SocketQPACK_decode_insert_count_inc (
+          buf, written, &decoded, &consumed);
+      TEST_ASSERT (result == QPACK_STREAM_OK, "decode large value succeeds");
+      TEST_ASSERT (decoded == increment, "roundtrip preserves value");
+      TEST_ASSERT (consumed == written, "consumed matches written");
+    }
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test sequential increments.
+ */
+static void
+test_insert_count_inc_sequential (void)
+{
+  uint64_t known_received = 0;
+  uint64_t insert_count = 100;
+  SocketQPACKStream_Result result;
+
+  printf ("  Insert count inc sequential... ");
+
+  /* Multiple sequential increments */
+  for (int i = 0; i < 10; i++)
+    {
+      result = SocketQPACK_apply_insert_count_inc (
+          &known_received, insert_count, 10);
+      TEST_ASSERT (result == QPACK_STREAM_OK, "sequential increment succeeds");
+    }
+
+  TEST_ASSERT (known_received == 100, "final known_received = 100");
+
+  /* Now further increments should fail */
+  result
+      = SocketQPACK_apply_insert_count_inc (&known_received, insert_count, 1);
+  TEST_ASSERT (result == QPACK_STREAM_ERR_INVALID_INDEX,
+               "cannot exceed insert_count");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
  * BUFFER MANAGEMENT TESTS
  * ============================================================================
  */
@@ -1071,6 +1509,29 @@ run_insert_count_inc_tests (void)
 }
 
 static void
+run_insert_count_inc_primitives_tests (void)
+{
+  printf (
+      "Insert Count Increment Primitives Tests (RFC 9204 Section 4.4.3):\n");
+  test_encode_insert_count_inc_basic ();
+  test_encode_insert_count_inc_zero ();
+  test_encode_insert_count_inc_null ();
+  test_encode_insert_count_inc_buffer_full ();
+  test_decode_insert_count_inc_basic ();
+  test_decode_insert_count_inc_zero ();
+  test_decode_insert_count_inc_null ();
+  test_decode_insert_count_inc_incomplete ();
+  test_decode_insert_count_inc_wrong_pattern ();
+  test_apply_insert_count_inc_basic ();
+  test_apply_insert_count_inc_zero ();
+  test_apply_insert_count_inc_exceed ();
+  test_apply_insert_count_inc_null ();
+  test_validate_insert_count_inc ();
+  test_insert_count_inc_roundtrip_large ();
+  test_insert_count_inc_sequential ();
+}
+
+static void
 run_buffer_tests (void)
 {
   printf ("Buffer Management Tests:\n");
@@ -1108,6 +1569,9 @@ main (void)
   printf ("\n");
 
   run_insert_count_inc_tests ();
+  printf ("\n");
+
+  run_insert_count_inc_primitives_tests ();
   printf ("\n");
 
   run_buffer_tests ();


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.4.3 - Insert Count Increment Instruction for QPACK decoder stream.

- Add standalone encode/decode functions for Insert Count Increment wire format
- Add apply function to update Known Received Count in encoder state
- Add validation function for increment bounds checking
- Comprehensive test coverage (16 new tests)

## Changes

- `include/http/qpack/SocketQPACKDecoderStream.h`: Add function declarations
  - `SocketQPACK_encode_insert_count_inc`: Encode instruction to buffer
  - `SocketQPACK_decode_insert_count_inc`: Decode wire format to increment value
  - `SocketQPACK_apply_insert_count_inc`: Apply increment to Known Received Count
  - `SocketQPACK_validate_insert_count_inc`: Validate increment bounds

- `src/http/qpack/SocketQPACK-decoder-stream.c`: Add implementations

- `src/test/test_qpack_decoder_stream.c`: Add 16 new tests covering:
  - Encode/decode basic operations
  - Zero increment error handling
  - NULL parameter validation
  - Buffer overflow protection
  - Round-trip with large values
  - Sequential increment application
  - Bound validation

## RFC Compliance

Per RFC 9204 Section 4.4.3:
- Wire format: `00xxxxxx` pattern with 6-bit prefix integer
- Increment of 0 returns `QPACK_DECODER_STREAM_ERROR`
- Increment cannot exceed dynamic table insert count
- Supports coalescing with other decoder instructions

## Test Plan

- [x] Tests pass with AddressSanitizer enabled
- [x] Tests pass with UndefinedBehaviorSanitizer enabled
- [x] All 144 tests pass (0 failures)

Closes #3283