### PR TITLE
fix: validate subprotocols for CRLF injection (fixes #3489)

### DIFF
--- a/src/socket/SocketWS-handshake.c
+++ b/src/socket/SocketWS-handshake.c
@@ -224,6 +224,13 @@ ws_write_subprotocol_header (char *buf,
   if (!subprotocols || !subprotocols[0])
     return 0;
 
+  /* Validate all subprotocols for CRLF injection (security fix for issue #3489) */
+  for (proto = subprotocols; *proto; proto++)
+    {
+      if (ws_validate_no_crlf (*proto, "subprotocol") < 0)
+        return -1;
+    }
+
   if (ws_snprintf_checked (buf, size, offset, "Sec-WebSocket-Protocol: ") < 0)
     return -1;
 


### PR DESCRIPTION
Add CRLF validation for subprotocol names to prevent HTTP header injection attacks.

The WebSocket handshake already validates host and path for CRLF characters, but subprotocols were not validated. Malicious subprotocol names like 'proto\r\nEvil: header' could inject arbitrary HTTP headers.

Fixes #3489