### PR TITLE
feat: add HTTP/3 constants and CMake build integration (RFC 9114)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,9 @@ set(LIB_SOURCES
     src/http/qpack/SocketQPACK-blocked.c
     src/http/qpack/SocketQPACK-config.c
 
+    # HTTP/3 Constants (RFC 9114)
+    src/http/SocketHTTP3-constants.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -881,6 +884,7 @@ set(TEST_SOURCES
     test_qpack_http3_integration
     test_qpack_error_integration
     test_qpack_vectors
+    test_http3_constants
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/SocketHTTP3-constants.h
+++ b/include/http/SocketHTTP3-constants.h
@@ -1,0 +1,196 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-constants.h
+ * @brief HTTP/3 constants: frame types, error codes, settings, stream types
+ *        (RFC 9114).
+ *
+ * This header defines the protocol constants needed for HTTP/3 framing,
+ * error reporting, settings negotiation, and unidirectional stream typing.
+ * QUIC varint encoding applies to all wire values (62-bit space), but named
+ * constants fit in standard C enums.
+ */
+
+#ifndef SOCKETHTTP3_CONSTANTS_INCLUDED
+#define SOCKETHTTP3_CONSTANTS_INCLUDED
+
+#include <stdint.h>
+
+/* ============================================================================
+ * FRAME TYPES (RFC 9114 Section 7.2)
+ * ============================================================================
+ */
+
+/** HTTP/3 frame types (RFC 9114 Section 7.2) */
+typedef enum
+{
+  HTTP3_FRAME_DATA = 0x00,         /**< §7.2.1 DATA */
+  HTTP3_FRAME_HEADERS = 0x01,      /**< §7.2.2 HEADERS */
+  HTTP3_FRAME_CANCEL_PUSH = 0x03,  /**< §7.2.3 CANCEL_PUSH */
+  HTTP3_FRAME_SETTINGS = 0x04,     /**< §7.2.4 SETTINGS */
+  HTTP3_FRAME_PUSH_PROMISE = 0x05, /**< §7.2.5 PUSH_PROMISE */
+  HTTP3_FRAME_GOAWAY = 0x07,       /**< §7.2.6 GOAWAY */
+  HTTP3_FRAME_MAX_PUSH_ID = 0x0d   /**< §7.2.7 MAX_PUSH_ID */
+} SocketHTTP3_FrameType;
+
+/* ============================================================================
+ * RESERVED HTTP/2 FRAME TYPES (RFC 9114 Section 11.2.1)
+ *
+ * These HTTP/2 frame types MUST NOT appear on the wire in HTTP/3.
+ * Receipt MUST be treated as H3_FRAME_UNEXPECTED.
+ * ============================================================================
+ */
+
+#define HTTP3_H2_FRAME_PRIORITY 0x02 /**< HTTP/2 PRIORITY — reserved */
+#define HTTP3_H2_FRAME_PING 0x06     /**< HTTP/2 PING — reserved */
+#define HTTP3_H2_FRAME_WINDOW_UPDATE \
+  0x08 /**< HTTP/2 WINDOW_UPDATE — reserved */
+#define HTTP3_H2_FRAME_CONTINUATION 0x09 /**< HTTP/2 CONTINUATION — reserved \
+                                          */
+
+/**
+ * @brief Check whether a frame type is a reserved HTTP/2 type.
+ *
+ * RFC 9114 §11.2.1: These frame types MUST NOT be sent in HTTP/3.
+ */
+#define HTTP3_IS_RESERVED_H2_FRAME(type)                              \
+  ((type) == HTTP3_H2_FRAME_PRIORITY || (type) == HTTP3_H2_FRAME_PING \
+   || (type) == HTTP3_H2_FRAME_WINDOW_UPDATE                          \
+   || (type) == HTTP3_H2_FRAME_CONTINUATION)
+
+/* ============================================================================
+ * ERROR CODES (RFC 9114 Section 8.1)
+ * ============================================================================
+ */
+
+/** HTTP/3 error codes (RFC 9114 Section 8.1) */
+typedef enum
+{
+  H3_NO_ERROR = 0x0100,
+  H3_GENERAL_PROTOCOL_ERROR = 0x0101,
+  H3_INTERNAL_ERROR = 0x0102,
+  H3_STREAM_CREATION_ERROR = 0x0103,
+  H3_CLOSED_CRITICAL_STREAM = 0x0104,
+  H3_FRAME_UNEXPECTED = 0x0105,
+  H3_FRAME_ERROR = 0x0106,
+  H3_EXCESSIVE_LOAD = 0x0107,
+  H3_ID_ERROR = 0x0108,
+  H3_SETTINGS_ERROR = 0x0109,
+  H3_MISSING_SETTINGS = 0x010a,
+  H3_REQUEST_REJECTED = 0x010b,
+  H3_REQUEST_CANCELLED = 0x010c,
+  H3_REQUEST_INCOMPLETE = 0x010d,
+  H3_MESSAGE_ERROR = 0x010e,
+  H3_CONNECT_ERROR = 0x010f,
+  H3_VERSION_FALLBACK = 0x0110
+} SocketHTTP3_ErrorCode;
+
+/* ============================================================================
+ * SETTINGS IDENTIFIERS (RFC 9114 Section 7.2.4.1)
+ * ============================================================================
+ */
+
+/** HTTP/3 settings identifiers (RFC 9114 Section 7.2.4.1) */
+typedef enum
+{
+  H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY = 0x01,
+  H3_SETTINGS_MAX_FIELD_SECTION_SIZE = 0x06,
+  H3_SETTINGS_QPACK_BLOCKED_STREAMS = 0x07
+} SocketHTTP3_SettingsId;
+
+/* ============================================================================
+ * RESERVED HTTP/2 SETTINGS (RFC 9114 Section 11.2.2)
+ *
+ * These HTTP/2 settings identifiers MUST NOT be sent in HTTP/3.
+ * Receipt MUST be treated as H3_SETTINGS_ERROR.
+ * ============================================================================
+ */
+
+#define HTTP3_H2_SETTINGS_HEADER_TABLE_SIZE                                   \
+  0x01                                                /**< Overloaded — but \
+                                                         H3 uses 0x01 for     \
+                                                         QPACK_MAX_TABLE_CAPACITY */
+#define HTTP3_H2_SETTINGS_ENABLE_PUSH 0x02            /**< Reserved */
+#define HTTP3_H2_SETTINGS_MAX_CONCURRENT_STREAMS 0x03 /**< Reserved */
+#define HTTP3_H2_SETTINGS_INITIAL_WINDOW_SIZE 0x04    /**< Reserved */
+#define HTTP3_H2_SETTINGS_MAX_FRAME_SIZE 0x05         /**< Reserved */
+
+/**
+ * @brief Check whether a settings identifier is a reserved HTTP/2 setting.
+ *
+ * RFC 9114 §11.2.2: Identifiers 0x02, 0x03, 0x04, 0x05 MUST NOT be sent.
+ * Note: 0x01 is reused by H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY and is valid.
+ */
+#define HTTP3_IS_RESERVED_H2_SETTING(id)               \
+  ((id) == HTTP3_H2_SETTINGS_ENABLE_PUSH               \
+   || (id) == HTTP3_H2_SETTINGS_MAX_CONCURRENT_STREAMS \
+   || (id) == HTTP3_H2_SETTINGS_INITIAL_WINDOW_SIZE    \
+   || (id) == HTTP3_H2_SETTINGS_MAX_FRAME_SIZE)
+
+/* ============================================================================
+ * UNIDIRECTIONAL STREAM TYPES (RFC 9114 Section 6.2)
+ * ============================================================================
+ */
+
+/** HTTP/3 unidirectional stream types (RFC 9114 Section 6.2) */
+typedef enum
+{
+  H3_STREAM_TYPE_CONTROL = 0x00,       /**< §6.2.1 Control stream */
+  H3_STREAM_TYPE_PUSH = 0x01,          /**< §6.2.2 Push stream */
+  H3_STREAM_TYPE_QPACK_ENCODER = 0x02, /**< §6.2.3 QPACK encoder */
+  H3_STREAM_TYPE_QPACK_DECODER = 0x03  /**< §6.2.3 QPACK decoder */
+} SocketHTTP3_StreamType;
+
+/* ============================================================================
+ * GREASE (RFC 9114 Section 7.2.8 / 6.2.3 / 8.1)
+ * ============================================================================
+ */
+
+/**
+ * @brief Check whether a value is a GREASE value.
+ *
+ * GREASE values follow the formula 0x1f * N + 0x21 for non-negative integer N.
+ * Used to exercise extensibility for frame types (§7.2.8), stream types
+ * (§6.2.3), and error codes (§8.1).
+ */
+#define H3_IS_GREASE(val) \
+  (((uint64_t)(val) >= 0x21) && (((uint64_t)(val) - 0x21) % 0x1f == 0))
+
+/* ============================================================================
+ * NAME LOOKUP FUNCTIONS
+ * ============================================================================
+ */
+
+/**
+ * @brief Return human-readable name for an HTTP/3 frame type.
+ * @param type  Frame type value.
+ * @return Static string, or "UNKNOWN" for unrecognised types.
+ */
+const char *SocketHTTP3_frame_type_name (uint64_t type);
+
+/**
+ * @brief Return human-readable name for an HTTP/3 error code.
+ * @param code  Error code value.
+ * @return Static string, or "UNKNOWN" for unrecognised codes.
+ */
+const char *SocketHTTP3_error_code_name (uint64_t code);
+
+/**
+ * @brief Return human-readable name for an HTTP/3 stream type.
+ * @param type  Stream type value.
+ * @return Static string, or "UNKNOWN" for unrecognised types.
+ */
+const char *SocketHTTP3_stream_type_name (uint64_t type);
+
+/**
+ * @brief Return human-readable name for an HTTP/3 settings identifier.
+ * @param id  Settings identifier value.
+ * @return Static string, or "UNKNOWN" for unrecognised identifiers.
+ */
+const char *SocketHTTP3_settings_name (uint64_t id);
+
+#endif /* SOCKETHTTP3_CONSTANTS_INCLUDED */

--- a/include/http/qpack/SocketQPACK.h
+++ b/include/http/qpack/SocketQPACK.h
@@ -181,25 +181,12 @@ typedef enum
 #define QPACK_RESULT_COUNT (QPACK_ERR_0RTT_MISMATCH + 1)
 
 /* ============================================================================
- * HTTP/3 ERROR CODES (RFC 9204 Section 4.2 & 6)
+ * HTTP/3 & QPACK ERROR CODES
  * ============================================================================
  */
 
-/**
- * @brief HTTP/3 error: Stream creation error (RFC 9114).
- *
- * RFC 9204 Section 4.2: Receipt of a second instance of either
- * encoder or decoder stream type MUST be treated as this error.
- */
-#define H3_STREAM_CREATION_ERROR 0x0103
-
-/**
- * @brief HTTP/3 error: Critical stream was closed (RFC 9114).
- *
- * RFC 9204 Section 4.2: Closure of either encoder or decoder
- * stream MUST be treated as this connection error.
- */
-#define H3_CLOSED_CRITICAL_STREAM 0x0104
+/* HTTP/3 error codes (RFC 9114 §8.1) — full set in SocketHTTP3-constants.h */
+#include "http/SocketHTTP3-constants.h"
 
 /**
  * @brief QPACK decompression failed (RFC 9204 Section 6).

--- a/src/http/SocketHTTP3-constants.c
+++ b/src/http/SocketHTTP3-constants.c
@@ -1,0 +1,122 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-constants.c
+ * @brief Name-lookup functions for HTTP/3 constants (RFC 9114).
+ */
+
+#include "http/SocketHTTP3-constants.h"
+
+const char *
+SocketHTTP3_frame_type_name (uint64_t type)
+{
+  switch (type)
+    {
+    case HTTP3_FRAME_DATA:
+      return "DATA";
+    case HTTP3_FRAME_HEADERS:
+      return "HEADERS";
+    case HTTP3_FRAME_CANCEL_PUSH:
+      return "CANCEL_PUSH";
+    case HTTP3_FRAME_SETTINGS:
+      return "SETTINGS";
+    case HTTP3_FRAME_PUSH_PROMISE:
+      return "PUSH_PROMISE";
+    case HTTP3_FRAME_GOAWAY:
+      return "GOAWAY";
+    case HTTP3_FRAME_MAX_PUSH_ID:
+      return "MAX_PUSH_ID";
+    case HTTP3_H2_FRAME_PRIORITY:
+      return "PRIORITY (reserved H2)";
+    case HTTP3_H2_FRAME_PING:
+      return "PING (reserved H2)";
+    case HTTP3_H2_FRAME_WINDOW_UPDATE:
+      return "WINDOW_UPDATE (reserved H2)";
+    case HTTP3_H2_FRAME_CONTINUATION:
+      return "CONTINUATION (reserved H2)";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+const char *
+SocketHTTP3_error_code_name (uint64_t code)
+{
+  switch (code)
+    {
+    case H3_NO_ERROR:
+      return "H3_NO_ERROR";
+    case H3_GENERAL_PROTOCOL_ERROR:
+      return "H3_GENERAL_PROTOCOL_ERROR";
+    case H3_INTERNAL_ERROR:
+      return "H3_INTERNAL_ERROR";
+    case H3_STREAM_CREATION_ERROR:
+      return "H3_STREAM_CREATION_ERROR";
+    case H3_CLOSED_CRITICAL_STREAM:
+      return "H3_CLOSED_CRITICAL_STREAM";
+    case H3_FRAME_UNEXPECTED:
+      return "H3_FRAME_UNEXPECTED";
+    case H3_FRAME_ERROR:
+      return "H3_FRAME_ERROR";
+    case H3_EXCESSIVE_LOAD:
+      return "H3_EXCESSIVE_LOAD";
+    case H3_ID_ERROR:
+      return "H3_ID_ERROR";
+    case H3_SETTINGS_ERROR:
+      return "H3_SETTINGS_ERROR";
+    case H3_MISSING_SETTINGS:
+      return "H3_MISSING_SETTINGS";
+    case H3_REQUEST_REJECTED:
+      return "H3_REQUEST_REJECTED";
+    case H3_REQUEST_CANCELLED:
+      return "H3_REQUEST_CANCELLED";
+    case H3_REQUEST_INCOMPLETE:
+      return "H3_REQUEST_INCOMPLETE";
+    case H3_MESSAGE_ERROR:
+      return "H3_MESSAGE_ERROR";
+    case H3_CONNECT_ERROR:
+      return "H3_CONNECT_ERROR";
+    case H3_VERSION_FALLBACK:
+      return "H3_VERSION_FALLBACK";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+const char *
+SocketHTTP3_stream_type_name (uint64_t type)
+{
+  switch (type)
+    {
+    case H3_STREAM_TYPE_CONTROL:
+      return "CONTROL";
+    case H3_STREAM_TYPE_PUSH:
+      return "PUSH";
+    case H3_STREAM_TYPE_QPACK_ENCODER:
+      return "QPACK_ENCODER";
+    case H3_STREAM_TYPE_QPACK_DECODER:
+      return "QPACK_DECODER";
+    default:
+      return "UNKNOWN";
+    }
+}
+
+const char *
+SocketHTTP3_settings_name (uint64_t id)
+{
+  switch (id)
+    {
+    case H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:
+      return "QPACK_MAX_TABLE_CAPACITY";
+    case H3_SETTINGS_MAX_FIELD_SECTION_SIZE:
+      return "MAX_FIELD_SECTION_SIZE";
+    case H3_SETTINGS_QPACK_BLOCKED_STREAMS:
+      return "QPACK_BLOCKED_STREAMS";
+    default:
+      return "UNKNOWN";
+    }
+}

--- a/src/test/test_http3_constants.c
+++ b/src/test/test_http3_constants.c
@@ -1,0 +1,396 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * test_http3_constants.c - HTTP/3 Constants Tests (RFC 9114)
+ *
+ * Part of the Socket Library
+ * Verifies frame types, error codes, settings, stream types, and GREASE.
+ */
+
+#include "http/SocketHTTP3-constants.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ============================================================================
+ * Test Utilities
+ * ============================================================================
+ */
+
+static int tests_run = 0;
+static int tests_passed = 0;
+
+#define TEST_ASSERT(cond, msg)                                               \
+  do                                                                         \
+    {                                                                        \
+      if (!(cond))                                                           \
+        {                                                                    \
+          fprintf (stderr, "FAIL: %s (%s:%d)\n", (msg), __FILE__, __LINE__); \
+          return 0;                                                          \
+        }                                                                    \
+    }                                                                        \
+  while (0)
+
+#define TEST_BEGIN(name)                  \
+  do                                      \
+    {                                     \
+      tests_run++;                        \
+      printf ("  Testing %s... ", #name); \
+      fflush (stdout);                    \
+    }                                     \
+  while (0)
+
+#define TEST_PASS()        \
+  do                       \
+    {                      \
+      tests_passed++;      \
+      printf ("PASSED\n"); \
+      return 1;            \
+    }                      \
+  while (0)
+
+/* ============================================================================
+ * Frame Type Tests (RFC 9114 Section 7.2)
+ * ============================================================================
+ */
+
+static int
+test_frame_type_values (void)
+{
+  TEST_BEGIN (frame_type_values);
+
+  TEST_ASSERT (HTTP3_FRAME_DATA == 0x00, "DATA must be 0x00");
+  TEST_ASSERT (HTTP3_FRAME_HEADERS == 0x01, "HEADERS must be 0x01");
+  TEST_ASSERT (HTTP3_FRAME_CANCEL_PUSH == 0x03, "CANCEL_PUSH must be 0x03");
+  TEST_ASSERT (HTTP3_FRAME_SETTINGS == 0x04, "SETTINGS must be 0x04");
+  TEST_ASSERT (HTTP3_FRAME_PUSH_PROMISE == 0x05, "PUSH_PROMISE must be 0x05");
+  TEST_ASSERT (HTTP3_FRAME_GOAWAY == 0x07, "GOAWAY must be 0x07");
+  TEST_ASSERT (HTTP3_FRAME_MAX_PUSH_ID == 0x0d, "MAX_PUSH_ID must be 0x0d");
+
+  TEST_PASS ();
+}
+
+static int
+test_frame_type_names (void)
+{
+  TEST_BEGIN (frame_type_names);
+
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x00), "DATA") == 0,
+               "DATA name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x01), "HEADERS") == 0,
+               "HEADERS name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x03), "CANCEL_PUSH") == 0,
+               "CANCEL_PUSH name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x04), "SETTINGS") == 0,
+               "SETTINGS name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x05), "PUSH_PROMISE") == 0,
+               "PUSH_PROMISE name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x07), "GOAWAY") == 0,
+               "GOAWAY name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0x0d), "MAX_PUSH_ID") == 0,
+               "MAX_PUSH_ID name");
+  TEST_ASSERT (strcmp (SocketHTTP3_frame_type_name (0xff), "UNKNOWN") == 0,
+               "unknown frame type returns UNKNOWN");
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
+ * Reserved HTTP/2 Frame Types (RFC 9114 Section 11.2.1)
+ * ============================================================================
+ */
+
+static int
+test_reserved_h2_frame_types (void)
+{
+  TEST_BEGIN (reserved_h2_frame_types);
+
+  TEST_ASSERT (HTTP3_H2_FRAME_PRIORITY == 0x02, "PRIORITY must be 0x02");
+  TEST_ASSERT (HTTP3_H2_FRAME_PING == 0x06, "PING must be 0x06");
+  TEST_ASSERT (HTTP3_H2_FRAME_WINDOW_UPDATE == 0x08,
+               "WINDOW_UPDATE must be 0x08");
+  TEST_ASSERT (HTTP3_H2_FRAME_CONTINUATION == 0x09,
+               "CONTINUATION must be 0x09");
+
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_FRAME (0x02), "0x02 is reserved");
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_FRAME (0x06), "0x06 is reserved");
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_FRAME (0x08), "0x08 is reserved");
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_FRAME (0x09), "0x09 is reserved");
+
+  TEST_ASSERT (!HTTP3_IS_RESERVED_H2_FRAME (0x00), "DATA not reserved");
+  TEST_ASSERT (!HTTP3_IS_RESERVED_H2_FRAME (0x01), "HEADERS not reserved");
+  TEST_ASSERT (!HTTP3_IS_RESERVED_H2_FRAME (0x04), "SETTINGS not reserved");
+
+  /* Verify name lookup identifies reserved types */
+  TEST_ASSERT (strstr (SocketHTTP3_frame_type_name (0x02), "reserved") != NULL,
+               "PRIORITY name contains 'reserved'");
+  TEST_ASSERT (strstr (SocketHTTP3_frame_type_name (0x06), "reserved") != NULL,
+               "PING name contains 'reserved'");
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
+ * Error Code Tests (RFC 9114 Section 8.1)
+ * ============================================================================
+ */
+
+static int
+test_error_code_values (void)
+{
+  TEST_BEGIN (error_code_values);
+
+  TEST_ASSERT (H3_NO_ERROR == 0x0100, "H3_NO_ERROR must be 0x0100");
+  TEST_ASSERT (H3_GENERAL_PROTOCOL_ERROR == 0x0101,
+               "H3_GENERAL_PROTOCOL_ERROR must be 0x0101");
+  TEST_ASSERT (H3_INTERNAL_ERROR == 0x0102, "H3_INTERNAL_ERROR must be 0x0102");
+  TEST_ASSERT (H3_STREAM_CREATION_ERROR == 0x0103,
+               "H3_STREAM_CREATION_ERROR must be 0x0103");
+  TEST_ASSERT (H3_CLOSED_CRITICAL_STREAM == 0x0104,
+               "H3_CLOSED_CRITICAL_STREAM must be 0x0104");
+  TEST_ASSERT (H3_FRAME_UNEXPECTED == 0x0105,
+               "H3_FRAME_UNEXPECTED must be 0x0105");
+  TEST_ASSERT (H3_FRAME_ERROR == 0x0106, "H3_FRAME_ERROR must be 0x0106");
+  TEST_ASSERT (H3_EXCESSIVE_LOAD == 0x0107, "H3_EXCESSIVE_LOAD must be 0x0107");
+  TEST_ASSERT (H3_ID_ERROR == 0x0108, "H3_ID_ERROR must be 0x0108");
+  TEST_ASSERT (H3_SETTINGS_ERROR == 0x0109, "H3_SETTINGS_ERROR must be 0x0109");
+  TEST_ASSERT (H3_MISSING_SETTINGS == 0x010a,
+               "H3_MISSING_SETTINGS must be 0x010a");
+  TEST_ASSERT (H3_REQUEST_REJECTED == 0x010b,
+               "H3_REQUEST_REJECTED must be 0x010b");
+  TEST_ASSERT (H3_REQUEST_CANCELLED == 0x010c,
+               "H3_REQUEST_CANCELLED must be 0x010c");
+  TEST_ASSERT (H3_REQUEST_INCOMPLETE == 0x010d,
+               "H3_REQUEST_INCOMPLETE must be 0x010d");
+  TEST_ASSERT (H3_MESSAGE_ERROR == 0x010e, "H3_MESSAGE_ERROR must be 0x010e");
+  TEST_ASSERT (H3_CONNECT_ERROR == 0x010f, "H3_CONNECT_ERROR must be 0x010f");
+  TEST_ASSERT (H3_VERSION_FALLBACK == 0x0110,
+               "H3_VERSION_FALLBACK must be 0x0110");
+
+  TEST_PASS ();
+}
+
+static int
+test_error_code_names (void)
+{
+  TEST_BEGIN (error_code_names);
+
+  TEST_ASSERT (strcmp (SocketHTTP3_error_code_name (H3_NO_ERROR), "H3_NO_ERROR")
+                   == 0,
+               "H3_NO_ERROR name");
+  TEST_ASSERT (strcmp (SocketHTTP3_error_code_name (H3_GENERAL_PROTOCOL_ERROR),
+                       "H3_GENERAL_PROTOCOL_ERROR")
+                   == 0,
+               "H3_GENERAL_PROTOCOL_ERROR name");
+  TEST_ASSERT (strcmp (SocketHTTP3_error_code_name (H3_VERSION_FALLBACK),
+                       "H3_VERSION_FALLBACK")
+                   == 0,
+               "H3_VERSION_FALLBACK name");
+  TEST_ASSERT (strcmp (SocketHTTP3_error_code_name (0xffff), "UNKNOWN") == 0,
+               "unknown error code returns UNKNOWN");
+
+  /* Verify all 17 codes return non-NULL, non-UNKNOWN strings */
+  for (uint64_t c = 0x0100; c <= 0x0110; c++)
+    {
+      const char *name = SocketHTTP3_error_code_name (c);
+      TEST_ASSERT (name != NULL, "error code name not NULL");
+      TEST_ASSERT (strcmp (name, "UNKNOWN") != 0,
+                   "known error code should not be UNKNOWN");
+    }
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
+ * Settings Tests (RFC 9114 Section 7.2.4.1)
+ * ============================================================================
+ */
+
+static int
+test_settings_values (void)
+{
+  TEST_BEGIN (settings_values);
+
+  TEST_ASSERT (H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY == 0x01,
+               "QPACK_MAX_TABLE_CAPACITY must be 0x01");
+  TEST_ASSERT (H3_SETTINGS_MAX_FIELD_SECTION_SIZE == 0x06,
+               "MAX_FIELD_SECTION_SIZE must be 0x06");
+  TEST_ASSERT (H3_SETTINGS_QPACK_BLOCKED_STREAMS == 0x07,
+               "QPACK_BLOCKED_STREAMS must be 0x07");
+
+  TEST_PASS ();
+}
+
+static int
+test_settings_names (void)
+{
+  TEST_BEGIN (settings_names);
+
+  TEST_ASSERT (
+      strcmp (SocketHTTP3_settings_name (0x01), "QPACK_MAX_TABLE_CAPACITY")
+          == 0,
+      "QPACK_MAX_TABLE_CAPACITY name");
+  TEST_ASSERT (
+      strcmp (SocketHTTP3_settings_name (0x06), "MAX_FIELD_SECTION_SIZE") == 0,
+      "MAX_FIELD_SECTION_SIZE name");
+  TEST_ASSERT (
+      strcmp (SocketHTTP3_settings_name (0x07), "QPACK_BLOCKED_STREAMS") == 0,
+      "QPACK_BLOCKED_STREAMS name");
+  TEST_ASSERT (strcmp (SocketHTTP3_settings_name (0xff), "UNKNOWN") == 0,
+               "unknown setting returns UNKNOWN");
+
+  TEST_PASS ();
+}
+
+static int
+test_reserved_h2_settings (void)
+{
+  TEST_BEGIN (reserved_h2_settings);
+
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_SETTING (0x02), "0x02 is reserved");
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_SETTING (0x03), "0x03 is reserved");
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_SETTING (0x04), "0x04 is reserved");
+  TEST_ASSERT (HTTP3_IS_RESERVED_H2_SETTING (0x05), "0x05 is reserved");
+
+  /* 0x01 is reused by QPACK_MAX_TABLE_CAPACITY and is valid */
+  TEST_ASSERT (!HTTP3_IS_RESERVED_H2_SETTING (0x01),
+               "0x01 is NOT reserved (reused by QPACK)");
+  TEST_ASSERT (!HTTP3_IS_RESERVED_H2_SETTING (0x06), "0x06 is NOT reserved");
+  TEST_ASSERT (!HTTP3_IS_RESERVED_H2_SETTING (0x07), "0x07 is NOT reserved");
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
+ * Stream Type Tests (RFC 9114 Section 6.2)
+ * ============================================================================
+ */
+
+static int
+test_stream_type_values (void)
+{
+  TEST_BEGIN (stream_type_values);
+
+  TEST_ASSERT (H3_STREAM_TYPE_CONTROL == 0x00, "CONTROL must be 0x00");
+  TEST_ASSERT (H3_STREAM_TYPE_PUSH == 0x01, "PUSH must be 0x01");
+  TEST_ASSERT (H3_STREAM_TYPE_QPACK_ENCODER == 0x02,
+               "QPACK_ENCODER must be 0x02");
+  TEST_ASSERT (H3_STREAM_TYPE_QPACK_DECODER == 0x03,
+               "QPACK_DECODER must be 0x03");
+
+  TEST_PASS ();
+}
+
+static int
+test_stream_type_names (void)
+{
+  TEST_BEGIN (stream_type_names);
+
+  TEST_ASSERT (strcmp (SocketHTTP3_stream_type_name (0x00), "CONTROL") == 0,
+               "CONTROL name");
+  TEST_ASSERT (strcmp (SocketHTTP3_stream_type_name (0x01), "PUSH") == 0,
+               "PUSH name");
+  TEST_ASSERT (strcmp (SocketHTTP3_stream_type_name (0x02), "QPACK_ENCODER")
+                   == 0,
+               "QPACK_ENCODER name");
+  TEST_ASSERT (strcmp (SocketHTTP3_stream_type_name (0x03), "QPACK_DECODER")
+                   == 0,
+               "QPACK_DECODER name");
+  TEST_ASSERT (strcmp (SocketHTTP3_stream_type_name (0xff), "UNKNOWN") == 0,
+               "unknown stream type returns UNKNOWN");
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
+ * GREASE Tests (RFC 9114 Section 7.2.8 / 6.2.3 / 8.1)
+ * ============================================================================
+ */
+
+static int
+test_grease_formula (void)
+{
+  TEST_BEGIN (grease_formula);
+
+  /* Formula: 0x1f * N + 0x21 for N >= 0 */
+  /* N=0: 0x21, N=1: 0x40, N=2: 0x5f, N=3: 0x7e */
+  TEST_ASSERT (H3_IS_GREASE (0x21), "N=0 → 0x21 is GREASE");
+  TEST_ASSERT (H3_IS_GREASE (0x40), "N=1 → 0x40 is GREASE");
+  TEST_ASSERT (H3_IS_GREASE (0x5f), "N=2 → 0x5f is GREASE");
+  TEST_ASSERT (H3_IS_GREASE (0x7e), "N=3 → 0x7e is GREASE");
+
+  /* Larger values */
+  TEST_ASSERT (H3_IS_GREASE (0x21 + 0x1f * 10), "N=10 is GREASE");
+  TEST_ASSERT (H3_IS_GREASE (0x21 + 0x1f * 100), "N=100 is GREASE");
+
+  /* Non-GREASE values */
+  TEST_ASSERT (!H3_IS_GREASE (0x00), "0x00 is not GREASE");
+  TEST_ASSERT (!H3_IS_GREASE (0x01), "0x01 is not GREASE");
+  TEST_ASSERT (!H3_IS_GREASE (0x20), "0x20 is not GREASE");
+  TEST_ASSERT (!H3_IS_GREASE (0x22), "0x22 is not GREASE");
+  TEST_ASSERT (!H3_IS_GREASE (0x3f), "0x3f is not GREASE");
+
+  /* Known frame/error/settings values should not be GREASE */
+  TEST_ASSERT (!H3_IS_GREASE (HTTP3_FRAME_DATA), "DATA not GREASE");
+  TEST_ASSERT (!H3_IS_GREASE (HTTP3_FRAME_HEADERS), "HEADERS not GREASE");
+  TEST_ASSERT (!H3_IS_GREASE (H3_NO_ERROR), "H3_NO_ERROR not GREASE");
+
+  TEST_PASS ();
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  printf ("=== HTTP/3 Constants Tests (RFC 9114) ===\n\n");
+
+  /* Frame type tests */
+  printf ("Frame Type Tests (§7.2):\n");
+  test_frame_type_values ();
+  test_frame_type_names ();
+  test_reserved_h2_frame_types ();
+  printf ("\n");
+
+  /* Error code tests */
+  printf ("Error Code Tests (§8.1):\n");
+  test_error_code_values ();
+  test_error_code_names ();
+  printf ("\n");
+
+  /* Settings tests */
+  printf ("Settings Tests (§7.2.4.1):\n");
+  test_settings_values ();
+  test_settings_names ();
+  test_reserved_h2_settings ();
+  printf ("\n");
+
+  /* Stream type tests */
+  printf ("Stream Type Tests (§6.2):\n");
+  test_stream_type_values ();
+  test_stream_type_names ();
+  printf ("\n");
+
+  /* GREASE tests */
+  printf ("GREASE Tests (§7.2.8):\n");
+  test_grease_formula ();
+  printf ("\n");
+
+  /* Summary */
+  printf ("=====================\n");
+  printf ("Tests: %d passed, %d failed, %d total\n",
+          tests_passed,
+          tests_run - tests_passed,
+          tests_run);
+
+  return (tests_passed == tests_run) ? 0 : 1;
+}


### PR DESCRIPTION
## Summary
- Define all HTTP/3 protocol constants from RFC 9114: frame types (§7.2), error codes (§8.1), settings (§7.2.4.1), stream types (§6.2)
- Add GREASE detection macro and reserved HTTP/2 frame/settings identification (§11.2.1, §11.2.2)
- Implement name-lookup functions for debug/logging
- Consolidate H3_ error codes from SocketQPACK.h into new centralized header
- Add source and test to CMakeLists.txt (unconditional — no external dependencies)

## Test plan
- [x] 11 new tests verify all numeric values against RFC 9114
- [x] Name lookup correctness for all frame types, error codes, settings, stream types
- [x] GREASE formula validation for multiple N values
- [x] Reserved HTTP/2 identification macros
- [x] Full test suite passes (178/178) with ASan + UBSan

Fixes #3548
Fixes #3558