### PR TITLE
feat(qpack): implement RFC 9204 Section 4.5.6 - Literal Field Line with Literal Name

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -371,6 +371,7 @@ set(LIB_SOURCES
     src/http/qpack/SocketQPACK-indexed.c
     src/http/qpack/SocketQPACK-literal-name-ref.c
     src/http/qpack/SocketQPACK-literal-postbase.c
+    src/http/qpack/SocketQPACK-field-literal.c
 
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
@@ -819,6 +820,7 @@ set(TEST_SOURCES
     test_qpack_indexed_postbase
     test_qpack_literal_name_ref
     test_qpack_literal_postbase
+    test_qpack_field_literal
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/qpack/SocketQPACK-private.h
+++ b/include/http/qpack/SocketQPACK-private.h
@@ -33,6 +33,36 @@
 #define QPACK_MIN_TABLE_CAPACITY 16
 
 /* ============================================================================
+ * FIELD LINE INSTRUCTION PATTERNS (RFC 9204 Section 4.5)
+ *
+ * Wire format patterns for field section instructions.
+ * ============================================================================
+ */
+
+/**
+ * @brief Literal Field Line with Literal Name instruction pattern.
+ *
+ * RFC 9204 Section 4.5.6:
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 0 | 0 | 1 | N | H |NameLen(3+)|
+ * +---+---+---+---+---+-----------+
+ * |  Name String (Length bytes)   |
+ * +---+---------------------------+
+ * | H |     Value Length (7+)     |
+ * +---+---------------------------+
+ * |  Value String (Length bytes)  |
+ * +-------------------------------+
+ */
+#define QPACK_FIELD_LITERAL_LITERAL_PATTERN 0x20 /**< 001xxxxx pattern mask */
+#define QPACK_FIELD_LITERAL_LITERAL_MASK 0xE0    /**< Top 3 bits mask */
+#define QPACK_FIELD_LITERAL_NEVER_INDEX 0x10     /**< N bit (never index) */
+#define QPACK_FIELD_LITERAL_NAME_HUFFMAN 0x08    /**< H bit for name */
+#define QPACK_FIELD_LITERAL_NAME_PREFIX 3        /**< Name length prefix bits */
+#define QPACK_FIELD_LITERAL_VALUE_HUFFMAN 0x80   /**< H bit for value */
+#define QPACK_FIELD_LITERAL_VALUE_PREFIX 7 /**< Value length prefix bits */
+
+/* ============================================================================
  * INDEX METADATA (Internal)
  *
  * Tracks metadata for dynamic table entries as per RFC 9204 Section 3.2.4.

--- a/src/http/qpack/SocketQPACK-field-literal.c
+++ b/src/http/qpack/SocketQPACK-field-literal.c
@@ -1,0 +1,360 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-field-literal.c
+ * @brief QPACK Literal Field Line with Literal Name (RFC 9204 Section 4.5.6)
+ *
+ * Implements encoding and decoding for the Literal Field Line with Literal Name
+ * instruction used in QPACK field sections. This instruction encodes a header
+ * field where both the name and value are represented as string literals.
+ *
+ * Wire format (RFC 9204 Section 4.5.6):
+ *
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 0 | 0 | 1 | N | H |NameLen(3+)|
+ * +---+---+---+---+---+-----------+
+ * |  Name String (Length bytes)   |
+ * +---+---------------------------+
+ * | H |     Value Length (7+)     |
+ * +---+---------------------------+
+ * |  Value String (Length bytes)  |
+ * +-------------------------------+
+ *
+ * Bit pattern: 001NHxxx
+ * - N bit (bit 4): Never-indexed flag (1 = sensitive, never add to dynamic
+ * table)
+ * - H bit (bit 3): Huffman encoding for name (1 = Huffman, 0 = literal)
+ * - xxx (bits 2-0): Start of 3-bit prefix integer for name length
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.5.6
+ */
+
+#include <string.h>
+
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include "core/SocketSecurity.h"
+#include "core/SocketUtil.h"
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * PATTERN VALIDATION (RFC 9204 Section 4.5.6)
+ * ============================================================================
+ */
+
+bool
+SocketQPACK_is_literal_field_literal_name (uint8_t first_byte)
+{
+  /*
+   * RFC 9204 Section 4.5.6: Pattern bits must be 001
+   * Mask with 0xE0 to check bits 7-5, compare with 0x20 (001xxxxx).
+   */
+  return (first_byte & QPACK_FIELD_LITERAL_LITERAL_MASK)
+         == QPACK_FIELD_LITERAL_LITERAL_PATTERN;
+}
+
+/* ============================================================================
+ * ENCODE LITERAL FIELD LINE WITH LITERAL NAME (RFC 9204 Section 4.5.6)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_encode_literal_field_literal_name (unsigned char *output,
+                                               size_t output_size,
+                                               const unsigned char *name,
+                                               size_t name_len,
+                                               bool name_huffman,
+                                               const unsigned char *value,
+                                               size_t value_len,
+                                               bool value_huffman,
+                                               bool never_indexed,
+                                               size_t *bytes_written)
+{
+  size_t offset = 0;
+  size_t name_encoded_len;
+  size_t value_encoded_len;
+  bool actually_huffman_name = false;
+  bool actually_huffman_value = false;
+  size_t prefix_len;
+  unsigned char first_byte;
+
+  /* Validate parameters */
+  if (output == NULL || bytes_written == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  if ((name == NULL && name_len > 0) || (value == NULL && value_len > 0))
+    return QPACK_ERR_NULL_PARAM;
+
+  *bytes_written = 0;
+
+  if (output_size == 0)
+    return QPACK_ERR_TABLE_SIZE;
+
+  /* Determine if Huffman encoding is beneficial for name */
+  if (name_huffman && name_len > 0)
+    {
+      name_encoded_len = SocketHPACK_huffman_encoded_size (name, name_len);
+      if (name_encoded_len < name_len)
+        actually_huffman_name = true;
+      else
+        name_encoded_len = name_len;
+    }
+  else
+    {
+      name_encoded_len = name_len;
+    }
+
+  /* Determine if Huffman encoding is beneficial for value */
+  if (value_huffman && value_len > 0)
+    {
+      value_encoded_len = SocketHPACK_huffman_encoded_size (value, value_len);
+      if (value_encoded_len < value_len)
+        actually_huffman_value = true;
+      else
+        value_encoded_len = value_len;
+    }
+  else
+    {
+      value_encoded_len = value_len;
+    }
+
+  /*
+   * Encode name length with 3-bit prefix
+   * First byte: 0 0 1 | N | H | NameLen(3+)
+   */
+
+  /* Encode the name length integer */
+  prefix_len = SocketHPACK_int_encode (name_encoded_len,
+                                       QPACK_FIELD_LITERAL_NAME_PREFIX,
+                                       output + offset,
+                                       output_size - offset);
+  if (prefix_len == 0)
+    return QPACK_ERR_INTEGER;
+
+  /* Build first byte with pattern 001, N bit, and H bit */
+  first_byte = QPACK_FIELD_LITERAL_LITERAL_PATTERN; /* 001xxxxx */
+
+  if (never_indexed)
+    first_byte |= QPACK_FIELD_LITERAL_NEVER_INDEX; /* N bit */
+
+  if (actually_huffman_name)
+    first_byte |= QPACK_FIELD_LITERAL_NAME_HUFFMAN; /* H bit */
+
+  /* Merge flags with the encoded integer (integer encoding uses lower bits) */
+  output[offset] = (output[offset] & 0x07) | first_byte;
+
+  offset += prefix_len;
+
+  /* Encode name string */
+  if (actually_huffman_name)
+    {
+      if (offset + name_encoded_len > output_size)
+        return QPACK_ERR_TABLE_SIZE;
+      ssize_t huff_result = SocketHPACK_huffman_encode (
+          name, name_len, output + offset, output_size - offset);
+      if (huff_result < 0)
+        return QPACK_ERR_HUFFMAN;
+      offset += (size_t)huff_result;
+    }
+  else
+    {
+      if (offset + name_len > output_size)
+        return QPACK_ERR_TABLE_SIZE;
+      if (name_len > 0)
+        memcpy (output + offset, name, name_len);
+      offset += name_len;
+    }
+
+  /*
+   * Encode value length with 7-bit prefix
+   * Byte: H | ValueLen(7+)
+   */
+  if (offset >= output_size)
+    return QPACK_ERR_TABLE_SIZE;
+
+  prefix_len = SocketHPACK_int_encode (value_encoded_len,
+                                       QPACK_FIELD_LITERAL_VALUE_PREFIX,
+                                       output + offset,
+                                       output_size - offset);
+  if (prefix_len == 0)
+    return QPACK_ERR_INTEGER;
+
+  /* Set H bit for value if using Huffman */
+  if (actually_huffman_value)
+    output[offset] |= QPACK_FIELD_LITERAL_VALUE_HUFFMAN;
+  else
+    output[offset] &= ~QPACK_FIELD_LITERAL_VALUE_HUFFMAN;
+
+  offset += prefix_len;
+
+  /* Encode value string */
+  if (actually_huffman_value)
+    {
+      if (offset + value_encoded_len > output_size)
+        return QPACK_ERR_TABLE_SIZE;
+      ssize_t huff_result = SocketHPACK_huffman_encode (
+          value, value_len, output + offset, output_size - offset);
+      if (huff_result < 0)
+        return QPACK_ERR_HUFFMAN;
+      offset += (size_t)huff_result;
+    }
+  else
+    {
+      if (offset + value_len > output_size)
+        return QPACK_ERR_TABLE_SIZE;
+      if (value_len > 0)
+        memcpy (output + offset, value, value_len);
+      offset += value_len;
+    }
+
+  *bytes_written = offset;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * DECODE LITERAL FIELD LINE WITH LITERAL NAME (RFC 9204 Section 4.5.6)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_decode_literal_field_literal_name (const unsigned char *input,
+                                               size_t input_len,
+                                               unsigned char *name_out,
+                                               size_t name_out_size,
+                                               size_t *name_len,
+                                               unsigned char *value_out,
+                                               size_t value_out_size,
+                                               size_t *value_len,
+                                               bool *never_indexed,
+                                               size_t *bytes_consumed)
+{
+  size_t offset = 0;
+  uint64_t name_wire_len;
+  uint64_t value_wire_len;
+  size_t consumed;
+  bool name_huffman;
+  bool value_huffman;
+  SocketHPACK_Result hpack_result;
+
+  /* Validate parameters */
+  if (bytes_consumed == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *bytes_consumed = 0;
+
+  if (name_out == NULL || value_out == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  if (name_len == NULL || value_len == NULL || never_indexed == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *name_len = 0;
+  *value_len = 0;
+  *never_indexed = false;
+
+  if (input_len == 0)
+    return QPACK_INCOMPLETE;
+
+  if (input == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* Verify pattern bits: 001xxxxx */
+  if (!SocketQPACK_is_literal_field_literal_name (input[0]))
+    return QPACK_ERR_DECOMPRESSION;
+
+  /* Extract N bit (never-indexed flag) */
+  *never_indexed = (input[0] & QPACK_FIELD_LITERAL_NEVER_INDEX) != 0;
+
+  /* Extract H bit for name (Huffman flag) */
+  name_huffman = (input[0] & QPACK_FIELD_LITERAL_NAME_HUFFMAN) != 0;
+
+  /* Decode name length with 3-bit prefix */
+  hpack_result = SocketHPACK_int_decode (input + offset,
+                                         input_len - offset,
+                                         QPACK_FIELD_LITERAL_NAME_PREFIX,
+                                         &name_wire_len,
+                                         &consumed);
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERR_INTEGER;
+
+  offset += consumed;
+
+  /* Validate name length against remaining input */
+  if (offset + name_wire_len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Decode name string */
+  if (name_huffman)
+    {
+      ssize_t decoded_len = SocketHPACK_huffman_decode (
+          input + offset, (size_t)name_wire_len, name_out, name_out_size);
+      if (decoded_len < 0)
+        return QPACK_ERR_HUFFMAN;
+      *name_len = (size_t)decoded_len;
+    }
+  else
+    {
+      if (name_wire_len > name_out_size)
+        return QPACK_ERR_HEADER_SIZE;
+      if (name_wire_len > 0)
+        memcpy (name_out, input + offset, (size_t)name_wire_len);
+      *name_len = (size_t)name_wire_len;
+    }
+
+  offset += (size_t)name_wire_len;
+
+  /* Need at least one more byte for value length */
+  if (offset >= input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Extract H bit for value (Huffman flag) */
+  value_huffman = (input[offset] & QPACK_FIELD_LITERAL_VALUE_HUFFMAN) != 0;
+
+  /* Decode value length with 7-bit prefix */
+  hpack_result = SocketHPACK_int_decode (input + offset,
+                                         input_len - offset,
+                                         QPACK_FIELD_LITERAL_VALUE_PREFIX,
+                                         &value_wire_len,
+                                         &consumed);
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERR_INTEGER;
+
+  offset += consumed;
+
+  /* Validate value length against remaining input */
+  if (offset + value_wire_len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Decode value string */
+  if (value_huffman)
+    {
+      ssize_t decoded_len = SocketHPACK_huffman_decode (
+          input + offset, (size_t)value_wire_len, value_out, value_out_size);
+      if (decoded_len < 0)
+        return QPACK_ERR_HUFFMAN;
+      *value_len = (size_t)decoded_len;
+    }
+  else
+    {
+      if (value_wire_len > value_out_size)
+        return QPACK_ERR_HEADER_SIZE;
+      if (value_wire_len > 0)
+        memcpy (value_out, input + offset, (size_t)value_wire_len);
+      *value_len = (size_t)value_wire_len;
+    }
+
+  offset += (size_t)value_wire_len;
+
+  *bytes_consumed = offset;
+  return QPACK_OK;
+}

--- a/src/test/test_qpack_field_literal.c
+++ b/src/test/test_qpack_field_literal.c
@@ -1,0 +1,908 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_field_literal.c
+ * @brief Unit tests for QPACK Literal Field Line with Literal Name
+ *        (RFC 9204 Section 4.5.6)
+ *
+ * Tests the encoding, decoding, and round-trip functionality for the
+ * Literal Field Line with Literal Name instruction used in QPACK field
+ * sections.
+ */
+
+#include "http/qpack/SocketQPACK.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Test assertion macro */
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          exit (1);                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+/* ============================================================================
+ * PATTERN VALIDATION TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test pattern validation for Literal Field Line with Literal Name.
+ */
+static void
+test_pattern_validation (void)
+{
+  printf ("  Pattern validation... ");
+
+  /* Valid patterns: 001xxxxx (0x20-0x3F) */
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x20) == true,
+               "0x20 is valid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x21) == true,
+               "0x21 is valid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x2F) == true,
+               "0x2F is valid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x30) == true,
+               "0x30 is valid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x3F) == true,
+               "0x3F is valid");
+
+  /* Invalid patterns: not 001xxxxx */
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x00) == false,
+               "0x00 is invalid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x1F) == false,
+               "0x1F is invalid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x40) == false,
+               "0x40 is invalid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0x80) == false,
+               "0x80 is invalid");
+  TEST_ASSERT (SocketQPACK_is_literal_field_literal_name (0xFF) == false,
+               "0xFF is invalid");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * ENCODING TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test basic encoding without Huffman or never-indexed.
+ */
+static void
+test_encode_basic (void)
+{
+  unsigned char buf[256];
+  size_t bytes_written;
+  SocketQPACK_Result result;
+
+  printf ("  Encode basic... ");
+
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      sizeof (buf),
+      (const unsigned char *)"x-custom",
+      8,
+      false, /* no Huffman for name */
+      (const unsigned char *)"test-value",
+      10,
+      false, /* no Huffman for value */
+      false, /* not never-indexed */
+      &bytes_written);
+
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+  TEST_ASSERT (bytes_written > 0, "bytes written > 0");
+
+  /* First byte should be 001xxxxx (pattern) without N or H bits */
+  TEST_ASSERT ((buf[0] & 0xE0) == 0x20, "correct pattern bits (001)");
+  TEST_ASSERT ((buf[0] & 0x10) == 0, "N bit is 0");
+  TEST_ASSERT ((buf[0] & 0x08) == 0, "H bit is 0");
+
+  /* Name length should be 8 (fits in 3 bits) */
+  TEST_ASSERT ((buf[0] & 0x07) == 7 || bytes_written > 2,
+               "name length encoding");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encoding with never-indexed flag.
+ */
+static void
+test_encode_never_indexed (void)
+{
+  unsigned char buf[256];
+  size_t bytes_written;
+  SocketQPACK_Result result;
+
+  printf ("  Encode with never-indexed... ");
+
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      sizeof (buf),
+      (const unsigned char *)"authorization",
+      13,
+      false,
+      (const unsigned char *)"Bearer token123",
+      15,
+      false,
+      true, /* never-indexed */
+      &bytes_written);
+
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+
+  /* First byte should have N bit set (bit 4) */
+  TEST_ASSERT ((buf[0] & 0xE0) == 0x20, "correct pattern bits (001)");
+  TEST_ASSERT ((buf[0] & 0x10) == 0x10, "N bit is set");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encoding with Huffman compression.
+ */
+static void
+test_encode_huffman (void)
+{
+  unsigned char buf_no_huff[256];
+  unsigned char buf_huff[256];
+  size_t len_no_huff, len_huff;
+  SocketQPACK_Result result;
+
+  printf ("  Encode with Huffman... ");
+
+  /* Without Huffman */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf_no_huff,
+      sizeof (buf_no_huff),
+      (const unsigned char *)"content-type",
+      12,
+      false,
+      (const unsigned char *)"application/json",
+      16,
+      false,
+      false,
+      &len_no_huff);
+  TEST_ASSERT (result == QPACK_OK, "no huffman encode success");
+
+  /* With Huffman */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf_huff,
+      sizeof (buf_huff),
+      (const unsigned char *)"content-type",
+      12,
+      true,
+      (const unsigned char *)"application/json",
+      16,
+      true,
+      false,
+      &len_huff);
+  TEST_ASSERT (result == QPACK_OK, "huffman encode success");
+
+  /* Huffman encoding should produce smaller output */
+  TEST_ASSERT (len_huff < len_no_huff, "Huffman is smaller");
+
+  /* H bit should be set for Huffman-encoded name */
+  TEST_ASSERT ((buf_huff[0] & 0x08) == 0x08, "name H bit is set");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test encoding with empty strings.
+ */
+static void
+test_encode_empty (void)
+{
+  unsigned char buf[256];
+  size_t bytes_written;
+  SocketQPACK_Result result;
+
+  printf ("  Encode empty strings... ");
+
+  /* Empty name */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      sizeof (buf),
+      NULL,
+      0,
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      &bytes_written);
+  TEST_ASSERT (result == QPACK_OK, "empty name success");
+  TEST_ASSERT ((buf[0] & 0x07) == 0, "name length is 0");
+
+  /* Empty value */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      sizeof (buf),
+      (const unsigned char *)"name",
+      4,
+      false,
+      NULL,
+      0,
+      false,
+      false,
+      &bytes_written);
+  TEST_ASSERT (result == QPACK_OK, "empty value success");
+
+  /* Both empty */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf, sizeof (buf), NULL, 0, false, NULL, 0, false, false, &bytes_written);
+  TEST_ASSERT (result == QPACK_OK, "both empty success");
+  /* Should be just 2 bytes: first byte (pattern + name len 0) + value len 0 */
+  TEST_ASSERT (bytes_written == 2, "minimum encoding is 2 bytes");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * DECODING TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test basic decoding.
+ */
+static void
+test_decode_basic (void)
+{
+  unsigned char encoded[256];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  Decode basic... ");
+
+  /* Encode first */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      encoded,
+      sizeof (encoded),
+      (const unsigned char *)"x-custom",
+      8,
+      false,
+      (const unsigned char *)"test-value",
+      10,
+      false,
+      false,
+      &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+
+  /* Decode */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          encoded_len,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_OK, "decode success");
+  TEST_ASSERT (consumed == encoded_len, "all bytes consumed");
+  TEST_ASSERT (name_len == 8, "name_len is 8");
+  TEST_ASSERT (memcmp (name_out, "x-custom", 8) == 0, "name matches");
+  TEST_ASSERT (value_len == 10, "value_len is 10");
+  TEST_ASSERT (memcmp (value_out, "test-value", 10) == 0, "value matches");
+  TEST_ASSERT (never_indexed == false, "never_indexed is false");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoding with never-indexed flag.
+ */
+static void
+test_decode_never_indexed (void)
+{
+  unsigned char encoded[256];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  Decode with never-indexed... ");
+
+  /* Encode with never-indexed */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      encoded,
+      sizeof (encoded),
+      (const unsigned char *)"authorization",
+      13,
+      false,
+      (const unsigned char *)"Bearer token",
+      12,
+      false,
+      true, /* never-indexed */
+      &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+
+  /* Decode */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          encoded_len,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_OK, "decode success");
+  TEST_ASSERT (never_indexed == true, "never_indexed is true");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoding with Huffman compression.
+ */
+static void
+test_decode_huffman (void)
+{
+  unsigned char encoded[256];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  Decode with Huffman... ");
+
+  /* Encode with Huffman */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      encoded,
+      sizeof (encoded),
+      (const unsigned char *)"content-type",
+      12,
+      true,
+      (const unsigned char *)"application/json",
+      16,
+      true,
+      false,
+      &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+
+  /* Decode */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          encoded_len,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_OK, "decode success");
+  TEST_ASSERT (name_len == 12, "name_len is 12");
+  TEST_ASSERT (memcmp (name_out, "content-type", 12) == 0, "name matches");
+  TEST_ASSERT (value_len == 16, "value_len is 16");
+  TEST_ASSERT (memcmp (value_out, "application/json", 16) == 0,
+               "value matches");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test decoding empty strings.
+ */
+static void
+test_decode_empty (void)
+{
+  unsigned char encoded[256];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  Decode empty strings... ");
+
+  /* Encode empty name */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      encoded,
+      sizeof (encoded),
+      NULL,
+      0,
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+
+  /* Decode */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          encoded_len,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_OK, "decode empty name success");
+  TEST_ASSERT (name_len == 0, "name_len is 0");
+  TEST_ASSERT (value_len == 5, "value_len is 5");
+
+  /* Encode both empty */
+  result = SocketQPACK_encode_literal_field_literal_name (encoded,
+                                                          sizeof (encoded),
+                                                          NULL,
+                                                          0,
+                                                          false,
+                                                          NULL,
+                                                          0,
+                                                          false,
+                                                          false,
+                                                          &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode both empty success");
+
+  /* Decode */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          encoded_len,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_OK, "decode both empty success");
+  TEST_ASSERT (name_len == 0, "name_len is 0");
+  TEST_ASSERT (value_len == 0, "value_len is 0");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test incomplete data handling.
+ */
+static void
+test_decode_incomplete (void)
+{
+  unsigned char encoded[256];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  Decode incomplete data... ");
+
+  /* Encode a complete instruction */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      encoded,
+      sizeof (encoded),
+      (const unsigned char *)"header",
+      6,
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode success");
+
+  /* Try to decode with truncated data */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          2, /* only 2 bytes */
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_INCOMPLETE, "incomplete data detected");
+
+  /* Empty buffer */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          0,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_INCOMPLETE, "empty buffer is incomplete");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * ERROR HANDLING TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test NULL parameter handling.
+ */
+static void
+test_null_params (void)
+{
+  unsigned char buf[256];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t bytes_written, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  NULL parameter handling... ");
+
+  /* Encode with NULL buffer */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      NULL,
+      256,
+      (const unsigned char *)"name",
+      4,
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      &bytes_written);
+  TEST_ASSERT (result == QPACK_ERR_NULL_PARAM, "NULL buffer fails");
+
+  /* Encode with NULL bytes_written */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      256,
+      (const unsigned char *)"name",
+      4,
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      NULL);
+  TEST_ASSERT (result == QPACK_ERR_NULL_PARAM, "NULL bytes_written fails");
+
+  /* Encode with NULL name but non-zero length */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      256,
+      NULL,
+      5, /* len > 0 with NULL */
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      &bytes_written);
+  TEST_ASSERT (result == QPACK_ERR_NULL_PARAM, "NULL name with len fails");
+
+  /* Decode with NULL name_out */
+  result = SocketQPACK_decode_literal_field_literal_name (buf,
+                                                          10,
+                                                          NULL,
+                                                          256,
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_ERR_NULL_PARAM, "decode NULL name_out fails");
+
+  /* Decode with NULL value_out */
+  result = SocketQPACK_decode_literal_field_literal_name (buf,
+                                                          10,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          NULL,
+                                                          256,
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_ERR_NULL_PARAM, "decode NULL value_out fails");
+
+  /* Decode with NULL bytes_consumed */
+  result = SocketQPACK_decode_literal_field_literal_name (buf,
+                                                          10,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          NULL);
+  TEST_ASSERT (result == QPACK_ERR_NULL_PARAM,
+               "decode NULL bytes_consumed fails");
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test buffer overflow protection.
+ */
+static void
+test_buffer_overflow (void)
+{
+  unsigned char buf[10];
+  size_t bytes_written;
+  SocketQPACK_Result result;
+
+  printf ("  Buffer overflow protection... ");
+
+  /* Try to encode with insufficient buffer */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      1, /* way too small */
+      (const unsigned char *)"long-header-name",
+      16,
+      false,
+      (const unsigned char *)"long-header-value",
+      17,
+      false,
+      false,
+      &bytes_written);
+  TEST_ASSERT (result == QPACK_ERR_TABLE_SIZE || result == QPACK_ERR_INTEGER,
+               "overflow protected");
+
+  /* Try encoding that just barely overflows */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      buf,
+      5, /* very small */
+      (const unsigned char *)"name",
+      4,
+      false,
+      (const unsigned char *)"value",
+      5,
+      false,
+      false,
+      &bytes_written);
+  TEST_ASSERT (result != QPACK_OK, "insufficient buffer detected");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * ROUND-TRIP TESTS
+ * ============================================================================
+ */
+
+/**
+ * Test encode-decode round-trip with various data.
+ */
+static void
+test_roundtrip (void)
+{
+  unsigned char encoded[1024];
+  unsigned char name_out[256];
+  unsigned char value_out[256];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+
+  printf ("  Round-trip various data... ");
+
+  /* Test various header types */
+  struct
+  {
+    const char *name;
+    const char *value;
+    bool never_idx;
+    bool name_huff;
+    bool value_huff;
+  } test_cases[]
+      = { { "content-type", "text/html; charset=utf-8", false, true, true },
+          { "x-custom-header", "custom-value", false, false, false },
+          { "authorization", "Bearer secret-token", true, false, false },
+          { "cookie", "session=abc123; user=john", true, true, true },
+          { "accept-encoding", "gzip, deflate, br", false, true, true },
+          { "cache-control", "no-cache, no-store", false, false, true },
+          { "", "empty-name-value", false, false, false },
+          { "empty-value", "", false, true, false } };
+
+  size_t num_tests = sizeof (test_cases) / sizeof (test_cases[0]);
+
+  for (size_t i = 0; i < num_tests; i++)
+    {
+      size_t name_in_len = strlen (test_cases[i].name);
+      size_t value_in_len = strlen (test_cases[i].value);
+
+      /* Encode */
+      result = SocketQPACK_encode_literal_field_literal_name (
+          encoded,
+          sizeof (encoded),
+          (const unsigned char *)test_cases[i].name,
+          name_in_len,
+          test_cases[i].name_huff,
+          (const unsigned char *)test_cases[i].value,
+          value_in_len,
+          test_cases[i].value_huff,
+          test_cases[i].never_idx,
+          &encoded_len);
+      TEST_ASSERT (result == QPACK_OK, "encode success");
+
+      /* Decode */
+      result
+          = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                           encoded_len,
+                                                           name_out,
+                                                           sizeof (name_out),
+                                                           &name_len,
+                                                           value_out,
+                                                           sizeof (value_out),
+                                                           &value_len,
+                                                           &never_indexed,
+                                                           &consumed);
+      TEST_ASSERT (result == QPACK_OK, "decode success");
+      TEST_ASSERT (consumed == encoded_len, "all bytes consumed");
+      TEST_ASSERT (name_len == name_in_len, "name length matches");
+      TEST_ASSERT (value_len == value_in_len, "value length matches");
+      if (name_in_len > 0)
+        TEST_ASSERT (memcmp (name_out, test_cases[i].name, name_in_len) == 0,
+                     "name matches");
+      if (value_in_len > 0)
+        TEST_ASSERT (memcmp (value_out, test_cases[i].value, value_in_len) == 0,
+                     "value matches");
+      TEST_ASSERT (never_indexed == test_cases[i].never_idx,
+                   "never_indexed matches");
+    }
+
+  printf ("PASS\n");
+}
+
+/**
+ * Test with long strings requiring multi-byte integer encoding.
+ */
+static void
+test_long_strings (void)
+{
+  unsigned char encoded[8192];
+  unsigned char name_out[1024];
+  unsigned char value_out[4096];
+  size_t encoded_len, name_len, value_len, consumed;
+  bool never_indexed;
+  SocketQPACK_Result result;
+  char long_name[300];
+  char long_value[2000];
+
+  printf ("  Long strings (multi-byte integers)... ");
+
+  /* Create strings that exceed 3-bit and 7-bit prefix limits */
+  memset (long_name, 'n', sizeof (long_name) - 1);
+  long_name[sizeof (long_name) - 1] = '\0';
+
+  memset (long_value, 'v', sizeof (long_value) - 1);
+  long_value[sizeof (long_value) - 1] = '\0';
+
+  /* Encode */
+  result = SocketQPACK_encode_literal_field_literal_name (
+      encoded,
+      sizeof (encoded),
+      (const unsigned char *)long_name,
+      strlen (long_name),
+      false, /* no huffman to test raw lengths */
+      (const unsigned char *)long_value,
+      strlen (long_value),
+      false,
+      false,
+      &encoded_len);
+  TEST_ASSERT (result == QPACK_OK, "encode long strings success");
+
+  /* Decode */
+  result = SocketQPACK_decode_literal_field_literal_name (encoded,
+                                                          encoded_len,
+                                                          name_out,
+                                                          sizeof (name_out),
+                                                          &name_len,
+                                                          value_out,
+                                                          sizeof (value_out),
+                                                          &value_len,
+                                                          &never_indexed,
+                                                          &consumed);
+  TEST_ASSERT (result == QPACK_OK, "decode long strings success");
+  TEST_ASSERT (consumed == encoded_len, "all bytes consumed");
+  TEST_ASSERT (name_len == strlen (long_name), "long name length matches");
+  TEST_ASSERT (value_len == strlen (long_value), "long value length matches");
+  TEST_ASSERT (memcmp (name_out, long_name, name_len) == 0,
+               "long name matches");
+  TEST_ASSERT (memcmp (value_out, long_value, value_len) == 0,
+               "long value matches");
+
+  printf ("PASS\n");
+}
+
+/* ============================================================================
+ * TEST SUITE
+ * ============================================================================
+ */
+
+static void
+run_pattern_tests (void)
+{
+  printf ("Pattern Validation Tests:\n");
+  test_pattern_validation ();
+}
+
+static void
+run_encode_tests (void)
+{
+  printf ("Encode Tests:\n");
+  test_encode_basic ();
+  test_encode_never_indexed ();
+  test_encode_huffman ();
+  test_encode_empty ();
+}
+
+static void
+run_decode_tests (void)
+{
+  printf ("Decode Tests:\n");
+  test_decode_basic ();
+  test_decode_never_indexed ();
+  test_decode_huffman ();
+  test_decode_empty ();
+  test_decode_incomplete ();
+}
+
+static void
+run_error_tests (void)
+{
+  printf ("Error Handling Tests:\n");
+  test_null_params ();
+  test_buffer_overflow ();
+}
+
+static void
+run_roundtrip_tests (void)
+{
+  printf ("Round-trip Tests:\n");
+  test_roundtrip ();
+  test_long_strings ();
+}
+
+int
+main (void)
+{
+  printf ("=== QPACK Literal Field Line with Literal Name Tests "
+          "(RFC 9204 Section 4.5.6) ===\n\n");
+
+  run_pattern_tests ();
+  printf ("\n");
+
+  run_encode_tests ();
+  printf ("\n");
+
+  run_decode_tests ();
+  printf ("\n");
+
+  run_error_tests ();
+  printf ("\n");
+
+  run_roundtrip_tests ();
+  printf ("\n");
+
+  printf ("=== All tests passed! ===\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.5.6 - Literal Field Line with Literal Name instruction for QPACK field sections.

- Adds `SocketQPACK_encode_literal_field_literal_name()` for encoding header fields with literal name and value
- Adds `SocketQPACK_decode_literal_field_literal_name()` for decoding header fields
- Adds `SocketQPACK_is_literal_field_literal_name()` for pattern validation
- Full support for N bit (never-indexed flag for sensitive headers like authorization, cookies)
- Optional Huffman compression for both name and value strings
- Proper handling of multi-byte integer encoding for long strings

## Test Plan

- [x] All 7 QPACK tests pass with sanitizers enabled
- [x] New test file `test_qpack_field_literal.c` with comprehensive coverage:
  - Pattern validation tests
  - Encode/decode basic functionality
  - Never-indexed flag handling
  - Huffman encoding/decoding
  - Empty string handling
  - Incomplete data detection
  - NULL parameter validation
  - Buffer overflow protection
  - Round-trip tests with various header types
  - Long strings (multi-byte integer encoding)

Closes #3297