### PR TITLE
fix: add index validation to QPACK duplicate encoder instruction

### DIFF
--- a/include/http/qpack/SocketQPACKEncoderStream.h
+++ b/include/http/qpack/SocketQPACKEncoderStream.h
@@ -355,7 +355,9 @@ extern SocketQPACKStream_Result SocketQPACK_EncoderStream_write_insert_literal (
  */
 extern SocketQPACKStream_Result
 SocketQPACK_EncoderStream_write_duplicate (SocketQPACK_EncoderStream_T stream,
-                                           uint64_t rel_index);
+                                           uint64_t rel_index,
+                                           uint64_t insert_count,
+                                           uint64_t dropped_count);
 
 /* ============================================================================
  * BUFFER MANAGEMENT

--- a/src/fuzz/fuzz_qpack_encoder_stream.c
+++ b/src/fuzz/fuzz_qpack_encoder_stream.c
@@ -270,8 +270,8 @@ LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
               if (res == QPACK_STREAM_OK)
                 {
                   uint64_t rel_index = val1 % 100;
-                  res = SocketQPACK_EncoderStream_write_duplicate (stream,
-                                                                   rel_index);
+                  res = SocketQPACK_EncoderStream_write_duplicate (
+                      stream, rel_index, 100, 0);
                   (void)res;
 
                   /* Reset buffer and write more */

--- a/src/test/test_qpack_vectors.c
+++ b/src/test/test_qpack_vectors.c
@@ -630,7 +630,7 @@ TEST (qpack_vector_b4_duplicate)
   ASSERT_EQ (sresult, QPACK_STREAM_OK);
 
   /* Write duplicate instruction for relative index 2 */
-  sresult = SocketQPACK_EncoderStream_write_duplicate (stream, 2);
+  sresult = SocketQPACK_EncoderStream_write_duplicate (stream, 2, 10, 0);
   ASSERT_EQ (sresult, QPACK_STREAM_OK);
 
   /* Verify wire format */


### PR DESCRIPTION
Fixes #3485

Adds defense-in-depth validation to `SocketQPACK_EncoderStream_write_duplicate` by requiring `insert_count` and `dropped_count` parameters and validating the relative index via `SocketQPACK_is_valid_relative_encoder` before encoding. This prevents corrupted encoder state from propagating invalid indices to the decoder.