### PR TITLE
chore: add build_*/ pattern to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Build artifacts
 build/
 build-*/
+build_*/
 *.o
 *.a
 *.so


### PR DESCRIPTION
## Summary
- Add `build_*/` pattern to `.gitignore` to ignore underscore-prefixed build directories
- Prevents `build_debug/`, `build_test/`, `build_fuzz/`, etc. from showing as untracked

Fixes #3445

## Test plan
- [x] Verified build directories matching `build_*` pattern are now ignored