### PR TITLE
refactor: replace port 65535 magic numbers with SOCKET_MAX_PORT

### DIFF
--- a/src/dns/SocketDNS.c
+++ b/src/dns/SocketDNS.c
@@ -111,16 +111,14 @@ initialize_mutex (struct SocketDNS_T *dns)
 static void
 initialize_queue_condition (struct SocketDNS_T *dns)
 {
-  /* TODO(Phase 2.x): Removed - no queue condition needed without worker threads
-   */
+  /* No queue condition needed - synchronous resolver uses direct callbacks */
   (void)dns;
 }
 
 static void
 initialize_result_condition (struct SocketDNS_T *dns)
 {
-  /* TODO(Phase 2.x): Removed - no result condition needed without worker
-   * threads */
+  /* No result condition needed - synchronous resolver uses direct callbacks */
   (void)dns;
 }
 

--- a/src/simple/SocketSimple-happyeyeballs.c
+++ b/src/simple/SocketSimple-happyeyeballs.c
@@ -62,7 +62,7 @@ Socket_simple_happyeyeballs_connect_config (
       return NULL;
     }
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return NULL;

--- a/src/simple/SocketSimple-proxy.c
+++ b/src/simple/SocketSimple-proxy.c
@@ -325,7 +325,7 @@ parse_port_number (const char *port_str)
     }
 
   /* Check for overflow or out of range */
-  if (errno == ERANGE || port <= 0 || port > 65535)
+  if (errno == ERANGE || port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
                         "Invalid port: out of range");
@@ -511,7 +511,7 @@ Socket_simple_proxy_connect_timeout (const SocketSimple_ProxyConfig *config,
         return Socket_simple_connect (target_host, target_port);
     }
 
-  if (!target_host || target_port <= 0 || target_port > 65535)
+  if (!target_host || target_port <= 0 || target_port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
                         "Invalid target host or port");
@@ -644,7 +644,7 @@ Socket_simple_proxy_tunnel (SocketSimple_Socket_T sock,
       return 0;
     }
 
-  if (!target_host || target_port <= 0 || target_port > 65535)
+  if (!target_host || target_port <= 0 || target_port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG,
                         "Invalid target host or port");

--- a/src/simple/SocketSimple-reconnect.c
+++ b/src/simple/SocketSimple-reconnect.c
@@ -122,7 +122,7 @@ Socket_simple_reconnect_new (const char *host,
       return NULL;
     }
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return NULL;

--- a/src/simple/SocketSimple-tcp.c
+++ b/src/simple/SocketSimple-tcp.c
@@ -58,7 +58,7 @@ Socket_simple_connect_timeout (const char *host, int port, int timeout_ms)
 
   Socket_simple_clear_error ();
 
