### PR TITLE
fix: reject unsupported Transfer-Encoding values (security)

### DIFF
--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -86,6 +86,17 @@
 #define SOCKETQPACK_MAX_BLOCKED_STREAMS 100
 #endif
 
+/**
+ * @brief Maximum header value size in bytes.
+ *
+ * RFC 9204 Section 2.2.3: Implementations should enforce limits on header
+ * sizes. This constant defines the maximum size for an individual header
+ * value to prevent memory exhaustion attacks.
+ */
+#ifndef SOCKETQPACK_MAX_HEADER_VALUE_SIZE
+#define SOCKETQPACK_MAX_HEADER_VALUE_SIZE (64 * 1024) /* 64KB */
+#endif
+
 /** RFC 9204 Section 3.2: Entry overhead is 32 bytes (same as HPACK) */
 #define SOCKETQPACK_ENTRY_OVERHEAD 32
 

--- a/src/http/SocketHTTP1-parser.c
+++ b/src/http/SocketHTTP1-parser.c
@@ -883,14 +883,12 @@ determine_body_mode (SocketHTTP1_Parser_T parser)
    * validation */
   if (has_te)
     {
-      /* Early return: no chunked encoding */
+      /* Early return: no chunked encoding - always reject unsupported transfer
+       * codings per RFC 9112 Section 7. Falling back to read-until-close can
+       * cause request smuggling when deployed behind proxies that interpret
+       * Transfer-Encoding differently. */
       if (!has_chunked_encoding (parser->headers))
-        {
-          if (parser->config.strict_mode)
-            return HTTP1_ERROR_UNSUPPORTED_TRANSFER_CODING;
-          set_body_mode_until_close (parser);
-          return HTTP1_OK;
-        }
+        return HTTP1_ERROR_UNSUPPORTED_TRANSFER_CODING;
 
       /* Early return: unsupported transfer codings in strict mode */
       if (parser->config.strict_mode


### PR DESCRIPTION
Fixes #3467