### PR TITLE
refactor: replace magic numbers with named constants

### DIFF
--- a/src/dns/SocketDNSSEC.c
+++ b/src/dns/SocketDNSSEC.c
@@ -17,6 +17,7 @@
 #include "dns/SocketDNSWire.h"
 #include <arpa/inet.h>
 #include <ctype.h>
+#include <stdint.h>
 #include <string.h>
 #include <time.h>
 
@@ -1663,7 +1664,7 @@ parse_bind_dnskey (const char *zone,
   unsigned long protocol = strtoul (fields[4], NULL, 10);
   unsigned long algorithm = strtoul (fields[5], NULL, 10);
 
-  if (flags > 65535 || protocol > 255 || algorithm > 255)
+  if (flags > UINT16_MAX || protocol > UINT8_MAX || algorithm > UINT8_MAX)
     return -1;
 
   /* Decode base64 public key */
@@ -1717,7 +1718,7 @@ parse_bind_ds (const char *zone,
   unsigned long algorithm = strtoul (fields[4], NULL, 10);
   unsigned long digesttype = strtoul (fields[5], NULL, 10);
 
-  if (keytag > 65535 || algorithm > 255 || digesttype > 255)
+  if (keytag > UINT16_MAX || algorithm > UINT8_MAX || digesttype > UINT8_MAX)
     return -1;
 
   /* Parse hex digest */

--- a/src/dns/SocketDNSoverHTTPS.c
+++ b/src/dns/SocketDNSoverHTTPS.c
@@ -537,7 +537,7 @@ doh_validate_response (const SocketHTTPClient_Response *response,
   (void)expected_id; /* Reserved for future logging */
 
   /* Check HTTP status */
-  if (response->status_code != 200)
+  if (response->status_code != HTTP_STATUS_OK)
     {
       *error_out = DOH_ERROR_HTTP;
       return -1;

--- a/src/dns/SocketDNSoverTLS.c
+++ b/src/dns/SocketDNSoverTLS.c
@@ -607,7 +607,7 @@ queue_query (T transport, struct SocketDNSoverTLS_Query *query)
   size_t total_len;
 
   /* Validate query length fits in 16-bit length prefix (CWE-681) */
-  if (query->query_len > 65535)
+  if (query->query_len > DOT_MAX_MESSAGE_SIZE)
     {
       return -1; /* Query too large for wire format */
     }

--- a/src/http/SocketHTTP1-parser.c
+++ b/src/http/SocketHTTP1-parser.c
@@ -1068,7 +1068,8 @@ finalize_response (SocketHTTP1_Parser_T parser)
 
   /* 1xx, 204, 304 responses have no body (RFC 9112 Section 6.3) */
   if ((parser->status_code >= 100 && parser->status_code < 200)
-      || parser->status_code == 204 || parser->status_code == 304)
+      || parser->status_code == HTTP_STATUS_NO_CONTENT
+      || parser->status_code == HTTP_STATUS_NOT_MODIFIED)
     {
       parser->body_mode = HTTP1_BODY_NONE;
       parser->body_complete = 1;
@@ -1526,8 +1527,8 @@ scan_header_name (const char *p, const char *end)
  */
 static inline int
 process_header_value_chunk (SocketHTTP1_Parser_T parser,
-                             const char *chunk,
-                             size_t chunk_len)
+                            const char *chunk,
+                            size_t chunk_len)
 {
   /* Guard: check line length limit */
   if (parser->header_line_length + chunk_len > parser->config.max_header_line)
@@ -1559,8 +1560,8 @@ process_header_value_chunk (SocketHTTP1_Parser_T parser,
  */
 static inline int
 process_header_name_chunk (SocketHTTP1_Parser_T parser,
-                            const char *chunk,
-                            size_t chunk_len)
+                           const char *chunk,
+                           size_t chunk_len)
 {
   /* Guard: check line length limit */
   if (parser->header_line_length + chunk_len > parser->config.max_header_line)

--- a/src/http/client/SocketHTTPClient-retry.c
+++ b/src/http/client/SocketHTTPClient-retry.c
@@ -150,8 +150,11 @@ httpclient_clear_response_for_retry (SocketHTTPClient_Response *response)
 int
 httpclient_is_redirect_status (int status_code)
 {
-  return (status_code == 301 || status_code == 302 || status_code == 303
-          || status_code == 307 || status_code == 308);
+  return (status_code == HTTP_STATUS_MOVED_PERMANENTLY
+          || status_code == HTTP_STATUS_FOUND
+          || status_code == HTTP_STATUS_SEE_OTHER
+          || status_code == HTTP_STATUS_TEMPORARY_REDIRECT
+          || status_code == HTTP_STATUS_PERMANENT_REDIRECT);
 }
 
 int

--- a/src/http/hpack/SocketHPACK-huffman.c
+++ b/src/http/hpack/SocketHPACK-huffman.c
@@ -734,7 +734,7 @@ static inline uint32_t
 hash_long_code (int bitlen, uint64_t code)
 {
   uint64_t key = HASH_KEY64 (bitlen, code);
-  return (uint32_t)((key * 2654435761ULL) % LONG_CODE_HASH_SIZE);
+  return (uint32_t)((key * (uint64_t)HASH_GOLDEN_RATIO) % LONG_CODE_HASH_SIZE);
 }
 
 /**

--- a/src/http/server/SocketHTTPServer-connections.c
+++ b/src/http/server/SocketHTTPServer-connections.c
@@ -643,11 +643,12 @@ connection_send_response (SocketHTTPServer_T server, ServerConnection *conn)
   response.headers = conn->response_headers;
 
   /* Track error metrics */
-  if (conn->response_status >= 400 && conn->response_status < 500)
+  if (conn->response_status >= HTTP_STATUS_4XX_MIN
+      && conn->response_status < HTTP_STATUS_5XX_MIN)
     {
       SERVER_METRICS_INC (server, SOCKET_CTR_HTTP_RESPONSES_4XX, errors_4xx);
     }
-  else if (conn->response_status >= 500)
+  else if (conn->response_status >= HTTP_STATUS_5XX_MIN)
     {
       SERVER_METRICS_INC (server, SOCKET_CTR_HTTP_RESPONSES_5XX, errors_5xx);
     }

--- a/src/http/server/SocketHTTPServer-h2.c
+++ b/src/http/server/SocketHTTPServer-h2.c
@@ -67,7 +67,7 @@ server_http2_stream_get_or_create (SocketHTTPServer_T server,
   memset (s, 0, sizeof (*s));
   s->arena = arena;
   s->stream = stream;
-  s->response_status = 200;
+  s->response_status = HTTP_STATUS_OK;
   s->response_headers = SocketHTTP_Headers_new (arena);
 
   s->next = conn->http2_streams;
@@ -712,7 +712,7 @@ server_http2_handle_request (HTTP2ServerCallbackCtx *ctx, ServerHTTP2Stream *s)
   if (!h2_check_request_preconditions (server, s, &req_ctx))
     return;
 
-  s->response_status = 200;
+  s->response_status = HTTP_STATUS_OK;
 
   h2_run_middleware_and_handler (server, s, &req_ctx);
 
@@ -1307,11 +1307,11 @@ prepare_h2_websocket_response (SocketHTTPServer_Request_T req,
   if (s->response_headers == NULL)
     return -1;
 
-  s->response_status = 200;
+  s->response_status = HTTP_STATUS_OK;
 
   memset (response, 0, sizeof (*response));
   response->version = HTTP_VERSION_2;
-  response->status_code = 200;
+  response->status_code = HTTP_STATUS_OK;
   response->headers = s->response_headers;
 
   return 0;

--- a/src/http/server/SocketHTTPServer-http1.c
+++ b/src/http/server/SocketHTTPServer-http1.c
@@ -524,7 +524,7 @@ server_invoke_handler (SocketHTTPServer_T server, ServerConnection *conn)
   req_ctx.arena = conn->arena;
   req_ctx.start_time_ms = conn->request_start_ms;
 
-  conn->response_status = 200;
+  conn->response_status = HTTP_STATUS_OK;
 
   /* Execute middleware chain in order */
   for (mw = server->middleware_chain; mw != NULL; mw = mw->next)


### PR DESCRIPTION
## Summary
- Replace hardcoded HTTP status codes with existing `SocketHTTP_StatusCode` enum values across 7 HTTP modules and DoH
- Replace DNSSEC field validation bounds (65535, 255) with `UINT16_MAX`/`UINT8_MAX` from `<stdint.h>`
- Replace DoT magic `65535` with existing `DOT_MAX_MESSAGE_SIZE` constant
- Replace HPACK inline hash constant with `(uint64_t)HASH_GOLDEN_RATIO` from SocketConfig.h
- Add `QPACK_HUFFMAN_EXPANSION_FACTOR` and `QPACK_MIN_DECODE_BUFFER_SIZE` local constants in 2 QPACK files

No new constants were added to shared headers — all HTTP status codes already existed in the `SocketHTTP_StatusCode` enum in `SocketHTTP.h`.

Fixes #3544

## Test plan
- [x] All 177 tests pass with ASan + UBSan enabled
- [x] All modified files formatted with clang-format