### PR TITLE
fix(qpack): implement RFC 9204 Section 4.2 and 6 error code mappings

### DIFF
--- a/include/http/qpack/SocketQPACKEncoderStream.h
+++ b/include/http/qpack/SocketQPACKEncoderStream.h
@@ -424,6 +424,27 @@ SocketQPACK_EncoderStream_buffer_size (SocketQPACK_EncoderStream_T stream);
 extern const char *
 SocketQPACKStream_result_string (SocketQPACKStream_Result result);
 
+/**
+ * @brief Convert stream result to HTTP/3 wire error code.
+ *
+ * RFC 9204 Section 4.2 & 6: Maps stream-level errors to appropriate HTTP/3
+ * application error codes for connection termination.
+ *
+ * Mapping per RFC 9204:
+ * - QPACK_STREAM_ERR_CLOSED_CRITICAL -> H3_CLOSED_CRITICAL_STREAM (0x0104)
+ *   (Section 4.2: Closure of encoder/decoder stream)
+ * - QPACK_STREAM_ERR_ALREADY_INIT -> H3_STREAM_CREATION_ERROR (0x0103)
+ *   (Section 4.2: Receipt of second instance of stream type)
+ * - Other errors -> QPACK_ENCODER_STREAM_ERROR (0x0201)
+ *
+ * @param result Stream result code
+ * @return HTTP/3 error code (0x0103, 0x0104, or 0x0201), or 0 if not an error
+ *
+ * @since 1.0.0
+ */
+extern uint64_t
+SocketQPACKStream_result_to_h3_error (SocketQPACKStream_Result result);
+
 /* ============================================================================
  * INSERT WITH NAME REFERENCE PRIMITIVES (RFC 9204 Section 4.3.2)
  * ============================================================================


### PR DESCRIPTION
## Summary

Implement HTTP/3 error code mappings per RFC 9204 Section 4.2 (Encoder and Decoder Streams) and Section 6 (Error Handling).

### RFC 9204 Section 4.2 - Encoder and Decoder Streams
- **H3_CLOSED_CRITICAL_STREAM (0x0104)**: Closure of encoder/decoder stream
- **H3_STREAM_CREATION_ERROR (0x0103)**: Receipt of duplicate stream type

### RFC 9204 Section 6 - Error Handling
- **QPACK_DECOMPRESSION_FAILED (0x0200)**: Decoder fails to interpret field section
- **QPACK_ENCODER_STREAM_ERROR (0x0201)**: Decoder fails to interpret encoder instruction
- **QPACK_DECODER_STREAM_ERROR (0x0202)**: Encoder fails to interpret decoder instruction

### Changes

**include/http/qpack/SocketQPACK.h**:
- Add HTTP/3 error code constants (0x0103, 0x0104, 0x0200-0x0202)
- Add `QPACK_RESULT_COUNT` macro for array bounds safety
- Add `SocketQPACK_result_string()` declaration
- Add `SocketQPACK_result_to_h3_error()` declaration

**include/http/qpack/SocketQPACKEncoderStream.h**:
- Add `SocketQPACKStream_result_to_h3_error()` declaration

**src/http/qpack/SocketQPACK-index.c**:
- Fix `result_string` array to include `QPACK_ERR_0RTT_MISMATCH`
- Use `QPACK_RESULT_COUNT` for bounds checking
- Implement `SocketQPACK_result_to_h3_error()` with RFC-compliant mappings

**src/http/qpack/SocketQPACK-encoder-stream.c**:
- Implement `SocketQPACKStream_result_to_h3_error()` with RFC-compliant mappings

**src/test/test_qpack_error_integration.c**:
- Add 14 test cases for H3 error code constant verification
- Test result-to-H3 error mappings for all error categories
- Test stream result-to-H3 error mappings

Fixes #3361

## Test plan
- [x] All 51 tests pass in `test_qpack_error_integration`
- [x] All 20 QPACK test suites pass
- [x] Tests pass with ASan/UBSan enabled
- [x] Verified error code values match RFC specifications