### PR TITLE
fix: prevent HTTP header injection via CRLF validation

### DIFF
--- a/src/http/qpack/SocketQPACK-literal-postbase.c
+++ b/src/http/qpack/SocketQPACK-literal-postbase.c
@@ -287,8 +287,12 @@ SocketQPACK_decode_literal_postbase_name (
       /*
        * Huffman-decode the value into arena-allocated buffer.
        * Estimate decoded size as 2x encoded size (typical expansion).
+       * Check for multiplication overflow before allocation (fixes #3457).
        */
-      size_t max_decoded = value_len * 2 + 16;
+      size_t max_decoded;
+      if (!SocketSecurity_check_multiply (value_len, 2, &max_decoded))
+        return QPACK_ERR_HEADER_SIZE;
+      max_decoded += 16;
       unsigned char *decoded_value = ALLOC (arena, max_decoded);
       if (decoded_value == NULL)
         return QPACK_ERR_INTERNAL;

--- a/src/simple/SocketSimple-http.c
+++ b/src/simple/SocketSimple-http.c
@@ -272,9 +272,15 @@ add_custom_headers (SocketHTTPClient_Request_T req, const char **headers)
               char name[SOCKET_SIMPLE_MAX_HEADER_NAME_LEN];
               memcpy (name, *h, name_len);
               name[name_len] = '\0';
+              /* Reject header names containing CRLF to prevent injection */
+              if (strchr (name, '\r') || strchr (name, '\n'))
+                continue;
               const char *value = colon + 1;
               while (*value == ' ')
                 value++;
+              /* Reject header values containing CRLF to prevent injection */
+              if (strchr (value, '\r') || strchr (value, '\n'))
+                continue;
               SocketHTTPClient_Request_header (req, name, value);
             }
         }


### PR DESCRIPTION
Fixes #3456

Adds validation in add_custom_headers() to reject headers containing CR or LF characters, preventing HTTP header injection attacks.