### PR TITLE
fix: return error on KRC overflow instead of saturating

### DIFF
--- a/src/http/qpack/SocketQPACK-decoder-stream.c
+++ b/src/http/qpack/SocketQPACK-decoder-stream.c
@@ -957,10 +957,14 @@ SocketQPACK_AckState_process_insert_count_inc (SocketQPACK_AckState_T state,
   if (increment == 0)
     return QPACK_STREAM_ERR_INVALID_INDEX;
 
+  /*
+   * RFC 9204 Section 4.4.3: Overflow in Known Received Count calculation
+   * is a decoder stream error. Do NOT saturate - return error (fixes #3460).
+   */
   if (!SocketSecurity_check_add (
           state->known_received_count, increment, &new_krc))
     {
-      new_krc = UINT64_MAX;
+      return QPACK_STREAM_ERR_INVALID_INDEX;
     }
 
   state->known_received_count = new_krc;


### PR DESCRIPTION
## Summary
Returns error on Known Received Count overflow instead of saturating to UINT64_MAX.

## Issue
Fixes #3460

## Security Impact
**HIGH** - Prevents Known Received Count desynchronization attacks where a malicious client sends a massive increment value to corrupt encoder state.

## RFC Compliance
RFC 9204 Section 4.4.3 states that overflow in Known Received Count calculation should be treated as a connection error.

## Changes
- Changed overflow handling in `SocketQPACK_AckState_process_insert_count_inc` from saturation to error return

## Testing
- Verified file compiles without errors