### PR TITLE
fuzz: add 9 critical QUIC protocol fuzz harnesses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1233,6 +1233,16 @@ if(ENABLE_FUZZING)
         fuzz_quic_frame
         fuzz_quic_transport_params
         fuzz_quic_retry
+        # QUIC protocol fuzzers (RFC 9000/9001/9002)
+        fuzz_quic_crypto
+        fuzz_quic_addr_validation
+        fuzz_quic_ack
+        fuzz_quic_flow
+        fuzz_quic_stream
+        fuzz_quic_loss
+        fuzz_quic_connection
+        fuzz_quic_handshake
+        fuzz_quic_tls
         # QPACK fuzzers (RFC 9204 - HTTP/3 header compression)
         fuzz_qpack_index
         fuzz_qpack_prefix

--- a/src/fuzz/fuzz_quic_ack.c
+++ b/src/fuzz/fuzz_quic_ack.c
@@ -1,0 +1,392 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_ack.c - libFuzzer for QUIC ACK Generation (RFC 9000 Section 13.2)
+ *
+ * Fuzzes ACK state management and encoding:
+ * - Packet number tracking with ranges
+ * - ACK frame encoding
+ * - Delayed ACK timing
+ * - ECN count tracking
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_ack
+ * ./fuzz_quic_ack corpus/quic_ack/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICAck.h"
+
+/* Operation types */
+enum
+{
+  OP_RECORD_PACKETS,
+  OP_ENCODE_ACK,
+  OP_SHOULD_SEND,
+  OP_ECN_TRACKING,
+  OP_QUERY_FUNCTIONS,
+  OP_PRUNE,
+  OP_RESULT_STRINGS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 17)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_RECORD_PACKETS:
+        {
+          /* Test packet recording */
+          int is_handshake = data[1] & 1;
+          uint64_t max_ack_delay = read_u64 (data + 2);
+
+          SocketQUICAckState_T state
+              = SocketQUICAck_new (arena, is_handshake,
+                                   max_ack_delay % QUIC_ACK_DEFAULT_MAX_DELAY_US
+                                       + 1);
+          if (!state)
+            break;
+
+          /* Record multiple packets from fuzz data */
+          size_t offset = 10;
+          while (offset + 17 <= size)
+            {
+              uint64_t pn = read_u64 (data + offset);
+              uint64_t recv_time = read_u64 (data + offset + 8);
+              int ack_eliciting = data[offset + 16] & 1;
+
+              SocketQUICAck_Result result = SocketQUICAck_record_packet (
+                  state, pn, recv_time, ack_eliciting);
+              (void)result;
+
+              offset += 17;
+            }
+
+          /* Check contains for some packet numbers */
+          for (size_t i = 0; i < 10 && 10 + i * 8 + 8 <= size; i++)
+            {
+              uint64_t pn = read_u64 (data + 10 + i * 8);
+              int contains = SocketQUICAck_contains (state, pn);
+              (void)contains;
+            }
+
+          /* Get largest and range count */
+          uint64_t largest = SocketQUICAck_get_largest (state);
+          size_t ranges = SocketQUICAck_range_count (state);
+          (void)largest;
+          (void)ranges;
+
+          /* Test reset */
+          SocketQUICAck_reset (state);
+
+          /* Record again after reset */
+          SocketQUICAck_record_packet (state, 100, 1000000, 1);
+          break;
+        }
+
+      case OP_ENCODE_ACK:
+        {
+          /* Test ACK frame encoding */
+          int is_handshake = data[1] & 1;
+
+          SocketQUICAckState_T state
+              = SocketQUICAck_new (arena, is_handshake,
+                                   QUIC_ACK_DEFAULT_MAX_DELAY_US);
+          if (!state)
+            break;
+
+          /* Record packets to create ranges */
+          size_t offset = 2;
+          int count = 0;
+          while (offset + 9 <= size && count < 50)
+            {
+              uint64_t pn = read_u64 (data + offset);
+              /* Limit packet numbers to avoid excessive range creation */
+              pn = pn % 10000;
+
+              SocketQUICAck_record_packet (state, pn, 1000000 + count * 1000,
+                                           1);
+              offset += 9;
+              count++;
+            }
+
+          /* Encode ACK frame */
+          uint8_t ack_buf[1024];
+          size_t ack_len = 0;
+          uint64_t current_time = read_u64 (data + 2);
+
+          SocketQUICAck_Result result
+              = SocketQUICAck_encode (state, current_time, ack_buf,
+                                      sizeof (ack_buf), &ack_len);
+          (void)result;
+
+          /* Encode with small buffer */
+          result = SocketQUICAck_encode (state, current_time, ack_buf, 10,
+                                         &ack_len);
+          (void)result;
+
+          /* Mark as sent */
+          SocketQUICAck_mark_sent (state, current_time);
+
+          /* Record more and encode again */
+          SocketQUICAck_record_packet (state, 20000, current_time + 1000, 1);
+          result = SocketQUICAck_encode (state, current_time + 2000, ack_buf,
+                                         sizeof (ack_buf), &ack_len);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICAck_encode (NULL, current_time, ack_buf, sizeof (ack_buf),
+                                &ack_len);
+          SocketQUICAck_encode (state, current_time, NULL, 0, &ack_len);
+          SocketQUICAck_encode (state, current_time, ack_buf, sizeof (ack_buf),
+                                NULL);
+          break;
+        }
+
+      case OP_SHOULD_SEND:
+        {
+          /* Test should_send logic */
+          int is_handshake = data[1] & 1;
+          uint64_t max_ack_delay
+              = (read_u64 (data + 2) % QUIC_ACK_DEFAULT_MAX_DELAY_US) + 1;
+
+          SocketQUICAckState_T state
+              = SocketQUICAck_new (arena, is_handshake, max_ack_delay);
+          if (!state)
+            break;
+
+          uint64_t current_time = read_u64 (data + 10);
+
+          /* Initially should not send */
+          int should = SocketQUICAck_should_send (state, current_time);
+          (void)should;
+
+          /* Record one ack-eliciting packet */
+          SocketQUICAck_record_packet (state, 0, current_time, 1);
+          should = SocketQUICAck_should_send (state, current_time);
+          (void)should;
+
+          /* For handshake space, should send immediately */
+          /* For application space, wait for threshold or delay */
+
+          /* Record more packets up to threshold */
+          for (int i = 1; i < QUIC_ACK_PACKET_THRESHOLD + 1; i++)
+            {
+              SocketQUICAck_record_packet (state, (uint64_t)i, current_time, 1);
+              should = SocketQUICAck_should_send (state, current_time);
+              (void)should;
+            }
+
+          /* Test after delay expires */
+          should = SocketQUICAck_should_send (state,
+                                              current_time + max_ack_delay * 2);
+          (void)should;
+
+          /* Mark sent and check again */
+          SocketQUICAck_mark_sent (state, current_time + max_ack_delay * 2);
+          should = SocketQUICAck_should_send (state,
+                                              current_time + max_ack_delay * 2);
+          (void)should;
+
+          /* Test NULL */
+          SocketQUICAck_should_send (NULL, current_time);
+          break;
+        }
+
+      case OP_ECN_TRACKING:
+        {
+          /* Test ECN count tracking */
+          SocketQUICAckState_T state
+              = SocketQUICAck_new (arena, 0, QUIC_ACK_DEFAULT_MAX_DELAY_US);
+          if (!state)
+            break;
+
+          /* Record ECN values */
+          size_t offset = 1;
+          while (offset < size)
+            {
+              int ecn_type = data[offset] % 4;
+              SocketQUICAck_record_ecn (state, ecn_type);
+
+              /* Also record a packet for this ECN */
+              if (offset + 9 <= size)
+                {
+                  uint64_t pn = read_u64 (data + offset + 1);
+                  SocketQUICAck_record_packet (state, pn % 10000,
+                                               1000000 + offset * 1000, 1);
+                }
+              offset += 9;
+            }
+
+          /* Encode should include ECN if validated */
+          uint8_t ack_buf[1024];
+          size_t ack_len = 0;
+          SocketQUICAck_encode (state, 2000000, ack_buf, sizeof (ack_buf),
+                                &ack_len);
+
+          /* Test all ECN types explicitly */
+          SocketQUICAck_record_ecn (state, QUIC_ECN_NOT_ECT);
+          SocketQUICAck_record_ecn (state, QUIC_ECN_ECT0);
+          SocketQUICAck_record_ecn (state, QUIC_ECN_ECT1);
+          SocketQUICAck_record_ecn (state, QUIC_ECN_CE);
+
+          /* Test NULL */
+          SocketQUICAck_record_ecn (NULL, QUIC_ECN_ECT0);
+          break;
+        }
+
+      case OP_QUERY_FUNCTIONS:
+        {
+          /* Test query functions */
+          SocketQUICAckState_T state
+              = SocketQUICAck_new (arena, 0, QUIC_ACK_DEFAULT_MAX_DELAY_US);
+          if (!state)
+            break;
+
+          /* Initially empty */
+          uint64_t largest = SocketQUICAck_get_largest (state);
+          size_t range_count = SocketQUICAck_range_count (state);
+          (void)largest;
+          (void)range_count;
+
+          /* Record packets with gaps to create ranges */
+          SocketQUICAck_record_packet (state, 0, 1000000, 1);
+          SocketQUICAck_record_packet (state, 1, 1001000, 1);
+          SocketQUICAck_record_packet (state, 2, 1002000, 1);
+          /* Gap */
+          SocketQUICAck_record_packet (state, 10, 1003000, 1);
+          SocketQUICAck_record_packet (state, 11, 1004000, 1);
+          /* Gap */
+          SocketQUICAck_record_packet (state, 100, 1005000, 1);
+
+          largest = SocketQUICAck_get_largest (state);
+          range_count = SocketQUICAck_range_count (state);
+          (void)largest;
+          (void)range_count;
+
+          /* Test contains for various packet numbers */
+          int c0 = SocketQUICAck_contains (state, 0);
+          int c5 = SocketQUICAck_contains (state, 5);
+          int c10 = SocketQUICAck_contains (state, 10);
+          int c50 = SocketQUICAck_contains (state, 50);
+          int c100 = SocketQUICAck_contains (state, 100);
+          int c200 = SocketQUICAck_contains (state, 200);
+          (void)c0;
+          (void)c5;
+          (void)c10;
+          (void)c50;
+          (void)c100;
+          (void)c200;
+
+          /* Test NULL */
+          SocketQUICAck_get_largest (NULL);
+          SocketQUICAck_range_count (NULL);
+          SocketQUICAck_contains (NULL, 0);
+          break;
+        }
+
+      case OP_PRUNE:
+        {
+          /* Test prune function */
+          SocketQUICAckState_T state
+              = SocketQUICAck_new (arena, 0, QUIC_ACK_DEFAULT_MAX_DELAY_US);
+          if (!state)
+            break;
+
+          /* Record many packets */
+          for (uint64_t i = 0; i < 100; i++)
+            {
+              SocketQUICAck_record_packet (state, i, 1000000 + i * 1000, 1);
+            }
+
+          /* Prune old packets */
+          size_t removed = 0;
+          uint64_t oldest_to_keep = read_u64 (data + 1) % 100;
+          SocketQUICAck_prune (state, oldest_to_keep, &removed);
+          (void)removed;
+
+          /* Check what's left */
+          size_t range_count = SocketQUICAck_range_count (state);
+          (void)range_count;
+
+          /* Prune with NULL removed_count */
+          SocketQUICAck_prune (state, 80, NULL);
+
+          /* Prune everything */
+          SocketQUICAck_prune (state, UINT64_MAX, &removed);
+
+          /* Test NULL state */
+          SocketQUICAck_prune (NULL, 50, &removed);
+          break;
+        }
+
+      case OP_RESULT_STRINGS:
+        {
+          /* Test result string function */
+          SocketQUICAck_Result results[] = { QUIC_ACK_OK,
+                                             QUIC_ACK_ERROR_NULL,
+                                             QUIC_ACK_ERROR_DUPLICATE,
+                                             QUIC_ACK_ERROR_OLD,
+                                             QUIC_ACK_ERROR_RANGE,
+                                             QUIC_ACK_ERROR_ENCODE,
+                                             QUIC_ACK_ERROR_BUFFER };
+
+          for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+            {
+              const char *str = SocketQUICAck_result_string (results[i]);
+              (void)str;
+            }
+
+          /* Test with fuzzed value */
+          const char *str
+              = SocketQUICAck_result_string ((SocketQUICAck_Result)data[1]);
+          (void)str;
+
+          /* Test reset with NULL */
+          SocketQUICAck_reset (NULL);
+
+          /* Test mark_sent with NULL */
+          SocketQUICAck_mark_sent (NULL, 0);
+          break;
+        }
+      }
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_addr_validation.c
+++ b/src/fuzz/fuzz_quic_addr_validation.c
@@ -1,0 +1,381 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_addr_validation.c - libFuzzer for QUIC Address Validation (RFC 9000
+ * §8)
+ *
+ * Fuzzes address validation token generation/verification and path challenge:
+ * - Token generation from sockaddr
+ * - Token validation with expiration
+ * - Amplification limit checking
+ * - PATH_CHALLENGE/PATH_RESPONSE generation and verification
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make
+ * fuzz_quic_addr_validation ./fuzz_quic_addr_validation corpus/quic_addr/
+ * -fork=16 -max_len=1024
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICAddrValidation.h"
+
+/* Operation types */
+enum
+{
+  OP_GENERATE_TOKEN,
+  OP_VALIDATE_TOKEN,
+  OP_AMPLIFICATION_LIMIT,
+  OP_PATH_CHALLENGE,
+  OP_PATH_RESPONSE,
+  OP_RESULT_STRINGS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+/* Helper to create sockaddr from fuzz data */
+static void
+make_sockaddr (const uint8_t *data, struct sockaddr_storage *addr,
+               socklen_t *len)
+{
+  int is_ipv6 = data[0] & 1;
+
+  if (is_ipv6)
+    {
+      struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *)addr;
+      memset (addr6, 0, sizeof (*addr6));
+      addr6->sin6_family = AF_INET6;
+      memcpy (&addr6->sin6_addr, data + 1, 16);
+      addr6->sin6_port = (data[17] << 8) | data[18];
+      *len = sizeof (struct sockaddr_in6);
+    }
+  else
+    {
+      struct sockaddr_in *addr4 = (struct sockaddr_in *)addr;
+      memset (addr4, 0, sizeof (*addr4));
+      addr4->sin_family = AF_INET;
+      memcpy (&addr4->sin_addr, data + 1, 4);
+      addr4->sin_port = (data[5] << 8) | data[6];
+      *len = sizeof (struct sockaddr_in);
+    }
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 60)
+    return 0;
+
+  uint8_t op = data[0] % OP_MAX;
+
+  switch (op)
+    {
+    case OP_GENERATE_TOKEN:
+      {
+        /* Test token generation */
+        struct sockaddr_storage addr;
+        socklen_t addr_len;
+        make_sockaddr (data + 1, &addr, &addr_len);
+
+        /* Secret key for HMAC (32 bytes) */
+        uint8_t secret[32];
+        memcpy (secret, data + 20, 32);
+
+        uint8_t token[QUIC_ADDR_VALIDATION_MAX_TOKEN_SIZE];
+        size_t token_len = sizeof (token);
+
+        SocketQUICAddrValidation_Result result
+            = SocketQUICAddrValidation_generate_token ((struct sockaddr *)&addr,
+                                                       secret, token,
+                                                       &token_len);
+        (void)result;
+
+        /* Test with small buffer */
+        token_len = 10;
+        result = SocketQUICAddrValidation_generate_token (
+            (struct sockaddr *)&addr, secret, token, &token_len);
+        (void)result;
+
+        /* Test with NULL inputs */
+        token_len = sizeof (token);
+        SocketQUICAddrValidation_generate_token (NULL, secret, token,
+                                                 &token_len);
+        SocketQUICAddrValidation_generate_token ((struct sockaddr *)&addr, NULL,
+                                                 token, &token_len);
+        SocketQUICAddrValidation_generate_token ((struct sockaddr *)&addr,
+                                                 secret, NULL, &token_len);
+        SocketQUICAddrValidation_generate_token ((struct sockaddr *)&addr,
+                                                 secret, token, NULL);
+        break;
+      }
+
+    case OP_VALIDATE_TOKEN:
+      {
+        /* Test token validation */
+        struct sockaddr_storage addr;
+        socklen_t addr_len;
+        make_sockaddr (data + 1, &addr, &addr_len);
+
+        uint8_t secret[32];
+        memcpy (secret, data + 20, 32);
+
+        /* First generate a valid token */
+        uint8_t token[QUIC_ADDR_VALIDATION_MAX_TOKEN_SIZE];
+        size_t token_len = sizeof (token);
+
+        SocketQUICAddrValidation_Result result
+            = SocketQUICAddrValidation_generate_token ((struct sockaddr *)&addr,
+                                                       secret, token,
+                                                       &token_len);
+
+        if (result == QUIC_ADDR_VALIDATION_OK)
+          {
+            /* Validate the token we just generated */
+            result = SocketQUICAddrValidation_validate_token (
+                token, token_len, (struct sockaddr *)&addr, secret);
+            (void)result;
+
+            /* Validate with different address */
+            struct sockaddr_in different_addr;
+            memset (&different_addr, 0, sizeof (different_addr));
+            different_addr.sin_family = AF_INET;
+            different_addr.sin_addr.s_addr = 0x12345678;
+            result = SocketQUICAddrValidation_validate_token (
+                token, token_len, (struct sockaddr *)&different_addr, secret);
+            (void)result;
+
+            /* Validate with different secret */
+            uint8_t wrong_secret[32];
+            memset (wrong_secret, 0xAB, 32);
+            result = SocketQUICAddrValidation_validate_token (
+                token, token_len, (struct sockaddr *)&addr, wrong_secret);
+            (void)result;
+          }
+
+        /* Test with fuzzed token directly */
+        size_t fuzz_token_len = size - 52;
+        if (fuzz_token_len > 0 && fuzz_token_len <= QUIC_ADDR_VALIDATION_MAX_TOKEN_SIZE)
+          {
+            result = SocketQUICAddrValidation_validate_token (
+                data + 52, fuzz_token_len, (struct sockaddr *)&addr, secret);
+            (void)result;
+          }
+
+        /* Test NULL inputs */
+        SocketQUICAddrValidation_validate_token (NULL, token_len,
+                                                 (struct sockaddr *)&addr,
+                                                 secret);
+        SocketQUICAddrValidation_validate_token (token, token_len, NULL,
+                                                 secret);
+        SocketQUICAddrValidation_validate_token (token, token_len,
+                                                 (struct sockaddr *)&addr,
+                                                 NULL);
+
+        /* Test with wrong token length */
+        SocketQUICAddrValidation_validate_token (token, 0,
+                                                 (struct sockaddr *)&addr,
+                                                 secret);
+        SocketQUICAddrValidation_validate_token (
+            token, QUIC_ADDR_VALIDATION_MAX_TOKEN_SIZE + 1,
+            (struct sockaddr *)&addr, secret);
+        break;
+      }
+
+    case OP_AMPLIFICATION_LIMIT:
+      {
+        /* Test amplification limit checking */
+        SocketQUICAddrValidation_State_T state;
+        memset (&state, 0, sizeof (state));
+
+        uint64_t bytes_received = read_u64 (data + 1);
+        uint64_t bytes_sent = read_u64 (data + 9);
+        size_t bytes_to_send = (size_t)read_u64 (data + 17);
+
+        state.bytes_received = bytes_received;
+        state.bytes_sent = bytes_sent;
+        state.address_validated = 0;
+
+        /* Check if we can send */
+        int can_send = SocketQUICAddrValidation_check_amplification_limit (
+            &state, bytes_to_send);
+        (void)can_send;
+
+        /* Update counters */
+        SocketQUICAddrValidation_update_counters (&state, 100, 50);
+        SocketQUICAddrValidation_update_counters (&state, 0, 1000);
+
+        /* Check again after update */
+        can_send = SocketQUICAddrValidation_check_amplification_limit (&state,
+                                                                       1000);
+        (void)can_send;
+
+        /* Mark as validated - should always allow send */
+        SocketQUICAddrValidation_mark_validated (&state, 12345678);
+        can_send = SocketQUICAddrValidation_check_amplification_limit (&state,
+                                                                       1000000);
+        (void)can_send;
+
+        /* Test NULL state */
+        SocketQUICAddrValidation_check_amplification_limit (NULL, 100);
+
+        /* Test edge cases */
+        state.address_validated = 0;
+        state.bytes_received = 0;
+        can_send
+            = SocketQUICAddrValidation_check_amplification_limit (&state, 1);
+        (void)can_send;
+
+        state.bytes_received = UINT64_MAX / 3;
+        can_send = SocketQUICAddrValidation_check_amplification_limit (
+            &state, UINT64_MAX);
+        (void)can_send;
+        break;
+      }
+
+    case OP_PATH_CHALLENGE:
+      {
+        /* Test PATH_CHALLENGE generation */
+        SocketQUICPathChallenge_T challenge;
+        SocketQUICPathChallenge_init (&challenge);
+
+        /* Create destination address */
+        struct sockaddr_storage addr;
+        socklen_t addr_len;
+        make_sockaddr (data + 1, &addr, &addr_len);
+
+        uint64_t timestamp = read_u64 (data + 20);
+
+        /* Generate a challenge */
+        SocketQUICAddrValidation_Result result
+            = SocketQUICPathChallenge_generate (&challenge,
+                                                (struct sockaddr *)&addr,
+                                                timestamp);
+        (void)result;
+
+        /* Check pending state */
+        int pending = SocketQUICPathChallenge_is_pending (&challenge);
+        (void)pending;
+
+        /* Generate another challenge (should overwrite) */
+        result = SocketQUICPathChallenge_generate (&challenge,
+                                                   (struct sockaddr *)&addr,
+                                                   timestamp + 1000);
+        (void)result;
+
+        /* Test NULL inputs */
+        SocketQUICPathChallenge_init (NULL);
+        SocketQUICPathChallenge_generate (NULL, (struct sockaddr *)&addr,
+                                          timestamp);
+        SocketQUICPathChallenge_generate (&challenge, NULL, timestamp);
+        SocketQUICPathChallenge_is_pending (NULL);
+        break;
+      }
+
+    case OP_PATH_RESPONSE:
+      {
+        /* Test PATH_RESPONSE verification */
+        SocketQUICPathChallenge_T challenge;
+        SocketQUICPathChallenge_init (&challenge);
+
+        struct sockaddr_storage addr;
+        socklen_t addr_len;
+        make_sockaddr (data + 1, &addr, &addr_len);
+
+        uint64_t timestamp = read_u64 (data + 20);
+
+        /* Generate a challenge first */
+        SocketQUICAddrValidation_Result result
+            = SocketQUICPathChallenge_generate (&challenge,
+                                                (struct sockaddr *)&addr,
+                                                timestamp);
+
+        if (result == QUIC_ADDR_VALIDATION_OK)
+          {
+            /* Verify with correct response (copy of challenge data) */
+            int valid = SocketQUICPathChallenge_verify_response (
+                &challenge, challenge.data, QUIC_PATH_CHALLENGE_SIZE);
+            (void)valid;
+
+            /* Verify with wrong response */
+            uint8_t wrong_response[QUIC_PATH_CHALLENGE_SIZE];
+            memcpy (wrong_response, data + 28, QUIC_PATH_CHALLENGE_SIZE);
+            valid = SocketQUICPathChallenge_verify_response (
+                &challenge, wrong_response, QUIC_PATH_CHALLENGE_SIZE);
+            (void)valid;
+
+            /* Verify with wrong length */
+            valid = SocketQUICPathChallenge_verify_response (
+                &challenge, challenge.data, QUIC_PATH_CHALLENGE_SIZE - 1);
+            (void)valid;
+            valid = SocketQUICPathChallenge_verify_response (
+                &challenge, challenge.data, QUIC_PATH_CHALLENGE_SIZE + 1);
+            (void)valid;
+            valid
+                = SocketQUICPathChallenge_verify_response (&challenge, challenge.data, 0);
+            (void)valid;
+
+            /* Complete the challenge */
+            SocketQUICPathChallenge_complete (&challenge);
+
+            /* Verify after complete (should fail - not pending) */
+            valid = SocketQUICPathChallenge_verify_response (
+                &challenge, challenge.data, QUIC_PATH_CHALLENGE_SIZE);
+            (void)valid;
+          }
+
+        /* Test NULL inputs */
+        SocketQUICPathChallenge_verify_response (NULL, data + 28,
+                                                 QUIC_PATH_CHALLENGE_SIZE);
+        SocketQUICPathChallenge_verify_response (&challenge, NULL,
+                                                 QUIC_PATH_CHALLENGE_SIZE);
+        SocketQUICPathChallenge_complete (NULL);
+        break;
+      }
+
+    case OP_RESULT_STRINGS:
+      {
+        /* Test result string function */
+        SocketQUICAddrValidation_Result results[]
+            = { QUIC_ADDR_VALIDATION_OK,
+                QUIC_ADDR_VALIDATION_ERROR_NULL,
+                QUIC_ADDR_VALIDATION_ERROR_INVALID,
+                QUIC_ADDR_VALIDATION_ERROR_EXPIRED,
+                QUIC_ADDR_VALIDATION_ERROR_BUFFER_SIZE,
+                QUIC_ADDR_VALIDATION_ERROR_CRYPTO,
+                QUIC_ADDR_VALIDATION_ERROR_AMPLIFICATION };
+
+        for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+          {
+            const char *str
+                = SocketQUICAddrValidation_result_string (results[i]);
+            (void)str;
+          }
+
+        /* Test with fuzzed value */
+        const char *str = SocketQUICAddrValidation_result_string (
+            (SocketQUICAddrValidation_Result)data[1]);
+        (void)str;
+        break;
+      }
+    }
+
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_connection.c
+++ b/src/fuzz/fuzz_quic_connection.c
@@ -1,0 +1,497 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_connection.c - libFuzzer for QUIC Connection Table (RFC 9000 §5)
+ *
+ * Fuzzes connection management and packet demultiplexing:
+ * - Connection table insert/lookup/remove
+ * - Connection ID management
+ * - Address-based lookup
+ * - Idle timeout and closing states
+ * - Stateless reset verification
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_connection
+ * ./fuzz_quic_connection corpus/quic_conn/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICConnection.h"
+#include "quic/SocketQUICConnectionID.h"
+
+/* Operation types */
+enum
+{
+  OP_CONN_TABLE_OPS,
+  OP_CONNECTION_LIFECYCLE,
+  OP_CID_MANAGEMENT,
+  OP_TIMEOUT_STATES,
+  OP_STATELESS_RESET,
+  OP_STRING_FUNCTIONS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 50)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_CONN_TABLE_OPS:
+        {
+          /* Test connection table operations */
+          size_t bucket_count
+              = (read_u64 (data + 1) % 1000) + 1; /* 1-1000 buckets */
+
+          SocketQUICConnTable_T table
+              = SocketQUICConnTable_new (arena, bucket_count);
+          if (!table)
+            break;
+
+          /* Create and add connections */
+          size_t offset = 9;
+          SocketQUICConnection_T connections[20];
+          int conn_count = 0;
+
+          while (offset + 20 <= size && conn_count < 20)
+            {
+              SocketQUICConnection_Role role
+                  = (data[offset] & 1) ? QUIC_CONN_ROLE_SERVER
+                                       : QUIC_CONN_ROLE_CLIENT;
+
+              SocketQUICConnection_T conn
+                  = SocketQUICConnection_new (arena, role);
+              if (!conn)
+                break;
+
+              /* Set up connection ID */
+              uint8_t cid_len = (data[offset + 1] % 20) + 1;
+              if (offset + 2 + cid_len > size)
+                break;
+
+              SocketQUICConnectionID_T cid;
+              SocketQUICConnectionID_init (&cid);
+              SocketQUICConnectionID_set (&cid, data + offset + 2, cid_len);
+
+              SocketQUICConnection_add_local_cid (conn, &cid);
+
+              /* Add to table */
+              SocketQUICConnection_Result result
+                  = SocketQUICConnTable_add (table, conn);
+              (void)result;
+
+              connections[conn_count++] = conn;
+              offset += 2 + cid_len;
+            }
+
+          /* Lookup connections by CID */
+          offset = 9;
+          while (offset + 10 <= size)
+            {
+              uint8_t cid_len = (data[offset] % 20) + 1;
+              if (offset + 1 + cid_len > size)
+                break;
+
+              SocketQUICConnection_T found
+                  = SocketQUICConnTable_lookup (table, data + offset + 1,
+                                                cid_len);
+              (void)found;
+
+              offset += 1 + cid_len;
+            }
+
+          /* Get table stats */
+          uint64_t chain_hits_cid = 0, chain_hits_addr = 0, max_chain = 0;
+          size_t count = 0;
+          SocketQUICConnTable_get_stats (table, &chain_hits_cid,
+                                         &chain_hits_addr, &max_chain, &count);
+          (void)chain_hits_cid;
+          (void)chain_hits_addr;
+          (void)max_chain;
+          (void)count;
+
+          count = SocketQUICConnTable_count (table);
+          (void)count;
+
+          /* Remove connections */
+          for (int i = 0; i < conn_count; i++)
+            {
+              SocketQUICConnTable_remove (table, connections[i]);
+            }
+
+          /* Test NULL inputs */
+          SocketQUICConnTable_lookup (NULL, data, 8);
+          SocketQUICConnTable_lookup (table, NULL, 0);
+          SocketQUICConnTable_add (NULL, NULL);
+          SocketQUICConnTable_remove (NULL, NULL);
+          SocketQUICConnTable_count (NULL);
+
+          /* Free table */
+          SocketQUICConnTable_free (&table);
+          break;
+        }
+
+      case OP_CONNECTION_LIFECYCLE:
+        {
+          /* Test connection creation and initialization */
+          SocketQUICConnection_Role role
+              = (data[1] & 1) ? QUIC_CONN_ROLE_SERVER : QUIC_CONN_ROLE_CLIENT;
+
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, role);
+          if (!conn)
+            break;
+
+          /* Initialize */
+          SocketQUICConnection_init (conn, role);
+
+          /* Set addresses */
+          uint8_t local_addr[16], peer_addr[16];
+          memcpy (local_addr, data + 2, 16);
+          memcpy (peer_addr, data + 18, 16);
+          uint16_t local_port = (data[34] << 8) | data[35];
+          uint16_t peer_port = (data[36] << 8) | data[37];
+          int is_ipv6 = data[38] & 1;
+
+          SocketQUICConnection_Result result
+              = SocketQUICConnection_set_addresses (conn, local_addr, peer_addr,
+                                                    local_port, peer_port,
+                                                    is_ipv6);
+          (void)result;
+
+          /* Get CIDs */
+          const SocketQUICConnectionID_T *local_cid
+              = SocketQUICConnection_get_local_cid (conn);
+          const SocketQUICConnectionID_T *peer_cid
+              = SocketQUICConnection_get_peer_cid (conn);
+          (void)local_cid;
+          (void)peer_cid;
+
+          /* Check zero DCID */
+          int uses_zero = SocketQUICConnection_uses_zero_dcid (conn);
+          (void)uses_zero;
+
+          /* Test NULL inputs */
+          SocketQUICConnection_init (NULL, role);
+          SocketQUICConnection_set_addresses (NULL, NULL, NULL, 0, 0, 0);
+          SocketQUICConnection_get_local_cid (NULL);
+          SocketQUICConnection_get_peer_cid (NULL);
+          SocketQUICConnection_uses_zero_dcid (NULL);
+
+          /* Free */
+          SocketQUICConnection_free (&conn);
+          break;
+        }
+
+      case OP_CID_MANAGEMENT:
+        {
+          /* Test CID add/retire operations */
+          SocketQUICConnTable_T table
+              = SocketQUICConnTable_new (arena, QUIC_CONNTABLE_DEFAULT_SIZE);
+          if (!table)
+            break;
+
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, QUIC_CONN_ROLE_CLIENT);
+          if (!conn)
+            break;
+
+          /* Add initial CID */
+          SocketQUICConnectionID_T initial_cid;
+          SocketQUICConnectionID_init (&initial_cid);
+          SocketQUICConnectionID_set (&initial_cid, data + 1, 8);
+          SocketQUICConnection_add_local_cid (conn, &initial_cid);
+
+          SocketQUICConnTable_add (table, conn);
+
+          /* Add more CIDs up to limit */
+          size_t offset = 9;
+          uint64_t seq = 1;
+          while (offset + 20 <= size && seq < QUIC_CONNECTION_MAX_CIDS + 2)
+            {
+              SocketQUICConnectionID_T new_cid;
+              SocketQUICConnectionID_init (&new_cid);
+
+              uint8_t cid_len = (data[offset] % 20) + 1;
+              if (offset + 1 + cid_len > size)
+                break;
+
+              SocketQUICConnectionID_set (&new_cid, data + offset + 1, cid_len);
+              new_cid.sequence = seq++;
+
+              SocketQUICConnection_Result result
+                  = SocketQUICConnTable_add_cid (table, conn, &new_cid);
+              (void)result;
+
+              offset += 1 + cid_len;
+            }
+
+          /* Retire some CIDs */
+          for (uint64_t i = 0; i < 5; i++)
+            {
+              uint64_t retire_seq = read_u64 (data + 1 + i * 8 % (size - 8));
+              SocketQUICConnTable_retire_cid (table, conn, retire_seq);
+            }
+
+          /* Add peer CIDs */
+          offset = 9;
+          while (offset + 20 <= size)
+            {
+              SocketQUICConnectionID_T peer_cid;
+              SocketQUICConnectionID_init (&peer_cid);
+
+              uint8_t cid_len = (data[offset] % 20) + 1;
+              if (offset + 1 + cid_len > size)
+                break;
+
+              SocketQUICConnectionID_set (&peer_cid, data + offset + 1,
+                                          cid_len);
+
+              SocketQUICConnection_add_peer_cid (conn, &peer_cid);
+              offset += 1 + cid_len;
+            }
+
+          /* Update DCID */
+          SocketQUICConnectionID_T new_dcid;
+          SocketQUICConnectionID_init (&new_dcid);
+          SocketQUICConnectionID_set (&new_dcid, data + 20, 8);
+          SocketQUICConnection_update_dcid (conn, &new_dcid);
+
+          /* Test NULL inputs */
+          SocketQUICConnTable_add_cid (NULL, conn, &initial_cid);
+          SocketQUICConnTable_add_cid (table, NULL, &initial_cid);
+          SocketQUICConnTable_add_cid (table, conn, NULL);
+          SocketQUICConnTable_retire_cid (NULL, conn, 0);
+          SocketQUICConnection_add_local_cid (NULL, &initial_cid);
+          SocketQUICConnection_add_peer_cid (NULL, &initial_cid);
+          SocketQUICConnection_update_dcid (NULL, &new_dcid);
+
+          SocketQUICConnTable_free (&table);
+          break;
+        }
+
+      case OP_TIMEOUT_STATES:
+        {
+          /* Test idle timeout and closing/draining states */
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, QUIC_CONN_ROLE_CLIENT);
+          if (!conn)
+            break;
+
+          uint64_t local_timeout = read_u64 (data + 1);
+          uint64_t peer_timeout = read_u64 (data + 9);
+          uint64_t now_ms = read_u64 (data + 17);
+          uint64_t pto_ms = (read_u64 (data + 25) % 10000) + 100;
+
+          /* Set idle timeout */
+          SocketQUICConnection_set_idle_timeout (conn, local_timeout,
+                                                 peer_timeout);
+
+          /* Reset idle timer */
+          SocketQUICConnection_reset_idle_timer (conn, now_ms);
+
+          /* Check idle timeout */
+          int timed_out = SocketQUICConnection_check_idle_timeout (conn, now_ms);
+          (void)timed_out;
+
+          timed_out = SocketQUICConnection_check_idle_timeout (
+              conn, now_ms + local_timeout + 1000);
+          (void)timed_out;
+
+          /* Test closing state */
+          SocketQUICConnection_initiate_close (conn, now_ms, pto_ms);
+
+          int is_closing = SocketQUICConnection_is_closing_or_draining (conn);
+          (void)is_closing;
+
+          int deadline_reached
+              = SocketQUICConnection_check_termination_deadline (conn, now_ms);
+          (void)deadline_reached;
+
+          /* Test draining state */
+          SocketQUICConnection_T conn2
+              = SocketQUICConnection_new (arena, QUIC_CONN_ROLE_SERVER);
+          if (conn2)
+            {
+              SocketQUICConnection_enter_draining (conn2, now_ms, pto_ms);
+              is_closing = SocketQUICConnection_is_closing_or_draining (conn2);
+              (void)is_closing;
+            }
+
+          /* Test NULL inputs */
+          SocketQUICConnection_set_idle_timeout (NULL, 0, 0);
+          SocketQUICConnection_reset_idle_timer (NULL, 0);
+          SocketQUICConnection_check_idle_timeout (NULL, 0);
+          SocketQUICConnection_initiate_close (NULL, 0, 0);
+          SocketQUICConnection_enter_draining (NULL, 0, 0);
+          SocketQUICConnection_is_closing_or_draining (NULL);
+          SocketQUICConnection_check_termination_deadline (NULL, 0);
+          break;
+        }
+
+      case OP_STATELESS_RESET:
+        {
+          /* Test stateless reset token handling */
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, QUIC_CONN_ROLE_CLIENT);
+          if (!conn)
+            break;
+
+          /* Set stateless reset token */
+          uint8_t token[QUIC_STATELESS_RESET_TOKEN_LEN];
+          memcpy (token, data + 1, QUIC_STATELESS_RESET_TOKEN_LEN);
+
+          SocketQUICConnection_set_stateless_reset_token (conn, token);
+
+          /* Verify stateless reset with matching token */
+          uint8_t packet[100];
+          size_t packet_len = (size > 50) ? 50 : size;
+          memcpy (packet, data + 17, packet_len - 17);
+          /* Put token at end of packet */
+          if (packet_len >= QUIC_STATELESS_RESET_TOKEN_LEN)
+            {
+              memcpy (packet + packet_len - QUIC_STATELESS_RESET_TOKEN_LEN,
+                      token, QUIC_STATELESS_RESET_TOKEN_LEN);
+            }
+
+          int valid = SocketQUICConnection_verify_stateless_reset (
+              packet, packet_len, token);
+          (void)valid;
+
+          /* Verify with wrong token */
+          uint8_t wrong_token[QUIC_STATELESS_RESET_TOKEN_LEN];
+          memset (wrong_token, 0xAB, QUIC_STATELESS_RESET_TOKEN_LEN);
+          valid = SocketQUICConnection_verify_stateless_reset (
+              packet, packet_len, wrong_token);
+          (void)valid;
+
+          /* Verify with fuzzed packet */
+          valid = SocketQUICConnection_verify_stateless_reset (data, size,
+                                                               token);
+          (void)valid;
+
+          /* Test edge cases */
+          valid = SocketQUICConnection_verify_stateless_reset (
+              packet, QUIC_STATELESS_RESET_TOKEN_LEN - 1, token);
+          (void)valid;
+          valid = SocketQUICConnection_verify_stateless_reset (
+              packet, QUIC_STATELESS_RESET_TOKEN_LEN, token);
+          (void)valid;
+
+          /* Test NULL inputs */
+          SocketQUICConnection_set_stateless_reset_token (NULL, token);
+          SocketQUICConnection_verify_stateless_reset (NULL, 0, token);
+          SocketQUICConnection_verify_stateless_reset (packet, packet_len,
+                                                       NULL);
+          break;
+        }
+
+      case OP_STRING_FUNCTIONS:
+        {
+          /* Test all string functions */
+
+          /* Result codes */
+          SocketQUICConnection_Result results[]
+              = { QUIC_CONN_OK,           QUIC_CONN_ERROR_NULL,
+                  QUIC_CONN_ERROR_FULL,   QUIC_CONN_ERROR_EXISTS,
+                  QUIC_CONN_ERROR_NOT_FOUND, QUIC_CONN_ERROR_CID_LIMIT,
+                  QUIC_CONN_ERROR_CHAIN_LIMIT, QUIC_CONN_ERROR_ZERO_DCID,
+                  QUIC_CONN_ERROR_MEMORY };
+          for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+            {
+              const char *str = SocketQUICConnection_result_string (results[i]);
+              (void)str;
+            }
+          SocketQUICConnection_result_string (
+              (SocketQUICConnection_Result)data[1]);
+
+          /* States */
+          SocketQUICConnection_State states[]
+              = { QUIC_CONN_STATE_IDLE,      QUIC_CONN_STATE_HANDSHAKE,
+                  QUIC_CONN_STATE_ESTABLISHED, QUIC_CONN_STATE_CLOSING,
+                  QUIC_CONN_STATE_DRAINING,  QUIC_CONN_STATE_CLOSED };
+          for (size_t i = 0; i < sizeof (states) / sizeof (states[0]); i++)
+            {
+              const char *str = SocketQUICConnection_state_string (states[i]);
+              (void)str;
+            }
+          SocketQUICConnection_state_string (
+              (SocketQUICConnection_State)data[2]);
+
+          /* Roles */
+          const char *client_str
+              = SocketQUICConnection_role_string (QUIC_CONN_ROLE_CLIENT);
+          const char *server_str
+              = SocketQUICConnection_role_string (QUIC_CONN_ROLE_SERVER);
+          (void)client_str;
+          (void)server_str;
+          SocketQUICConnection_role_string ((SocketQUICConnection_Role)data[3]);
+
+          /* Test address lookup */
+          SocketQUICConnTable_T table
+              = SocketQUICConnTable_new (arena, QUIC_CONNTABLE_DEFAULT_SIZE);
+          if (table)
+            {
+              uint8_t local_addr[16], peer_addr[16];
+              memcpy (local_addr, data + 4, 16);
+              memcpy (peer_addr, data + 20, 16);
+
+              SocketQUICConnection_T found
+                  = SocketQUICConnTable_lookup_by_addr (table, local_addr,
+                                                        peer_addr, 443, 12345,
+                                                        data[36] & 1);
+              (void)found;
+
+              SocketQUICConnTable_lookup_by_addr (NULL, local_addr, peer_addr,
+                                                  0, 0, 0);
+              SocketQUICConnTable_free (&table);
+            }
+          break;
+        }
+      }
+  }
+  EXCEPT (SocketQUICConnTable_Failed)
+  {
+    /* Expected on table errors */
+  }
+  EXCEPT (SocketQUICConnection_Failed)
+  {
+    /* Expected on connection errors */
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_crypto.c
+++ b/src/fuzz/fuzz_quic_crypto.c
@@ -1,0 +1,509 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_crypto.c - libFuzzer for QUIC Cryptographic Operations (RFC 9001)
+ *
+ * Fuzzes key derivation, packet protection, and header protection:
+ * - Initial key derivation from DCID
+ * - Traffic key derivation from secrets
+ * - AEAD encryption/decryption
+ * - Header protection/unprotection
+ * - Key update operations
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_crypto
+ * ./fuzz_quic_crypto corpus/quic_crypto/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICCrypto.h"
+#include "quic/SocketQUICConnectionID.h"
+
+/* Operation types */
+enum
+{
+  OP_DERIVE_INITIAL_KEYS,
+  OP_DERIVE_TRAFFIC_KEYS,
+  OP_DERIVE_PACKET_KEYS,
+  OP_ENCRYPT_DECRYPT,
+  OP_HEADER_PROTECTION,
+  OP_KEY_UPDATE,
+  OP_AEAD_SIZES,
+  OP_RESULT_STRINGS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+/* Helper to read uint32_t from buffer */
+static uint32_t
+read_u32 (const uint8_t *data)
+{
+  return ((uint32_t)data[0] << 24) | ((uint32_t)data[1] << 16)
+         | ((uint32_t)data[2] << 8) | data[3];
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 17)
+    return 0;
+
+  uint8_t op = data[0] % OP_MAX;
+
+  switch (op)
+    {
+    case OP_DERIVE_INITIAL_KEYS:
+      {
+        /* Test initial key derivation from DCID */
+        if (size < 25)
+          return 0;
+
+        uint8_t dcid_len = (data[1] % 20) + 1; /* 1-20 bytes */
+        if (size < (size_t)(2 + dcid_len + 4))
+          return 0;
+
+        SocketQUICConnectionID_T dcid;
+        SocketQUICConnectionID_init (&dcid);
+        SocketQUICConnectionID_set (&dcid, data + 2, dcid_len);
+
+        uint32_t version = read_u32 (data + 2 + dcid_len);
+
+        /* Try known versions */
+        uint32_t versions[]
+            = { QUIC_VERSION_1, QUIC_VERSION_2, version, 0, 0xFFFFFFFF };
+
+        for (size_t i = 0; i < sizeof (versions) / sizeof (versions[0]); i++)
+          {
+            SocketQUICInitialKeys_T keys;
+            SocketQUICCryptoSecrets_T secrets;
+
+            SocketQUICCrypto_Result result
+                = SocketQUICCrypto_derive_initial_keys (&dcid, versions[i],
+                                                        &keys);
+            (void)result;
+
+            result = SocketQUICCrypto_derive_initial_secrets (&dcid,
+                                                              versions[i],
+                                                              &secrets, &keys);
+            (void)result;
+
+            /* Test with NULL secrets output */
+            result = SocketQUICCrypto_derive_initial_secrets (&dcid,
+                                                              versions[i], NULL,
+                                                              &keys);
+            (void)result;
+
+            /* Clear secrets */
+            SocketQUICCryptoSecrets_clear (&secrets);
+          }
+
+        /* Test NULL inputs */
+        SocketQUICInitialKeys_T keys;
+        SocketQUICCrypto_derive_initial_keys (NULL, QUIC_VERSION_1, &keys);
+        SocketQUICCrypto_derive_initial_keys (&dcid, QUIC_VERSION_1, NULL);
+        break;
+      }
+
+    case OP_DERIVE_TRAFFIC_KEYS:
+      {
+        /* Test traffic key derivation */
+        if (size < 49)
+          return 0;
+
+        uint8_t secret[48];
+        memcpy (secret, data + 1, 48);
+
+        uint8_t key[32];
+        uint8_t iv[12];
+        uint8_t hp_key[32];
+
+        /* Test with 32-byte secret (SHA-256) */
+        SocketQUICCrypto_Result result = SocketQUICCrypto_derive_traffic_keys (
+            secret, SOCKET_CRYPTO_SHA256_SIZE, key, iv, hp_key);
+        (void)result;
+
+        /* Test with 48-byte secret (SHA-384) */
+        result = SocketQUICCrypto_derive_traffic_keys (secret, 48, key, iv,
+                                                       hp_key);
+        (void)result;
+
+        /* Test with wrong sizes */
+        result = SocketQUICCrypto_derive_traffic_keys (secret, 0, key, iv,
+                                                       hp_key);
+        (void)result;
+        result = SocketQUICCrypto_derive_traffic_keys (secret, 16, key, iv,
+                                                       hp_key);
+        (void)result;
+
+        /* Test NULL inputs */
+        SocketQUICCrypto_derive_traffic_keys (NULL, 32, key, iv, hp_key);
+        SocketQUICCrypto_derive_traffic_keys (secret, 32, NULL, iv, hp_key);
+        break;
+      }
+
+    case OP_DERIVE_PACKET_KEYS:
+      {
+        /* Test packet key derivation for different AEAD algorithms */
+        if (size < 50)
+          return 0;
+
+        uint8_t secret[48];
+        memcpy (secret, data + 1, 48);
+        uint8_t aead_idx = data[49] % (QUIC_AEAD_COUNT + 1);
+
+        SocketQUICPacketKeys_T keys;
+        SocketQUICPacketKeys_init (&keys);
+
+        for (int aead = 0; aead < QUIC_AEAD_COUNT; aead++)
+          {
+            size_t secret_len = 0;
+            SocketQUICCrypto_get_aead_secret_len ((SocketQUIC_AEAD)aead,
+                                                  &secret_len);
+
+            SocketQUICCrypto_Result result = SocketQUICCrypto_derive_packet_keys (
+                secret, secret_len, (SocketQUIC_AEAD)aead, &keys);
+            (void)result;
+
+            /* Test with wrong secret length */
+            result = SocketQUICCrypto_derive_packet_keys (
+                secret, secret_len + 1, (SocketQUIC_AEAD)aead, &keys);
+            (void)result;
+
+            SocketQUICPacketKeys_clear (&keys);
+          }
+
+        /* Test invalid AEAD */
+        SocketQUICCrypto_derive_packet_keys (secret, 32,
+                                             (SocketQUIC_AEAD)aead_idx, &keys);
+        SocketQUICCrypto_derive_packet_keys (secret, 32, (SocketQUIC_AEAD)255,
+                                             &keys);
+
+        /* Test NULL inputs */
+        SocketQUICCrypto_derive_packet_keys (NULL, 32, QUIC_AEAD_AES_128_GCM,
+                                             &keys);
+        SocketQUICCrypto_derive_packet_keys (secret, 32, QUIC_AEAD_AES_128_GCM,
+                                             NULL);
+        break;
+      }
+
+    case OP_ENCRYPT_DECRYPT:
+      {
+        /* Test AEAD encryption and decryption */
+        if (size < 100)
+          return 0;
+
+        /* Set up keys from fuzz data */
+        SocketQUICPacketKeys_T keys;
+        SocketQUICPacketKeys_init (&keys);
+
+        memcpy (keys.key, data + 1, 32);
+        memcpy (keys.iv, data + 33, 12);
+        memcpy (keys.hp_key, data + 45, 32);
+        keys.key_len = 16;
+        keys.hp_len = 16;
+        keys.aead = (SocketQUIC_AEAD)(data[77] % QUIC_AEAD_COUNT);
+
+        uint64_t packet_number = read_u64 (data + 78);
+
+        /* Header and plaintext from remaining data */
+        size_t header_len = (data[86] % 20) + 1;
+        size_t plaintext_len = (data[87] % 50) + 1;
+
+        if (size < 88 + header_len + plaintext_len)
+          return 0;
+
+        const uint8_t *header = data + 88;
+        const uint8_t *plaintext = data + 88 + header_len;
+
+        uint8_t ciphertext[256];
+        size_t ciphertext_len = sizeof (ciphertext);
+
+        SocketQUICCrypto_Result result = SocketQUICCrypto_encrypt_payload (
+            &keys, packet_number, header, header_len, plaintext, plaintext_len,
+            ciphertext, &ciphertext_len);
+
+        if (result == QUIC_CRYPTO_OK)
+          {
+            /* Try to decrypt what we encrypted */
+            uint8_t decrypted[256];
+            size_t decrypted_len = sizeof (decrypted);
+
+            result = SocketQUICCrypto_decrypt_payload (&keys, packet_number,
+                                                       header, header_len,
+                                                       ciphertext, ciphertext_len,
+                                                       decrypted, &decrypted_len);
+            (void)result;
+          }
+
+        /* Test with fuzzed ciphertext directly */
+        if (size >= 120)
+          {
+            uint8_t decrypted[256];
+            size_t decrypted_len = sizeof (decrypted);
+            result = SocketQUICCrypto_decrypt_payload (
+                &keys, packet_number, header, header_len, data + 100,
+                size - 100, decrypted, &decrypted_len);
+            (void)result;
+          }
+
+        /* Test NULL and edge cases */
+        SocketQUICCrypto_encrypt_payload (NULL, 0, header, header_len,
+                                          plaintext, plaintext_len, ciphertext,
+                                          &ciphertext_len);
+        SocketQUICCrypto_encrypt_payload (&keys, 0, NULL, 0, plaintext,
+                                          plaintext_len, ciphertext,
+                                          &ciphertext_len);
+
+        SocketQUICPacketKeys_clear (&keys);
+        break;
+      }
+
+    case OP_HEADER_PROTECTION:
+      {
+        /* Test header protection operations */
+        if (size < 80)
+          return 0;
+
+        uint8_t hp_key[32];
+        memcpy (hp_key, data + 1, 32);
+
+        uint8_t packet[256];
+        size_t packet_len = (size - 40 > 256) ? 256 : (size - 40);
+        if (packet_len < 21)
+          packet_len = 21; /* Minimum for header protection */
+        memcpy (packet, data + 33, packet_len);
+
+        size_t pn_offset = (data[34] % (packet_len - 16)) + 1;
+        if (pn_offset > packet_len - 16)
+          pn_offset = 1;
+
+        /* Test for each AEAD algorithm */
+        for (int aead = 0; aead < QUIC_AEAD_COUNT; aead++)
+          {
+            size_t key_len = (aead == QUIC_AEAD_AES_128_GCM) ? 16 : 32;
+
+            /* Make a copy for protect/unprotect roundtrip */
+            uint8_t test_packet[256];
+            memcpy (test_packet, packet, packet_len);
+
+            SocketQUICCrypto_Result result = SocketQUICCrypto_protect_header (
+                hp_key, key_len, (SocketQUIC_AEAD)aead, test_packet, packet_len,
+                pn_offset);
+            (void)result;
+
+            /* Unprotect should restore original */
+            result = SocketQUICCrypto_unprotect_header (
+                hp_key, key_len, (SocketQUIC_AEAD)aead, test_packet, packet_len,
+                pn_offset);
+            (void)result;
+          }
+
+        /* Test the _ex variants with SocketQUICPacketKeys_T */
+        SocketQUICPacketKeys_T keys;
+        SocketQUICPacketKeys_init (&keys);
+        memcpy (keys.hp_key, hp_key, 32);
+        keys.hp_len = 16;
+        keys.aead = QUIC_AEAD_AES_128_GCM;
+
+        uint8_t test_packet2[256];
+        memcpy (test_packet2, packet, packet_len);
+        SocketQUICCrypto_protect_header_ex (&keys, test_packet2, packet_len,
+                                            pn_offset);
+        SocketQUICCrypto_unprotect_header_ex (&keys, test_packet2, packet_len,
+                                              pn_offset);
+
+        /* Test NULL and edge cases */
+        SocketQUICCrypto_protect_header (NULL, 16, QUIC_AEAD_AES_128_GCM,
+                                         test_packet2, packet_len, pn_offset);
+        SocketQUICCrypto_protect_header (hp_key, 16, QUIC_AEAD_AES_128_GCM,
+                                         NULL, 0, 0);
+        SocketQUICCrypto_protect_header_ex (NULL, test_packet2, packet_len,
+                                            pn_offset);
+        break;
+      }
+
+    case OP_KEY_UPDATE:
+      {
+        /* Test key update state machine */
+        if (size < 100)
+          return 0;
+
+        SocketQUICKeyUpdate_T state;
+        SocketQUICKeyUpdate_init (&state);
+
+        uint8_t write_secret[48];
+        uint8_t read_secret[48];
+        memcpy (write_secret, data + 1, 48);
+        memcpy (read_secret, data + 49, 48);
+
+        /* Test for each AEAD */
+        for (int aead = 0; aead < QUIC_AEAD_COUNT; aead++)
+          {
+            size_t secret_len = 0;
+            SocketQUICCrypto_get_aead_secret_len ((SocketQUIC_AEAD)aead,
+                                                  &secret_len);
+
+            SocketQUICKeyUpdate_init (&state);
+            SocketQUICCrypto_Result result
+                = SocketQUICKeyUpdate_set_initial_keys (
+                    &state, write_secret, read_secret, secret_len,
+                    (SocketQUIC_AEAD)aead);
+            (void)result;
+
+            /* Test can_initiate before any acks */
+            int can = SocketQUICKeyUpdate_can_initiate (&state);
+            (void)can;
+
+            /* Record some packets */
+            SocketQUICKeyUpdate_on_packet_sent (&state, 0);
+            SocketQUICKeyUpdate_on_packet_sent (&state, 1);
+
+            /* Record ACK - should enable key update */
+            SocketQUICKeyUpdate_on_ack_received (&state, 0);
+            can = SocketQUICKeyUpdate_can_initiate (&state);
+            (void)can;
+
+            /* Try to initiate key update */
+            if (can)
+              {
+                result = SocketQUICKeyUpdate_initiate (&state);
+                (void)result;
+              }
+
+            /* Test received key phase processing */
+            int received_phase = data[97] & 1;
+            result
+                = SocketQUICKeyUpdate_process_received (&state, received_phase);
+            (void)result;
+
+            /* Get read keys for decryption */
+            const SocketQUICPacketKeys_T *read_keys = NULL;
+            result = SocketQUICKeyUpdate_get_read_keys (&state, received_phase,
+                                                        100, &read_keys);
+            (void)result;
+
+            /* Test encryption/decryption counting */
+            SocketQUICKeyUpdate_on_encrypt (&state);
+            SocketQUICKeyUpdate_on_decrypt (&state);
+            SocketQUICKeyUpdate_on_decrypt_failure (&state);
+
+            /* Check limits */
+            int conf_limit
+                = SocketQUICKeyUpdate_confidentiality_limit_reached (&state);
+            int int_limit
+                = SocketQUICKeyUpdate_integrity_limit_exceeded (&state);
+            (void)conf_limit;
+            (void)int_limit;
+
+            SocketQUICKeyUpdate_clear (&state);
+          }
+
+        /* Test derive_next_secret */
+        uint8_t next_secret[48];
+        SocketQUICCrypto_derive_next_secret (write_secret, 32,
+                                             QUIC_AEAD_AES_128_GCM,
+                                             next_secret);
+        SocketQUICCrypto_derive_next_secret (write_secret, 48,
+                                             QUIC_AEAD_AES_256_GCM,
+                                             next_secret);
+
+        /* Test NULL inputs */
+        SocketQUICKeyUpdate_init (NULL);
+        SocketQUICKeyUpdate_clear (NULL);
+        SocketQUICKeyUpdate_set_initial_keys (NULL, write_secret, read_secret,
+                                              32, QUIC_AEAD_AES_128_GCM);
+        SocketQUICKeyUpdate_can_initiate (NULL);
+        break;
+      }
+
+    case OP_AEAD_SIZES:
+      {
+        /* Test AEAD size query functions */
+        for (int aead = 0; aead <= QUIC_AEAD_COUNT; aead++)
+          {
+            size_t key_len = 0, iv_len = 0, hp_len = 0, secret_len = 0;
+
+            SocketQUICCrypto_get_aead_key_sizes ((SocketQUIC_AEAD)aead,
+                                                 &key_len, &iv_len, &hp_len);
+            SocketQUICCrypto_get_aead_secret_len ((SocketQUIC_AEAD)aead,
+                                                  &secret_len);
+
+            /* Test with NULL outputs */
+            SocketQUICCrypto_get_aead_key_sizes ((SocketQUIC_AEAD)aead, NULL,
+                                                 NULL, NULL);
+            SocketQUICCrypto_get_aead_secret_len ((SocketQUIC_AEAD)aead, NULL);
+
+            /* Test AEAD name */
+            const char *name = SocketQUIC_AEAD_string ((SocketQUIC_AEAD)aead);
+            (void)name;
+
+            /* Test limits */
+            uint64_t conf_limit
+                = SocketQUICCrypto_get_confidentiality_limit ((SocketQUIC_AEAD)aead);
+            uint64_t int_limit
+                = SocketQUICCrypto_get_integrity_limit ((SocketQUIC_AEAD)aead);
+            (void)conf_limit;
+            (void)int_limit;
+          }
+
+        /* Test key phase helpers */
+        uint8_t first_byte = data[1];
+        int phase = SocketQUICCrypto_get_key_phase (first_byte);
+        (void)phase;
+
+        SocketQUICCrypto_set_key_phase (&first_byte, 0);
+        SocketQUICCrypto_set_key_phase (&first_byte, 1);
+        break;
+      }
+
+    case OP_RESULT_STRINGS:
+      {
+        /* Test result string functions */
+        SocketQUICCrypto_Result results[]
+            = { QUIC_CRYPTO_OK,       QUIC_CRYPTO_ERROR_NULL,
+                QUIC_CRYPTO_ERROR_VERSION, QUIC_CRYPTO_ERROR_HKDF,
+                QUIC_CRYPTO_ERROR_NO_TLS,  QUIC_CRYPTO_ERROR_AEAD,
+                QUIC_CRYPTO_ERROR_SECRET_LEN, QUIC_CRYPTO_ERROR_BUFFER,
+                QUIC_CRYPTO_ERROR_TAG,     QUIC_CRYPTO_ERROR_INPUT };
+
+        for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+          {
+            const char *str = SocketQUICCrypto_result_string (results[i]);
+            (void)str;
+          }
+
+        /* Test with fuzzed value */
+        const char *str
+            = SocketQUICCrypto_result_string ((SocketQUICCrypto_Result)data[1]);
+        (void)str;
+
+        /* Test salt access */
+        const uint8_t *salt = NULL;
+        size_t salt_len = 0;
+        SocketQUICCrypto_get_initial_salt (QUIC_VERSION_1, &salt, &salt_len);
+        SocketQUICCrypto_get_initial_salt (QUIC_VERSION_2, &salt, &salt_len);
+        SocketQUICCrypto_get_initial_salt (0, &salt, &salt_len);
+        SocketQUICCrypto_get_initial_salt (QUIC_VERSION_1, NULL, NULL);
+        break;
+      }
+    }
+
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_flow.c
+++ b/src/fuzz/fuzz_quic_flow.c
@@ -1,0 +1,321 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_flow.c - libFuzzer for QUIC Flow Control (RFC 9000 Section 4)
+ *
+ * Fuzzes connection and stream-level flow control:
+ * - Send/receive window management
+ * - MAX_DATA/MAX_STREAM_DATA updates
+ * - Stream count limits (MAX_STREAMS)
+ * - Blocked state detection
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_flow
+ * ./fuzz_quic_flow corpus/quic_flow/ -fork=16 -max_len=1024
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICFlow.h"
+
+/* Operation types */
+enum
+{
+  OP_CONNECTION_FLOW,
+  OP_STREAM_FLOW,
+  OP_STREAM_COUNTS,
+  OP_WINDOW_UPDATES,
+  OP_RESULT_STRINGS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 50)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_CONNECTION_FLOW:
+        {
+          /* Test connection-level flow control */
+          SocketQUICFlow_T fc = SocketQUICFlow_new (arena);
+          if (!fc)
+            break;
+
+          /* Initialize with fuzzed values */
+          uint64_t recv_max = read_u64 (data + 1);
+          uint64_t send_max = read_u64 (data + 9);
+          uint64_t max_bidi = read_u64 (data + 17) % 1000;
+          uint64_t max_uni = read_u64 (data + 25) % 1000;
+
+          SocketQUICFlow_Result result
+              = SocketQUICFlow_init (fc, recv_max, send_max, max_bidi, max_uni);
+          (void)result;
+
+          /* Test can_send with various sizes */
+          size_t bytes_to_send = (size_t)read_u64 (data + 33);
+          int can = SocketQUICFlow_can_send (fc, bytes_to_send);
+          (void)can;
+
+          /* Consume some send window */
+          result = SocketQUICFlow_consume_send (fc, 1000);
+          (void)result;
+
+          /* Check windows */
+          uint64_t send_win = SocketQUICFlow_send_window (fc);
+          uint64_t recv_win = SocketQUICFlow_recv_window (fc);
+          (void)send_win;
+          (void)recv_win;
+
+          /* Consume receive window */
+          result = SocketQUICFlow_consume_recv (fc, 500);
+          (void)result;
+
+          /* Try to exceed limits */
+          result = SocketQUICFlow_consume_send (fc, QUIC_FLOW_MAX_WINDOW);
+          (void)result;
+
+          /* Update max data values */
+          uint64_t new_send_max = read_u64 (data + 41);
+          result = SocketQUICFlow_update_send_max (fc, new_send_max);
+          (void)result;
+
+          result = SocketQUICFlow_update_recv_max (fc, recv_max * 2);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICFlow_can_send (NULL, 100);
+          SocketQUICFlow_consume_send (NULL, 100);
+          SocketQUICFlow_consume_recv (NULL, 100);
+          SocketQUICFlow_send_window (NULL);
+          SocketQUICFlow_recv_window (NULL);
+          SocketQUICFlow_update_send_max (NULL, 1000);
+          SocketQUICFlow_update_recv_max (NULL, 1000);
+          SocketQUICFlow_init (NULL, 0, 0, 0, 0);
+          break;
+        }
+
+      case OP_STREAM_FLOW:
+        {
+          /* Test stream-level flow control */
+          uint64_t stream_id = read_u64 (data + 1);
+
+          SocketQUICFlowStream_T fs
+              = SocketQUICFlowStream_new (arena, stream_id);
+          if (!fs)
+            break;
+
+          /* Initialize with fuzzed values */
+          uint64_t recv_max = read_u64 (data + 9);
+          uint64_t send_max = read_u64 (data + 17);
+
+          SocketQUICFlow_Result result
+              = SocketQUICFlowStream_init (fs, stream_id, recv_max, send_max);
+          (void)result;
+
+          /* Test can_send */
+          size_t bytes = (size_t)read_u64 (data + 25);
+          int can = SocketQUICFlowStream_can_send (fs, bytes);
+          (void)can;
+
+          /* Consume windows */
+          result = SocketQUICFlowStream_consume_send (fs, 100);
+          (void)result;
+          result = SocketQUICFlowStream_consume_recv (fs, 200);
+          (void)result;
+
+          /* Check windows */
+          uint64_t send_win = SocketQUICFlowStream_send_window (fs);
+          uint64_t recv_win = SocketQUICFlowStream_recv_window (fs);
+          (void)send_win;
+          (void)recv_win;
+
+          /* Update max values */
+          uint64_t new_max = read_u64 (data + 33);
+          result = SocketQUICFlowStream_update_send_max (fs, new_max);
+          (void)result;
+          result = SocketQUICFlowStream_update_recv_max (fs, new_max);
+          (void)result;
+
+          /* Test with maximum window */
+          result
+              = SocketQUICFlowStream_update_send_max (fs, QUIC_FLOW_MAX_WINDOW);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICFlowStream_can_send (NULL, 100);
+          SocketQUICFlowStream_consume_send (NULL, 100);
+          SocketQUICFlowStream_consume_recv (NULL, 100);
+          SocketQUICFlowStream_send_window (NULL);
+          SocketQUICFlowStream_recv_window (NULL);
+          SocketQUICFlowStream_update_send_max (NULL, 1000);
+          SocketQUICFlowStream_update_recv_max (NULL, 1000);
+          SocketQUICFlowStream_init (NULL, 0, 0, 0);
+          break;
+        }
+
+      case OP_STREAM_COUNTS:
+        {
+          /* Test stream count management */
+          SocketQUICFlow_T fc = SocketQUICFlow_new (arena);
+          if (!fc)
+            break;
+
+          uint64_t max_bidi = (read_u64 (data + 1) % 100) + 1;
+          uint64_t max_uni = (read_u64 (data + 9) % 100) + 1;
+
+          SocketQUICFlow_init (fc, QUIC_FLOW_DEFAULT_CONN_WINDOW,
+                               QUIC_FLOW_DEFAULT_CONN_WINDOW, max_bidi,
+                               max_uni);
+
+          /* Check if we can open streams */
+          int can_bidi = SocketQUICFlow_can_open_stream_bidi (fc);
+          int can_uni = SocketQUICFlow_can_open_stream_uni (fc);
+          (void)can_bidi;
+          (void)can_uni;
+
+          /* Open streams until limit */
+          for (uint64_t i = 0; i < max_bidi + 5; i++)
+            {
+              can_bidi = SocketQUICFlow_can_open_stream_bidi (fc);
+              SocketQUICFlow_Result result
+                  = SocketQUICFlow_open_stream_bidi (fc);
+              (void)can_bidi;
+              (void)result;
+            }
+
+          for (uint64_t i = 0; i < max_uni + 5; i++)
+            {
+              can_uni = SocketQUICFlow_can_open_stream_uni (fc);
+              SocketQUICFlow_Result result
+                  = SocketQUICFlow_open_stream_uni (fc);
+              (void)can_uni;
+              (void)result;
+            }
+
+          /* Close some streams */
+          for (int i = 0; i < 10; i++)
+            {
+              SocketQUICFlow_close_stream_bidi (fc);
+              SocketQUICFlow_close_stream_uni (fc);
+            }
+
+          /* Update stream limits */
+          uint64_t new_max_bidi = read_u64 (data + 17);
+          uint64_t new_max_uni = read_u64 (data + 25);
+          SocketQUICFlow_update_max_streams_bidi (fc, new_max_bidi);
+          SocketQUICFlow_update_max_streams_uni (fc, new_max_uni);
+
+          /* Test NULL inputs */
+          SocketQUICFlow_can_open_stream_bidi (NULL);
+          SocketQUICFlow_can_open_stream_uni (NULL);
+          SocketQUICFlow_open_stream_bidi (NULL);
+          SocketQUICFlow_open_stream_uni (NULL);
+          SocketQUICFlow_close_stream_bidi (NULL);
+          SocketQUICFlow_close_stream_uni (NULL);
+          SocketQUICFlow_update_max_streams_bidi (NULL, 100);
+          SocketQUICFlow_update_max_streams_uni (NULL, 100);
+          break;
+        }
+
+      case OP_WINDOW_UPDATES:
+        {
+          /* Test window update edge cases */
+          SocketQUICFlow_T fc = SocketQUICFlow_new (arena);
+          if (!fc)
+            break;
+
+          /* Initialize with small windows */
+          SocketQUICFlow_init (fc, 1000, 1000, 10, 10);
+
+          /* Repeatedly consume and update */
+          for (int i = 0; i < 20; i++)
+            {
+              size_t bytes = (size_t)(data[1 + i % (size - 1)] * 10);
+              SocketQUICFlow_consume_send (fc, bytes);
+              SocketQUICFlow_consume_recv (fc, bytes);
+
+              uint64_t new_max = read_u64 (data + 1 + (i * 8) % (size - 8));
+              SocketQUICFlow_update_send_max (fc, new_max);
+              SocketQUICFlow_update_recv_max (fc, new_max);
+            }
+
+          /* Test with extreme values */
+          SocketQUICFlow_update_send_max (fc, 0);
+          SocketQUICFlow_update_recv_max (fc, 0);
+          SocketQUICFlow_update_send_max (fc, UINT64_MAX);
+          SocketQUICFlow_update_recv_max (fc, UINT64_MAX);
+          SocketQUICFlow_update_send_max (fc, QUIC_FLOW_MAX_WINDOW);
+          SocketQUICFlow_update_recv_max (fc, QUIC_FLOW_MAX_WINDOW);
+          SocketQUICFlow_update_send_max (fc, QUIC_FLOW_MAX_WINDOW + 1);
+          SocketQUICFlow_update_recv_max (fc, QUIC_FLOW_MAX_WINDOW + 1);
+
+          /* Stream flow with extreme values */
+          SocketQUICFlowStream_T fs = SocketQUICFlowStream_new (arena, 0);
+          if (fs)
+            {
+              SocketQUICFlowStream_init (fs, 0, 0, 0);
+              SocketQUICFlowStream_update_send_max (fs, QUIC_FLOW_MAX_WINDOW);
+              SocketQUICFlowStream_consume_send (fs, QUIC_FLOW_MAX_WINDOW);
+            }
+          break;
+        }
+
+      case OP_RESULT_STRINGS:
+        {
+          /* Test result string function */
+          SocketQUICFlow_Result results[]
+              = { QUIC_FLOW_OK,        QUIC_FLOW_ERROR_NULL,
+                  QUIC_FLOW_ERROR_BLOCKED, QUIC_FLOW_ERROR_OVERFLOW,
+                  QUIC_FLOW_ERROR_INVALID };
+
+          for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+            {
+              const char *str = SocketQUICFlow_result_string (results[i]);
+              (void)str;
+            }
+
+          /* Test with fuzzed value */
+          const char *str
+              = SocketQUICFlow_result_string ((SocketQUICFlow_Result)data[1]);
+          (void)str;
+          break;
+        }
+      }
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_handshake.c
+++ b/src/fuzz/fuzz_quic_handshake.c
@@ -1,0 +1,431 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_handshake.c - libFuzzer for QUIC Handshake (RFC 9000 Section 7)
+ *
+ * Fuzzes handshake state machine and key management:
+ * - Handshake state transitions
+ * - Key availability checks
+ * - Key discard triggers
+ * - 0-RTT early data state machine
+ * - Transport parameter handling
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_handshake
+ * ./fuzz_quic_handshake corpus/quic_handshake/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICConnection.h"
+#include "quic/SocketQUICHandshake.h"
+#include "quic/SocketQUICTransportParams.h"
+
+/* Operation types */
+enum
+{
+  OP_HANDSHAKE_LIFECYCLE,
+  OP_KEY_MANAGEMENT,
+  OP_KEY_DISCARD,
+  OP_0RTT_STATE,
+  OP_TRANSPORT_PARAMS,
+  OP_STRING_FUNCTIONS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 50)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_HANDSHAKE_LIFECYCLE:
+        {
+          /* Test handshake creation and state queries */
+          SocketQUICConnection_Role role
+              = (data[1] & 1) ? QUIC_CONN_ROLE_SERVER : QUIC_CONN_ROLE_CLIENT;
+
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, role);
+          if (!conn)
+            break;
+
+          SocketQUICHandshake_T hs
+              = SocketQUICHandshake_new (arena, conn, role);
+          if (!hs)
+            break;
+
+          /* Query initial state */
+          SocketQUICHandshakeState state = SocketQUICHandshake_get_state (hs);
+          int is_complete = SocketQUICHandshake_is_complete (hs);
+          int is_confirmed = SocketQUICHandshake_is_confirmed (hs);
+          (void)state;
+          (void)is_complete;
+          (void)is_confirmed;
+
+          /* Get peer params (should be NULL initially) */
+          const SocketQUICTransportParams_T *peer_params
+              = SocketQUICHandshake_get_peer_params (hs);
+          (void)peer_params;
+
+          /* Try process (may fail without TLS setup, but exercises code paths) */
+          SocketQUICHandshake_Result result = SocketQUICHandshake_process (hs);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICHandshake_get_state (NULL);
+          SocketQUICHandshake_is_complete (NULL);
+          SocketQUICHandshake_is_confirmed (NULL);
+          SocketQUICHandshake_get_peer_params (NULL);
+          SocketQUICHandshake_process (NULL);
+
+          /* Free */
+          SocketQUICHandshake_free (&hs);
+          break;
+        }
+
+      case OP_KEY_MANAGEMENT:
+        {
+          /* Test key availability and retrieval */
+          SocketQUICConnection_Role role
+              = (data[1] & 1) ? QUIC_CONN_ROLE_SERVER : QUIC_CONN_ROLE_CLIENT;
+
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, role);
+          if (!conn)
+            break;
+
+          SocketQUICHandshake_T hs
+              = SocketQUICHandshake_new (arena, conn, role);
+          if (!hs)
+            break;
+
+          /* Check key availability for all levels */
+          for (int level = 0; level < QUIC_CRYPTO_LEVEL_COUNT; level++)
+            {
+              int has_keys
+                  = SocketQUICHandshake_has_keys (hs, (SocketQUICCryptoLevel)level);
+              void *keys
+                  = SocketQUICHandshake_get_keys (hs, (SocketQUICCryptoLevel)level);
+              (void)has_keys;
+              (void)keys;
+            }
+
+          /* Check send/receive availability */
+          int can_send_init = SocketQUICHandshake_can_send_initial (hs);
+          int can_recv_init = SocketQUICHandshake_can_receive_initial (hs);
+          int can_send_hs = SocketQUICHandshake_can_send_handshake (hs);
+          int can_recv_hs = SocketQUICHandshake_can_receive_handshake (hs);
+          int can_send_0rtt = SocketQUICHandshake_can_send_0rtt (hs);
+          int can_recv_0rtt = SocketQUICHandshake_can_receive_0rtt (hs);
+          (void)can_send_init;
+          (void)can_recv_init;
+          (void)can_send_hs;
+          (void)can_recv_hs;
+          (void)can_send_0rtt;
+          (void)can_recv_0rtt;
+
+          /* Discard keys */
+          for (int level = 0; level < QUIC_CRYPTO_LEVEL_COUNT; level++)
+            {
+              SocketQUICHandshake_discard_keys (hs, (SocketQUICCryptoLevel)level);
+            }
+
+          /* Test NULL inputs */
+          SocketQUICHandshake_has_keys (NULL, QUIC_CRYPTO_LEVEL_INITIAL);
+          SocketQUICHandshake_get_keys (NULL, QUIC_CRYPTO_LEVEL_INITIAL);
+          SocketQUICHandshake_discard_keys (NULL, QUIC_CRYPTO_LEVEL_INITIAL);
+          SocketQUICHandshake_can_send_initial (NULL);
+          SocketQUICHandshake_can_receive_initial (NULL);
+          SocketQUICHandshake_can_send_handshake (NULL);
+          SocketQUICHandshake_can_receive_handshake (NULL);
+          SocketQUICHandshake_can_send_0rtt (NULL);
+          SocketQUICHandshake_can_receive_0rtt (NULL);
+
+          SocketQUICHandshake_free (&hs);
+          break;
+        }
+
+      case OP_KEY_DISCARD:
+        {
+          /* Test key discard trigger functions */
+          SocketQUICConnection_Role role
+              = (data[1] & 1) ? QUIC_CONN_ROLE_SERVER : QUIC_CONN_ROLE_CLIENT;
+
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, role);
+          if (!conn)
+            break;
+
+          SocketQUICHandshake_T hs
+              = SocketQUICHandshake_new (arena, conn, role);
+          if (!hs)
+            break;
+
+          /* Test key discard triggers (order from RFC 9001) */
+
+          /* §4.9.1: Initial keys discarded when first Handshake sent/received
+           */
+          if (role == QUIC_CONN_ROLE_CLIENT)
+            {
+              /* Client: first Handshake packet sent */
+              SocketQUICHandshake_on_handshake_packet_sent (hs);
+              /* Should be idempotent */
+              SocketQUICHandshake_on_handshake_packet_sent (hs);
+            }
+          else
+            {
+              /* Server: first Handshake packet received */
+              SocketQUICHandshake_on_handshake_packet_received (hs);
+              SocketQUICHandshake_on_handshake_packet_received (hs);
+            }
+
+          /* Check Initial keys are discarded */
+          int can_send = SocketQUICHandshake_can_send_initial (hs);
+          int can_recv = SocketQUICHandshake_can_receive_initial (hs);
+          (void)can_send;
+          (void)can_recv;
+
+          /* §4.9.2: Handshake keys discarded when confirmed */
+          SocketQUICHandshake_on_confirmed (hs);
+          SocketQUICHandshake_on_confirmed (hs); /* Idempotent */
+
+          /* Check Handshake keys are discarded */
+          can_send = SocketQUICHandshake_can_send_handshake (hs);
+          can_recv = SocketQUICHandshake_can_receive_handshake (hs);
+          (void)can_send;
+          (void)can_recv;
+
+          /* §4.9.3: 0-RTT keys discarded when 1-RTT keys installed */
+          SocketQUICHandshake_on_1rtt_keys_installed (hs);
+          SocketQUICHandshake_on_1rtt_keys_installed (hs);
+
+          /* Server also discards on 1-RTT packet received */
+          if (role == QUIC_CONN_ROLE_SERVER)
+            {
+              SocketQUICHandshake_on_1rtt_packet_received (hs);
+              SocketQUICHandshake_on_1rtt_packet_received (hs);
+            }
+
+          /* Check 0-RTT keys are discarded */
+          int can_send_0rtt = SocketQUICHandshake_can_send_0rtt (hs);
+          int can_recv_0rtt = SocketQUICHandshake_can_receive_0rtt (hs);
+          (void)can_send_0rtt;
+          (void)can_recv_0rtt;
+
+          /* Test NULL inputs */
+          SocketQUICHandshake_on_handshake_packet_sent (NULL);
+          SocketQUICHandshake_on_handshake_packet_received (NULL);
+          SocketQUICHandshake_on_confirmed (NULL);
+          SocketQUICHandshake_on_1rtt_keys_installed (NULL);
+          SocketQUICHandshake_on_1rtt_packet_received (NULL);
+
+          SocketQUICHandshake_free (&hs);
+          break;
+        }
+
+      case OP_0RTT_STATE:
+        {
+          /* Test 0-RTT early data state machine */
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, QUIC_CONN_ROLE_CLIENT);
+          if (!conn)
+            break;
+
+          SocketQUICHandshake_T hs
+              = SocketQUICHandshake_new (arena, conn, QUIC_CONN_ROLE_CLIENT);
+          if (!hs)
+            break;
+
+          /* Initialize 0-RTT state */
+          SocketQUICHandshake_0rtt_init (hs);
+
+          /* Check initial state */
+          SocketQUIC0RTT_State state = SocketQUICHandshake_0rtt_get_state (hs);
+          int available = SocketQUICHandshake_0rtt_available (hs);
+          int accepted = SocketQUICHandshake_0rtt_accepted (hs);
+          (void)state;
+          (void)available;
+          (void)accepted;
+
+          /* Set a ticket (from fuzz data) */
+          size_t ticket_len = (data[2] % 100) + 10;
+          if (size >= 3 + ticket_len)
+            {
+              SocketQUICTransportParams_T saved_params;
+              SocketQUICTransportParams_init (&saved_params);
+              saved_params.max_idle_timeout = read_u64 (data + 3 + ticket_len);
+
+              const char *alpn = "h3";
+              SocketQUICHandshake_Result result
+                  = SocketQUICHandshake_0rtt_set_ticket (hs, data + 3,
+                                                         ticket_len,
+                                                         &saved_params, alpn,
+                                                         strlen (alpn));
+              (void)result;
+
+              /* Check state after ticket set */
+              state = SocketQUICHandshake_0rtt_get_state (hs);
+              available = SocketQUICHandshake_0rtt_available (hs);
+              (void)state;
+              (void)available;
+            }
+
+          /* Test HelloRetryRequest (forces 0-RTT rejection) */
+          SocketQUICHandshake_on_hello_retry_request (hs);
+          available = SocketQUICHandshake_0rtt_available (hs);
+          (void)available;
+
+          /* Test rejection handling */
+          SocketQUICHandshake_Result result
+              = SocketQUICHandshake_0rtt_handle_rejection (hs);
+          state = SocketQUICHandshake_0rtt_get_state (hs);
+          (void)result;
+          (void)state;
+
+          /* Test NULL inputs */
+          SocketQUICHandshake_0rtt_init (NULL);
+          SocketQUICHandshake_0rtt_get_state (NULL);
+          SocketQUICHandshake_0rtt_available (NULL);
+          SocketQUICHandshake_0rtt_accepted (NULL);
+          SocketQUICHandshake_0rtt_set_ticket (NULL, NULL, 0, NULL, NULL, 0);
+          SocketQUICHandshake_0rtt_handle_rejection (NULL);
+          SocketQUICHandshake_on_hello_retry_request (NULL);
+
+          SocketQUICHandshake_free (&hs);
+          break;
+        }
+
+      case OP_TRANSPORT_PARAMS:
+        {
+          /* Test transport parameter handling */
+          SocketQUICConnection_Role role
+              = (data[1] & 1) ? QUIC_CONN_ROLE_SERVER : QUIC_CONN_ROLE_CLIENT;
+
+          SocketQUICConnection_T conn
+              = SocketQUICConnection_new (arena, role);
+          if (!conn)
+            break;
+
+          SocketQUICHandshake_T hs
+              = SocketQUICHandshake_new (arena, conn, role);
+          if (!hs)
+            break;
+
+          /* Create transport parameters from fuzz data */
+          SocketQUICTransportParams_T params;
+          SocketQUICTransportParams_init (&params);
+
+          params.max_idle_timeout = read_u64 (data + 2);
+          params.max_udp_payload_size = read_u64 (data + 10) % 65536;
+          params.initial_max_data = read_u64 (data + 18);
+          params.initial_max_stream_data_bidi_local = read_u64 (data + 26);
+          params.initial_max_stream_data_bidi_remote = read_u64 (data + 34);
+          params.initial_max_stream_data_uni = read_u64 (data + 42);
+
+          /* Set transport parameters */
+          SocketQUICHandshake_Result result
+              = SocketQUICHandshake_set_transport_params (hs, &params);
+          (void)result;
+
+          /* Get peer params (not available yet) */
+          const SocketQUICTransportParams_T *peer
+              = SocketQUICHandshake_get_peer_params (hs);
+          (void)peer;
+
+          /* Test NULL inputs */
+          SocketQUICHandshake_set_transport_params (NULL, &params);
+          SocketQUICHandshake_set_transport_params (hs, NULL);
+
+          SocketQUICHandshake_free (&hs);
+          break;
+        }
+
+      case OP_STRING_FUNCTIONS:
+        {
+          /* Test all string conversion functions */
+
+          /* Crypto levels */
+          for (int level = 0; level <= QUIC_CRYPTO_LEVEL_COUNT; level++)
+            {
+              const char *str = SocketQUICHandshake_crypto_level_string (
+                  (SocketQUICCryptoLevel)level);
+              (void)str;
+            }
+          SocketQUICHandshake_crypto_level_string ((SocketQUICCryptoLevel)data[1]);
+
+          /* Handshake states */
+          SocketQUICHandshakeState states[]
+              = { QUIC_HANDSHAKE_STATE_IDLE,     QUIC_HANDSHAKE_STATE_INITIAL,
+                  QUIC_HANDSHAKE_STATE_HANDSHAKE, QUIC_HANDSHAKE_STATE_COMPLETE,
+                  QUIC_HANDSHAKE_STATE_CONFIRMED, QUIC_HANDSHAKE_STATE_FAILED };
+          for (size_t i = 0; i < sizeof (states) / sizeof (states[0]); i++)
+            {
+              const char *str = SocketQUICHandshake_state_string (states[i]);
+              (void)str;
+            }
+          SocketQUICHandshake_state_string ((SocketQUICHandshakeState)data[2]);
+
+          /* Result codes */
+          SocketQUICHandshake_Result results[]
+              = { QUIC_HANDSHAKE_OK,
+                  QUIC_HANDSHAKE_ERROR_NULL,
+                  QUIC_HANDSHAKE_ERROR_STATE,
+                  QUIC_HANDSHAKE_ERROR_CRYPTO,
+                  QUIC_HANDSHAKE_ERROR_TLS,
+                  QUIC_HANDSHAKE_ERROR_BUFFER,
+                  QUIC_HANDSHAKE_ERROR_OFFSET,
+                  QUIC_HANDSHAKE_ERROR_DUPLICATE,
+                  QUIC_HANDSHAKE_ERROR_TRANSPORT,
+                  QUIC_HANDSHAKE_ERROR_MEMORY };
+          for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+            {
+              const char *str = SocketQUICHandshake_result_string (results[i]);
+              (void)str;
+            }
+          SocketQUICHandshake_result_string (
+              (SocketQUICHandshake_Result)data[3]);
+          break;
+        }
+      }
+  }
+  EXCEPT (SocketQUICHandshake_Failed)
+  {
+    /* Expected on handshake errors */
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_loss.c
+++ b/src/fuzz/fuzz_quic_loss.c
@@ -1,0 +1,362 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_loss.c - libFuzzer for QUIC Loss Detection (RFC 9002)
+ *
+ * Fuzzes loss detection and RTT estimation:
+ * - Sent packet tracking
+ * - ACK processing and loss detection
+ * - RTT estimation (smoothed RTT, variance, min RTT)
+ * - PTO calculation
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_loss
+ * ./fuzz_quic_loss corpus/quic_loss/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICLoss.h"
+
+/* Operation types */
+enum
+{
+  OP_SENT_PACKET_TRACKING,
+  OP_ACK_PROCESSING,
+  OP_RTT_ESTIMATION,
+  OP_TIMERS,
+  OP_QUERY_FUNCTIONS,
+  OP_RESULT_STRINGS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+/* Callback for lost packets */
+static void
+lost_packet_callback (const SocketQUICLossSentPacket_T *packet, void *context)
+{
+  (void)packet;
+  size_t *count = (size_t *)context;
+  if (count)
+    (*count)++;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 50)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_SENT_PACKET_TRACKING:
+        {
+          /* Test sent packet recording */
+          int is_handshake = data[1] & 1;
+          uint64_t max_ack_delay
+              = (read_u64 (data + 2) % QUIC_LOSS_INITIAL_RTT_US) + 1;
+
+          SocketQUICLossState_T state
+              = SocketQUICLoss_new (arena, is_handshake, max_ack_delay);
+          if (!state)
+            break;
+
+          /* Record packets from fuzz data */
+          uint64_t sent_time = 1000000; /* 1 second */
+          size_t offset = 10;
+
+          while (offset + 10 <= size)
+            {
+              uint64_t pn = read_u64 (data + offset);
+              /* Limit packet numbers to avoid huge hash tables */
+              pn = pn % 10000;
+
+              size_t sent_bytes = (data[offset + 8] * 10) + 50;
+              int ack_eliciting = data[offset + 9] & 1;
+              int in_flight = data[offset + 9] & 2;
+              int is_crypto = data[offset + 9] & 4;
+
+              SocketQUICLoss_Result result = SocketQUICLoss_on_packet_sent (
+                  state, pn, sent_time, sent_bytes, ack_eliciting, in_flight,
+                  is_crypto);
+              (void)result;
+
+              sent_time += 1000; /* 1ms between packets */
+              offset += 10;
+            }
+
+          /* Check bytes in flight */
+          size_t bytes = SocketQUICLoss_bytes_in_flight (state);
+          int has_inflight = SocketQUICLoss_has_in_flight (state);
+          (void)bytes;
+          (void)has_inflight;
+
+          /* Test reset */
+          SocketQUICLoss_reset (state);
+          bytes = SocketQUICLoss_bytes_in_flight (state);
+          (void)bytes;
+
+          /* Test NULL inputs */
+          SocketQUICLoss_on_packet_sent (NULL, 0, 0, 100, 1, 1, 0);
+          SocketQUICLoss_bytes_in_flight (NULL);
+          SocketQUICLoss_has_in_flight (NULL);
+          SocketQUICLoss_reset (NULL);
+          break;
+        }
+
+      case OP_ACK_PROCESSING:
+        {
+          /* Test ACK processing and loss detection */
+          SocketQUICLossState_T state
+              = SocketQUICLoss_new (arena, 0, 25000);
+          if (!state)
+            break;
+
+          SocketQUICLossRTT_T rtt;
+          SocketQUICLoss_init_rtt (&rtt);
+
+          /* Record some packets */
+          uint64_t base_time = 1000000;
+          for (uint64_t pn = 0; pn < 50; pn++)
+            {
+              SocketQUICLoss_on_packet_sent (state, pn, base_time + pn * 1000,
+                                             100, 1, 1, 0);
+            }
+
+          /* Process ACKs from fuzz data */
+          size_t offset = 1;
+          size_t lost_count = 0;
+
+          while (offset + 24 <= size)
+            {
+              uint64_t largest_acked = read_u64 (data + offset) % 50;
+              uint64_t ack_delay = read_u64 (data + offset + 8) % 100000;
+              uint64_t recv_time = base_time + read_u64 (data + offset + 16);
+
+              SocketQUICLoss_Result result = SocketQUICLoss_on_ack_received (
+                  state, &rtt, largest_acked, ack_delay, recv_time,
+                  lost_packet_callback, &lost_count, NULL);
+              (void)result;
+
+              offset += 24;
+            }
+
+          /* Test with NULL callback */
+          SocketQUICLoss_on_ack_received (state, &rtt, 40, 10000,
+                                          base_time + 100000, NULL, NULL,
+                                          &lost_count);
+
+          /* Test NULL inputs */
+          SocketQUICLoss_on_ack_received (NULL, &rtt, 0, 0, 0, NULL, NULL,
+                                          NULL);
+          SocketQUICLoss_on_ack_received (state, NULL, 0, 0, 0, NULL, NULL,
+                                          NULL);
+          break;
+        }
+
+      case OP_RTT_ESTIMATION:
+        {
+          /* Test RTT estimation */
+          SocketQUICLossRTT_T rtt;
+          SocketQUICLoss_init_rtt (&rtt);
+
+          /* Process RTT samples from fuzz data */
+          size_t offset = 1;
+          while (offset + 17 <= size)
+            {
+              uint64_t latest_rtt = read_u64 (data + offset);
+              /* Limit RTT to reasonable values */
+              latest_rtt = (latest_rtt % 10000000) + 1; /* 1us to 10s */
+
+              uint64_t ack_delay = read_u64 (data + offset + 8);
+              ack_delay = ack_delay % latest_rtt; /* Delay < RTT */
+
+              int is_handshake = data[offset + 16] & 1;
+
+              SocketQUICLoss_update_rtt (&rtt, latest_rtt, ack_delay,
+                                         is_handshake);
+
+              offset += 17;
+            }
+
+          /* Check RTT values are reasonable */
+          (void)rtt.smoothed_rtt;
+          (void)rtt.rtt_var;
+          (void)rtt.min_rtt;
+          (void)rtt.latest_rtt;
+          (void)rtt.has_sample;
+
+          /* Test with edge cases */
+          SocketQUICLoss_init_rtt (&rtt);
+          SocketQUICLoss_update_rtt (&rtt, 1, 0, 1);          /* Minimum RTT */
+          SocketQUICLoss_update_rtt (&rtt, UINT64_MAX, 0, 0); /* Maximum RTT */
+          SocketQUICLoss_update_rtt (&rtt, 100000, 99999, 0); /* High ack delay */
+          SocketQUICLoss_update_rtt (&rtt, 100000, 100001,
+                                     0); /* Delay > RTT */
+
+          /* Test NULL */
+          SocketQUICLoss_update_rtt (NULL, 1000, 0, 0);
+          SocketQUICLoss_init_rtt (NULL);
+          break;
+        }
+
+      case OP_TIMERS:
+        {
+          /* Test PTO and loss time calculations */
+          SocketQUICLossRTT_T rtt;
+          SocketQUICLoss_init_rtt (&rtt);
+
+          /* Add some RTT samples */
+          SocketQUICLoss_update_rtt (&rtt, 50000, 0, 1);  /* 50ms */
+          SocketQUICLoss_update_rtt (&rtt, 60000, 5000, 0); /* 60ms */
+          SocketQUICLoss_update_rtt (&rtt, 55000, 3000, 0); /* 55ms */
+
+          /* Test PTO calculation with various pto_count values */
+          uint64_t max_ack_delay = read_u64 (data + 1) % 100000 + 1;
+
+          for (int pto_count = 0; pto_count <= QUIC_LOSS_MAX_PTO_COUNT + 1;
+               pto_count++)
+            {
+              uint64_t pto
+                  = SocketQUICLoss_get_pto (&rtt, max_ack_delay, pto_count);
+              (void)pto;
+            }
+
+          /* Test with uninitialized RTT */
+          SocketQUICLossRTT_T empty_rtt;
+          SocketQUICLoss_init_rtt (&empty_rtt);
+          uint64_t pto = SocketQUICLoss_get_pto (&empty_rtt, 25000, 0);
+          (void)pto;
+
+          /* Test loss time calculation */
+          SocketQUICLossState_T state
+              = SocketQUICLoss_new (arena, 0, max_ack_delay);
+          if (state)
+            {
+              /* Record some packets */
+              for (uint64_t i = 0; i < 10; i++)
+                {
+                  SocketQUICLoss_on_packet_sent (state, i, 1000000 + i * 1000,
+                                                 100, 1, 1, 0);
+                }
+
+              uint64_t current_time = read_u64 (data + 9);
+              int pto_count = data[17] % (QUIC_LOSS_MAX_PTO_COUNT + 1);
+
+              uint64_t loss_time = SocketQUICLoss_get_loss_time (
+                  state, &rtt, pto_count, current_time);
+              (void)loss_time;
+
+              /* Test loss timeout handling */
+              size_t lost = 0;
+              SocketQUICLoss_on_loss_timeout (state, &rtt, current_time + 100000,
+                                              lost_packet_callback, &lost,
+                                              NULL);
+            }
+
+          /* Test NULL */
+          SocketQUICLoss_get_pto (NULL, 25000, 0);
+          SocketQUICLoss_get_loss_time (NULL, &rtt, 0, 0);
+          SocketQUICLoss_get_loss_time (state, NULL, 0, 0);
+          SocketQUICLoss_on_loss_timeout (NULL, &rtt, 0, NULL, NULL, NULL);
+          break;
+        }
+
+      case OP_QUERY_FUNCTIONS:
+        {
+          /* Test query functions extensively */
+          SocketQUICLossState_T state
+              = SocketQUICLoss_new (arena, 0, 25000);
+          if (!state)
+            break;
+
+          /* Initially empty */
+          size_t bytes = SocketQUICLoss_bytes_in_flight (state);
+          int has = SocketQUICLoss_has_in_flight (state);
+          (void)bytes;
+          (void)has;
+
+          /* Add packets with various properties */
+          SocketQUICLoss_on_packet_sent (state, 0, 1000000, 100, 1, 1, 0);
+          SocketQUICLoss_on_packet_sent (state, 1, 1001000, 200, 0, 1, 0);
+          SocketQUICLoss_on_packet_sent (state, 2, 1002000, 150, 1, 0, 0);
+          SocketQUICLoss_on_packet_sent (state, 3, 1003000, 300, 1, 1, 1);
+
+          bytes = SocketQUICLoss_bytes_in_flight (state);
+          has = SocketQUICLoss_has_in_flight (state);
+          (void)bytes;
+          (void)has;
+
+          /* Try to add duplicate */
+          SocketQUICLoss_Result result
+              = SocketQUICLoss_on_packet_sent (state, 0, 2000000, 100, 1, 1, 0);
+          (void)result;
+
+          /* ACK some packets */
+          SocketQUICLossRTT_T rtt;
+          SocketQUICLoss_init_rtt (&rtt);
+          SocketQUICLoss_on_ack_received (state, &rtt, 1, 1000, 1100000, NULL,
+                                          NULL, NULL);
+
+          bytes = SocketQUICLoss_bytes_in_flight (state);
+          (void)bytes;
+          break;
+        }
+
+      case OP_RESULT_STRINGS:
+        {
+          /* Test result string function */
+          SocketQUICLoss_Result results[] = { QUIC_LOSS_OK,
+                                              QUIC_LOSS_ERROR_NULL,
+                                              QUIC_LOSS_ERROR_DUPLICATE,
+                                              QUIC_LOSS_ERROR_NOT_FOUND,
+                                              QUIC_LOSS_ERROR_FULL,
+                                              QUIC_LOSS_ERROR_INVALID };
+
+          for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+            {
+              const char *str = SocketQUICLoss_result_string (results[i]);
+              (void)str;
+            }
+
+          /* Test with fuzzed value */
+          const char *str
+              = SocketQUICLoss_result_string ((SocketQUICLoss_Result)data[1]);
+          (void)str;
+          break;
+        }
+      }
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_stream.c
+++ b/src/fuzz/fuzz_quic_stream.c
@@ -1,0 +1,345 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_stream.c - libFuzzer for QUIC Stream Management (RFC 9000 Section
+ * 2-3)
+ *
+ * Fuzzes stream ID operations and state machine transitions:
+ * - Stream ID type detection and validation
+ * - Stream ID sequence calculations
+ * - Send/receive state machine transitions
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_stream
+ * ./fuzz_quic_stream corpus/quic_stream/ -fork=16 -max_len=1024
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICStream.h"
+
+/* Operation types */
+enum
+{
+  OP_STREAM_ID_FUNCTIONS,
+  OP_STATE_TRANSITIONS,
+  OP_STREAM_LIFECYCLE,
+  OP_STRING_FUNCTIONS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 20)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_STREAM_ID_FUNCTIONS:
+        {
+          /* Test stream ID utility functions */
+          uint64_t stream_id = read_u64 (data + 1);
+
+          /* Test type detection */
+          int is_client = SocketQUICStream_is_client_initiated (stream_id);
+          int is_server = SocketQUICStream_is_server_initiated (stream_id);
+          int is_bidi = SocketQUICStream_is_bidirectional (stream_id);
+          int is_uni = SocketQUICStream_is_unidirectional (stream_id);
+          (void)is_client;
+          (void)is_server;
+          (void)is_bidi;
+          (void)is_uni;
+
+          /* These should be mutually exclusive */
+          SocketQUICStreamType type = SocketQUICStream_type (stream_id);
+          (void)type;
+
+          /* Validate stream ID */
+          int is_valid = SocketQUICStream_is_valid_id (stream_id);
+          (void)is_valid;
+
+          /* Get sequence number */
+          uint64_t seq = SocketQUICStream_sequence (stream_id);
+          (void)seq;
+
+          /* Get next stream ID */
+          uint64_t next = SocketQUICStream_next_id (stream_id);
+          (void)next;
+
+          /* Test with special values */
+          stream_id = 0;
+          type = SocketQUICStream_type (stream_id);
+          is_valid = SocketQUICStream_is_valid_id (stream_id);
+          next = SocketQUICStream_next_id (stream_id);
+          (void)type;
+          (void)is_valid;
+          (void)next;
+
+          stream_id = QUIC_STREAM_ID_MAX;
+          type = SocketQUICStream_type (stream_id);
+          is_valid = SocketQUICStream_is_valid_id (stream_id);
+          next = SocketQUICStream_next_id (stream_id);
+          (void)type;
+          (void)is_valid;
+          (void)next;
+
+          stream_id = QUIC_STREAM_ID_MAX + 1;
+          is_valid = SocketQUICStream_is_valid_id (stream_id);
+          (void)is_valid;
+
+          /* Test first_id for each type */
+          uint64_t first_bidi_client
+              = SocketQUICStream_first_id (QUIC_STREAM_BIDI_CLIENT);
+          uint64_t first_bidi_server
+              = SocketQUICStream_first_id (QUIC_STREAM_BIDI_SERVER);
+          uint64_t first_uni_client
+              = SocketQUICStream_first_id (QUIC_STREAM_UNI_CLIENT);
+          uint64_t first_uni_server
+              = SocketQUICStream_first_id (QUIC_STREAM_UNI_SERVER);
+          (void)first_bidi_client;
+          (void)first_bidi_server;
+          (void)first_uni_client;
+          (void)first_uni_server;
+
+          /* Test stream ID iteration */
+          stream_id = 0;
+          for (int i = 0; i < 20 && stream_id != 0; i++)
+            {
+              next = SocketQUICStream_next_id (stream_id);
+              if (next == 0)
+                break; /* Overflow */
+              stream_id = next;
+            }
+          break;
+        }
+
+      case OP_STATE_TRANSITIONS:
+        {
+          /* Test state machine transitions */
+          uint64_t stream_id = read_u64 (data + 1);
+
+          SocketQUICStream_T stream
+              = SocketQUICStream_new (arena, stream_id % 1000);
+          if (!stream)
+            break;
+
+          /* Test send-side transitions */
+          SocketQUICStreamState send_state
+              = SocketQUICStream_get_send_state (stream);
+          (void)send_state;
+
+          /* Try all send events */
+          SocketQUICStreamEvent send_events[] = { QUIC_STREAM_EVENT_SEND_DATA,
+                                                  QUIC_STREAM_EVENT_SEND_FIN,
+                                                  QUIC_STREAM_EVENT_ALL_DATA_ACKED,
+                                                  QUIC_STREAM_EVENT_SEND_RESET,
+                                                  QUIC_STREAM_EVENT_RESET_ACKED };
+
+          for (size_t i = 0; i < sizeof (send_events) / sizeof (send_events[0]);
+               i++)
+            {
+              SocketQUICStream_Result result
+                  = SocketQUICStream_transition_send (stream, send_events[i]);
+              (void)result;
+              send_state = SocketQUICStream_get_send_state (stream);
+              (void)send_state;
+            }
+
+          /* Reset and test receive-side transitions */
+          SocketQUICStream_reset (stream);
+
+          SocketQUICStreamState recv_state
+              = SocketQUICStream_get_recv_state (stream);
+          (void)recv_state;
+
+          SocketQUICStreamEvent recv_events[]
+              = { QUIC_STREAM_EVENT_RECV_DATA,
+                  QUIC_STREAM_EVENT_RECV_FIN,
+                  QUIC_STREAM_EVENT_ALL_DATA_RECVD,
+                  QUIC_STREAM_EVENT_APP_READ_DATA,
+                  QUIC_STREAM_EVENT_RECV_RESET,
+                  QUIC_STREAM_EVENT_APP_READ_RESET,
+                  QUIC_STREAM_EVENT_RECV_STOP_SENDING };
+
+          for (size_t i = 0; i < sizeof (recv_events) / sizeof (recv_events[0]);
+               i++)
+            {
+              SocketQUICStream_Result result
+                  = SocketQUICStream_transition_recv (stream, recv_events[i]);
+              (void)result;
+              recv_state = SocketQUICStream_get_recv_state (stream);
+              (void)recv_state;
+            }
+
+          /* Test with fuzzed event sequence */
+          SocketQUICStream_reset (stream);
+          size_t offset = 9;
+          while (offset < size)
+            {
+              uint8_t event_idx = data[offset] % QUIC_STREAM_EVENT_MAX;
+              SocketQUICStreamEvent event = (SocketQUICStreamEvent)event_idx;
+
+              /* Randomly choose send or receive transition */
+              if (data[offset] & 0x80)
+                {
+                  SocketQUICStream_transition_send (stream, event);
+                }
+              else
+                {
+                  SocketQUICStream_transition_recv (stream, event);
+                }
+              offset++;
+            }
+
+          /* Test NULL inputs */
+          SocketQUICStream_transition_send (NULL, QUIC_STREAM_EVENT_SEND_DATA);
+          SocketQUICStream_transition_recv (NULL, QUIC_STREAM_EVENT_RECV_DATA);
+          break;
+        }
+
+      case OP_STREAM_LIFECYCLE:
+        {
+          /* Test stream creation and access functions */
+          uint64_t stream_id = read_u64 (data + 1);
+
+          /* Create stream */
+          SocketQUICStream_T stream = SocketQUICStream_new (arena, stream_id);
+          if (!stream)
+            break;
+
+          /* Get properties */
+          uint64_t id = SocketQUICStream_get_id (stream);
+          SocketQUICStreamType type = SocketQUICStream_get_type (stream);
+          SocketQUICStreamState state = SocketQUICStream_get_state (stream);
+          int is_local = SocketQUICStream_is_local (stream);
+          (void)id;
+          (void)type;
+          (void)state;
+          (void)is_local;
+
+          /* Test init with different IDs */
+          SocketQUICStream_Result result
+              = SocketQUICStream_init (stream, stream_id + 4);
+          (void)result;
+
+          /* Reset */
+          result = SocketQUICStream_reset (stream);
+          (void)result;
+
+          /* Create multiple streams */
+          for (uint64_t i = 0; i < 10; i++)
+            {
+              uint64_t sid = (stream_id + i * 4) % QUIC_STREAM_ID_MAX;
+              SocketQUICStream_T s = SocketQUICStream_new (arena, sid);
+              if (s)
+                {
+                  SocketQUICStream_get_id (s);
+                  SocketQUICStream_get_type (s);
+                }
+            }
+
+          /* Test NULL inputs */
+          SocketQUICStream_get_id (NULL);
+          SocketQUICStream_get_type (NULL);
+          SocketQUICStream_get_state (NULL);
+          SocketQUICStream_is_local (NULL);
+          SocketQUICStream_get_send_state (NULL);
+          SocketQUICStream_get_recv_state (NULL);
+          SocketQUICStream_init (NULL, 0);
+          SocketQUICStream_reset (NULL);
+          break;
+        }
+
+      case OP_STRING_FUNCTIONS:
+        {
+          /* Test all string conversion functions */
+
+          /* Stream types */
+          SocketQUICStreamType types[] = { QUIC_STREAM_BIDI_CLIENT,
+                                           QUIC_STREAM_BIDI_SERVER,
+                                           QUIC_STREAM_UNI_CLIENT,
+                                           QUIC_STREAM_UNI_SERVER };
+          for (size_t i = 0; i < sizeof (types) / sizeof (types[0]); i++)
+            {
+              const char *str = SocketQUICStream_type_string (types[i]);
+              (void)str;
+            }
+          SocketQUICStream_type_string ((SocketQUICStreamType)data[1]);
+
+          /* Stream states */
+          SocketQUICStreamState states[]
+              = { QUIC_STREAM_STATE_READY,      QUIC_STREAM_STATE_SEND,
+                  QUIC_STREAM_STATE_DATA_SENT,  QUIC_STREAM_STATE_RESET_SENT,
+                  QUIC_STREAM_STATE_DATA_RECVD, QUIC_STREAM_STATE_RESET_RECVD,
+                  QUIC_STREAM_STATE_RECV,       QUIC_STREAM_STATE_SIZE_KNOWN,
+                  QUIC_STREAM_STATE_DATA_READ,  QUIC_STREAM_STATE_RESET_READ };
+          for (size_t i = 0; i < sizeof (states) / sizeof (states[0]); i++)
+            {
+              const char *str = SocketQUICStream_state_string (states[i]);
+              (void)str;
+            }
+          SocketQUICStream_state_string ((SocketQUICStreamState)data[2]);
+
+          /* Result codes */
+          SocketQUICStream_Result results[]
+              = { QUIC_STREAM_OK,
+                  QUIC_STREAM_ERROR_NULL,
+                  QUIC_STREAM_ERROR_INVALID_ID,
+                  QUIC_STREAM_ERROR_INVALID_TYPE,
+                  QUIC_STREAM_ERROR_WRONG_ROLE,
+                  QUIC_STREAM_ERROR_STATE,
+                  QUIC_STREAM_ERROR_LIMIT };
+          for (size_t i = 0; i < sizeof (results) / sizeof (results[0]); i++)
+            {
+              const char *str = SocketQUICStream_result_string (results[i]);
+              (void)str;
+            }
+          SocketQUICStream_result_string ((SocketQUICStream_Result)data[3]);
+
+          /* Events */
+          for (int i = 0; i < QUIC_STREAM_EVENT_MAX; i++)
+            {
+              const char *str
+                  = SocketQUICStream_event_string ((SocketQUICStreamEvent)i);
+              (void)str;
+            }
+          SocketQUICStream_event_string ((SocketQUICStreamEvent)data[4]);
+          break;
+        }
+      }
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}

