### PR TITLE
feat(qpack): implement RFC 9204 Section 4.5.4 - Literal Field Line with Name Reference

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -369,6 +369,7 @@ set(LIB_SOURCES
     src/http/qpack/SocketQPACK-base.c
     src/http/qpack/SocketQPACK-representation.c
     src/http/qpack/SocketQPACK-indexed.c
+    src/http/qpack/SocketQPACK-literal-name-ref.c
 
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
@@ -812,17 +813,10 @@ set(TEST_SOURCES
     test_qpack_insert_literal
     test_qpack_decoder_stream
     test_qpack_prefix
-<<<<<<< HEAD
-<<<<<<< HEAD
     test_qpack_base
-||||||| parent of 3c615e83 (feat(qpack): implement RFC 9204 Section 4.5.2 - Indexed Field Line)
-=======
     test_qpack_indexed_field
->>>>>>> 3c615e83 (feat(qpack): implement RFC 9204 Section 4.5.2 - Indexed Field Line)
-||||||| parent of 6bf255fd (feat(qpack): implement RFC 9204 Section 4.5.3 - Indexed Field Line with Post-Base Index)
-=======
     test_qpack_indexed_postbase
->>>>>>> 6bf255fd (feat(qpack): implement RFC 9204 Section 4.5.3 - Indexed Field Line with Post-Base Index)
+    test_qpack_literal_name_ref
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/src/http/qpack/SocketQPACK-literal-name-ref.c
+++ b/src/http/qpack/SocketQPACK-literal-name-ref.c
@@ -1,0 +1,610 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQPACK-literal-name-ref.c
+ * @brief QPACK Literal Field Line with Name Reference (RFC 9204 Section 4.5.4)
+ *
+ * Implements encoding and decoding for the Literal Field Line with Name
+ * Reference representation used in QPACK encoded field sections. This
+ * representation references a name from the static or dynamic table with
+ * a literal value.
+ *
+ * Wire format (RFC 9204 Section 4.5.4):
+ *
+ *   0   1   2   3   4   5   6   7
+ * +---+---+---+---+---+---+---+---+
+ * | 0 | 1 | N | T |Name Index (4+)|
+ * +---+---+---+---+---------------+
+ * | H |     Value Length (7+)     |
+ * +---+---------------------------+
+ * |  Value String (Length bytes)  |
+ * +-------------------------------+
+ *
+ * Bit pattern: 01NTxxxx
+ * - Bits 7-6: Pattern = 01 (literal with name reference)
+ * - Bit 5: N = Never-indexed bit (0=can cache, 1=must not cache)
+ * - Bit 4: T = Table selection (0=dynamic, 1=static)
+ * - Bits 3-0: First 4 bits of name index (continuation follows if >= 15)
+ *
+ * @see https://www.rfc-editor.org/rfc/rfc9204#section-4.5.4
+ */
+
+#include <string.h>
+
+#include "http/qpack/SocketQPACK-private.h"
+#include "http/qpack/SocketQPACK.h"
+
+#include "core/SocketSecurity.h"
+#include "core/SocketUtil.h"
+#include "http/SocketHPACK.h"
+
+/* ============================================================================
+ * INTERNAL CONSTANTS
+ * ============================================================================
+ */
+
+/** Literal Field Line with Name Reference pattern mask: 01xxxxxx */
+#define QPACK_LITERAL_NAMEREF_PATTERN 0x40
+
+/** Pattern check mask (bits 7-6) */
+#define QPACK_LITERAL_NAMEREF_PATTERN_MASK 0xC0
+
+/** Never-indexed bit mask (bit 5) */
+#define QPACK_LITERAL_NAMEREF_NEVER_INDEX 0x20
+
+/** Static table bit mask (bit 4) */
+#define QPACK_LITERAL_NAMEREF_STATIC 0x10
+
+/** Name index prefix size in bits */
+#define QPACK_LITERAL_NAMEREF_PREFIX 4
+
+/** Huffman flag bit in value length byte (bit 7) */
+#define QPACK_VALUE_HUFFMAN_FLAG 0x80
+
+/** Value length prefix size in bits */
+#define QPACK_VALUE_LENGTH_PREFIX 7
+
+/** Maximum integer encoding buffer size */
+#define QPACK_INT_ENCODE_BUF_SIZE 16
+
+/* ============================================================================
+ * QPACK STATIC TABLE (RFC 9204 Appendix A)
+ *
+ * The QPACK static table has 99 entries (indices 0-98).
+ * This table is separate from the HPACK static table (61 entries).
+ * ============================================================================
+ */
+
+/**
+ * @brief QPACK static table entry.
+ */
+typedef struct
+{
+  const char *name;
+  size_t name_len;
+  const char *value;
+  size_t value_len;
+} QPACKStaticEntry;
+
+/**
+ * @brief QPACK static table (RFC 9204 Appendix A).
+ *
+ * 99 entries indexed from 0 to 98.
+ */
+static const QPACKStaticEntry qpack_static_table[] = {
+  { ":authority", 10, "", 0 },
+  { ":path", 5, "/", 1 },
+  { "age", 3, "0", 1 },
+  { "content-disposition", 19, "", 0 },
+  { "content-length", 14, "0", 1 },
+  { "cookie", 6, "", 0 },
+  { "date", 4, "", 0 },
+  { "etag", 4, "", 0 },
+  { "if-modified-since", 17, "", 0 },
+  { "if-none-match", 13, "", 0 },
+  { "last-modified", 13, "", 0 },
+  { "link", 4, "", 0 },
+  { "location", 8, "", 0 },
+  { "referer", 7, "", 0 },
+  { "set-cookie", 10, "", 0 },
+  { ":method", 7, "CONNECT", 7 },
+  { ":method", 7, "DELETE", 6 },
+  { ":method", 7, "GET", 3 },
+  { ":method", 7, "HEAD", 4 },
+  { ":method", 7, "OPTIONS", 7 },
+  { ":method", 7, "POST", 4 },
+  { ":method", 7, "PUT", 3 },
+  { ":scheme", 7, "http", 4 },
+  { ":scheme", 7, "https", 5 },
+  { ":status", 7, "103", 3 },
+  { ":status", 7, "200", 3 },
+  { ":status", 7, "304", 3 },
+  { ":status", 7, "404", 3 },
+  { ":status", 7, "503", 3 },
+  { "accept", 6, "*/*", 3 },
+  { "accept", 6, "application/dns-message", 23 },
+  { "accept-encoding", 15, "gzip, deflate, br", 17 },
+  { "accept-ranges", 13, "bytes", 5 },
+  { "access-control-allow-headers", 28, "cache-control", 13 },
+  { "access-control-allow-headers", 28, "content-type", 12 },
+  { "access-control-allow-origin", 27, "*", 1 },
+  { "cache-control", 13, "max-age=0", 9 },
+  { "cache-control", 13, "max-age=2592000", 15 },
+  { "cache-control", 13, "max-age=604800", 14 },
+  { "cache-control", 13, "no-cache", 8 },
+  { "cache-control", 13, "no-store", 8 },
+  { "cache-control", 13, "public, max-age=31536000", 24 },
+  { "content-encoding", 16, "br", 2 },
+  { "content-encoding", 16, "gzip", 4 },
+  { "content-type", 12, "application/dns-message", 23 },
+  { "content-type", 12, "application/javascript", 22 },
+  { "content-type", 12, "application/json", 16 },
+  { "content-type", 12, "application/x-www-form-urlencoded", 33 },
+  { "content-type", 12, "image/gif", 9 },
+  { "content-type", 12, "image/jpeg", 10 },
+  { "content-type", 12, "image/png", 9 },
+  { "content-type", 12, "text/css", 8 },
+  { "content-type", 12, "text/html; charset=utf-8", 24 },
+  { "content-type", 12, "text/plain", 10 },
+  { "content-type", 12, "text/plain;charset=utf-8", 24 },
+  { "range", 5, "bytes=0-", 8 },
+  { "strict-transport-security", 25, "max-age=31536000", 16 },
+  { "strict-transport-security",
+    25,
+    "max-age=31536000; includesubdomains",
+    35 },
+  { "strict-transport-security",
+    25,
+    "max-age=31536000; includesubdomains; preload",
+    44 },
+  { "vary", 4, "accept-encoding", 15 },
+  { "vary", 4, "origin", 6 },
+  { "x-content-type-options", 22, "nosniff", 7 },
+  { "x-xss-protection", 16, "1; mode=block", 13 },
+  { ":status", 7, "100", 3 },
+  { ":status", 7, "204", 3 },
+  { ":status", 7, "206", 3 },
+  { ":status", 7, "302", 3 },
+  { ":status", 7, "400", 3 },
+  { ":status", 7, "403", 3 },
+  { ":status", 7, "421", 3 },
+  { ":status", 7, "425", 3 },
+  { ":status", 7, "500", 3 },
+  { "accept-language", 15, "", 0 },
+  { "access-control-allow-credentials", 32, "FALSE", 5 },
+  { "access-control-allow-credentials", 32, "TRUE", 4 },
+  { "access-control-allow-headers", 28, "*", 1 },
+  { "access-control-allow-methods", 28, "get", 3 },
+  { "access-control-allow-methods", 28, "get, post, options", 18 },
+  { "access-control-allow-methods", 28, "options", 7 },
+  { "access-control-expose-headers", 29, "content-length", 14 },
+  { "access-control-request-headers", 30, "content-type", 12 },
+  { "access-control-request-method", 29, "get", 3 },
+  { "access-control-request-method", 29, "post", 4 },
+  { "alt-svc", 7, "clear", 5 },
+  { "authorization", 13, "", 0 },
+  { "content-security-policy",
+    23,
+    "script-src 'none'; object-src 'none'; base-uri 'none'",
+    53 },
+  { "early-data", 10, "1", 1 },
+  { "expect-ct", 9, "", 0 },
+  { "forwarded", 9, "", 0 },
+  { "if-range", 8, "", 0 },
+  { "origin", 6, "", 0 },
+  { "purpose", 7, "prefetch", 8 },
+  { "server", 6, "", 0 },
+  { "timing-allow-origin", 19, "*", 1 },
+  { "upgrade-insecure-requests", 25, "1", 1 },
+  { "user-agent", 10, "", 0 },
+  { "x-forwarded-for", 15, "", 0 },
+  { "x-frame-options", 15, "deny", 4 },
+  { "x-frame-options", 15, "sameorigin", 10 },
+};
+
+/**
+ * @brief Get entry from QPACK static table.
+ *
+ * @param index  Static table index (0-98)
+ * @param[out] name     Pointer to name string
+ * @param[out] name_len Length of name
+ * @return QPACK_OK on success, QPACK_ERR_INVALID_INDEX if out of bounds
+ */
+static SocketQPACK_Result
+qpack_static_get (uint64_t index, const char **name, size_t *name_len)
+{
+  if (index >= SOCKETQPACK_STATIC_TABLE_SIZE)
+    return QPACK_ERR_INVALID_INDEX;
+
+  *name = qpack_static_table[index].name;
+  *name_len = qpack_static_table[index].name_len;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * ENCODE LITERAL FIELD LINE WITH NAME REFERENCE (RFC 9204 Section 4.5.4)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_encode_literal_name_ref (unsigned char *output,
+                                     size_t output_size,
+                                     bool is_static,
+                                     uint64_t name_index,
+                                     bool never_indexed,
+                                     const unsigned char *value,
+                                     size_t value_len,
+                                     bool use_huffman,
+                                     size_t *bytes_written)
+{
+  unsigned char int_buf[QPACK_INT_ENCODE_BUF_SIZE];
+  size_t pos = 0;
+  size_t int_len;
+  unsigned char first_byte;
+  size_t huffman_len = 0;
+  bool actually_use_huffman = false;
+
+  /* Parameter validation */
+  if (output == NULL || bytes_written == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  if (value == NULL && value_len > 0)
+    return QPACK_ERR_NULL_PARAM;
+
+  *bytes_written = 0;
+
+  if (output_size == 0)
+    return QPACK_ERR_TABLE_SIZE;
+
+  /*
+   * RFC 9204 Section 4.5.4: Build first byte
+   *
+   *   0   1   2   3   4   5   6   7
+   * +---+---+---+---+---+---+---+---+
+   * | 0 | 1 | N | T |Name Index (4+)|
+   * +---+---+---+---+---------------+
+   *
+   * - Bits 7-6: Pattern = 01
+   * - Bit 5: N = Never-indexed
+   * - Bit 4: T = Static (1) or Dynamic (0)
+   */
+  first_byte = QPACK_LITERAL_NAMEREF_PATTERN; /* 01xxxxxx */
+  if (never_indexed)
+    first_byte |= QPACK_LITERAL_NAMEREF_NEVER_INDEX; /* bit 5 = N */
+  if (is_static)
+    first_byte |= QPACK_LITERAL_NAMEREF_STATIC; /* bit 4 = T */
+
+  /* Encode name index with 4-bit prefix */
+  int_len = SocketHPACK_int_encode (
+      name_index, QPACK_LITERAL_NAMEREF_PREFIX, int_buf, sizeof (int_buf));
+  if (int_len == 0)
+    return QPACK_ERR_INTEGER;
+
+  /* Merge first byte flags with integer encoding */
+  int_buf[0] |= first_byte;
+
+  /* Check if we have room for the index */
+  if (pos + int_len > output_size)
+    return QPACK_ERR_TABLE_SIZE;
+
+  memcpy (output + pos, int_buf, int_len);
+  pos += int_len;
+
+  /* Determine if Huffman encoding is beneficial */
+  if (use_huffman && value_len > 0)
+    {
+      huffman_len = SocketHPACK_huffman_encoded_size (value, value_len);
+      if (huffman_len < value_len)
+        actually_use_huffman = true;
+    }
+
+  /* Encode value length with 7-bit prefix */
+  size_t encoded_value_len = actually_use_huffman ? huffman_len : value_len;
+  int_len = SocketHPACK_int_encode (
+      encoded_value_len, QPACK_VALUE_LENGTH_PREFIX, int_buf, sizeof (int_buf));
+  if (int_len == 0)
+    return QPACK_ERR_INTEGER;
+
+  /* Set Huffman flag if using Huffman encoding */
+  if (actually_use_huffman)
+    int_buf[0] |= QPACK_VALUE_HUFFMAN_FLAG;
+
+  /* Check if we have room for value length + value data */
+  if (pos + int_len + encoded_value_len > output_size)
+    return QPACK_ERR_TABLE_SIZE;
+
+  memcpy (output + pos, int_buf, int_len);
+  pos += int_len;
+
+  /* Encode value string */
+  if (value_len > 0)
+    {
+      if (actually_use_huffman)
+        {
+          ssize_t huff_result = SocketHPACK_huffman_encode (
+              value, value_len, output + pos, output_size - pos);
+          if (huff_result < 0)
+            return QPACK_ERR_HUFFMAN;
+          pos += (size_t)huff_result;
+        }
+      else
+        {
+          memcpy (output + pos, value, value_len);
+          pos += value_len;
+        }
+    }
+
+  *bytes_written = pos;
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * DECODE LITERAL FIELD LINE WITH NAME REFERENCE (RFC 9204 Section 4.5.4)
+ * ============================================================================
+ */
+
+/**
+ * @brief Internal decode implementation with optional arena.
+ */
+static SocketQPACK_Result
+decode_literal_name_ref_internal (const unsigned char *input,
+                                  size_t input_len,
+                                  Arena_T arena,
+                                  SocketQPACK_LiteralNameRef *result,
+                                  size_t *consumed)
+{
+  size_t pos = 0;
+  uint64_t name_index;
+  uint64_t value_len;
+  size_t int_consumed;
+  SocketHPACK_Result hpack_result;
+  bool is_static;
+  bool never_indexed;
+  bool value_huffman;
+
+  /* Parameter validation */
+  if (result == NULL || consumed == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *consumed = 0;
+  memset (result, 0, sizeof (*result));
+
+  /* Need at least one byte */
+  if (input_len < 1)
+    return QPACK_INCOMPLETE;
+
+  if (input == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /*
+   * RFC 9204 Section 4.5.4: Verify pattern
+   *
+   * First byte must match: 01xxxxxx (bits 7-6 = 01)
+   */
+  if ((input[0] & QPACK_LITERAL_NAMEREF_PATTERN_MASK)
+      != QPACK_LITERAL_NAMEREF_PATTERN)
+    return QPACK_ERR_INTERNAL; /* Not a Literal Field Line with Name Ref */
+
+  /* Extract N and T bits */
+  never_indexed = (input[0] & QPACK_LITERAL_NAMEREF_NEVER_INDEX) != 0;
+  is_static = (input[0] & QPACK_LITERAL_NAMEREF_STATIC) != 0;
+
+  /* Decode name index (4-bit prefix integer) */
+  hpack_result = SocketHPACK_int_decode (input,
+                                         input_len,
+                                         QPACK_LITERAL_NAMEREF_PREFIX,
+                                         &name_index,
+                                         &int_consumed);
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERR_INTEGER;
+
+  pos += int_consumed;
+
+  /* Decode value length (7-bit prefix integer) */
+  if (pos >= input_len)
+    return QPACK_INCOMPLETE;
+
+  value_huffman = (input[pos] & QPACK_VALUE_HUFFMAN_FLAG) != 0;
+
+  hpack_result = SocketHPACK_int_decode (input + pos,
+                                         input_len - pos,
+                                         QPACK_VALUE_LENGTH_PREFIX,
+                                         &value_len,
+                                         &int_consumed);
+  if (hpack_result == HPACK_INCOMPLETE)
+    return QPACK_INCOMPLETE;
+  if (hpack_result != HPACK_OK)
+    return QPACK_ERR_INTEGER;
+
+  pos += int_consumed;
+
+  /* Check if we have enough bytes for the value string */
+  if (pos + value_len > input_len)
+    return QPACK_INCOMPLETE;
+
+  /* Populate result */
+  result->name_index = name_index;
+  result->is_static = is_static;
+  result->never_indexed = never_indexed;
+  result->value_huffman = value_huffman;
+
+  if (value_len == 0)
+    {
+      result->value = NULL;
+      result->value_len = 0;
+    }
+  else if (value_huffman)
+    {
+      /* Huffman-decode the value */
+      if (arena == NULL)
+        {
+          /* No arena provided - cannot decode Huffman */
+          /* Point to raw data and let caller handle it */
+          result->value = (const char *)(input + pos);
+          result->value_len = value_len;
+        }
+      else
+        {
+          /* Allocate decode buffer (worst case ~2x expansion) */
+          size_t decode_buf_size = value_len * 2;
+          if (decode_buf_size < 64)
+            decode_buf_size = 64;
+
+          char *decode_buf = ALLOC (arena, decode_buf_size);
+          if (decode_buf == NULL)
+            return QPACK_ERR_INTERNAL;
+
+          ssize_t decoded_len
+              = SocketHPACK_huffman_decode (input + pos,
+                                            value_len,
+                                            (unsigned char *)decode_buf,
+                                            decode_buf_size);
+          if (decoded_len < 0)
+            return QPACK_ERR_HUFFMAN;
+
+          result->value = decode_buf;
+          result->value_len = (size_t)decoded_len;
+        }
+    }
+  else
+    {
+      /* Literal value - point directly into input buffer */
+      result->value = (const char *)(input + pos);
+      result->value_len = value_len;
+    }
+
+  pos += value_len;
+  *consumed = pos;
+
+  return QPACK_OK;
+}
+
+SocketQPACK_Result
+SocketQPACK_decode_literal_name_ref (const unsigned char *input,
+                                     size_t input_len,
+                                     SocketQPACK_LiteralNameRef *result,
+                                     size_t *consumed)
+{
+  return decode_literal_name_ref_internal (
+      input, input_len, NULL, result, consumed);
+}
+
+SocketQPACK_Result
+SocketQPACK_decode_literal_name_ref_arena (const unsigned char *input,
+                                           size_t input_len,
+                                           Arena_T arena,
+                                           SocketQPACK_LiteralNameRef *result,
+                                           size_t *consumed)
+{
+  if (arena == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  return decode_literal_name_ref_internal (
+      input, input_len, arena, result, consumed);
+}
+
+/* ============================================================================
+ * VALIDATE NAME INDEX (RFC 9204 Section 4.5.4)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_validate_literal_name_ref_index (bool is_static,
+                                             uint64_t name_index,
+                                             uint64_t base,
+                                             uint64_t dropped_count)
+{
+  /*
+   * RFC 9204 Section 4.5.4: Validate name reference index
+   *
+   * For static table: index must be 0-98 (99 entries)
+   * For dynamic table: index is field-relative, converted via Base
+   */
+  if (is_static)
+    {
+      /* Static table has 99 entries (indices 0-98) */
+      if (name_index >= SOCKETQPACK_STATIC_TABLE_SIZE)
+        return QPACK_ERR_INVALID_INDEX;
+      return QPACK_OK;
+    }
+
+  /* Dynamic table: field-relative index validation */
+  /* rel_index must be < base to reference a valid entry */
+  if (name_index >= base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Convert to absolute index: absolute = base - relative - 1 */
+  uint64_t abs_index = base - name_index - 1;
+
+  /* Check if entry has been evicted */
+  if (abs_index < dropped_count)
+    return QPACK_ERR_EVICTED_INDEX;
+
+  return QPACK_OK;
+}
+
+/* ============================================================================
+ * RESOLVE NAME (RFC 9204 Section 4.5.4)
+ * ============================================================================
+ */
+
+SocketQPACK_Result
+SocketQPACK_resolve_literal_name_ref (bool is_static,
+                                      uint64_t name_index,
+                                      uint64_t base,
+                                      SocketQPACK_Table_T table,
+                                      const char **name,
+                                      size_t *name_len)
+{
+  SocketQPACK_Result result;
+
+  if (name == NULL || name_len == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  *name = NULL;
+  *name_len = 0;
+
+  if (is_static)
+    {
+      /* Lookup in static table */
+      result = qpack_static_get (name_index, name, name_len);
+      return result;
+    }
+
+  /* Dynamic table lookup */
+  if (table == NULL)
+    return QPACK_ERR_NULL_PARAM;
+
+  /* Convert field-relative to absolute index */
+  if (name_index >= base)
+    return QPACK_ERR_INVALID_INDEX;
+
+  uint64_t abs_index = base - name_index - 1;
+
+  /* Validate absolute index against table bounds */
+  if (abs_index < table->dropped_count)
+    return QPACK_ERR_EVICTED_INDEX;
+
+  if (abs_index >= table->insert_count)
+    return QPACK_ERR_INVALID_INDEX;
+
+  /* Convert absolute index to ring buffer position */
+  /* Ring buffer position = head + (abs_index - dropped_count) */
+  size_t ring_offset = (size_t)(abs_index - table->dropped_count);
+  if (ring_offset >= table->count)
+    return QPACK_ERR_INVALID_INDEX;
+
+  size_t ring_pos = RINGBUF_WRAP (table->head + ring_offset, table->capacity);
+  QPACK_DynamicEntry *entry = &table->entries[ring_pos];
+
+  *name = entry->name;
+  *name_len = entry->name_len;
+
+  return QPACK_OK;
+}

--- a/src/test/test_qpack_literal_name_ref.c
+++ b/src/test/test_qpack_literal_name_ref.c
@@ -1,0 +1,859 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_qpack_literal_name_ref.c
+ * @brief Unit tests for QPACK Literal Field Line with Name Reference
+ *        (RFC 9204 Section 4.5.4)
+ *
+ * Tests encoding, decoding, and validation of the Literal Field Line with
+ * Name Reference representation.
+ */
+
+#include <string.h>
+
+#include "core/Arena.h"
+#include "http/qpack/SocketQPACK.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * ENCODE NULL PARAMETER TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_encode_null_output)
+{
+  size_t written = 999;
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (NULL,
+                                             16,
+                                             true,
+                                             0,
+                                             false,
+                                             (const unsigned char *)"value",
+                                             5,
+                                             false,
+                                             &written);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_literal_name_ref_encode_null_written)
+{
+  unsigned char buf[32];
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             true,
+                                             0,
+                                             false,
+                                             (const unsigned char *)"value",
+                                             5,
+                                             false,
+                                             NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_literal_name_ref_encode_null_value_with_len)
+{
+  unsigned char buf[32];
+  size_t written;
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf, sizeof (buf), true, 0, false, NULL, 5, false, &written);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_literal_name_ref_encode_zero_buffer)
+{
+  unsigned char buf[1];
+  size_t written;
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             0,
+                                             true,
+                                             0,
+                                             false,
+                                             (const unsigned char *)"value",
+                                             5,
+                                             false,
+                                             &written);
+  ASSERT_EQ (result, QPACK_ERR_TABLE_SIZE);
+}
+
+/* ============================================================================
+ * ENCODE BASIC TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_encode_static_basic)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+
+  /* Static table index 17 (:method = GET), value "GET" */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             true,
+                                             17,
+                                             false,
+                                             (const unsigned char *)"GET",
+                                             3,
+                                             false,
+                                             &written);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT (written >= 2); /* At least pattern byte + value length byte */
+
+  /* First byte: 01 N=0 T=1 index=17 (needs continuation since 17 >= 15) */
+  /* Pattern: 0101xxxx where xxxx is first 4 bits of index */
+  ASSERT_EQ ((buf[0] & 0xC0), 0x40); /* Pattern 01 */
+  ASSERT_EQ ((buf[0] & 0x20), 0x00); /* N=0 */
+  ASSERT_EQ ((buf[0] & 0x10), 0x10); /* T=1 (static) */
+}
+
+TEST (qpack_literal_name_ref_encode_static_never_indexed)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+
+  /* Static table index 5 (cookie), never-indexed */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             true,
+                                             5,
+                                             true,
+                                             (const unsigned char *)"secret",
+                                             6,
+                                             false,
+                                             &written);
+
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* First byte: 01 N=1 T=1 index=5 */
+  ASSERT_EQ ((buf[0] & 0xC0), 0x40); /* Pattern 01 */
+  ASSERT_EQ ((buf[0] & 0x20), 0x20); /* N=1 (never-indexed) */
+  ASSERT_EQ ((buf[0] & 0x10), 0x10); /* T=1 (static) */
+  ASSERT_EQ ((buf[0] & 0x0F), 5);    /* Index = 5 */
+}
+
+TEST (qpack_literal_name_ref_encode_dynamic_basic)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+
+  /* Dynamic table index 0 (field-relative), value "bar" */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             false,
+                                             0,
+                                             false,
+                                             (const unsigned char *)"bar",
+                                             3,
+                                             false,
+                                             &written);
+
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* First byte: 01 N=0 T=0 index=0 */
+  ASSERT_EQ ((buf[0] & 0xC0), 0x40); /* Pattern 01 */
+  ASSERT_EQ ((buf[0] & 0x20), 0x00); /* N=0 */
+  ASSERT_EQ ((buf[0] & 0x10), 0x00); /* T=0 (dynamic) */
+  ASSERT_EQ ((buf[0] & 0x0F), 0);    /* Index = 0 */
+}
+
+TEST (qpack_literal_name_ref_encode_empty_value)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+
+  /* Static table index 0 (:authority), empty value */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf, sizeof (buf), true, 0, false, NULL, 0, false, &written);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (written, 2); /* Pattern byte + value length (0) */
+
+  /* First byte: 01 N=0 T=1 index=0 */
+  ASSERT_EQ (buf[0], 0x50); /* 01010000 */
+  /* Second byte: H=0 length=0 */
+  ASSERT_EQ (buf[1], 0x00);
+}
+
+TEST (qpack_literal_name_ref_encode_large_index)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+
+  /* Static table index 98 (last entry, x-frame-options: sameorigin) */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             true,
+                                             98,
+                                             false,
+                                             (const unsigned char *)"test",
+                                             4,
+                                             false,
+                                             &written);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT (written > 2); /* Needs continuation bytes for index 98 */
+
+  /* First byte should have index overflow (>= 15) */
+  ASSERT_EQ ((buf[0] & 0x0F), 0x0F); /* Index prefix = 15 (overflow) */
+}
+
+TEST (qpack_literal_name_ref_encode_buffer_too_small)
+{
+  unsigned char buf[2];
+  size_t written = 0;
+
+  /* Try to encode with buffer too small for index + value */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf,
+      sizeof (buf),
+      true,
+      0,
+      false,
+      (const unsigned char *)"this is a long value",
+      20,
+      false,
+      &written);
+
+  ASSERT_EQ (result, QPACK_ERR_TABLE_SIZE);
+}
+
+/* ============================================================================
+ * DECODE NULL PARAMETER TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_decode_null_result)
+{
+  unsigned char buf[] = { 0x50, 0x03, 'f', 'o', 'o' };
+  size_t consumed = 999;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), NULL, &consumed);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_literal_name_ref_decode_null_consumed)
+{
+  unsigned char buf[] = { 0x50, 0x03, 'f', 'o', 'o' };
+  SocketQPACK_LiteralNameRef decoded;
+
+  SocketQPACK_Result result
+      = SocketQPACK_decode_literal_name_ref (buf, sizeof (buf), &decoded, NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_literal_name_ref_decode_empty_input)
+{
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 999;
+
+  SocketQPACK_Result result
+      = SocketQPACK_decode_literal_name_ref (NULL, 0, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+  ASSERT_EQ (consumed, 0);
+}
+
+/* ============================================================================
+ * DECODE BASIC TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_decode_static_basic)
+{
+  /* Encoded: Static index 5, N=0, value "cookie-value" */
+  unsigned char buf[]
+      = { 0x55, /* 01010101 = pattern 01, N=0, T=1, index=5 */
+          0x0C, /* H=0, length=12 */
+          'c',  'o', 'o', 'k', 'i', 'e', '-', 'v', 'a', 'l', 'u', 'e' };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, sizeof (buf));
+  ASSERT_EQ (decoded.name_index, 5);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.never_indexed, false);
+  ASSERT_EQ (decoded.value_huffman, false);
+  ASSERT_EQ (decoded.value_len, 12);
+  ASSERT (memcmp (decoded.value, "cookie-value", 12) == 0);
+}
+
+TEST (qpack_literal_name_ref_decode_static_never_indexed)
+{
+  /* Encoded: Static index 5, N=1, value "secret" */
+  unsigned char buf[] = { 0x75, /* 01110101 = pattern 01, N=1, T=1, index=5 */
+                          0x06, /* H=0, length=6 */
+                          's',  'e', 'c', 'r', 'e', 't' };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 5);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.never_indexed, true);
+  ASSERT_EQ (decoded.value_len, 6);
+}
+
+TEST (qpack_literal_name_ref_decode_dynamic_basic)
+{
+  /* Encoded: Dynamic index 3, N=0, value "test" */
+  unsigned char buf[] = { 0x43, /* 01000011 = pattern 01, N=0, T=0, index=3 */
+                          0x04, /* H=0, length=4 */
+                          't',  'e', 's', 't' };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 3);
+  ASSERT_EQ (decoded.is_static, false);
+  ASSERT_EQ (decoded.never_indexed, false);
+  ASSERT_EQ (decoded.value_len, 4);
+}
+
+TEST (qpack_literal_name_ref_decode_empty_value)
+{
+  /* Encoded: Static index 0 (:authority), empty value */
+  unsigned char buf[] = { 0x50, /* 01010000 = pattern 01, N=0, T=1, index=0 */
+                          0x00 /* H=0, length=0 */ };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, 2);
+  ASSERT_EQ (decoded.name_index, 0);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.value_len, 0);
+}
+
+TEST (qpack_literal_name_ref_decode_large_index)
+{
+  /* Encoded: Static index 98 (uses continuation byte) */
+  unsigned char buf[]
+      = { 0x5F, /* 01011111 = pattern 01, N=0, T=1, index=15 (overflow) */
+          0x53, /* Continuation: 98 - 15 = 83 = 0x53 */
+          0x03, /* H=0, length=3 */
+          'f',  'o', 'o' };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 98);
+  ASSERT_EQ (decoded.is_static, true);
+}
+
+TEST (qpack_literal_name_ref_decode_incomplete_index)
+{
+  /* Index needs continuation but not present */
+  unsigned char buf[] = { 0x5F /* Overflow index, needs more bytes */ };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+}
+
+TEST (qpack_literal_name_ref_decode_incomplete_value_len)
+{
+  /* Index complete but no value length byte */
+  unsigned char buf[] = { 0x50 /* pattern 01, N=0, T=1, index=0 */ };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+}
+
+TEST (qpack_literal_name_ref_decode_incomplete_value)
+{
+  /* Value length says 10 but only 3 bytes present */
+  unsigned char buf[] = { 0x50, /* pattern 01, N=0, T=1, index=0 */
+                          0x0A, /* H=0, length=10 */
+                          'a',
+                          'b',
+                          'c' };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_INCOMPLETE);
+}
+
+TEST (qpack_literal_name_ref_decode_wrong_pattern)
+{
+  /* Wrong pattern: 10xxxxxx instead of 01xxxxxx */
+  unsigned char buf[] = { 0x80, /* Wrong pattern */ 0x03, 'f', 'o', 'o' };
+
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref (
+      buf, sizeof (buf), &decoded, &consumed);
+
+  ASSERT_EQ (result, QPACK_ERR_INTERNAL);
+}
+
+/* ============================================================================
+ * ROUND-TRIP TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_roundtrip_static)
+{
+  unsigned char buf[64];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Encode: static index 25 (:status=200), value "OK" */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             true,
+                                             25,
+                                             false,
+                                             (const unsigned char *)"OK",
+                                             2,
+                                             false,
+                                             &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result
+      = SocketQPACK_decode_literal_name_ref (buf, written, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (consumed, written);
+  ASSERT_EQ (decoded.name_index, 25);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.never_indexed, false);
+  ASSERT_EQ (decoded.value_len, 2);
+  ASSERT (memcmp (decoded.value, "OK", 2) == 0);
+}
+
+TEST (qpack_literal_name_ref_roundtrip_dynamic)
+{
+  unsigned char buf[64];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Encode: dynamic index 7, value "custom-value" */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf,
+      sizeof (buf),
+      false,
+      7,
+      false,
+      (const unsigned char *)"custom-value",
+      12,
+      false,
+      &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result
+      = SocketQPACK_decode_literal_name_ref (buf, written, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 7);
+  ASSERT_EQ (decoded.is_static, false);
+  ASSERT_EQ (decoded.value_len, 12);
+}
+
+TEST (qpack_literal_name_ref_roundtrip_never_indexed)
+{
+  unsigned char buf[64];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Encode: static index 85 (authorization), never-indexed, value "Bearer
+   * token" */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf,
+      sizeof (buf),
+      true,
+      85,
+      true,
+      (const unsigned char *)"Bearer token",
+      12,
+      false,
+      &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result
+      = SocketQPACK_decode_literal_name_ref (buf, written, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 85);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.never_indexed, true);
+  ASSERT_EQ (decoded.value_len, 12);
+}
+
+TEST (qpack_literal_name_ref_roundtrip_empty_value)
+{
+  unsigned char buf[32];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Encode: static index 0 (:authority), empty value */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf, sizeof (buf), true, 0, false, NULL, 0, false, &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode */
+  result
+      = SocketQPACK_decode_literal_name_ref (buf, written, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 0);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.value_len, 0);
+}
+
+/* ============================================================================
+ * HUFFMAN ENCODING TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_encode_huffman)
+{
+  unsigned char buf[64];
+  size_t written = 0;
+
+  /* Encode with Huffman - "www.example.com" compresses well */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf,
+      sizeof (buf),
+      true,
+      0,
+      false,
+      (const unsigned char *)"www.example.com",
+      15,
+      true,
+      &written);
+
+  ASSERT_EQ (result, QPACK_OK);
+  /* Huffman encoding should be used since it compresses */
+  /* Value length byte should have H bit set */
+  /* First byte is index, second+ is value length */
+  ASSERT ((buf[1] & 0x80) == 0x80); /* H bit should be set */
+}
+
+TEST (qpack_literal_name_ref_decode_huffman_with_arena)
+{
+  Arena_T arena = Arena_new ();
+  unsigned char buf[64];
+  size_t written = 0;
+
+  /* First encode with Huffman */
+  SocketQPACK_Result result = SocketQPACK_encode_literal_name_ref (
+      buf,
+      sizeof (buf),
+      true,
+      0,
+      false,
+      (const unsigned char *)"www.example.com",
+      15,
+      true,
+      &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  /* Decode with arena for Huffman support */
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  result = SocketQPACK_decode_literal_name_ref_arena (
+      buf, written, arena, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 0);
+  ASSERT_EQ (decoded.is_static, true);
+  ASSERT_EQ (decoded.value_len, 15);
+  ASSERT (memcmp (decoded.value, "www.example.com", 15) == 0);
+
+  Arena_dispose (&arena);
+}
+
+TEST (qpack_literal_name_ref_decode_arena_null)
+{
+  unsigned char buf[] = { 0x50, 0x00 };
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  SocketQPACK_Result result = SocketQPACK_decode_literal_name_ref_arena (
+      buf, sizeof (buf), NULL, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+/* ============================================================================
+ * VALIDATE INDEX TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_validate_static_valid)
+{
+  SocketQPACK_Result result = SocketQPACK_validate_literal_name_ref_index (
+      true, 0, /* base (ignored for static) */ 0, /* dropped (ignored) */ 0);
+  ASSERT_EQ (result, QPACK_OK);
+
+  result = SocketQPACK_validate_literal_name_ref_index (true, 98, 0, 0);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+TEST (qpack_literal_name_ref_validate_static_invalid)
+{
+  /* Index 99 is out of bounds (static table has 0-98) */
+  SocketQPACK_Result result
+      = SocketQPACK_validate_literal_name_ref_index (true, 99, 0, 0);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_INDEX);
+
+  result = SocketQPACK_validate_literal_name_ref_index (true, 1000, 0, 0);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_INDEX);
+}
+
+TEST (qpack_literal_name_ref_validate_dynamic_valid)
+{
+  /* Base=10, dropped=0: valid indices are 0-9 (absolute 0-9) */
+  SocketQPACK_Result result
+      = SocketQPACK_validate_literal_name_ref_index (false, 0, 10, 0);
+  ASSERT_EQ (result, QPACK_OK);
+
+  result = SocketQPACK_validate_literal_name_ref_index (false, 9, 10, 0);
+  ASSERT_EQ (result, QPACK_OK);
+}
+
+TEST (qpack_literal_name_ref_validate_dynamic_out_of_bounds)
+{
+  /* Base=10: index 10 is out of bounds */
+  SocketQPACK_Result result
+      = SocketQPACK_validate_literal_name_ref_index (false, 10, 10, 0);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_INDEX);
+}
+
+TEST (qpack_literal_name_ref_validate_dynamic_evicted)
+{
+  /* Base=10, dropped=5: valid indices are 0-4 (absolute 5-9)
+   * Index 5 would map to absolute 4, which is < dropped */
+  SocketQPACK_Result result
+      = SocketQPACK_validate_literal_name_ref_index (false, 9, 10, 5);
+  /* rel=9, abs = 10 - 9 - 1 = 0, which is < dropped=5 */
+  ASSERT_EQ (result, QPACK_ERR_EVICTED_INDEX);
+}
+
+/* ============================================================================
+ * RESOLVE NAME TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_resolve_static)
+{
+  const char *name = NULL;
+  size_t name_len = 0;
+
+  /* Index 0 is :authority */
+  SocketQPACK_Result result = SocketQPACK_resolve_literal_name_ref (
+      true, 0, 0, NULL, &name, &name_len);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (name_len, 10);
+  ASSERT (memcmp (name, ":authority", 10) == 0);
+}
+
+TEST (qpack_literal_name_ref_resolve_static_method)
+{
+  const char *name = NULL;
+  size_t name_len = 0;
+
+  /* Index 17 is :method (GET) */
+  SocketQPACK_Result result = SocketQPACK_resolve_literal_name_ref (
+      true, 17, 0, NULL, &name, &name_len);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (name_len, 7);
+  ASSERT (memcmp (name, ":method", 7) == 0);
+}
+
+TEST (qpack_literal_name_ref_resolve_static_invalid)
+{
+  const char *name = NULL;
+  size_t name_len = 0;
+
+  SocketQPACK_Result result = SocketQPACK_resolve_literal_name_ref (
+      true, 99, 0, NULL, &name, &name_len);
+  ASSERT_EQ (result, QPACK_ERR_INVALID_INDEX);
+}
+
+TEST (qpack_literal_name_ref_resolve_null_params)
+{
+  const char *name = NULL;
+  size_t name_len = 0;
+
+  SocketQPACK_Result result = SocketQPACK_resolve_literal_name_ref (
+      true, 0, 0, NULL, NULL, &name_len);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+
+  result = SocketQPACK_resolve_literal_name_ref (true, 0, 0, NULL, &name, NULL);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+TEST (qpack_literal_name_ref_resolve_dynamic_null_table)
+{
+  const char *name = NULL;
+  size_t name_len = 0;
+
+  /* Dynamic table lookup requires non-NULL table */
+  SocketQPACK_Result result = SocketQPACK_resolve_literal_name_ref (
+      false, 0, 10, NULL, &name, &name_len);
+  ASSERT_EQ (result, QPACK_ERR_NULL_PARAM);
+}
+
+/* ============================================================================
+ * EDGE CASE TESTS
+ * ============================================================================
+ */
+
+TEST (qpack_literal_name_ref_max_index_continuation)
+{
+  unsigned char buf[64];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Test with large index that requires multiple continuation bytes */
+  /* Index 1000 (way beyond static table, but valid for dynamic) */
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             false,
+                                             1000,
+                                             false,
+                                             (const unsigned char *)"v",
+                                             1,
+                                             false,
+                                             &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  result
+      = SocketQPACK_decode_literal_name_ref (buf, written, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.name_index, 1000);
+  ASSERT_EQ (decoded.is_static, false);
+}
+
+TEST (qpack_literal_name_ref_large_value)
+{
+  unsigned char buf[512];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Create a 200-byte value */
+  unsigned char value[200];
+  memset (value, 'x', sizeof (value));
+
+  SocketQPACK_Result result
+      = SocketQPACK_encode_literal_name_ref (buf,
+                                             sizeof (buf),
+                                             true,
+                                             0,
+                                             false,
+                                             value,
+                                             sizeof (value),
+                                             false,
+                                             &written);
+  ASSERT_EQ (result, QPACK_OK);
+
+  result
+      = SocketQPACK_decode_literal_name_ref (buf, written, &decoded, &consumed);
+  ASSERT_EQ (result, QPACK_OK);
+  ASSERT_EQ (decoded.value_len, 200);
+}
+
+TEST (qpack_literal_name_ref_all_flags_combination)
+{
+  unsigned char buf[64];
+  size_t written = 0;
+  SocketQPACK_LiteralNameRef decoded;
+  size_t consumed = 0;
+
+  /* Test all flag combinations */
+  struct
+  {
+    bool is_static;
+    bool never_indexed;
+  } combinations[]
+      = { { false, false }, { false, true }, { true, false }, { true, true } };
+
+  for (size_t i = 0; i < 4; i++)
+    {
+      written = 0;
+      consumed = 0;
+
+      SocketQPACK_Result result
+          = SocketQPACK_encode_literal_name_ref (buf,
+                                                 sizeof (buf),
+                                                 combinations[i].is_static,
+                                                 5,
+                                                 combinations[i].never_indexed,
+                                                 (const unsigned char *)"test",
+                                                 4,
+                                                 false,
+                                                 &written);
+      ASSERT_EQ (result, QPACK_OK);
+
+      result = SocketQPACK_decode_literal_name_ref (
+          buf, written, &decoded, &consumed);
+      ASSERT_EQ (result, QPACK_OK);
+      ASSERT_EQ (decoded.is_static, combinations[i].is_static);
+      ASSERT_EQ (decoded.never_indexed, combinations[i].never_indexed);
+    }
+}
+
+/* ============================================================================
+ * MAIN
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

Implements RFC 9204 Section 4.5.4 - Literal Field Line with Name Reference for QPACK encoded field sections.

- Adds encoding and decoding functions for the Literal Field Line with Name Reference representation
- Implements full QPACK static table (99 entries per RFC 9204 Appendix A)
- Supports N bit (never-indexed) for sensitive headers that must not be cached by intermediaries
- Supports T bit for static/dynamic table selection
- Supports Huffman encoding for value strings
- Uses field-relative indexing for dynamic table references

## Changes

- `include/http/qpack/SocketQPACK.h`: Added `SocketQPACK_LiteralNameRef` struct and encode/decode/validate/resolve function declarations
- `src/http/qpack/SocketQPACK-literal-name-ref.c`: New implementation file with 600+ lines of RFC-compliant code
- `src/test/test_qpack_literal_name_ref.c`: 42 unit tests covering all functionality
- `CMakeLists.txt`: Added new source and test files

## Test Plan

- [x] 42 unit tests pass for the new implementation
- [x] All 7 QPACK tests pass (including new test)
- [x] All 146 tests pass with sanitizers enabled (ASan + UBSan)
- [x] Code formatted with clang-format

Closes #3296