### PR TITLE
feat(qpack): implement RFC 9204 Section 4.5.1.2 - Base Encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -366,6 +366,7 @@ set(LIB_SOURCES
     src/http/qpack/SocketQPACK-encoder.c
     src/http/qpack/SocketQPACK-decoder-stream.c
     src/http/qpack/SocketQPACK-prefix.c
+    src/http/qpack/SocketQPACK-base.c
 
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
@@ -809,6 +810,7 @@ set(TEST_SOURCES
     test_qpack_insert_literal
     test_qpack_decoder_stream
     test_qpack_prefix
+    test_qpack_base
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -94,7 +94,8 @@ typedef enum
   QPACK_ERR_INTEGER,       /**< Integer decoding error */
   QPACK_ERR_DECOMPRESSION, /**< Decompression failed (bomb protection) */
   QPACK_ERR_NULL_PARAM,    /**< NULL parameter passed to function */
-  QPACK_ERR_INTERNAL       /**< Internal error */
+  QPACK_ERR_INTERNAL,      /**< Internal error */
+  QPACK_ERR_INVALID_BASE   /**< Invalid Base calculation (Section 4.5.1.2) */
 } SocketQPACK_Result;
 
 /* ============================================================================
@@ -701,6 +702,88 @@ extern QPACK_WARN_UNUSED SocketQPACK_Result SocketQPACK_validate_prefix (
  * @since 1.0.0
  */
 extern uint64_t SocketQPACK_compute_max_entries (uint64_t max_table_capacity);
+
+/* ============================================================================
+ * BASE ENCODING (RFC 9204 Section 4.5.1.2)
+ * ============================================================================
+ */
+
+/**
+ * @brief Calculate Base from Sign bit, Required Insert Count, and Delta Base.
+ *
+ * RFC 9204 Section 4.5.1.2: Computes the Base value used for relative
+ * indexing in field sections. The formula depends on the Sign bit:
+ *
+ *   - Sign = 0 (positive): Base = ReqInsertCount + DeltaBase
+ *   - Sign = 1 (negative): Base = ReqInsertCount - DeltaBase - 1
+ *
+ * @param sign              Sign bit (0 or 1)
+ * @param req_insert_count  Required Insert Count from prefix
+ * @param delta_base        Delta Base value (7-bit prefix variable integer)
+ * @param[out] base_out     Output: computed Base value (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if base_out is NULL,
+ *         QPACK_ERR_INVALID_BASE if Sign=1 and ReqInsertCount <= DeltaBase,
+ *         QPACK_ERR_BASE_OVERFLOW if overflow would occur
+ *
+ * @note For Sign=1 (negative delta), ReqInsertCount MUST be > DeltaBase
+ *       to ensure Base >= 0.
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+SocketQPACK_calculate_base (int sign,
+                            uint64_t req_insert_count,
+                            uint64_t delta_base,
+                            uint64_t *base_out);
+
+/**
+ * @brief Validate Base calculation constraints.
+ *
+ * RFC 9204 Section 4.5.1.2: Validates that the Sign bit and Delta Base
+ * values are consistent with the Required Insert Count, ensuring the
+ * resulting Base value is non-negative.
+ *
+ * Validation rules:
+ *   - If Sign = 1 (negative delta): ReqInsertCount MUST be > DeltaBase
+ *   - Base value MUST be non-negative (always true for uint64_t)
+ *   - No overflow in Base calculation
+ *
+ * @param sign              Sign bit (0 or 1)
+ * @param req_insert_count  Required Insert Count from prefix
+ * @param delta_base        Delta Base value
+ * @return QPACK_OK if valid,
+ *         QPACK_ERR_INVALID_BASE if constraints violated
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result SocketQPACK_validate_base (
+    int sign, uint64_t req_insert_count, uint64_t delta_base);
+
+/**
+ * @brief Encode Base as Delta Base with Sign bit for field section prefix.
+ *
+ * RFC 9204 Section 4.5.1.2: Computes the Sign bit and Delta Base value
+ * that will encode the given Base relative to Required Insert Count.
+ *
+ * Encoding rules:
+ *   - If Base >= ReqInsertCount: Sign = 0, DeltaBase = Base - ReqInsertCount
+ *   - If Base < ReqInsertCount: Sign = 1, DeltaBase = ReqInsertCount - Base - 1
+ *
+ * @param req_insert_count  Required Insert Count for the field section
+ * @param base              Absolute Base value to encode
+ * @param[out] sign_out     Output: Sign bit (0 or 1, must not be NULL)
+ * @param[out] delta_out    Output: Delta Base value (must not be NULL)
+ * @return QPACK_OK on success,
+ *         QPACK_ERR_NULL_PARAM if sign_out or delta_out is NULL
+ *
+ * @since 1.0.0
+ */
+extern QPACK_WARN_UNUSED SocketQPACK_Result
+SocketQPACK_encode_base (uint64_t req_insert_count,
+                         uint64_t base,
+                         int *sign_out,
+                         uint64_t *delta_out);
 
 /* ============================================================================
  * UTILITY FUNCTIONS

--- a/src/http/qpack/SocketQPACK-base.c
+++ b/src/http/qpack/SocketQPACK-base.c
@@ -1,0 +1,146 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-base.c
+ * @brief QPACK Base Encoding (RFC 9204 Section 4.5.1.2)
+ *
+ * Implements Base calculation from Sign bit and Delta Base for QPACK
+ * field section prefix. Base is used for relative indexing in field
+ * sections.
+ *
+ * Wire format:
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | S |      Delta Base (7+)      |
+ * +---+---------------------------+
+ *
+ * Base Calculation:
+ *   - S=0: Base = Required Insert Count + Delta Base
+ *   - S=1: Base = Required Insert Count - Delta Base - 1
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.5.1.2
+ */
+
+#include "http/qpack/SocketQPACK.h"
+
+#include <stdint.h>
+
+/* ============================================================================
+ * CALCULATE BASE (RFC 9204 Section 4.5.1.2)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_calculate_base (int sign,
+                            uint64_t req_insert_count,
+                            uint64_t delta_base,
+                            uint64_t *base_out)
+{
+  if (base_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *base_out = 0;
+
+  if (sign == 0)
+    {
+      /*
+       * RFC 9204 Section 4.5.1.2: Positive delta
+       * Base = Required Insert Count + Delta Base
+       *
+       * Check for overflow.
+       */
+      if (delta_base > UINT64_MAX - req_insert_count)
+        return QPACK_ERR_BASE_OVERFLOW;
+
+      *base_out = req_insert_count + delta_base;
+    }
+  else
+    {
+      /*
+       * RFC 9204 Section 4.5.1.2: Negative delta
+       * Base = Required Insert Count - Delta Base - 1
+       *
+       * For this to yield a valid (non-negative) Base:
+       *   Required Insert Count > Delta Base
+       * which means: req_insert_count >= delta_base + 1
+       */
+      if (req_insert_count <= delta_base)
+        return QPACK_ERR_INVALID_BASE;
+
+      *base_out = req_insert_count - delta_base - 1;
+    }
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * VALIDATE BASE (RFC 9204 Section 4.5.1.2)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_validate_base (int sign,
+                           uint64_t req_insert_count,
+                           uint64_t delta_base)
+{
+  if (sign == 0)
+    {
+      /*
+       * Positive delta: Base = req_insert_count + delta_base
+       * Check for overflow only.
+       */
+      if (delta_base > UINT64_MAX - req_insert_count)
+        return QPACK_ERR_INVALID_BASE;
+    }
+  else
+    {
+      /*
+       * Negative delta: Base = req_insert_count - delta_base - 1
+       * req_insert_count MUST be > delta_base to ensure non-negative Base.
+       */
+      if (req_insert_count <= delta_base)
+        return QPACK_ERR_INVALID_BASE;
+    }
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * ENCODE BASE (RFC 9204 Section 4.5.1.2)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_encode_base (uint64_t req_insert_count,
+                         uint64_t base,
+                         int *sign_out,
+                         uint64_t *delta_out)
+{
+  if (sign_out == NULL || delta_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  if (base >= req_insert_count)
+    {
+      /*
+       * RFC 9204 Section 4.5.1.2: Positive delta
+       * Sign = 0, Delta Base = Base - Required Insert Count
+       */
+      *sign_out = 0;
+      *delta_out = base - req_insert_count;
+    }
+  else
+    {
+      /*
+       * RFC 9204 Section 4.5.1.2: Negative delta
+       * Sign = 1, Delta Base = Required Insert Count - Base - 1
+       */
+      *sign_out = 1;
+      *delta_out = req_insert_count - base - 1;
+    }
+
+  return QPACK_OK;
+}

--- a/src/http/qpack/SocketQPACK-index.c
+++ b/src/http/qpack/SocketQPACK-index.c
@@ -50,6 +50,7 @@ SocketQPACK_result_string (SocketQPACK_Result result)
     [QPACK_ERR_DECOMPRESSION] = "Decompression failed",
     [QPACK_ERR_NULL_PARAM] = "NULL parameter passed to function",
     [QPACK_ERR_INTERNAL] = "Internal error",
+    [QPACK_ERR_INVALID_BASE] = "Invalid Base calculation",
   };
 
   if (result >= 0 && (size_t)result < ARRAY_LENGTH (strings))

--- a/src/test/test_qpack_base.c
+++ b/src/test/test_qpack_base.c
@@ -1,0 +1,410 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_base.c
+ * @brief Unit tests for QPACK Base Encoding (RFC 9204 Section 4.5.1.2)
+ *
+ * Tests the Base calculation, validation, and encoding functions per RFC 9204.
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "http/qpack/SocketQPACK.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * CALCULATE BASE - NULL PARAMETER TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_calculate_base_null_output)
+{
+  SocketQPACK_Result result = SocketQPACK_calculate_base (0, 10, 5, NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+/* ============================================================================
+ * CALCULATE BASE - POSITIVE DELTA (Sign = 0)
+ * ============================================================================
+ */
+
+TEST (qpack_calculate_base_positive_delta_zero)
+{
+  uint64_t base = 999;
+  SocketQPACK_Result result = SocketQPACK_calculate_base (0, 10, 0, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=0, RIC=10, Delta=0 -> Base = 10 + 0 = 10 */
+  ASSERT_EQ (base, 10);
+}
+
+TEST (qpack_calculate_base_positive_delta_simple)
+{
+  uint64_t base = 0;
+  SocketQPACK_Result result = SocketQPACK_calculate_base (0, 10, 5, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=0, RIC=10, Delta=5 -> Base = 10 + 5 = 15 */
+  ASSERT_EQ (base, 15);
+}
+
+TEST (qpack_calculate_base_positive_delta_ric_zero)
+{
+  uint64_t base = 999;
+  SocketQPACK_Result result = SocketQPACK_calculate_base (0, 0, 0, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=0, RIC=0, Delta=0 -> Base = 0 + 0 = 0 */
+  ASSERT_EQ (base, 0);
+}
+
+TEST (qpack_calculate_base_positive_delta_large_values)
+{
+  uint64_t base = 0;
+  SocketQPACK_Result result
+      = SocketQPACK_calculate_base (0, 1000000, 500000, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=0, RIC=1000000, Delta=500000 -> Base = 1500000 */
+  ASSERT_EQ (base, 1500000);
+}
+
+TEST (qpack_calculate_base_positive_delta_overflow)
+{
+  uint64_t base = 999;
+  /* Try to overflow: RIC + Delta > UINT64_MAX */
+  SocketQPACK_Result result
+      = SocketQPACK_calculate_base (0, UINT64_MAX, 1, &base);
+  ASSERT_EQ (result, QPACK_ERR_BASE_OVERFLOW);
+}
+
+TEST (qpack_calculate_base_positive_delta_max_no_overflow)
+{
+  uint64_t base = 0;
+  /* RIC + Delta = UINT64_MAX (no overflow) */
+  SocketQPACK_Result result
+      = SocketQPACK_calculate_base (0, UINT64_MAX - 1, 1, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (base, UINT64_MAX);
+}
+
+/* ============================================================================
+ * CALCULATE BASE - NEGATIVE DELTA (Sign = 1)
+ * ============================================================================
+ */
+
+TEST (qpack_calculate_base_negative_delta_simple)
+{
+  uint64_t base = 999;
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 10, 4, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=1, RIC=10, Delta=4 -> Base = 10 - 4 - 1 = 5 */
+  ASSERT_EQ (base, 5);
+}
+
+TEST (qpack_calculate_base_negative_delta_zero)
+{
+  uint64_t base = 999;
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 10, 0, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=1, RIC=10, Delta=0 -> Base = 10 - 0 - 1 = 9 */
+  ASSERT_EQ (base, 9);
+}
+
+TEST (qpack_calculate_base_negative_delta_base_zero)
+{
+  uint64_t base = 999;
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 5, 4, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  /* Sign=1, RIC=5, Delta=4 -> Base = 5 - 4 - 1 = 0 */
+  ASSERT_EQ (base, 0);
+}
+
+TEST (qpack_calculate_base_negative_delta_invalid_underflow)
+{
+  uint64_t base = 999;
+  /* Sign=1, RIC=5, Delta=5 -> Base = 5 - 5 - 1 = -1 (underflow) */
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 5, 5, &base);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_calculate_base_negative_delta_ric_equals_delta)
+{
+  uint64_t base = 999;
+  /* Sign=1, RIC=10, Delta=10 -> Invalid (RIC <= Delta) */
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 10, 10, &base);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_calculate_base_negative_delta_ric_less_than_delta)
+{
+  uint64_t base = 999;
+  /* Sign=1, RIC=5, Delta=10 -> Invalid (RIC < Delta) */
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 5, 10, &base);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_calculate_base_negative_delta_ric_zero)
+{
+  uint64_t base = 999;
+  /* Sign=1, RIC=0, Delta=0 -> Invalid (RIC <= Delta) */
+  SocketQPACK_Result result = SocketQPACK_calculate_base (1, 0, 0, &base);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_calculate_base_negative_delta_large_values)
+{
+  uint64_t base = 0;
+  /* Sign=1, RIC=1000000, Delta=500000 -> Base = 1000000 - 500000 - 1 = 499999
+   */
+  SocketQPACK_Result result
+      = SocketQPACK_calculate_base (1, 1000000, 500000, &base);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (base, 499999);
+}
+
+/* ============================================================================
+ * VALIDATE BASE TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_validate_base_positive_valid)
+{
+  /* Sign=0, RIC=10, Delta=5: valid */
+  SocketQPACK_Result result = SocketQPACK_validate_base (0, 10, 5);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+TEST (qpack_validate_base_positive_overflow)
+{
+  /* Sign=0, RIC=UINT64_MAX, Delta=1: overflow */
+  SocketQPACK_Result result = SocketQPACK_validate_base (0, UINT64_MAX, 1);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_validate_base_negative_valid)
+{
+  /* Sign=1, RIC=10, Delta=4: valid (10 > 4) */
+  SocketQPACK_Result result = SocketQPACK_validate_base (1, 10, 4);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+TEST (qpack_validate_base_negative_equal)
+{
+  /* Sign=1, RIC=10, Delta=10: invalid (10 <= 10) */
+  SocketQPACK_Result result = SocketQPACK_validate_base (1, 10, 10);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_validate_base_negative_underflow)
+{
+  /* Sign=1, RIC=5, Delta=10: invalid (5 < 10) */
+  SocketQPACK_Result result = SocketQPACK_validate_base (1, 5, 10);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_BASE);
+}
+
+TEST (qpack_validate_base_negative_boundary)
+{
+  /* Sign=1, RIC=5, Delta=4: valid, Base = 0 */
+  SocketQPACK_Result result = SocketQPACK_validate_base (1, 5, 4);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+/* ============================================================================
+ * ENCODE BASE TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_encode_base_null_sign)
+{
+  uint64_t delta = 0;
+  SocketQPACK_Result result = SocketQPACK_encode_base (10, 15, NULL, &delta);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_encode_base_null_delta)
+{
+  int sign = 0;
+  SocketQPACK_Result result = SocketQPACK_encode_base (10, 15, &sign, NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_encode_base_positive_delta)
+{
+  int sign = 999;
+  uint64_t delta = 999;
+  /* RIC=10, Base=15 -> Sign=0 (Base >= RIC), Delta = 15 - 10 = 5 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (10, 15, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 5);
+}
+
+TEST (qpack_encode_base_negative_delta)
+{
+  int sign = 999;
+  uint64_t delta = 999;
+  /* RIC=10, Base=5 -> Sign=1 (Base < RIC), Delta = 10 - 5 - 1 = 4 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (10, 5, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 1);
+  ASSERT_EQ (delta, 4);
+}
+
+TEST (qpack_encode_base_equal)
+{
+  int sign = 999;
+  uint64_t delta = 999;
+  /* RIC=10, Base=10 -> Sign=0 (Base >= RIC), Delta = 10 - 10 = 0 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (10, 10, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 0);
+}
+
+TEST (qpack_encode_base_zero_zero)
+{
+  int sign = 999;
+  uint64_t delta = 999;
+  /* RIC=0, Base=0 -> Sign=0, Delta=0 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (0, 0, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 0);
+}
+
+TEST (qpack_encode_base_base_zero)
+{
+  int sign = 999;
+  uint64_t delta = 999;
+  /* RIC=5, Base=0 -> Sign=1 (Base < RIC), Delta = 5 - 0 - 1 = 4 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (5, 0, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 1);
+  ASSERT_EQ (delta, 4);
+}
+
+TEST (qpack_encode_base_ric_zero)
+{
+  int sign = 999;
+  uint64_t delta = 999;
+  /* RIC=0, Base=5 -> Sign=0 (Base >= RIC), Delta = 5 - 0 = 5 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (0, 5, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 5);
+}
+
+TEST (qpack_encode_base_large_values)
+{
+  int sign = 0;
+  uint64_t delta = 0;
+  /* RIC=1000000, Base=1500000 -> Sign=0, Delta=500000 */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_base (1000000, 1500000, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 500000);
+}
+
+/* ============================================================================
+ * ROUND-TRIP TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_base_roundtrip_positive)
+{
+  int sign = 0;
+  uint64_t delta = 0;
+  uint64_t base_out = 0;
+
+  /* Encode: RIC=42, Base=50 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (42, 50, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 8);
+
+  /* Decode */
+  result = SocketQPACK_calculate_base (sign, 42, delta, &base_out);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (base_out, 50);
+}
+
+TEST (qpack_base_roundtrip_negative)
+{
+  int sign = 0;
+  uint64_t delta = 0;
+  uint64_t base_out = 0;
+
+  /* Encode: RIC=42, Base=30 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (42, 30, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 1);
+  ASSERT_EQ (delta, 11); /* 42 - 30 - 1 = 11 */
+
+  /* Decode */
+  result = SocketQPACK_calculate_base (sign, 42, delta, &base_out);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (base_out, 30);
+}
+
+TEST (qpack_base_roundtrip_equal)
+{
+  int sign = 0;
+  uint64_t delta = 0;
+  uint64_t base_out = 0;
+
+  /* Encode: RIC=100, Base=100 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (100, 100, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 0);
+  ASSERT_EQ (delta, 0);
+
+  /* Decode */
+  result = SocketQPACK_calculate_base (sign, 100, delta, &base_out);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (base_out, 100);
+}
+
+TEST (qpack_base_roundtrip_zero_base)
+{
+  int sign = 0;
+  uint64_t delta = 0;
+  uint64_t base_out = 999;
+
+  /* Encode: RIC=10, Base=0 */
+  SocketQPACK_Result result = SocketQPACK_encode_base (10, 0, &sign, &delta);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (sign, 1);
+  ASSERT_EQ (delta, 9); /* 10 - 0 - 1 = 9 */
+
+  /* Decode */
+  result = SocketQPACK_calculate_base (sign, 10, delta, &base_out);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (base_out, 0);
+}
+
+/* ============================================================================
+ * RESULT STRING TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_result_string_invalid_base)
+{
+  const char *str = SocketQPACK_result_string (QPACK_ERR_INVALID_BASE);
+  ASSERT_NOT_NULL (str);
+  ASSERT (str[0] != '\0');
+}
+
+/* ============================================================================
+ * MAIN
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.5.1.2 - Base Encoding for QPACK field section prefix.

- Add `SocketQPACK_calculate_base()` to compute Base from Sign bit, Required Insert Count, and Delta Base
- Add `SocketQPACK_validate_base()` to validate Sign bit constraints  
- Add `SocketQPACK_encode_base()` to compute Sign and Delta Base from absolute Base value
- Add `QPACK_ERR_INVALID_BASE` error code for Base calculation failures
- Add 35 comprehensive tests covering:
  - Positive delta (Sign=0): Base = RIC + DeltaBase
  - Negative delta (Sign=1): Base = RIC - DeltaBase - 1
  - Edge cases: zero values, overflow detection, underflow validation
  - Round-trip encoding/decoding verification

## Test Plan

- [x] All 35 new Base encoding tests pass
- [x] All existing QPACK tests pass (7/7)
- [x] Full test suite passes with sanitizers (146/146, with one pre-existing intermittent failure)

Closes #3289