--- a/src/fuzz/fuzz_quic_tls.c
+++ b/src/fuzz/fuzz_quic_tls.c
@@ -1,0 +1,315 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_quic_tls.c - libFuzzer for QUIC TLS Integration (RFC 9001)
+ *
+ * Fuzzes TLS-related functions and transport parameter handling:
+ * - TLS result string functions
+ * - Transport parameter encoding/decoding
+ * - Transport parameter validation
+ * - 0-RTT parameter validation
+ *
+ * Build/Run: CC=clang cmake -DENABLE_FUZZING=ON .. && make fuzz_quic_tls
+ * ./fuzz_quic_tls corpus/quic_tls/ -fork=16 -max_len=4096
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "quic/SocketQUICTLS.h"
+#include "quic/SocketQUICTransportParams.h"
+
+/* Operation types */
+enum
+{
+  OP_TRANSPORT_PARAMS_ENCODE,
+  OP_TRANSPORT_PARAMS_DECODE,
+  OP_TRANSPORT_PARAMS_VALIDATE,
+  OP_0RTT_VALIDATION,
+  OP_STRING_FUNCTIONS,
+  OP_MAX
+};
+
+/* Helper to read uint64_t from buffer */
+static uint64_t
+read_u64 (const uint8_t *data)
+{
+  uint64_t val = 0;
+  for (int i = 0; i < 8; i++)
+    val = (val << 8) | data[i];
+  return val;
+}
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (size < 50)
+    return 0;
+
+  volatile Arena_T arena = Arena_new ();
+  if (!arena)
+    return 0;
+
+  TRY
+  {
+    uint8_t op = data[0] % OP_MAX;
+
+    switch (op)
+      {
+      case OP_TRANSPORT_PARAMS_ENCODE:
+        {
+          /* Test transport parameter encoding */
+          SocketQUICTransportParams_T params;
+          SocketQUICTransportParams_init (&params);
+
+          /* Fill params from fuzz data */
+          params.max_idle_timeout = read_u64 (data + 1);
+          params.max_udp_payload_size = (read_u64 (data + 9) % 65536) + 1200;
+          params.initial_max_data = read_u64 (data + 17);
+          params.initial_max_stream_data_bidi_local = read_u64 (data + 25);
+          params.initial_max_stream_data_bidi_remote = read_u64 (data + 33);
+          params.initial_max_stream_data_uni = read_u64 (data + 41);
+          params.initial_max_streams_bidi = (data[49] % 100) + 1;
+
+          /* Try to encode parameters as client and server */
+          uint8_t encoded[1024];
+
+          size_t encoded_len = SocketQUICTransportParams_encode (
+              &params, QUIC_ROLE_CLIENT, encoded, sizeof (encoded));
+          (void)encoded_len;
+
+          encoded_len = SocketQUICTransportParams_encode (
+              &params, QUIC_ROLE_SERVER, encoded, sizeof (encoded));
+          (void)encoded_len;
+
+          /* Test encoded size calculation */
+          size_t calc_size = SocketQUICTransportParams_encoded_size (
+              &params, QUIC_ROLE_CLIENT);
+          (void)calc_size;
+
+          /* Test NULL inputs */
+          SocketQUICTransportParams_encode (NULL, QUIC_ROLE_CLIENT, encoded,
+                                            sizeof (encoded));
+          SocketQUICTransportParams_encode (&params, QUIC_ROLE_CLIENT, NULL,
+                                            sizeof (encoded));
+          SocketQUICTransportParams_encoded_size (NULL, QUIC_ROLE_CLIENT);
+          break;
+        }
+
+      case OP_TRANSPORT_PARAMS_DECODE:
+        {
+          /* Test transport parameter decoding */
+          SocketQUICTransportParams_T decoded;
+          SocketQUICTransportParams_init (&decoded);
+          size_t consumed = 0;
+
+          /* Try to decode fuzzed data as transport params from client */
+          SocketQUICTransportParams_Result result
+              = SocketQUICTransportParams_decode (data + 1, size - 1,
+                                                  QUIC_ROLE_CLIENT, &decoded,
+                                                  &consumed);
+          (void)result;
+
+          /* Also try from server role */
+          SocketQUICTransportParams_init (&decoded);
+          consumed = 0;
+          result = SocketQUICTransportParams_decode (
+              data + 1, size - 1, QUIC_ROLE_SERVER, &decoded, &consumed);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICTransportParams_decode (NULL, 0, QUIC_ROLE_CLIENT, &decoded,
+                                            &consumed);
+          SocketQUICTransportParams_decode (data, size, QUIC_ROLE_CLIENT, NULL,
+                                            &consumed);
+          SocketQUICTransportParams_decode (data, size, QUIC_ROLE_CLIENT,
+                                            &decoded, NULL);
+          break;
+        }
+
+      case OP_TRANSPORT_PARAMS_VALIDATE:
+        {
+          /* Test transport parameter validation */
+          SocketQUICTransportParams_T params;
+          SocketQUICTransportParams_init (&params);
+
+          /* Fill with fuzzed values */
+          params.max_idle_timeout = read_u64 (data + 1);
+          params.max_udp_payload_size = read_u64 (data + 9);
+          params.initial_max_data = read_u64 (data + 17);
+          params.ack_delay_exponent = data[25];
+          params.max_ack_delay = read_u64 (data + 26);
+          params.active_connection_id_limit = data[34];
+
+          /* Validate as client and server */
+          SocketQUICTransportParams_Result result
+              = SocketQUICTransportParams_validate (&params, QUIC_ROLE_CLIENT);
+          (void)result;
+
+          result
+              = SocketQUICTransportParams_validate (&params, QUIC_ROLE_SERVER);
+          (void)result;
+
+          /* Test required params validation */
+          result = SocketQUICTransportParams_validate_required (
+              &params, QUIC_ROLE_CLIENT);
+          (void)result;
+
+          result = SocketQUICTransportParams_validate_required (
+              &params, QUIC_ROLE_SERVER);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICTransportParams_validate (NULL, QUIC_ROLE_CLIENT);
+          SocketQUICTransportParams_validate_required (NULL, QUIC_ROLE_CLIENT);
+          break;
+        }
+
+      case OP_0RTT_VALIDATION:
+        {
+          /* Test 0-RTT transport parameter validation */
+          SocketQUICTransportParams_T original;
+          SocketQUICTransportParams_T resumption;
+
+          SocketQUICTransportParams_init (&original);
+          SocketQUICTransportParams_init (&resumption);
+
+          /* Set up original params */
+          original.max_idle_timeout = read_u64 (data + 1);
+          original.initial_max_data = read_u64 (data + 9);
+          original.initial_max_stream_data_bidi_local = read_u64 (data + 17);
+          original.initial_max_stream_data_bidi_remote = read_u64 (data + 25);
+          original.initial_max_stream_data_uni = read_u64 (data + 33);
+          original.initial_max_streams_bidi = data[41] % 100;
+          original.initial_max_streams_uni = data[42] % 100;
+          original.active_connection_id_limit = (data[43] % 8) + 2;
+
+          /* Set up resumption params (may be same or different) */
+          if (data[44] & 1)
+            {
+              /* Same as original */
+              memcpy (&resumption, &original, sizeof (resumption));
+            }
+          else
+            {
+              /* Different values */
+              resumption.max_idle_timeout
+                  = read_u64 (data + 45 % (size > 52 ? size - 8 : 1));
+              resumption.initial_max_data = original.initial_max_data * 2;
+              resumption.initial_max_streams_bidi
+                  = original.initial_max_streams_bidi + 10;
+            }
+
+          /* Validate 0-RTT params */
+          SocketQUICTLS_Result result
+              = SocketQUICTLS_validate_0rtt_params (&original, &resumption);
+          (void)result;
+
+          /* Test cases where resumption params are smaller (should fail) */
+          resumption.initial_max_data = original.initial_max_data / 2;
+          result = SocketQUICTLS_validate_0rtt_params (&original, &resumption);
+          (void)result;
+
+          resumption.initial_max_data = original.initial_max_data;
+          resumption.initial_max_streams_bidi = 0;
+          result = SocketQUICTLS_validate_0rtt_params (&original, &resumption);
+          (void)result;
+
+          /* Test NULL inputs */
+          SocketQUICTLS_validate_0rtt_params (NULL, &resumption);
+          SocketQUICTLS_validate_0rtt_params (&original, NULL);
+          break;
+        }
+
+      case OP_STRING_FUNCTIONS:
+        {
+          /* Test all TLS-related string functions */
+
+          /* TLS Result codes */
+          SocketQUICTLS_Result tls_results[]
+              = { QUIC_TLS_OK,          QUIC_TLS_ERROR_NULL,
+                  QUIC_TLS_ERROR_INIT,  QUIC_TLS_ERROR_CERT,
+                  QUIC_TLS_ERROR_KEY,   QUIC_TLS_ERROR_ALPN,
+                  QUIC_TLS_ERROR_TRANSPORT, QUIC_TLS_ERROR_HANDSHAKE,
+                  QUIC_TLS_ERROR_SECRETS, QUIC_TLS_ERROR_ALERT,
+                  QUIC_TLS_ERROR_NO_TLS, QUIC_TLS_ERROR_WANT_READ,
+                  QUIC_TLS_ERROR_WANT_WRITE, QUIC_TLS_ERROR_LEVEL };
+          for (size_t i = 0;
+               i < sizeof (tls_results) / sizeof (tls_results[0]); i++)
+            {
+              const char *str = SocketQUICTLS_result_string (tls_results[i]);
+              (void)str;
+            }
+          /* Test with fuzzed value */
+          SocketQUICTLS_result_string ((SocketQUICTLS_Result)data[1]);
+
+          /* Transport params result codes */
+          SocketQUICTransportParams_Result tp_results[]
+              = { QUIC_TP_OK,
+                  QUIC_TP_ERROR_NULL,
+                  QUIC_TP_ERROR_BUFFER,
+                  QUIC_TP_ERROR_INCOMPLETE,
+                  QUIC_TP_ERROR_INVALID_VALUE,
+                  QUIC_TP_ERROR_DUPLICATE,
+                  QUIC_TP_ERROR_ROLE,
+                  QUIC_TP_ERROR_REQUIRED,
+                  QUIC_TP_ERROR_ENCODING };
+          for (size_t i = 0; i < sizeof (tp_results) / sizeof (tp_results[0]);
+               i++)
+            {
+              const char *str
+                  = SocketQUICTransportParams_result_string (tp_results[i]);
+              (void)str;
+            }
+          /* Test with fuzzed value */
+          SocketQUICTransportParams_result_string (
+              (SocketQUICTransportParams_Result)data[2]);
+
+          /* Test transport param ID strings */
+          SocketQUICTransportParamID ids[] = {
+            QUIC_TP_ORIGINAL_DCID,
+            QUIC_TP_MAX_IDLE_TIMEOUT,
+            QUIC_TP_STATELESS_RESET_TOKEN,
+            QUIC_TP_MAX_UDP_PAYLOAD_SIZE,
+            QUIC_TP_INITIAL_MAX_DATA,
+            QUIC_TP_INITIAL_MAX_STREAM_DATA_BIDI_LOCAL,
+            QUIC_TP_INITIAL_MAX_STREAM_DATA_BIDI_REMOTE,
+            QUIC_TP_INITIAL_MAX_STREAM_DATA_UNI,
+            QUIC_TP_INITIAL_MAX_STREAMS_BIDI,
+            QUIC_TP_INITIAL_MAX_STREAMS_UNI,
+            QUIC_TP_ACK_DELAY_EXPONENT,
+            QUIC_TP_MAX_ACK_DELAY,
+            QUIC_TP_DISABLE_ACTIVE_MIGRATION,
+            QUIC_TP_PREFERRED_ADDRESS,
+            QUIC_TP_ACTIVE_CONNID_LIMIT,
+            QUIC_TP_INITIAL_SCID,
+            QUIC_TP_RETRY_SCID
+          };
+          for (size_t i = 0; i < sizeof (ids) / sizeof (ids[0]); i++)
+            {
+              const char *str = SocketQUICTransportParams_id_string (ids[i]);
+              (void)str;
+            }
+          /* Test with fuzzed value */
+          SocketQUICTransportParams_id_string (
+              (SocketQUICTransportParamID)data[3]);
+          break;
+        }
+      }
+  }
+  EXCEPT (Arena_Failed)
+  {
+    /* Expected on allocation failure */
+  }
+  END_TRY;
+
+  Arena_dispose ((Arena_T *)&arena);
+  return 0;
+}


