### PR TITLE
refactor: centralize magic numbers into SocketConfig.h

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -1819,6 +1819,61 @@ typedef struct SocketTimeouts_Extended
 #endif
 
 /* ============================================================================
+ * HTTP Pool Configuration
+ * ============================================================================
+ */
+
+/**
+ * @brief Maximum hash chain length for HTTP client connection pool.
+ *
+ * SECURITY: Limits hash chain traversal to prevent DoS via hash collision
+ * attacks on the HTTP connection pool.
+ */
+#ifndef SOCKET_HTTP_POOL_MAX_CHAIN_LEN
+#define SOCKET_HTTP_POOL_MAX_CHAIN_LEN 1024
+#endif
+
+/**
+ * @brief Hash table load factor for HTTP client connection pool.
+ *
+ * Hash table size = max_connections / load_factor. A load factor of 8
+ * balances memory usage with lookup performance.
+ */
+#ifndef SOCKET_HTTP_POOL_LOAD_FACTOR
+#define SOCKET_HTTP_POOL_LOAD_FACTOR 8
+#endif
+
+/**
+ * @brief Maximum hash chain length for HTTP header hash table.
+ *
+ * SECURITY: Limits chain traversal during header lookups to prevent
+ * algorithmic complexity attacks.
+ */
+#ifndef SOCKETHTTP_MAX_CHAIN_LEN
+#define SOCKETHTTP_MAX_CHAIN_LEN 10
+#endif
+
+/**
+ * @brief Maximum DoS chain-length warnings before hard failure.
+ *
+ * After this many warnings about excessive chain lengths, the connection
+ * is rejected to prevent resource exhaustion.
+ */
+#ifndef SOCKETHTTP_MAX_DOS_WARNINGS
+#define SOCKETHTTP_MAX_DOS_WARNINGS 3
+#endif
+
+/**
+ * @brief Default batch size for SocketPool_foreach iteration.
+ *
+ * Balances lock contention vs iteration overhead. The pool mutex is
+ * released and reacquired every batch_size iterations.
+ */
+#ifndef SOCKET_POOL_FOREACH_BATCH_SIZE
+#define SOCKET_POOL_FOREACH_BATCH_SIZE 100
+#endif
+
+/* ============================================================================
  * Hash and Algorithm Constants
  * ============================================================================
  */

--- a/src/http/SocketHTTP-headers.c
+++ b/src/http/SocketHTTP-headers.c
@@ -25,9 +25,8 @@
  */
 
 #define HEADER_ENTRY_NULL_OVERHEAD 2
-#define SOCKETHTTP_MAX_CHAIN_LEN 10
+/* SOCKETHTTP_MAX_CHAIN_LEN and SOCKETHTTP_MAX_DOS_WARNINGS from SocketConfig.h */
 #define SOCKETHTTP_MAX_CHAIN_SEARCH_LEN (SOCKETHTTP_MAX_CHAIN_LEN * 2)
-#define SOCKETHTTP_MAX_DOS_WARNINGS 3 /* Hard fail after this many warnings */
 
 #define VALIDATE_HEADERS_NAME(headers, name, retval) \
   do                                                 \

--- a/src/pool/SocketPool-ops.c
+++ b/src/pool/SocketPool-ops.c
@@ -36,21 +36,9 @@
 
 /* SOCKET_LOG_COMPONENT defined in SocketPool-private.h */
 
-/**
- * Default batch size for SocketPool_foreach iteration.
- * Balances lock contention vs iteration overhead.
- */
-#ifndef SOCKET_POOL_FOREACH_BATCH_SIZE
-#define SOCKET_POOL_FOREACH_BATCH_SIZE 100
-#endif
-
-/**
- * Divisor for converting percentage (0-100) to fraction.
- * Used in SocketPool_prewarm to calculate slot count from percentage.
- */
-#ifndef SOCKET_PERCENTAGE_DIVISOR
-#define SOCKET_PERCENTAGE_DIVISOR 100
-#endif
+/* Uses centralized constants from SocketConfig.h:
+ * SOCKET_POOL_FOREACH_BATCH_SIZE - iteration batch size
+ * SOCKET_PERCENTAGE_DIVISOR      - percentage conversion */
 
 #define T SocketPool_T
 


### PR DESCRIPTION
## Summary
- Move 5 local magic number constants from 3 source files into centralized `SocketConfig.h`
- Replace `POOL_MAX_HASH_CHAIN_LEN` → `SOCKET_HTTP_POOL_MAX_CHAIN_LEN` and `POOL_TARGET_LOAD_FACTOR` → `SOCKET_HTTP_POOL_LOAD_FACTOR` in SocketHTTPClient-pool.c
- Remove duplicate `SOCKET_POOL_FOREACH_BATCH_SIZE` and `SOCKET_PERCENTAGE_DIVISOR` from SocketPool-ops.c (already in SocketConfig.h)
- Move `SOCKETHTTP_MAX_CHAIN_LEN` and `SOCKETHTTP_MAX_DOS_WARNINGS` from SocketHTTP-headers.c to SocketConfig.h

Fixes #3532

## Test plan
- [x] All 177 tests pass with ASan+UBSan enabled
- [x] No behavior change — pure constant centralization