### PR TITLE
feat(qpack): implement RFC 9204 Section 4.5.1 - Encoded Field Section Prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ set(LIB_SOURCES
     src/http/qpack/SocketQPACK-capacity.c
     src/http/qpack/SocketQPACK-encoder.c
     src/http/qpack/SocketQPACK-decoder-stream.c
+    src/http/qpack/SocketQPACK-prefix.c
 
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
@@ -807,6 +808,7 @@ set(TEST_SOURCES
     test_qpack_capacity
     test_qpack_insert_literal
     test_qpack_decoder_stream
+    test_qpack_prefix
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/src/http/qpack/SocketQPACK-prefix.c
+++ b/src/http/qpack/SocketQPACK-prefix.c
@@ -1,0 +1,371 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-prefix.c
+ * @brief QPACK Encoded Field Section Prefix (RFC 9204 Section 4.5.1)
+ *
+ * Implements encoding and decoding for the Field Section Prefix, which
+ * precedes all encoded field sections in QPACK. The prefix communicates
+ * the Required Insert Count and Base to the decoder.
+ *
+ * Wire format (RFC 9204 Section 4.5.1):
+ *
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * |   Required Insert Count (8+)  |
+ * +---+---+---+---+---+---+---+---+
+ * | S |      Delta Base (7+)      |
+ * +---+---------------------------+
+ *
+ * Required Insert Count is encoded using 8-bit prefix integer.
+ * Delta Base is encoded with 7-bit prefix, and S bit indicates sign:
+ * - S=0: Base = Required Insert Count + Delta Base
+ * - S=1: Base = Required Insert Count - Delta Base - 1
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.5.1
+ */
+
+#include <string.h>
+
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include "core/SocketUtil.h"
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * CONSTANTS
+ * ============================================================================
+ */
+
+/** Required Insert Count prefix bits (8-bit integer) */
+#define RIC_PREFIX_BITS 8
+
+/** Delta Base prefix bits (7-bit integer) */
+#define DELTA_BASE_PREFIX_BITS 7
+
+/** Sign bit mask for Delta Base (bit 7 of second field) */
+#define DELTA_BASE_SIGN_BIT 0x80
+
+/* ============================================================================
+ * ENCODE FIELD SECTION PREFIX (RFC 9204 Section 4.5.1)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_encode_prefix (uint64_t required_insert_count,
+                           uint64_t base,
+                           uint64_t max_entries,
+                           unsigned char *output,
+                           size_t output_size,
+                           size_t *bytes_written)
+{
+  size_t offset = 0;
+  size_t encoded_len;
+  uint64_t encoded_ric;
+  uint64_t delta_base;
+  int sign_bit;
+
+  /* Validate parameters */
+  if (output == NULL || bytes_written == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *bytes_written = 0;
+
+  if (output_size == 0)
+    return QPACK_ERR_TABLE_SIZE;
+
+  /*
+   * RFC 9204 Section 4.5.1.1: Encoding the Required Insert Count
+   *
+   * If Required Insert Count is 0, encode as 0.
+   * Otherwise, encode using modular arithmetic:
+   *   EncodedRIC = (RIC mod (2 * MaxEntries)) + 1
+   *
+   * MaxEntries is derived from SETTINGS_QPACK_MAX_TABLE_CAPACITY / 32.
+   */
+  if (required_insert_count == 0)
+    {
+      encoded_ric = 0;
+    }
+  else
+    {
+      if (max_entries == 0)
+        return QPACK_ERR_TABLE_SIZE; /* Invalid max_entries */
+
+      encoded_ric = (required_insert_count % (2 * max_entries)) + 1;
+    }
+
+  /* Encode Required Insert Count as 8-bit prefix integer */
+  encoded_len = SocketHPACK_int_encode (
+      encoded_ric, RIC_PREFIX_BITS, output, output_size);
+  if (encoded_len == 0)
+    return QPACK_ERR_INTEGER;
+
+  offset += encoded_len;
+
+  /*
+   * RFC 9204 Section 4.5.1.2: Encoding the Base
+   *
+   * Base is encoded as Delta Base relative to Required Insert Count.
+   * Sign bit determines the direction:
+   *   - S=0 (positive): Base = RIC + Delta Base
+   *   - S=1 (negative): Base = RIC - Delta Base - 1
+   */
+  if (base >= required_insert_count)
+    {
+      /* Positive delta: S=0 */
+      sign_bit = 0;
+      delta_base = base - required_insert_count;
+    }
+  else
+    {
+      /* Negative delta: S=1 */
+      sign_bit = 1;
+      delta_base = required_insert_count - base - 1;
+    }
+
+  /* Check buffer space */
+  if (offset >= output_size)
+    return QPACK_ERR_TABLE_SIZE;
+
+  /* Encode Delta Base as 7-bit prefix integer */
+  encoded_len = SocketHPACK_int_encode (delta_base,
+                                        DELTA_BASE_PREFIX_BITS,
+                                        output + offset,
+                                        output_size - offset);
+  if (encoded_len == 0)
+    return QPACK_ERR_INTEGER;
+
+  /* Set sign bit (bit 7 of the Delta Base byte) */
+  if (sign_bit)
+    output[offset] |= DELTA_BASE_SIGN_BIT;
+  else
+    output[offset] &= ~DELTA_BASE_SIGN_BIT;
+
+  offset += encoded_len;
+
+  *bytes_written = offset;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * DECODE FIELD SECTION PREFIX (RFC 9204 Section 4.5.1)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_decode_prefix (const unsigned char *input,
+                           size_t input_len,
+                           uint64_t max_entries,
+                           uint64_t total_insert_count,
+                           SocketQPACK_FieldSectionPrefix *prefix,
+                           size_t *bytes_consumed)
+{
+  size_t offset = 0;
+  size_t consumed;
+  uint64_t encoded_ric;
+  uint64_t delta_base;
+  uint64_t required_insert_count;
+  uint64_t base;
+  int sign_bit;
+  SocketHPACK_Result hpack_result;
+
+  /* Validate parameters */
+  if (prefix == NULL || bytes_consumed == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *bytes_consumed = 0;
+  prefix->required_insert_count = 0;
+  prefix->delta_base = 0;
+  prefix->base = 0;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (input == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /*
+   * RFC 9204 Section 4.5.1.1: Decode Required Insert Count
+   *
+   * Decode the 8-bit prefix integer.
+   */
+  hpack_result = SocketHPACK_int_decode (input + offset,
+                                         input_len - offset,
+                                         RIC_PREFIX_BITS,
+                                         &encoded_ric,
+                                         &consumed);
+
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERR_INTEGER;
+
+  offset += consumed;
+
+  /*
+   * RFC 9204 Section 4.5.1.1: Decode Required Insert Count from encoded value
+   *
+   * If EncodedRIC == 0, then RIC = 0.
+   * Otherwise, recover RIC using:
+   *   FullRange = 2 * MaxEntries
+   *   MaxValue = TotalInsertCount + MaxEntries
+   *   MaxWrapped = floor(MaxValue / FullRange) * FullRange
+   *   RIC = MaxWrapped + EncodedRIC - 1
+   *
+   *   If RIC > MaxValue, subtract FullRange.
+   */
+  if (encoded_ric == 0)
+    {
+      required_insert_count = 0;
+    }
+  else
+    {
+      if (max_entries == 0)
+        return QPACK_ERR_TABLE_SIZE;
+
+      uint64_t full_range = 2 * max_entries;
+      uint64_t max_value = total_insert_count + max_entries;
+      uint64_t max_wrapped = (max_value / full_range) * full_range;
+
+      required_insert_count = max_wrapped + encoded_ric - 1;
+
+      /* Handle wraparound */
+      if (required_insert_count > max_value)
+        {
+          if (required_insert_count < full_range)
+            return QPACK_ERR_DECOMPRESSION; /* Cannot decode RIC */
+          required_insert_count -= full_range;
+        }
+    }
+
+  /*
+   * RFC 9204 Section 4.5.1: Validate Required Insert Count
+   *
+   * The decoder MUST treat it as a connection error of type
+   * QPACK_DECOMPRESSION_FAILED if Required Insert Count is greater than
+   * the number of entries the decoder has actually inserted.
+   */
+  if (required_insert_count > total_insert_count)
+    return QPACK_ERR_DECOMPRESSION;
+
+  /* Check for Delta Base byte */
+  if (offset >= input_len)
+    return QPACK_INCOMPLETE;
+
+  /*
+   * RFC 9204 Section 4.5.1.2: Decode Delta Base
+   *
+   * Extract sign bit (bit 7) and decode 7-bit prefix integer.
+   */
+  sign_bit = (input[offset] & DELTA_BASE_SIGN_BIT) ? 1 : 0;
+
+  hpack_result = SocketHPACK_int_decode (input + offset,
+                                         input_len - offset,
+                                         DELTA_BASE_PREFIX_BITS,
+                                         &delta_base,
+                                         &consumed);
+
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERR_INTEGER;
+
+  offset += consumed;
+
+  /*
+   * RFC 9204 Section 4.5.1.2: Compute Base from Delta Base
+   *
+   * S=0: Base = RIC + Delta Base
+   * S=1: Base = RIC - Delta Base - 1
+   */
+  if (sign_bit == 0)
+    {
+      /* Check for overflow */
+      if (delta_base > UINT64_MAX - required_insert_count)
+        return QPACK_ERR_DECOMPRESSION;
+      base = required_insert_count + delta_base;
+    }
+  else
+    {
+      /* Check for underflow */
+      if (delta_base + 1 > required_insert_count)
+        return QPACK_ERR_DECOMPRESSION;
+      base = required_insert_count - delta_base - 1;
+    }
+
+  /* Store decoded values */
+  prefix->required_insert_count = required_insert_count;
+  prefix->delta_base
+      = sign_bit ? -(int64_t)(delta_base + 1) : (int64_t)delta_base;
+  prefix->base = base;
+
+  *bytes_consumed = offset;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * VALIDATE PREFIX (RFC 9204 Section 4.5.1)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_validate_prefix (const SocketQPACK_FieldSectionPrefix *prefix,
+                             uint64_t total_insert_count)
+{
+  if (prefix == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /*
+   * RFC 9204 Section 4.5.1:
+   * Required Insert Count MUST NOT exceed total entries inserted.
+   */
+  if (prefix->required_insert_count > total_insert_count)
+    return QPACK_ERR_DECOMPRESSION;
+
+  /*
+   * RFC 9204 Section 4.5.1.2:
+   * Base must be within valid range. For negative delta, base < RIC.
+   * For positive delta, base >= RIC.
+   */
+  if (prefix->delta_base >= 0)
+    {
+      /* Positive delta: base should equal RIC + delta_base */
+      if (prefix->base
+          != prefix->required_insert_count + (uint64_t)prefix->delta_base)
+        return QPACK_ERR_BASE_OVERFLOW;
+    }
+  else
+    {
+      /* Negative delta: base should equal RIC - |delta_base| */
+      uint64_t abs_delta = (uint64_t)(-(prefix->delta_base + 1)) + 1;
+      if (abs_delta > prefix->required_insert_count)
+        return QPACK_ERR_BASE_OVERFLOW;
+      if (prefix->base != prefix->required_insert_count - abs_delta)
+        return QPACK_ERR_BASE_OVERFLOW;
+    }
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * COMPUTE MAX ENTRIES (RFC 9204 Section 4.5.1)
+ * ============================================================================
+ */
+
+uint64_t
+SocketQPACK_compute_max_entries (uint64_t max_table_capacity)
+{
+  /*
+   * RFC 9204 Section 4.5.1.1:
+   * MaxEntries = floor(MaxTableCapacity / 32)
+   *
+   * 32 is the QPACK entry overhead (SOCKETQPACK_ENTRY_OVERHEAD).
+   */
+  return max_table_capacity / SOCKETQPACK_ENTRY_OVERHEAD;
+}

--- a/src/test/test_qpack_prefix.c
+++ b/src/test/test_qpack_prefix.c
@@ -1,0 +1,610 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_prefix.c
+ * @brief Unit tests for QPACK Field Section Prefix (RFC 9204 Section 4.5.1)
+ *
+ * Tests encoding, decoding, and validation of the Field Section Prefix.
+ */
+
+#include <string.h>
+
+#include "core/Arena.h"
+#include "http/qpack/SocketQPACK.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * COMPUTE MAX ENTRIES TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_compute_max_entries_zero)
+{
+  uint64_t max_entries = SocketQPACK_compute_max_entries (0);
+  ASSERT_EQ (max_entries, 0);
+}
+
+TEST (qpack_compute_max_entries_small)
+{
+  /* 31 bytes / 32 = 0 entries */
+  uint64_t max_entries = SocketQPACK_compute_max_entries (31);
+  ASSERT_EQ (max_entries, 0);
+}
+
+TEST (qpack_compute_max_entries_exact)
+{
+  /* 32 bytes / 32 = 1 entry */
+  uint64_t max_entries = SocketQPACK_compute_max_entries (32);
+  ASSERT_EQ (max_entries, 1);
+}
+
+TEST (qpack_compute_max_entries_default)
+{
+  /* 4096 bytes / 32 = 128 entries */
+  uint64_t max_entries = SocketQPACK_compute_max_entries (4096);
+  ASSERT_EQ (max_entries, 128);
+}
+
+TEST (qpack_compute_max_entries_large)
+{
+  /* 64KB / 32 = 2048 entries */
+  uint64_t max_entries = SocketQPACK_compute_max_entries (65536);
+  ASSERT_EQ (max_entries, 2048);
+}
+
+/* ============================================================================
+ * ENCODE PREFIX NULL PARAMETER TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_encode_prefix_null_output)
+{
+  size_t written = 999;
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (0, 0, 128, NULL, 16, &written);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_encode_prefix_null_written)
+{
+  unsigned char buf[16];
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (0, 0, 128, buf, sizeof (buf), NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_encode_prefix_zero_buffer)
+{
+  unsigned char buf[1];
+  size_t written = 999;
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (0, 0, 128, buf, 0, &written);
+  ASSERT_EQ (result, QPACK_ERR_TABLE_SIZE);
+}
+
+/* ============================================================================
+ * ENCODE PREFIX BASIC TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_encode_prefix_ric_zero_base_zero)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=0, Base=0 -> EncodedRIC=0, DeltaBase=0, S=0 */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (0, 0, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2);
+  /* First byte: EncodedRIC=0 */
+  ASSERT_EQ (buf[0], 0x00);
+  /* Second byte: S=0, DeltaBase=0 */
+  ASSERT_EQ (buf[1], 0x00);
+}
+
+TEST (qpack_encode_prefix_ric_one_base_one)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=1, Base=1 with MaxEntries=128
+   * EncodedRIC = (1 % 256) + 1 = 2
+   * DeltaBase = 1 - 1 = 0, S=0
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (1, 1, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2);
+  ASSERT_EQ (buf[0], 0x02);
+  ASSERT_EQ (buf[1], 0x00);
+}
+
+TEST (qpack_encode_prefix_positive_delta)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=10, Base=15 with MaxEntries=128
+   * EncodedRIC = (10 % 256) + 1 = 11
+   * DeltaBase = 15 - 10 = 5, S=0
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (10, 15, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2);
+  ASSERT_EQ (buf[0], 11);
+  /* S=0, DeltaBase=5 -> 0x05 */
+  ASSERT_EQ (buf[1], 0x05);
+}
+
+TEST (qpack_encode_prefix_negative_delta)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=10, Base=5 with MaxEntries=128
+   * EncodedRIC = (10 % 256) + 1 = 11
+   * DeltaBase = 10 - 5 - 1 = 4, S=1
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (10, 5, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2);
+  ASSERT_EQ (buf[0], 11);
+  /* S=1, DeltaBase=4 -> 0x80 | 0x04 = 0x84 */
+  ASSERT_EQ (buf[1], 0x84);
+}
+
+TEST (qpack_encode_prefix_base_zero_ric_nonzero)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=5, Base=0 with MaxEntries=128
+   * EncodedRIC = (5 % 256) + 1 = 6
+   * DeltaBase = 5 - 0 - 1 = 4, S=1
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (5, 0, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2);
+  ASSERT_EQ (buf[0], 6);
+  /* S=1, DeltaBase=4 -> 0x84 */
+  ASSERT_EQ (buf[1], 0x84);
+}
+
+TEST (qpack_encode_prefix_large_ric)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=300, Base=300 with MaxEntries=128
+   * EncodedRIC = (300 % 256) + 1 = 45
+   * DeltaBase = 0, S=0
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (300, 300, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2);
+  ASSERT_EQ (buf[0], 45);
+  ASSERT_EQ (buf[1], 0x00);
+}
+
+TEST (qpack_encode_prefix_max_entries_zero)
+{
+  unsigned char buf[16];
+  size_t written = 999;
+
+  /* max_entries=0 with non-zero RIC should fail */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (10, 10, 0, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_ERR_TABLE_SIZE);
+}
+
+/* ============================================================================
+ * DECODE PREFIX NULL PARAMETER TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_decode_prefix_null_prefix)
+{
+  unsigned char buf[] = { 0x00, 0x00 };
+  size_t consumed = 999;
+  SocketQPACK_Result result
+      = SocketQPACK_decode_prefix (buf, sizeof (buf), 128, 0, NULL, &consumed);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_decode_prefix_null_consumed)
+{
+  unsigned char buf[] = { 0x00, 0x00 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  SocketQPACK_Result result
+      = SocketQPACK_decode_prefix (buf, sizeof (buf), 128, 0, &prefix, NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_decode_prefix_empty_input)
+{
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 999;
+  SocketQPACK_Result result
+      = SocketQPACK_decode_prefix (NULL, 0, 128, 0, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+  ASSERT_EQ (consumed, 0);
+}
+
+/* ============================================================================
+ * DECODE PREFIX BASIC TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_decode_prefix_ric_zero_base_zero)
+{
+  unsigned char buf[] = { 0x00, 0x00 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 0, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, 2);
+  ASSERT_EQ (prefix.required_insert_count, 0);
+  ASSERT_EQ (prefix.base, 0);
+  ASSERT_EQ (prefix.delta_base, 0);
+}
+
+TEST (qpack_decode_prefix_ric_one_base_one)
+{
+  /* EncodedRIC=2 -> RIC=1, S=0, DeltaBase=0 -> Base=1 */
+  unsigned char buf[] = { 0x02, 0x00 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 10, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, 2);
+  ASSERT_EQ (prefix.required_insert_count, 1);
+  ASSERT_EQ (prefix.base, 1);
+  ASSERT_EQ (prefix.delta_base, 0);
+}
+
+TEST (qpack_decode_prefix_positive_delta)
+{
+  /* EncodedRIC=11 -> RIC=10, S=0, DeltaBase=5 -> Base=15 */
+  unsigned char buf[] = { 11, 0x05 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 20, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, 2);
+  ASSERT_EQ (prefix.required_insert_count, 10);
+  ASSERT_EQ (prefix.base, 15);
+  ASSERT_EQ (prefix.delta_base, 5);
+}
+
+TEST (qpack_decode_prefix_negative_delta)
+{
+  /* EncodedRIC=11 -> RIC=10, S=1, DeltaBase=4 -> Base=10-4-1=5 */
+  unsigned char buf[] = { 11, 0x84 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 20, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, 2);
+  ASSERT_EQ (prefix.required_insert_count, 10);
+  ASSERT_EQ (prefix.base, 5);
+  /* delta_base should be negative: -(4+1) = -5 */
+  ASSERT_EQ (prefix.delta_base, -5);
+}
+
+TEST (qpack_decode_prefix_ric_exceeds_total)
+{
+  /* EncodedRIC=11 -> RIC=10, but total_insert_count=5 */
+  unsigned char buf[] = { 11, 0x00 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 5, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_ERR_DECOMPRESSION);
+}
+
+TEST (qpack_decode_prefix_incomplete_ric)
+{
+  /* Only one byte, but RIC encoding may need more */
+  unsigned char buf[] = { 0xFF }; /* 8-bit prefix max, needs continuation */
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 1000, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+}
+
+TEST (qpack_decode_prefix_incomplete_delta)
+{
+  /* Only RIC byte, no delta base byte */
+  unsigned char buf[] = { 0x02 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 10, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+}
+
+TEST (qpack_decode_prefix_max_entries_zero)
+{
+  unsigned char buf[] = { 0x02, 0x00 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* max_entries=0 with non-zero encoded RIC should fail */
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 0, 10, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_ERR_TABLE_SIZE);
+}
+
+/* ============================================================================
+ * ROUND-TRIP TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_prefix_roundtrip_zero)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* Encode RIC=0, Base=0 */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (0, 0, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result = SocketQPACK_decode_prefix (buf, written, 128, 0, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, written);
+  ASSERT_EQ (prefix.required_insert_count, 0);
+  ASSERT_EQ (prefix.base, 0);
+}
+
+TEST (qpack_prefix_roundtrip_positive_delta)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* Encode RIC=42, Base=50 */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (42, 50, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result
+      = SocketQPACK_decode_prefix (buf, written, 128, 100, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, written);
+  ASSERT_EQ (prefix.required_insert_count, 42);
+  ASSERT_EQ (prefix.base, 50);
+}
+
+TEST (qpack_prefix_roundtrip_negative_delta)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* Encode RIC=42, Base=30 */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (42, 30, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result
+      = SocketQPACK_decode_prefix (buf, written, 128, 100, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, written);
+  ASSERT_EQ (prefix.required_insert_count, 42);
+  ASSERT_EQ (prefix.base, 30);
+}
+
+TEST (qpack_prefix_roundtrip_large_values)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* Encode RIC=1000, Base=1200 with MaxEntries=2048 */
+  SocketQPACK_Result result = SocketQPACK_encode_prefix (
+      1000, 1200, 2048, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result = SocketQPACK_decode_prefix (
+      buf, written, 2048, 2000, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, written);
+  ASSERT_EQ (prefix.required_insert_count, 1000);
+  ASSERT_EQ (prefix.base, 1200);
+}
+
+/* ============================================================================
+ * VALIDATE PREFIX TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_validate_prefix_null)
+{
+  SocketQPACK_Result result = SocketQPACK_validate_prefix (NULL, 100);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_validate_prefix_ric_exceeds)
+{
+  SocketQPACK_FieldSectionPrefix prefix
+      = { .required_insert_count = 100, .delta_base = 0, .base = 100 };
+
+  SocketQPACK_Result result = SocketQPACK_validate_prefix (&prefix, 50);
+  ASSERT_EQ (result, QPACK_ERR_DECOMPRESSION);
+}
+
+TEST (qpack_validate_prefix_valid_positive)
+{
+  SocketQPACK_FieldSectionPrefix prefix
+      = { .required_insert_count = 42, .delta_base = 8, .base = 50 };
+
+  SocketQPACK_Result result = SocketQPACK_validate_prefix (&prefix, 100);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+TEST (qpack_validate_prefix_valid_negative)
+{
+  SocketQPACK_FieldSectionPrefix prefix
+      = { .required_insert_count = 42, .delta_base = -12, .base = 30 };
+
+  SocketQPACK_Result result = SocketQPACK_validate_prefix (&prefix, 100);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+TEST (qpack_validate_prefix_valid_zero)
+{
+  SocketQPACK_FieldSectionPrefix prefix
+      = { .required_insert_count = 0, .delta_base = 0, .base = 0 };
+
+  SocketQPACK_Result result = SocketQPACK_validate_prefix (&prefix, 0);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+/* ============================================================================
+ * EDGE CASE TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_encode_prefix_delta_base_zero)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+
+  /* RIC=50, Base=50 -> DeltaBase=0, S=0 */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (50, 50, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Second byte should be 0x00 (S=0, DeltaBase=0) */
+  ASSERT_EQ (buf[1], 0x00);
+}
+
+TEST (qpack_decode_prefix_wraparound)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* MaxEntries=128, so FullRange=256
+   * Encode RIC=300, which wraps: EncodedRIC = (300 % 256) + 1 = 45
+   * With total_insert_count=350, we should recover RIC=300
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (300, 300, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  result
+      = SocketQPACK_decode_prefix (buf, written, 128, 350, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (prefix.required_insert_count, 300);
+  ASSERT_EQ (prefix.base, 300);
+}
+
+TEST (qpack_decode_prefix_base_underflow_check)
+{
+  /* Try to decode with negative delta that would underflow base */
+  /* EncodedRIC=2 -> RIC=1, S=1, DeltaBase=5 -> Base=1-5-1=-5 (underflow) */
+  unsigned char buf[] = { 0x02, 0x85 };
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_prefix (
+      buf, sizeof (buf), 128, 10, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_ERR_DECOMPRESSION);
+}
+
+/* ============================================================================
+ * MULTI-BYTE INTEGER TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_encode_prefix_multi_byte_ric)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* With MaxEntries=128, encode RIC=500
+   * EncodedRIC = (500 % 256) + 1 = 245
+   * 245 fits in 8 bits (< 255), so single byte
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (500, 500, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  result
+      = SocketQPACK_decode_prefix (buf, written, 128, 600, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (prefix.required_insert_count, 500);
+}
+
+TEST (qpack_encode_prefix_multi_byte_delta)
+{
+  unsigned char buf[16];
+  size_t written = 0;
+  SocketQPACK_FieldSectionPrefix prefix;
+  size_t consumed = 0;
+
+  /* RIC=100, Base=300 -> DeltaBase=200, needs continuation (> 127)
+   * For correct decoding, total_insert_count must be >= RIC and allow
+   * the modular arithmetic to recover the original RIC.
+   * With MaxEntries=128, FullRange=256:
+   * - EncodedRIC = (100 % 256) + 1 = 101
+   * - For TotalInserts=200: MaxValue=328, MaxWrapped=256, RIC=256+100=356 > 328
+   *   So RIC=356-256=100. And 100 <= 200, so validation passes.
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_prefix (100, 300, 128, buf, sizeof (buf), &written);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT (written > 2); /* Should need continuation bytes */
+
+  result
+      = SocketQPACK_decode_prefix (buf, written, 128, 200, &prefix, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (prefix.required_insert_count, 100);
+  ASSERT_EQ (prefix.base, 300);
+}
+
+/* ============================================================================
+ * MAIN
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.5.1 - Encoded Field Section Prefix for QPACK.

- Add `SocketQPACK_encode_prefix()` to encode Required Insert Count and Delta Base
- Add `SocketQPACK_decode_prefix()` to decode prefix with RIC recovery via modular arithmetic
- Add `SocketQPACK_validate_prefix()` to validate prefix against table state
- Add `SocketQPACK_compute_max_entries()` to compute MaxEntries from table capacity

## Test Plan

- [x] 40 unit tests covering encoding, decoding, validation, and edge cases
- [x] Tests pass with AddressSanitizer and UndefinedBehaviorSanitizer enabled
- [x] Round-trip encoding/decoding verified for various RIC/Base combinations
- [x] Wraparound handling tested for large Required Insert Count values

Closes #3291