### PR TITLE
fix(build): make -Wno-nonnull-compare GCC-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,8 +9,13 @@ set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS ON)  # Enable GNU extensions (_GNU_SOURCE)
 
-# Compiler flags
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-variable -Wno-comment -Wno-implicit-int -Wno-ignored-qualifiers -Wno-return-type -Wno-error=return-type -Wno-nonnull-compare -fno-delete-null-pointer-checks -D_GNU_SOURCE -pthread -fno-strict-aliasing -fPIC")
+# Compiler flags (common to GCC and Clang)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Werror -Wno-unused-function -Wno-unused-variable -Wno-comment -Wno-implicit-int -Wno-ignored-qualifiers -Wno-return-type -Wno-error=return-type -fno-delete-null-pointer-checks -D_GNU_SOURCE -pthread -fno-strict-aliasing -fPIC")
+
+# GCC-specific flags
+if(CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-nonnull-compare")
+endif()
 
 # Executable stack warning is expected and harmless:
 # - Caused by setjmp/longjmp in TRY/EXCEPT/FINALLY exception handling


### PR DESCRIPTION
## Summary
- Move `-Wno-nonnull-compare` to a GCC-only conditional block
- This flag is GCC-specific and causes Clang builds to fail

## Problem
`./scripts/build_fuzz.sh` was failing with:
```
error: unknown warning option '-Wno-nonnull-compare' [-Werror,-Wunknown-warning-option]
```

libFuzzer requires Clang, which doesn't recognize this GCC-specific warning flag.

## Test plan
- [x] `./scripts/build_fuzz.sh` builds 129 fuzzers successfully
- [x] Regular GCC build works with `-Wno-nonnull-compare` still applied
- [x] All 160 tests pass