### PR TITLE
fix: implement per-stream reference tracking for QPACK stream cancellation

### DIFF
--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -516,9 +516,8 @@ SocketQPACK_decode_set_capacity (const unsigned char *input,
  *
  * @since 1.0.0
  */
-extern bool
-SocketQPACK_can_reduce_capacity (SocketQPACK_Table_T table,
-                                 uint64_t new_capacity);
+extern bool SocketQPACK_can_reduce_capacity (SocketQPACK_Table_T table,
+                                             uint64_t new_capacity);
 
 /**
  * @brief Apply Set Dynamic Table Capacity to a table.
@@ -666,6 +665,39 @@ SocketQPACK_Table_get (SocketQPACK_Table_T table,
                        size_t *name_len,
                        const char **value,
                        size_t *value_len);
+
+/**
+ * @brief Record a dynamic table reference for a stream.
+ *
+ * Tracks that the given stream references the dynamic table entry at
+ * abs_index. Used for accurate stream cancellation (RFC 9204 §4.4.2).
+ *
+ * @param table     Dynamic table
+ * @param stream_id HTTP/3 stream ID
+ * @param abs_index Absolute index of referenced entry
+ *
+ * @return QPACK_OK on success, QPACK_ERR_TABLE_SIZE if ref limit reached
+ *
+ * @since 1.0.0
+ */
+extern SocketQPACK_Result
+SocketQPACK_Table_record_stream_ref (SocketQPACK_Table_T table,
+                                     uint64_t stream_id,
+                                     uint64_t abs_index);
+
+/**
+ * @brief Release all dynamic table references for a stream.
+ *
+ * Decrements ref_count only on entries referenced by the given stream.
+ * Called on stream cancellation or section acknowledgment.
+ *
+ * @param table     Dynamic table
+ * @param stream_id HTTP/3 stream ID
+ *
+ * @since 1.0.0
+ */
+extern void SocketQPACK_Table_release_stream_refs (SocketQPACK_Table_T table,
+                                                   uint64_t stream_id);
 
 /* ============================================================================
  * INSERT WITH LITERAL NAME (RFC 9204 Section 4.3.3)

--- a/src/http/qpack/SocketQPACK-decoder-stream.c
+++ b/src/http/qpack/SocketQPACK-decoder-stream.c
@@ -553,31 +553,13 @@ SocketQPACK_stream_cancel_release_refs (SocketQPACK_Table_T table,
   /*
    * RFC 9204 Section 4.4.2: Release dynamic table references
    *
-   * When a Stream Cancellation is received, we need to release all
-   * dynamic table references held by that stream.
-   *
-   * Conservative implementation (fixes #3477): Since per-stream reference
-   * tracking is not yet implemented, we decrement ref_count on all entries
-   * that have references. This may under-count but prevents stuck entries
-   * that can never be evicted.
-   *
-   * TODO: Implement proper per-stream reference tracking for accurate
-   * reference management.
+   * Release only the references held by the cancelled stream, using
+   * per-stream reference tracking for accurate ref_count management.
    */
-  (void)stream_id;
-
   if (table == NULL)
     return QPACK_STREAM_OK;
 
-  /* Walk all entries and decrement ref_count for referenced entries */
-  for (size_t i = 0; i < table->count; i++)
-    {
-      size_t idx = RINGBUF_WRAP (table->head + i, table->capacity);
-      if (table->entries[idx].meta.ref_count > 0)
-        {
-          table->entries[idx].meta.ref_count--;
-        }
-    }
+  SocketQPACK_Table_release_stream_refs (table, stream_id);
 
   return QPACK_STREAM_OK;
 }


### PR DESCRIPTION
## Summary
- Add `QPACK_StreamRef` struct to track (stream_id, abs_index) pairs in dynamic table
- Add `SocketQPACK_Table_record_stream_ref()` and `SocketQPACK_Table_release_stream_refs()` APIs
- Replace conservative cancel (decrement ALL refs) with accurate per-stream release
- Bounded ref array (QPACK_MAX_STREAM_REFS=4096) prevents unbounded growth from malicious peers
- Add integration test `qpack_sync_per_stream_ref_tracking`

Fixes #3540

## Test plan
- [x] All 177 tests pass with ASan+UBSan
- [x] New test verifies cancel only affects the cancelled stream's refs
- [x] Existing QPACK tests (21 files) all pass