### PR TITLE
fix: default to SSL_VERIFY_PEER on unknown verify mode

### DIFF
--- a/src/tls/SocketTLSContext-verify.c
+++ b/src/tls/SocketTLSContext-verify.c
@@ -67,7 +67,11 @@ verify_mode_to_openssl (TLSVerifyMode mode)
     case TLS_VERIFY_CLIENT_ONCE:
       return SSL_VERIFY_PEER | SSL_VERIFY_CLIENT_ONCE;
     default:
-      return SSL_VERIFY_NONE;
+      /* Fail-secure: unknown mode defaults to peer verification enabled */
+      SOCKET_LOG_ERROR_MSG ("Invalid TLSVerifyMode: %d, defaulting to "
+                            "SSL_VERIFY_PEER for security",
+                            (int)mode);
+      return SSL_VERIFY_PEER;
     }
 }
 


### PR DESCRIPTION
The default case in verify_mode_to_openssl() now returns SSL_VERIFY_PEER
instead of SSL_VERIFY_NONE, following fail-secure principles.

Fixes #3453