-  if (!host || port <= 0 || port > 65535)
+  if (!host || port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid host or port");
       return NULL;
@@ -107,7 +107,7 @@ Socket_simple_listen (const char *host, int port, int backlog)
 
   Socket_simple_clear_error ();
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return NULL;
@@ -542,7 +542,7 @@ Socket_simple_udp_bind (const char *host, int port)
 
   Socket_simple_clear_error ();
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return NULL;
@@ -614,7 +614,7 @@ Socket_simple_udp_sendto (SocketSimple_Socket_T sock,
       return -1;
     }
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return -1;
@@ -891,7 +891,7 @@ Socket_simple_udp_connect (SocketSimple_Socket_T sock,
       return -1;
     }
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return -1;

--- a/src/simple/SocketSimple-tls.c
+++ b/src/simple/SocketSimple-tls.c
@@ -122,7 +122,7 @@ Socket_simple_connect_tls_ex (const char *host,
 
   Socket_simple_clear_error ();
 
-  if (!host || port <= 0 || port > 65535)
+  if (!host || port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid host or port");
       return NULL;
@@ -499,7 +499,7 @@ Socket_simple_listen_tls (const char *host,
 
   Socket_simple_clear_error ();
 
-  if (port <= 0 || port > 65535)
+  if (port <= 0 || port > SOCKET_MAX_PORT)
     {
       simple_set_error (SOCKET_SIMPLE_ERR_INVALID_ARG, "Invalid port");
       return NULL;

--- a/src/socket/SocketProxy-socks5.c
+++ b/src/socket/SocketProxy-socks5.c
@@ -613,7 +613,7 @@ proxy_socks5_send_connect (struct SocketProxy_Conn_T *conn)
   size_t len = 0;
 
   /* Validate target port range */
-  if (conn->target_port < 1 || conn->target_port > 65535)
+  if (conn->target_port < 1 || conn->target_port > SOCKET_MAX_PORT)
     {
       socketproxy_set_error (conn,
                              PROXY_ERROR,

--- a/src/socket/SocketProxy.c
+++ b/src/socket/SocketProxy.c
@@ -372,7 +372,7 @@ socketproxy_parse_ipv6_hostport (const char *start,
       if (*endptr != '\0' && *endptr != '/' && *endptr != '?' && *endptr != '#')
         return -1;
 
-      if (p < 1 || p > 65535)
+      if (p < 1 || p > SOCKET_MAX_PORT)
         return -1;
 
       config->port = (int)p;
@@ -420,14 +420,14 @@ socketproxy_parse_ipv4_hostport (const char *start,
       host_end = colon;
       char *endptr;
       long p = strtol (colon + 1, &endptr, 10);
-      if (endptr <= colon + 1 || p < 1 || p > 65535)
+      if (endptr <= colon + 1 || p < 1 || p > SOCKET_MAX_PORT)
         {
           return -1;
         }
       config->port = (int)p;
       if (endptr > authority_end)
         authority_end = endptr;
-      if (config->port <= 0 || config->port > 65535)
+      if (config->port <= 0 || config->port > SOCKET_MAX_PORT)
         return -1;
     }
 
@@ -736,9 +736,9 @@ proxy_validate_target (const char *target_host, int target_port)
           "Target hostname contains forbidden characters (CR or LF)");
       RAISE_PROXY_ERROR (SocketProxy_Failed);
     }
-  if (target_port < 1 || target_port > 65535)
+  if (target_port < 1 || target_port > SOCKET_MAX_PORT)
     {
-      PROXY_ERROR_MSG ("Invalid target port %d (must be 1-65535)", target_port);
+      PROXY_ERROR_MSG ("Invalid target port %d (must be " SOCKET_PORT_VALID_RANGE ")", target_port);
       RAISE_PROXY_ERROR (SocketProxy_Failed);
     }
   return 0;
@@ -1057,7 +1057,7 @@ SocketProxy_Conn_start (SocketDNSResolver_T resolver,
   assert (poll != NULL);
   assert (proxy != NULL);
   assert (target_host != NULL);
-  assert (target_port > 0 && target_port <= 65535);
+  assert (target_port > 0 && target_port <= SOCKET_MAX_PORT);
 
   /* Validate inputs */
   proxy_validate_config (proxy);
@@ -1095,7 +1095,7 @@ SocketProxy_Conn_new (const SocketProxy_Config *proxy,
 
   assert (proxy != NULL);
   assert (target_host != NULL);
-  assert (target_port > 0 && target_port <= 65535);
+  assert (target_port > 0 && target_port <= SOCKET_MAX_PORT);
 
   /* Validate inputs */
   proxy_validate_config (proxy);
@@ -2023,7 +2023,7 @@ SocketProxy_tunnel (Socket_T socket,
   assert (socket != NULL);
   assert (proxy != NULL);
   assert (target_host != NULL);
-  assert (target_port > 0 && target_port <= 65535);
+  assert (target_port > 0 && target_port <= SOCKET_MAX_PORT);
 
   /* Early validation guards */
   if (proxy->type == SOCKET_PROXY_NONE)
@@ -2034,7 +2034,7 @@ SocketProxy_tunnel (Socket_T socket,
     return PROXY_ERROR_PROTOCOL;
   if (strpbrk (target_host, "\r\n") != NULL)
     return PROXY_ERROR_PROTOCOL;
-  if (target_port < 1 || target_port > 65535)
+  if (target_port < 1 || target_port > SOCKET_MAX_PORT)
     return PROXY_ERROR_PROTOCOL;
 
   proxy_tunnel_init_context (

--- a/src/socket/SocketReconnect.c
+++ b/src/socket/SocketReconnect.c
@@ -952,9 +952,9 @@ SocketReconnect_new (const char *host,
       SOCKET_ERROR_MSG ("Host cannot be NULL");
       RAISE_MODULE_ERROR (SocketReconnect_Failed);
     }
-  if (!(port > 0 && port <= 65535))
+  if (!(port > 0 && port <= SOCKET_MAX_PORT))
     {
-      SOCKET_ERROR_FMT ("Invalid port %d (must be 1-65535)", port);
+      SOCKET_ERROR_FMT ("Invalid port %d (must be " SOCKET_PORT_VALID_RANGE ")", port);
       RAISE_MODULE_ERROR (SocketReconnect_Failed);
     }
 

--- a/src/socket/SocketWS.c
+++ b/src/socket/SocketWS.c
@@ -1564,7 +1564,7 @@ ws_parse_url_port (const char *port_start, const char *path_start, int *port)
     return 0;
 
   p = strtol (port_start + 1, &endptr, 10);
-  if (endptr == port_start + 1 || p < 1 || p > 65535)
+  if (endptr == port_start + 1 || p < 1 || p > SOCKET_MAX_PORT)
     {
       SOCKET_ERROR_MSG ("Invalid port in WebSocket URL");
       return -1;


### PR DESCRIPTION
## Summary
- Replace all hardcoded `65535` port validation with `SOCKET_MAX_PORT` constant across 10 production files
- Update error message strings to use `SOCKET_PORT_VALID_RANGE` macro
- Clean up 2 stale `TODO(Phase 2.x)` comments in `SocketDNS.c`

Fixes #3528

## Changes

**Port validation (10 files):**
- `src/simple/SocketSimple-tcp.c` (5 locations)
- `src/simple/SocketSimple-tls.c` (2 locations)
- `src/simple/SocketSimple-proxy.c` (3 locations)
- `src/simple/SocketSimple-reconnect.c` (1 location)
- `src/simple/SocketSimple-happyeyeballs.c` (1 location)
- `src/simple/SocketSimple-dtls.c` (already used `SOCKET_MAX_PORT` - no change needed)
- `src/socket/SocketProxy.c` (9 locations)
- `src/socket/SocketProxy-socks5.c` (1 location)
- `src/socket/SocketReconnect.c` (1 location + error message)
- `src/socket/SocketWS.c` (1 location)

**Stale comment cleanup:**
- `src/dns/SocketDNS.c` - Replaced `TODO(Phase 2.x)` comments with descriptive comments explaining current design

## Test plan
- [x] All 177 tests pass with ASan + UBSan enabled
- [x] No behavior changes - purely mechanical constant substitution