### PR TITLE
fix: prevent integer overflow in Huffman decode buffer allocation

### DIFF
--- a/src/http/qpack/SocketQPACK-encoder-stream.c
+++ b/src/http/qpack/SocketQPACK-encoder-stream.c
@@ -952,7 +952,10 @@ SocketQPACK_decode_insert_nameref (const unsigned char *input,
     {
       /* Huffman-decode the value */
       /* Allocate decode buffer (worst case 2x expansion) */
-      size_t decode_buf_size = value_len * 2;
+      /* Check for multiplication overflow before allocation (fixes #3457) */
+      size_t decode_buf_size;
+      if (!SocketSecurity_check_multiply (value_len, 2, &decode_buf_size))
+        return QPACK_STREAM_ERR_INTERNAL;
       if (decode_buf_size < 64)
         decode_buf_size = 64;
 


### PR DESCRIPTION
## Summary
Adds overflow check using `SocketSecurity_check_multiply()` before calculating Huffman decode buffer size in QPACK encoder stream.

## Issue
Fixes #3457

## Security Impact
**CRITICAL** - Prevents potential RCE via heap buffer overflow when an attacker sends a malicious QPACK instruction with a large value_len that would cause integer overflow in the size calculation.

## Changes
- Added multiplication overflow check before allocating Huffman decode buffer
- Returns `QPACK_STREAM_ERR_INTERNAL` if overflow would occur

## Testing
- Verified file compiles without errors