### PR TITLE
fix: DTLS accept returns separate client handle to prevent UAF

### DIFF
--- a/src/simple/SocketSimple-tcp.c
+++ b/src/simple/SocketSimple-tcp.c
@@ -515,7 +515,8 @@ Socket_simple_close (SocketSimple_Socket_T *sock)
     }
 #endif
 
-  if (s->dgram)
+  /* Only free dgram if we own it (DTLS client sessions don't own the dgram) */
+  if (s->dgram && s->owns_dgram)
     {
       SocketDgram_free (&s->dgram);
     }


### PR DESCRIPTION
Fixes #3468

The DTLS accept function was returning the same server socket handle, which caused use-after-free if the caller closed what they thought was a client connection.

**Fix:**
- Add owns_dgram flag to SocketSimple_Socket structure
- Create a new client session handle that shares the dgram but doesn't own it
- Closing the client handle no longer frees the underlying server socket

This maintains API consistency with TCP accept semantics while being safe for DTLS's connectionless nature.