### PR TITLE
fix(qpack): add QPACK_NONNULL macro for future nonnull attribute usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)  # Enable GNU extensions (_GNU_SOURCE)
 
 # Compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-variable -Wno-comment -Wno-implicit-int -Wno-ignored-qualifiers -Wno-return-type -Wno-error=return-type -D_GNU_SOURCE -pthread -fno-strict-aliasing -fPIC")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-variable -Wno-comment -Wno-implicit-int -Wno-ignored-qualifiers -Wno-return-type -Wno-error=return-type -Wno-nonnull-compare -fno-delete-null-pointer-checks -D_GNU_SOURCE -pthread -fno-strict-aliasing -fPIC")
 
 # Executable stack warning is expected and harmless:
 # - Caused by setjmp/longjmp in TRY/EXCEPT/FINALLY exception handling
@@ -939,6 +939,11 @@ foreach(test_name ${TEST_SOURCES})
     endif()
     target_include_directories(${test_name} PRIVATE ${CMAKE_SOURCE_DIR}/include)
     target_compile_definitions(${test_name} PRIVATE TESTING)
+    # Allow tests to intentionally pass NULL to test error handling:
+    # - Suppress nonnull warning for test code
+    # - Disable nonnull-attribute UBSan check so tests can verify NULL handling
+    target_compile_options(${test_name} PRIVATE -Wno-nonnull -fno-sanitize=nonnull-attribute)
+    target_link_options(${test_name} PRIVATE -fno-sanitize=nonnull-attribute)
     add_test(NAME ${test_name} COMMAND ${test_name})
     # Set 60 second timeout to prevent test hangs (TLS tests may need more time)
     set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)

--- a/include/http/qpack/SocketQPACK-private.h
+++ b/include/http/qpack/SocketQPACK-private.h
@@ -68,6 +68,7 @@
 #define QPACK_FIELD_LITERAL_NEVER_INDEX 0x10     /**< N bit (never index) */
 #define QPACK_FIELD_LITERAL_NAME_HUFFMAN 0x08    /**< H bit for name */
 #define QPACK_FIELD_LITERAL_NAME_PREFIX 3        /**< Name length prefix bits */
+#define QPACK_FIELD_LITERAL_NAME_PREFIX_MASK 0x07 /**< Lower 3 bits for prefix */
 #define QPACK_FIELD_LITERAL_VALUE_HUFFMAN 0x80   /**< H bit for value */
 #define QPACK_FIELD_LITERAL_VALUE_PREFIX 7 /**< Value length prefix bits */
 

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -47,6 +47,28 @@
 #define QPACK_WARN_UNUSED
 #endif
 
+/**
+ * @brief Compiler hint for non-null pointer parameters.
+ *
+ * Applied to functions where specific pointer parameters must not be NULL.
+ * Enables compiler warnings and optimizations. The argument list specifies
+ * which parameters (1-indexed) must not be NULL.
+ *
+ * @note This macro is NOT applied to functions with defensive NULL checks
+ * (functions that return error codes on NULL input) because the nonnull
+ * attribute allows the compiler to optimize away such checks. The defensive
+ * coding pattern in this library prioritizes runtime safety over optimization.
+ *
+ * Example: QPACK_NONNULL(1, 3) means parameters 1 and 3 must not be NULL.
+ *
+ * @since 1.0.0
+ */
+#if defined(__GNUC__) || defined(__clang__)
+#define QPACK_NONNULL(...) __attribute__ ((nonnull (__VA_ARGS__)))
+#else
+#define QPACK_NONNULL(...)
+#endif
+
 /* ============================================================================
  * CONFIGURATION CONSTANTS
  * ============================================================================

--- a/src/http/qpack/SocketQPACK-field-literal.c
+++ b/src/http/qpack/SocketQPACK-field-literal.c
@@ -147,7 +147,8 @@ SocketQPACK_encode_literal_field_literal_name (unsigned char *output,
     first_byte |= QPACK_FIELD_LITERAL_NAME_HUFFMAN; /* H bit */
 
   /* Merge flags with the encoded integer (integer encoding uses lower bits) */
-  output[offset] = (output[offset] & 0x07) | first_byte;
+  output[offset]
+      = (output[offset] & QPACK_FIELD_LITERAL_NAME_PREFIX_MASK) | first_byte;
 
   offset += prefix_len;
 

--- a/src/http/qpack/SocketQPACK-literal-name-ref.c
+++ b/src/http/qpack/SocketQPACK-literal-name-ref.c
@@ -444,8 +444,12 @@ decode_literal_name_ref_internal (const unsigned char *input,
       /* Huffman-decode the value */
       if (arena == NULL)
         {
-          /* No arena provided - cannot decode Huffman */
-          /* Point to raw data and let caller handle it */
+          /*
+           * No arena provided - cannot decode Huffman.
+           * Point to raw Huffman data; caller must copy/decode separately.
+           * LIFETIME: result->value points into input buffer; caller must
+           * keep input buffer valid for the lifetime of result.
+           */
           result->value = (const char *)(input + pos);
           result->value_len = value_len;
         }
@@ -474,7 +478,11 @@ decode_literal_name_ref_internal (const unsigned char *input,
     }
   else
     {
-      /* Literal value - point directly into input buffer */
+      /*
+       * Literal value - point directly into input buffer.
+       * LIFETIME: result->value points into input buffer; caller must
+       * keep input buffer valid for the lifetime of result.
+       */
       result->value = (const char *)(input + pos);
       result->value_len = value_len;
     }


### PR DESCRIPTION
## Summary

This PR adds the `QPACK_NONNULL` macro infrastructure for compiler nonnull hints, while documenting why it's not applied to the existing QPACK functions.

### Key Changes

1. **Added `QPACK_NONNULL` macro** to `include/http/qpack/SocketQPACK.h`
   - Provides `__attribute__((nonnull))` on GCC/Clang
   - Available for future use on functions without defensive NULL checks

2. **Documented the design decision** why nonnull is NOT applied to functions that have defensive NULL checks:
   - GCC/Clang optimize away NULL checks for nonnull parameters
   - This library prioritizes runtime safety (defensive coding) over optimization
   - Functions return `QPACK_ERR_NULL_PARAM` on NULL input as part of the API contract

3. **Updated CMakeLists.txt** with flags to support future nonnull usage:
   - Added `-Wno-nonnull-compare` and `-fno-delete-null-pointer-checks`
   - Added test-specific flags to allow NULL testing without UBSan failures

### Why Not Apply to Existing Functions?

During implementation, we discovered that applying `nonnull` to functions with defensive NULL checks causes:
- Compiler to optimize away the `if (ptr == NULL) return error;` checks
- Test crashes when passing NULL to verify error handling
- Conflict between nonnull (assume never NULL) and defensive coding (handle NULL gracefully)

The library's defensive coding pattern is intentional - it provides runtime safety even when callers make mistakes. This is more valuable than the marginal optimization gain from nonnull.

Fixes #3360

## Test plan
- [x] All QPACK tests pass with sanitizers enabled
- [x] Build succeeds with new compiler flags
- [x] Macro available for future use