### PR TITLE
fix: validate QUIC AEAD key length and fuzzer bounds

### DIFF
--- a/src/fuzz/fuzz_quic_ack.c
+++ b/src/fuzz/fuzz_quic_ack.c
@@ -51,7 +51,7 @@ read_u64 (const uint8_t *data)
 int
 LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 {
-  if (size < 17)
+  if (size < 18)
     return 0;
 
   volatile Arena_T arena = Arena_new ();

--- a/src/fuzz/fuzz_quic_handshake.c
+++ b/src/fuzz/fuzz_quic_handshake.c
@@ -277,7 +277,7 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
 
           /* Set a ticket (from fuzz data) */
           size_t ticket_len = (data[2] % 100) + 10;
-          if (size >= 3 + ticket_len)
+          if (size >= 3 + ticket_len + 8)
             {
               SocketQUICTransportParams_T saved_params;
               SocketQUICTransportParams_init (&saved_params);

--- a/src/quic/SocketQUICCrypto.c
+++ b/src/quic/SocketQUICCrypto.c
@@ -807,6 +807,10 @@ SocketQUICCrypto_encrypt_payload (const SocketQUICPacketKeys_T *keys,
   if (keys->aead < 0 || keys->aead >= QUIC_AEAD_COUNT)
     return QUIC_CRYPTO_ERROR_AEAD;
 
+  /* Validate key length matches AEAD algorithm requirements */
+  if (keys->key_len != aead_params[keys->aead].key_len)
+    return QUIC_CRYPTO_ERROR_AEAD;
+
   /* Check output buffer size */
   required_size = plaintext_len + SOCKET_CRYPTO_AEAD_TAG_SIZE;
   if (*ciphertext_len < required_size)
@@ -885,6 +889,10 @@ SocketQUICCrypto_decrypt_payload (const SocketQUICPacketKeys_T *keys,
 
   /* Validate AEAD algorithm */
   if (keys->aead < 0 || keys->aead >= QUIC_AEAD_COUNT)
+    return QUIC_CRYPTO_ERROR_AEAD;
+
+  /* Validate key length matches AEAD algorithm requirements */
+  if (keys->key_len != aead_params[keys->aead].key_len)
     return QUIC_CRYPTO_ERROR_AEAD;
 
   /* Calculate payload length (ciphertext minus tag) */


### PR DESCRIPTION
## Summary

- Add key_len validation in QUIC crypto encrypt/decrypt functions
- Fix bounds check bugs in fuzz_quic_ack.c and fuzz_quic_handshake.c

Fixes #3404

## Changes

### Library Fix: Key Length Validation

`SocketQUICCrypto_encrypt_payload` and `SocketQUICCrypto_decrypt_payload` now validate that `keys->key_len` matches the expected size for `keys->aead` before calling crypto functions. Returns `QUIC_CRYPTO_ERROR_AEAD` instead of letting an uncaught exception propagate.

### Fuzzer Fixes: Bounds Checks

1. **fuzz_quic_ack.c**: Increased minimum size from 17 to 18 bytes to prevent `read_u64` overflow
2. **fuzz_quic_handshake.c**: Fixed bounds check to account for 8-byte read after ticket data

## Test plan

- [x] All 34 QUIC tests pass with sanitizers
- [x] All 5 crash inputs now handled without crashing
- [x] Quick fuzz test runs successfully