### PR DESCRIPTION
## Summary

Add comprehensive libFuzzer harnesses for 9 critical QUIC modules that were previously unfuzzed:

| Harness | Target Module | RFC Coverage |
|---------|---------------|--------------|
| `fuzz_quic_crypto` | SocketQUICCrypto | RFC 9001 key derivation, AEAD, header protection |
| `fuzz_quic_addr_validation` | SocketQUICAddrValidation | RFC 9000 §8 address validation, amplification limits |
| `fuzz_quic_ack` | SocketQUICAck | RFC 9000 §13.2 ACK generation, ECN |
| `fuzz_quic_flow` | SocketQUICFlow | RFC 9000 §4 flow control |
| `fuzz_quic_stream` | SocketQUICStream | RFC 9000 §2-3 stream state machine |
| `fuzz_quic_loss` | SocketQUICLoss | RFC 9002 loss detection, RTT estimation |
| `fuzz_quic_connection` | SocketQUICConnection | Connection table, CID management |
| `fuzz_quic_handshake` | SocketQUICHandshake | Handshake state, key management |
| `fuzz_quic_tls` | SocketQUICTLS + TransportParams | Transport parameter encoding/decoding |

Each harness:
- Uses operation dispatch for multiple test paths
- Tests NULL pointer handling
- Exercises edge cases and boundary conditions
- Follows established Arena-based memory patterns

Fixes #3402

## Test plan

- [x] All 9 fuzzers build with `CC=clang cmake -DENABLE_FUZZING=ON`
- [x] Smoke test each fuzzer for 2+ seconds
- [x] Fuzzers are finding inputs to explore (coverage increasing)