### PR TITLE
feat: implement HTTP/3 frame parser/serializer (RFC 9114 §7)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,9 @@ set(LIB_SOURCES
     # HTTP/3 Constants (RFC 9114)
     src/http/SocketHTTP3-constants.c
 
+    # HTTP/3 Framing (RFC 9114 Section 7)
+    src/http/h3/SocketHTTP3-frame.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -885,6 +888,7 @@ set(TEST_SOURCES
     test_qpack_error_integration
     test_qpack_vectors
     test_http3_constants
+    test_http3_frame
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/SocketHTTP3-frame.h
+++ b/include/http/SocketHTTP3-frame.h
@@ -1,0 +1,248 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-frame.h
+ * @brief HTTP/3 frame parser/serializer (RFC 9114 Section 7).
+ *
+ * Provides parsing and serialization for all HTTP/3 frame types:
+ *   - DATA (0x00), HEADERS (0x01): header-only parse (payload is opaque)
+ *   - CANCEL_PUSH (0x03): single push ID varint
+ *   - SETTINGS (0x04): key-value varint pairs with duplicate detection
+ *   - PUSH_PROMISE (0x05): push ID + encoded field section
+ *   - GOAWAY (0x07): stream/push ID varint
+ *   - MAX_PUSH_ID (0x0D): push ID varint
+ *
+ * Frame validation checks stream context (control/request/push) per RFC 9114.
+ *
+ * Wire format: Type(varint) + Length(varint) + Payload[Length]
+ */
+
+#ifndef SOCKETHTTP3_FRAME_INCLUDED
+#define SOCKETHTTP3_FRAME_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Parse result codes for frame header parsing.
+ */
+typedef enum
+{
+  HTTP3_PARSE_OK = 0,     /**< Parse succeeded */
+  HTTP3_PARSE_INCOMPLETE, /**< Need more data */
+  HTTP3_PARSE_ERROR       /**< Protocol violation */
+} SocketHTTP3_ParseResult;
+
+/**
+ * @brief Logical stream context for frame validation.
+ *
+ * Distinct from SocketHTTP3_StreamType (wire-level unidirectional stream type
+ * bytes). This classifies the logical stream for frame-level validation per
+ * RFC 9114 Section 7.2.
+ */
+typedef enum
+{
+  HTTP3_STREAM_CONTROL, /**< Control stream */
+  HTTP3_STREAM_REQUEST, /**< Request stream (bidirectional) */
+  HTTP3_STREAM_PUSH     /**< Push stream (server-initiated) */
+} SocketHTTP3_StreamContext;
+
+/**
+ * @brief Decoded frame header (type + length).
+ *
+ * On the wire, both fields are QUIC variable-length integers.
+ */
+typedef struct
+{
+  uint64_t type;   /**< Frame type */
+  uint64_t length; /**< Payload length in bytes */
+} SocketHTTP3_FrameHeader;
+
+/**
+ * @brief HTTP/3 SETTINGS parameters (RFC 9114 Section 7.2.4).
+ */
+typedef struct
+{
+  uint64_t max_field_section_size;   /**< 0x06, default: UINT64_MAX */
+  uint64_t qpack_max_table_capacity; /**< 0x01, default: 0 */
+  uint64_t qpack_blocked_streams;    /**< 0x07, default: 0 */
+} SocketHTTP3_Settings;
+
+/** Max buffer size for Settings_write output (3 settings * (8+8) varint pairs)
+ */
+#define HTTP3_SETTINGS_MAX_WRITE_SIZE 48
+
+/* ============================================================================
+ * Frame Header Parse/Write
+ * ============================================================================
+ */
+
+/**
+ * @brief Parse a frame header from buffer.
+ *
+ * Decodes two sequential QUIC varints (type + length). DATA and HEADERS
+ * frames have no dedicated parse functions -- the caller reads header.length
+ * bytes of opaque payload after parsing the header.
+ *
+ * @param buf       Input buffer.
+ * @param buflen    Input buffer length.
+ * @param header    Output: decoded frame header.
+ * @param consumed  Output: bytes consumed from input.
+ * @return HTTP3_PARSE_OK on success, HTTP3_PARSE_INCOMPLETE if buffer too
+ * short.
+ */
+SocketHTTP3_ParseResult
+SocketHTTP3_Frame_parse_header (const uint8_t *buf,
+                                size_t buflen,
+                                SocketHTTP3_FrameHeader *header,
+                                size_t *consumed);
+
+/**
+ * @brief Write a frame header to buffer.
+ *
+ * @param type    Frame type.
+ * @param length  Payload length.
+ * @param buf     Output buffer.
+ * @param buflen  Output buffer size.
+ * @return Bytes written on success, -1 if buffer too small or value overflow.
+ */
+int SocketHTTP3_Frame_write_header (uint64_t type,
+                                    uint64_t length,
+                                    uint8_t *buf,
+                                    size_t buflen);
+
+/* ============================================================================
+ * SETTINGS (RFC 9114 Section 7.2.4)
+ * ============================================================================
+ */
+
+/**
+ * @brief Initialize settings to RFC defaults.
+ *
+ * max_field_section_size = UINT64_MAX, qpack_max_table_capacity = 0,
+ * qpack_blocked_streams = 0.
+ */
+void SocketHTTP3_Settings_init (SocketHTTP3_Settings *settings);
+
+/**
+ * @brief Parse SETTINGS payload.
+ *
+ * Processes varint pairs (id, value). Rejects reserved HTTP/2 settings
+ * (0x02-0x05), detects duplicate identifiers (all IDs, not just known),
+ * and silently ignores GREASE and unknown identifiers.
+ *
+ * @param buf       SETTINGS payload (after frame header).
+ * @param len       Payload length.
+ * @param settings  Output: parsed settings (must be pre-initialized).
+ * @return 0 on success, 1 if incomplete, negative H3 error code on violation.
+ */
+int SocketHTTP3_Settings_parse (const uint8_t *buf,
+                                size_t len,
+                                SocketHTTP3_Settings *settings);
+
+/**
+ * @brief Write SETTINGS payload.
+ *
+ * Only writes non-default settings to minimize wire size.
+ *
+ * @param settings  Settings to serialize.
+ * @param buf       Output buffer.
+ * @param buflen    Output buffer size.
+ * @return Bytes written on success, -1 on error.
+ */
+int SocketHTTP3_Settings_write (const SocketHTTP3_Settings *settings,
+                                uint8_t *buf,
+                                size_t buflen);
+
+/* ============================================================================
+ * Single-Varint Payload Frames
+ * ============================================================================
+ */
+
+/**
+ * @brief Parse GOAWAY payload (RFC 9114 Section 7.2.6).
+ * @return 0 on success, 1 if incomplete, -1 on error.
+ */
+int SocketHTTP3_Goaway_parse (const uint8_t *buf, size_t len, uint64_t *id);
+
+/**
+ * @brief Write GOAWAY payload.
+ * @return Bytes written on success, -1 on error.
+ */
+int SocketHTTP3_Goaway_write (uint64_t id, uint8_t *buf, size_t buflen);
+
+/**
+ * @brief Parse MAX_PUSH_ID payload (RFC 9114 Section 7.2.7).
+ * @return 0 on success, 1 if incomplete, -1 on error.
+ */
+int SocketHTTP3_MaxPushId_parse (const uint8_t *buf, size_t len, uint64_t *id);
+
+/**
+ * @brief Write MAX_PUSH_ID payload.
+ * @return Bytes written on success, -1 on error.
+ */
+int SocketHTTP3_MaxPushId_write (uint64_t id, uint8_t *buf, size_t buflen);
+
+/**
+ * @brief Parse CANCEL_PUSH payload (RFC 9114 Section 7.2.3).
+ * @return 0 on success, 1 if incomplete, -1 on error.
+ */
+int SocketHTTP3_CancelPush_parse (const uint8_t *buf,
+                                  size_t len,
+                                  uint64_t *push_id);
+
+/**
+ * @brief Write CANCEL_PUSH payload.
+ * @return Bytes written on success, -1 on error.
+ */
+int
+SocketHTTP3_CancelPush_write (uint64_t push_id, uint8_t *buf, size_t buflen);
+
+/* ============================================================================
+ * PUSH_PROMISE (RFC 9114 Section 7.2.5)
+ * ============================================================================
+ */
+
+/**
+ * @brief Extract push ID from PUSH_PROMISE payload.
+ *
+ * Decodes the push_id varint at the start of the payload and sets
+ * payload_offset to the start of the encoded field section.
+ *
+ * @param buf             PUSH_PROMISE payload.
+ * @param len             Payload length.
+ * @param push_id         Output: decoded push ID.
+ * @param payload_offset  Output: byte offset to encoded field section.
+ * @return 0 on success, 1 if incomplete, -1 on error.
+ */
+int SocketHTTP3_PushPromise_parse_id (const uint8_t *buf,
+                                      size_t len,
+                                      uint64_t *push_id,
+                                      size_t *payload_offset);
+
+/* ============================================================================
+ * Frame Validation
+ * ============================================================================
+ */
+
+/**
+ * @brief Validate a frame type on a given stream context.
+ *
+ * Checks whether the frame type is permitted on the stream type per
+ * RFC 9114 Section 7.2. The is_first_frame flag is caller-managed state
+ * for enforcing SETTINGS as the first frame on a control stream.
+ *
+ * @param frame_type    Frame type to validate.
+ * @param stream_type   Logical stream context.
+ * @param is_first_frame  1 if this is the first frame on a control stream.
+ * @return 0 if allowed, H3 error code otherwise.
+ */
+uint64_t SocketHTTP3_Frame_validate (uint64_t frame_type,
+                                     SocketHTTP3_StreamContext stream_type,
+                                     int is_first_frame);
+
+#endif /* SOCKETHTTP3_FRAME_INCLUDED */

--- a/src/http/h3/SocketHTTP3-frame.c
+++ b/src/http/h3/SocketHTTP3-frame.c
@@ -1,0 +1,371 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-frame.c
+ * @brief HTTP/3 frame parser/serializer implementation (RFC 9114 Section 7).
+ */
+
+#include "http/SocketHTTP3-frame.h"
+#include "http/SocketHTTP3-constants.h"
+#include "quic/SocketQUICVarInt.h"
+
+#include <string.h>
+
+/* Maximum number of unique setting IDs we track for duplicate detection.
+ * SETTINGS frames are small; 64 is generous. */
+#define MAX_SETTINGS_IDS 64
+
+/* ============================================================================
+ * Frame Header Parse/Write
+ * ============================================================================
+ */
+
+SocketHTTP3_ParseResult
+SocketHTTP3_Frame_parse_header (const uint8_t *buf,
+                                size_t buflen,
+                                SocketHTTP3_FrameHeader *header,
+                                size_t *consumed)
+{
+  if (buflen == 0)
+    return HTTP3_PARSE_INCOMPLETE;
+
+  uint64_t type_val;
+  size_t type_consumed;
+  SocketQUICVarInt_Result res;
+
+  res = SocketQUICVarInt_decode (buf, buflen, &type_val, &type_consumed);
+  if (res == QUIC_VARINT_INCOMPLETE)
+    return HTTP3_PARSE_INCOMPLETE;
+  if (res != QUIC_VARINT_OK)
+    return HTTP3_PARSE_ERROR;
+
+  uint64_t len_val;
+  size_t len_consumed;
+  res = SocketQUICVarInt_decode (
+      buf + type_consumed, buflen - type_consumed, &len_val, &len_consumed);
+  if (res == QUIC_VARINT_INCOMPLETE)
+    return HTTP3_PARSE_INCOMPLETE;
+  if (res != QUIC_VARINT_OK)
+    return HTTP3_PARSE_ERROR;
+
+  header->type = type_val;
+  header->length = len_val;
+  *consumed = type_consumed + len_consumed;
+  return HTTP3_PARSE_OK;
+}
+
+int
+SocketHTTP3_Frame_write_header (uint64_t type,
+                                uint64_t length,
+                                uint8_t *buf,
+                                size_t buflen)
+{
+  size_t type_size = SocketQUICVarInt_size (type);
+  size_t len_size = SocketQUICVarInt_size (length);
+
+  if (type_size == 0 || len_size == 0)
+    return -1;
+
+  if (type_size + len_size > buflen)
+    return -1;
+
+  size_t pos = 0;
+  if (!encode_varint_field (type, buf, &pos, buflen))
+    return -1;
+  if (!encode_varint_field (length, buf, &pos, buflen))
+    return -1;
+
+  return (int)pos;
+}
+
+/* ============================================================================
+ * SETTINGS (RFC 9114 Section 7.2.4)
+ * ============================================================================
+ */
+
+void
+SocketHTTP3_Settings_init (SocketHTTP3_Settings *settings)
+{
+  settings->max_field_section_size = UINT64_MAX;
+  settings->qpack_max_table_capacity = 0;
+  settings->qpack_blocked_streams = 0;
+}
+
+int
+SocketHTTP3_Settings_parse (const uint8_t *buf,
+                            size_t len,
+                            SocketHTTP3_Settings *settings)
+{
+  size_t offset = 0;
+  uint64_t seen_ids[MAX_SETTINGS_IDS];
+  size_t seen_count = 0;
+
+  while (offset < len)
+    {
+      uint64_t id, value;
+      size_t id_consumed, val_consumed;
+      SocketQUICVarInt_Result res;
+
+      res = SocketQUICVarInt_decode (
+          buf + offset, len - offset, &id, &id_consumed);
+      if (res == QUIC_VARINT_INCOMPLETE)
+        return 1;
+      if (res != QUIC_VARINT_OK)
+        return -(int)H3_SETTINGS_ERROR;
+
+      offset += id_consumed;
+
+      res = SocketQUICVarInt_decode (
+          buf + offset, len - offset, &value, &val_consumed);
+      if (res == QUIC_VARINT_INCOMPLETE)
+        return 1;
+      if (res != QUIC_VARINT_OK)
+        return -(int)H3_SETTINGS_ERROR;
+
+      offset += val_consumed;
+
+      /* Reserved HTTP/2 settings (0x02-0x05) → H3_SETTINGS_ERROR */
+      if (HTTP3_IS_RESERVED_H2_SETTING (id))
+        return -(int)H3_SETTINGS_ERROR;
+
+      /* Duplicate detection for ALL identifiers */
+      for (size_t i = 0; i < seen_count; i++)
+        {
+          if (seen_ids[i] == id)
+            return -(int)H3_SETTINGS_ERROR;
+        }
+      if (seen_count < MAX_SETTINGS_IDS)
+        seen_ids[seen_count++] = id;
+
+      /* GREASE values: silently ignore (RFC 9114 §7.2.4.1) */
+      if (H3_IS_GREASE (id))
+        continue;
+
+      /* Apply known settings */
+      switch (id)
+        {
+        case H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY:
+          settings->qpack_max_table_capacity = value;
+          break;
+        case H3_SETTINGS_MAX_FIELD_SECTION_SIZE:
+          settings->max_field_section_size = value;
+          break;
+        case H3_SETTINGS_QPACK_BLOCKED_STREAMS:
+          settings->qpack_blocked_streams = value;
+          break;
+        default:
+          /* Unknown non-GREASE identifiers: silently ignore */
+          break;
+        }
+    }
+
+  return 0;
+}
+
+int
+SocketHTTP3_Settings_write (const SocketHTTP3_Settings *settings,
+                            uint8_t *buf,
+                            size_t buflen)
+{
+  size_t pos = 0;
+
+  /* Only write non-default settings to minimize wire size */
+  if (settings->qpack_max_table_capacity != 0)
+    {
+      if (!encode_varint_field (
+              H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, buf, &pos, buflen))
+        return -1;
+      if (!encode_varint_field (
+              settings->qpack_max_table_capacity, buf, &pos, buflen))
+        return -1;
+    }
+
+  if (settings->max_field_section_size != UINT64_MAX)
+    {
+      if (!encode_varint_field (
+              H3_SETTINGS_MAX_FIELD_SECTION_SIZE, buf, &pos, buflen))
+        return -1;
+      if (!encode_varint_field (
+              settings->max_field_section_size, buf, &pos, buflen))
+        return -1;
+    }
+
+  if (settings->qpack_blocked_streams != 0)
+    {
+      if (!encode_varint_field (
+              H3_SETTINGS_QPACK_BLOCKED_STREAMS, buf, &pos, buflen))
+        return -1;
+      if (!encode_varint_field (
+              settings->qpack_blocked_streams, buf, &pos, buflen))
+        return -1;
+    }
+
+  return (int)pos;
+}
+
+/* ============================================================================
+ * Single-Varint Helpers
+ * ============================================================================
+ */
+
+static int
+parse_single_varint (const uint8_t *buf, size_t len, uint64_t *value)
+{
+  if (len == 0)
+    return 1;
+
+  size_t consumed;
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (buf, len, value, &consumed);
+
+  if (res == QUIC_VARINT_INCOMPLETE)
+    return 1;
+  if (res != QUIC_VARINT_OK)
+    return -1;
+
+  return 0;
+}
+
+static int
+write_single_varint (uint64_t value, uint8_t *buf, size_t buflen)
+{
+  size_t written = SocketQUICVarInt_encode (value, buf, buflen);
+  if (written == 0)
+    return -1;
+  return (int)written;
+}
+
+/* ============================================================================
+ * GOAWAY (RFC 9114 Section 7.2.6)
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_Goaway_parse (const uint8_t *buf, size_t len, uint64_t *id)
+{
+  return parse_single_varint (buf, len, id);
+}
+
+int
+SocketHTTP3_Goaway_write (uint64_t id, uint8_t *buf, size_t buflen)
+{
+  return write_single_varint (id, buf, buflen);
+}
+
+/* ============================================================================
+ * MAX_PUSH_ID (RFC 9114 Section 7.2.7)
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_MaxPushId_parse (const uint8_t *buf, size_t len, uint64_t *id)
+{
+  return parse_single_varint (buf, len, id);
+}
+
+int
+SocketHTTP3_MaxPushId_write (uint64_t id, uint8_t *buf, size_t buflen)
+{
+  return write_single_varint (id, buf, buflen);
+}
+
+/* ============================================================================
+ * CANCEL_PUSH (RFC 9114 Section 7.2.3)
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_CancelPush_parse (const uint8_t *buf, size_t len, uint64_t *push_id)
+{
+  return parse_single_varint (buf, len, push_id);
+}
+
+int
+SocketHTTP3_CancelPush_write (uint64_t push_id, uint8_t *buf, size_t buflen)
+{
+  return write_single_varint (push_id, buf, buflen);
+}
+
+/* ============================================================================
+ * PUSH_PROMISE (RFC 9114 Section 7.2.5)
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_PushPromise_parse_id (const uint8_t *buf,
+                                  size_t len,
+                                  uint64_t *push_id,
+                                  size_t *payload_offset)
+{
+  if (len == 0)
+    return 1;
+
+  size_t consumed;
+  SocketQUICVarInt_Result res
+      = SocketQUICVarInt_decode (buf, len, push_id, &consumed);
+
+  if (res == QUIC_VARINT_INCOMPLETE)
+    return 1;
+  if (res != QUIC_VARINT_OK)
+    return -1;
+
+  *payload_offset = consumed;
+  return 0;
+}
+
+/* ============================================================================
+ * Frame Validation (RFC 9114 Section 7.2)
+ * ============================================================================
+ */
+
+uint64_t
+SocketHTTP3_Frame_validate (uint64_t frame_type,
+                            SocketHTTP3_StreamContext stream_type,
+                            int is_first_frame)
+{
+  /* Reserved HTTP/2 frame types → always rejected */
+  if (HTTP3_IS_RESERVED_H2_FRAME (frame_type))
+    return H3_FRAME_UNEXPECTED;
+
+  /* First frame on control stream MUST be SETTINGS (RFC 9114 §6.2.1) */
+  if (stream_type == HTTP3_STREAM_CONTROL && is_first_frame
+      && frame_type != HTTP3_FRAME_SETTINGS)
+    return H3_MISSING_SETTINGS;
+
+  /* GREASE and unknown frame types → always allowed (must be ignored) */
+  if (H3_IS_GREASE (frame_type))
+    return 0;
+
+  switch (frame_type)
+    {
+    case HTTP3_FRAME_DATA:
+    case HTTP3_FRAME_HEADERS:
+      /* DATA and HEADERS: request and push streams only */
+      if (stream_type == HTTP3_STREAM_CONTROL)
+        return H3_FRAME_UNEXPECTED;
+      return 0;
+
+    case HTTP3_FRAME_CANCEL_PUSH:
+    case HTTP3_FRAME_SETTINGS:
+    case HTTP3_FRAME_GOAWAY:
+    case HTTP3_FRAME_MAX_PUSH_ID:
+      /* Control-stream-only frames */
+      if (stream_type != HTTP3_STREAM_CONTROL)
+        return H3_FRAME_UNEXPECTED;
+      return 0;
+
+    case HTTP3_FRAME_PUSH_PROMISE:
+      /* PUSH_PROMISE: request stream only */
+      if (stream_type != HTTP3_STREAM_REQUEST)
+        return H3_FRAME_UNEXPECTED;
+      return 0;
+
+    default:
+      /* Unknown non-GREASE frames: allowed (must be ignored) */
+      return 0;
+    }
+}

--- a/src/test/test_http3_frame.c
+++ b/src/test/test_http3_frame.c
@@ -1,0 +1,778 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_http3_frame.c
+ * @brief Unit tests for HTTP/3 frame parser/serializer (RFC 9114 Section 7).
+ */
+
+#include <string.h>
+
+#include "http/SocketHTTP3-constants.h"
+#include "http/SocketHTTP3-frame.h"
+#include "quic/SocketQUICVarInt.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Frame Header Round-Trip Tests
+ * ============================================================================
+ */
+
+TEST (h3_frame_header_roundtrip_data)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_DATA, 100, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_DATA, header.type);
+  ASSERT_EQ (100ULL, header.length);
+  ASSERT_EQ ((size_t)written, consumed);
+}
+
+TEST (h3_frame_header_roundtrip_headers)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_HEADERS, 256, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_HEADERS, header.type);
+  ASSERT_EQ (256ULL, header.length);
+}
+
+TEST (h3_frame_header_roundtrip_settings)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_SETTINGS, 0, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_SETTINGS, header.type);
+  ASSERT_EQ (0ULL, header.length);
+}
+
+TEST (h3_frame_header_roundtrip_goaway)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_GOAWAY, 8, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_GOAWAY, header.type);
+  ASSERT_EQ (8ULL, header.length);
+}
+
+TEST (h3_frame_header_roundtrip_max_push_id)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_MAX_PUSH_ID, 4, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_MAX_PUSH_ID, header.type);
+}
+
+TEST (h3_frame_header_roundtrip_cancel_push)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_CANCEL_PUSH, 2, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_CANCEL_PUSH, header.type);
+}
+
+TEST (h3_frame_header_roundtrip_push_promise)
+{
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_PUSH_PROMISE, 1024, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_PUSH_PROMISE, header.type);
+  ASSERT_EQ (1024ULL, header.length);
+}
+
+/* ============================================================================
+ * Boundary Varint Tests
+ * ============================================================================
+ */
+
+TEST (h3_frame_header_boundary_1byte)
+{
+  /* Type 0 (1-byte varint), length 63 (1-byte varint max) */
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (0, 63, buf, sizeof (buf));
+  ASSERT_EQ (2, written);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (0ULL, header.type);
+  ASSERT_EQ (63ULL, header.length);
+}
+
+TEST (h3_frame_header_boundary_2byte)
+{
+  /* Length 16383 (2-byte varint max) */
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (0, 16383, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (16383ULL, header.length);
+}
+
+TEST (h3_frame_header_boundary_4byte)
+{
+  /* Length 1073741823 (4-byte varint max) */
+  uint8_t buf[16];
+  int written
+      = SocketHTTP3_Frame_write_header (0, 1073741823ULL, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (1073741823ULL, header.length);
+}
+
+TEST (h3_frame_header_boundary_8byte)
+{
+  /* Length requiring 8-byte varint */
+  uint64_t big_val = 1073741824ULL;
+  uint8_t buf[16];
+  int written = SocketHTTP3_Frame_write_header (0, big_val, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (big_val, header.length);
+}
+
+/* ============================================================================
+ * Incomplete Buffer Tests
+ * ============================================================================
+ */
+
+TEST (h3_frame_header_incomplete_empty)
+{
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res
+      = SocketHTTP3_Frame_parse_header (NULL, 0, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_INCOMPLETE, res);
+}
+
+TEST (h3_frame_header_incomplete_type_only)
+{
+  /* Encode just the type, no length */
+  uint8_t buf[1] = { 0x04 }; /* SETTINGS type = 0x04 */
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res
+      = SocketHTTP3_Frame_parse_header (buf, 1, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_INCOMPLETE, res);
+}
+
+/* ============================================================================
+ * Settings Tests
+ * ============================================================================
+ */
+
+TEST (h3_settings_init_defaults)
+{
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  ASSERT_EQ (UINT64_MAX, settings.max_field_section_size);
+  ASSERT_EQ (0ULL, settings.qpack_max_table_capacity);
+  ASSERT_EQ (0ULL, settings.qpack_blocked_streams);
+}
+
+TEST (h3_settings_parse_known_params)
+{
+  /* Encode: QPACK_MAX_TABLE_CAPACITY=4096, MAX_FIELD_SECTION_SIZE=8192,
+   * QPACK_BLOCKED_STREAMS=100 */
+  uint8_t buf[48];
+  size_t pos = 0;
+
+  encode_varint_field (
+      H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, buf, &pos, sizeof (buf));
+  encode_varint_field (4096, buf, &pos, sizeof (buf));
+  encode_varint_field (
+      H3_SETTINGS_MAX_FIELD_SECTION_SIZE, buf, &pos, sizeof (buf));
+  encode_varint_field (8192, buf, &pos, sizeof (buf));
+  encode_varint_field (
+      H3_SETTINGS_QPACK_BLOCKED_STREAMS, buf, &pos, sizeof (buf));
+  encode_varint_field (100, buf, &pos, sizeof (buf));
+
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (4096ULL, settings.qpack_max_table_capacity);
+  ASSERT_EQ (8192ULL, settings.max_field_section_size);
+  ASSERT_EQ (100ULL, settings.qpack_blocked_streams);
+}
+
+TEST (h3_settings_parse_unknown_params)
+{
+  /* Unknown setting ID 0xFF with value 42 — should be silently ignored */
+  uint8_t buf[16];
+  size_t pos = 0;
+
+  encode_varint_field (0xFF, buf, &pos, sizeof (buf));
+  encode_varint_field (42, buf, &pos, sizeof (buf));
+
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+  ASSERT_EQ (0, ret);
+  /* Settings should remain at defaults */
+  ASSERT_EQ (UINT64_MAX, settings.max_field_section_size);
+  ASSERT_EQ (0ULL, settings.qpack_max_table_capacity);
+  ASSERT_EQ (0ULL, settings.qpack_blocked_streams);
+}
+
+TEST (h3_settings_parse_grease_params)
+{
+  /* GREASE setting 0x21 (0x1f*0 + 0x21) with value 999 — silently ignored */
+  uint8_t buf[16];
+  size_t pos = 0;
+
+  encode_varint_field (0x21, buf, &pos, sizeof (buf));
+  encode_varint_field (999, buf, &pos, sizeof (buf));
+
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (UINT64_MAX, settings.max_field_section_size);
+}
+
+TEST (h3_settings_parse_duplicate_id)
+{
+  /* Duplicate QPACK_MAX_TABLE_CAPACITY → H3_SETTINGS_ERROR */
+  uint8_t buf[32];
+  size_t pos = 0;
+
+  encode_varint_field (
+      H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, buf, &pos, sizeof (buf));
+  encode_varint_field (100, buf, &pos, sizeof (buf));
+  encode_varint_field (
+      H3_SETTINGS_QPACK_MAX_TABLE_CAPACITY, buf, &pos, sizeof (buf));
+  encode_varint_field (200, buf, &pos, sizeof (buf));
+
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+  ASSERT_EQ (-(int)H3_SETTINGS_ERROR, ret);
+}
+
+TEST (h3_settings_parse_duplicate_unknown_id)
+{
+  /* Duplicate unknown ID 0xAA → H3_SETTINGS_ERROR */
+  uint8_t buf[32];
+  size_t pos = 0;
+
+  encode_varint_field (0xAA, buf, &pos, sizeof (buf));
+  encode_varint_field (1, buf, &pos, sizeof (buf));
+  encode_varint_field (0xAA, buf, &pos, sizeof (buf));
+  encode_varint_field (2, buf, &pos, sizeof (buf));
+
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+  ASSERT_EQ (-(int)H3_SETTINGS_ERROR, ret);
+}
+
+TEST (h3_settings_parse_reserved_h2_id)
+{
+  /* Reserved HTTP/2 setting 0x02 (ENABLE_PUSH) → H3_SETTINGS_ERROR */
+  uint8_t buf[16];
+  size_t pos = 0;
+
+  encode_varint_field (0x02, buf, &pos, sizeof (buf));
+  encode_varint_field (1, buf, &pos, sizeof (buf));
+
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+  ASSERT_EQ (-(int)H3_SETTINGS_ERROR, ret);
+}
+
+TEST (h3_settings_parse_reserved_h2_ids_all)
+{
+  /* All reserved HTTP/2 settings (0x02-0x05) must be rejected */
+  for (uint64_t id = 0x02; id <= 0x05; id++)
+    {
+      uint8_t buf[16];
+      size_t pos = 0;
+      encode_varint_field (id, buf, &pos, sizeof (buf));
+      encode_varint_field (0, buf, &pos, sizeof (buf));
+
+      SocketHTTP3_Settings settings;
+      SocketHTTP3_Settings_init (&settings);
+      int ret = SocketHTTP3_Settings_parse (buf, pos, &settings);
+      ASSERT_EQ (-(int)H3_SETTINGS_ERROR, ret);
+    }
+}
+
+TEST (h3_settings_roundtrip)
+{
+  SocketHTTP3_Settings orig;
+  SocketHTTP3_Settings_init (&orig);
+  orig.qpack_max_table_capacity = 4096;
+  orig.max_field_section_size = 16384;
+  orig.qpack_blocked_streams = 128;
+
+  uint8_t buf[HTTP3_SETTINGS_MAX_WRITE_SIZE];
+  int written = SocketHTTP3_Settings_write (&orig, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_Settings parsed;
+  SocketHTTP3_Settings_init (&parsed);
+  int ret = SocketHTTP3_Settings_parse (buf, (size_t)written, &parsed);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (orig.qpack_max_table_capacity, parsed.qpack_max_table_capacity);
+  ASSERT_EQ (orig.max_field_section_size, parsed.max_field_section_size);
+  ASSERT_EQ (orig.qpack_blocked_streams, parsed.qpack_blocked_streams);
+}
+
+TEST (h3_settings_write_defaults_empty)
+{
+  /* Default settings should produce zero bytes (nothing to write) */
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+
+  uint8_t buf[48];
+  int written = SocketHTTP3_Settings_write (&settings, buf, sizeof (buf));
+  ASSERT_EQ (0, written);
+}
+
+/* ============================================================================
+ * Single-Varint Frame Round-Trip Tests
+ * ============================================================================
+ */
+
+TEST (h3_goaway_roundtrip)
+{
+  uint8_t buf[8];
+  int written = SocketHTTP3_Goaway_write (42, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  uint64_t id;
+  int ret = SocketHTTP3_Goaway_parse (buf, (size_t)written, &id);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (42ULL, id);
+}
+
+TEST (h3_goaway_roundtrip_large)
+{
+  uint64_t big_id = 1073741824ULL;
+  uint8_t buf[8];
+  int written = SocketHTTP3_Goaway_write (big_id, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  uint64_t id;
+  int ret = SocketHTTP3_Goaway_parse (buf, (size_t)written, &id);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (big_id, id);
+}
+
+TEST (h3_max_push_id_roundtrip)
+{
+  uint8_t buf[8];
+  int written = SocketHTTP3_MaxPushId_write (7, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  uint64_t id;
+  int ret = SocketHTTP3_MaxPushId_parse (buf, (size_t)written, &id);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (7ULL, id);
+}
+
+TEST (h3_cancel_push_roundtrip)
+{
+  uint8_t buf[8];
+  int written = SocketHTTP3_CancelPush_write (99, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  uint64_t push_id;
+  int ret = SocketHTTP3_CancelPush_parse (buf, (size_t)written, &push_id);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (99ULL, push_id);
+}
+
+/* ============================================================================
+ * PUSH_PROMISE Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_promise_parse_id)
+{
+  /* Simulate: push_id=5, followed by 10 bytes of encoded field section */
+  uint8_t buf[16];
+  size_t pos = 0;
+  encode_varint_field (5, buf, &pos, sizeof (buf));
+  /* Fill remaining with dummy field section data */
+  memset (buf + pos, 0xAB, 10);
+  size_t total = pos + 10;
+
+  uint64_t push_id;
+  size_t payload_offset;
+  int ret = SocketHTTP3_PushPromise_parse_id (
+      buf, total, &push_id, &payload_offset);
+  ASSERT_EQ (0, ret);
+  ASSERT_EQ (5ULL, push_id);
+  ASSERT_EQ (pos, payload_offset);
+  /* Verify remaining bytes are the field section */
+  ASSERT_EQ ((unsigned char)0xAB, buf[payload_offset]);
+}
+
+TEST (h3_push_promise_parse_id_incomplete)
+{
+  uint64_t push_id;
+  size_t payload_offset;
+  int ret
+      = SocketHTTP3_PushPromise_parse_id (NULL, 0, &push_id, &payload_offset);
+  ASSERT_EQ (1, ret);
+}
+
+/* ============================================================================
+ * Frame Validation Tests
+ * ============================================================================
+ */
+
+TEST (h3_validate_data_on_request)
+{
+  ASSERT_EQ (
+      0ULL,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_DATA, HTTP3_STREAM_REQUEST, 0));
+}
+
+TEST (h3_validate_data_on_push)
+{
+  ASSERT_EQ (
+      0ULL,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_DATA, HTTP3_STREAM_PUSH, 0));
+}
+
+TEST (h3_validate_data_on_control)
+{
+  ASSERT_EQ (
+      H3_FRAME_UNEXPECTED,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_DATA, HTTP3_STREAM_CONTROL, 0));
+}
+
+TEST (h3_validate_headers_on_request)
+{
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_HEADERS, HTTP3_STREAM_REQUEST, 0));
+}
+
+TEST (h3_validate_headers_on_control)
+{
+  ASSERT_EQ (H3_FRAME_UNEXPECTED,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_HEADERS, HTTP3_STREAM_CONTROL, 0));
+}
+
+TEST (h3_validate_settings_on_control)
+{
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_SETTINGS, HTTP3_STREAM_CONTROL, 1));
+}
+
+TEST (h3_validate_settings_on_request)
+{
+  ASSERT_EQ (H3_FRAME_UNEXPECTED,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_SETTINGS, HTTP3_STREAM_REQUEST, 0));
+}
+
+TEST (h3_validate_goaway_on_control)
+{
+  ASSERT_EQ (
+      0ULL,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_GOAWAY, HTTP3_STREAM_CONTROL, 0));
+}
+
+TEST (h3_validate_goaway_on_request)
+{
+  ASSERT_EQ (
+      H3_FRAME_UNEXPECTED,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_GOAWAY, HTTP3_STREAM_REQUEST, 0));
+}
+
+TEST (h3_validate_max_push_id_on_control)
+{
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_MAX_PUSH_ID, HTTP3_STREAM_CONTROL, 0));
+}
+
+TEST (h3_validate_max_push_id_on_push)
+{
+  ASSERT_EQ (H3_FRAME_UNEXPECTED,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_MAX_PUSH_ID, HTTP3_STREAM_PUSH, 0));
+}
+
+TEST (h3_validate_cancel_push_on_control)
+{
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_CANCEL_PUSH, HTTP3_STREAM_CONTROL, 0));
+}
+
+TEST (h3_validate_cancel_push_on_request)
+{
+  ASSERT_EQ (H3_FRAME_UNEXPECTED,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_CANCEL_PUSH, HTTP3_STREAM_REQUEST, 0));
+}
+
+TEST (h3_validate_push_promise_on_request)
+{
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_PUSH_PROMISE, HTTP3_STREAM_REQUEST, 0));
+}
+
+TEST (h3_validate_push_promise_on_control)
+{
+  ASSERT_EQ (H3_FRAME_UNEXPECTED,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_PUSH_PROMISE, HTTP3_STREAM_CONTROL, 0));
+}
+
+TEST (h3_validate_push_promise_on_push)
+{
+  ASSERT_EQ (H3_FRAME_UNEXPECTED,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_PUSH_PROMISE, HTTP3_STREAM_PUSH, 0));
+}
+
+/* ============================================================================
+ * Reserved HTTP/2 Frame Validation
+ * ============================================================================
+ */
+
+TEST (h3_validate_reserved_h2_frames)
+{
+  uint64_t reserved[] = { 0x02, 0x06, 0x08, 0x09 };
+  for (size_t i = 0; i < sizeof (reserved) / sizeof (reserved[0]); i++)
+    {
+      ASSERT_EQ (
+          H3_FRAME_UNEXPECTED,
+          SocketHTTP3_Frame_validate (reserved[i], HTTP3_STREAM_REQUEST, 0));
+      ASSERT_EQ (
+          H3_FRAME_UNEXPECTED,
+          SocketHTTP3_Frame_validate (reserved[i], HTTP3_STREAM_CONTROL, 0));
+      ASSERT_EQ (
+          H3_FRAME_UNEXPECTED,
+          SocketHTTP3_Frame_validate (reserved[i], HTTP3_STREAM_PUSH, 0));
+    }
+}
+
+/* ============================================================================
+ * GREASE Frame Validation
+ * ============================================================================
+ */
+
+TEST (h3_validate_grease_frames_allowed)
+{
+  /* GREASE values: 0x21, 0x40, 0x5f */
+  ASSERT_EQ (0ULL, SocketHTTP3_Frame_validate (0x21, HTTP3_STREAM_REQUEST, 0));
+  ASSERT_EQ (0ULL, SocketHTTP3_Frame_validate (0x40, HTTP3_STREAM_CONTROL, 0));
+  ASSERT_EQ (0ULL, SocketHTTP3_Frame_validate (0x5f, HTTP3_STREAM_PUSH, 0));
+}
+
+/* ============================================================================
+ * Zero-Length DATA Frame
+ * ============================================================================
+ */
+
+TEST (h3_zero_length_data_valid)
+{
+  uint8_t buf[16];
+  int written
+      = SocketHTTP3_Frame_write_header (HTTP3_FRAME_DATA, 0, buf, sizeof (buf));
+  ASSERT (written > 0);
+
+  SocketHTTP3_FrameHeader header;
+  size_t consumed;
+  SocketHTTP3_ParseResult res = SocketHTTP3_Frame_parse_header (
+      buf, (size_t)written, &header, &consumed);
+  ASSERT_EQ (HTTP3_PARSE_OK, res);
+  ASSERT_EQ (HTTP3_FRAME_DATA, header.type);
+  ASSERT_EQ (0ULL, header.length);
+}
+
+/* ============================================================================
+ * First Frame Must Be SETTINGS on Control Stream
+ * ============================================================================
+ */
+
+TEST (h3_validate_first_frame_settings_ok)
+{
+  /* SETTINGS as first frame on control stream: allowed */
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_Frame_validate (
+                 HTTP3_FRAME_SETTINGS, HTTP3_STREAM_CONTROL, 1));
+}
+
+TEST (h3_validate_first_frame_not_settings)
+{
+  /* DATA as first frame on control stream: H3_MISSING_SETTINGS */
+  ASSERT_EQ (
+      H3_MISSING_SETTINGS,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_DATA, HTTP3_STREAM_CONTROL, 1));
+}
+
+TEST (h3_validate_first_frame_goaway_missing_settings)
+{
+  /* GOAWAY as first frame on control stream: H3_MISSING_SETTINGS */
+  ASSERT_EQ (
+      H3_MISSING_SETTINGS,
+      SocketHTTP3_Frame_validate (HTTP3_FRAME_GOAWAY, HTTP3_STREAM_CONTROL, 1));
+}
+
+/* ============================================================================
+ * Write Buffer Too Small
+ * ============================================================================
+ */
+
+TEST (h3_write_header_buffer_too_small)
+{
+  uint8_t buf[1]; /* Too small for type + length */
+  int written = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_DATA, 100, buf, sizeof (buf));
+  ASSERT_EQ (-1, written);
+}
+
+TEST (h3_goaway_write_buffer_too_small)
+{
+  uint8_t buf[0];
+  int written = SocketHTTP3_Goaway_write (42, buf, 0);
+  ASSERT_EQ (-1, written);
+}
+
+TEST (h3_settings_write_buffer_too_small)
+{
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  settings.qpack_max_table_capacity = 4096;
+
+  uint8_t buf[1]; /* Too small */
+  int written = SocketHTTP3_Settings_write (&settings, buf, sizeof (buf));
+  ASSERT_EQ (-1, written);
+}
+
+/* ============================================================================
+ * Single-Varint Incomplete Parse
+ * ============================================================================
+ */
+
+TEST (h3_goaway_parse_incomplete)
+{
+  uint64_t id;
+  int ret = SocketHTTP3_Goaway_parse (NULL, 0, &id);
+  ASSERT_EQ (1, ret);
+}
+
+TEST (h3_max_push_id_parse_incomplete)
+{
+  uint64_t id;
+  int ret = SocketHTTP3_MaxPushId_parse (NULL, 0, &id);
+  ASSERT_EQ (1, ret);
+}
+
+TEST (h3_cancel_push_parse_incomplete)
+{
+  uint64_t push_id;
+  int ret = SocketHTTP3_CancelPush_parse (NULL, 0, &push_id);
+  ASSERT_EQ (1, ret);
+}
+
+/* ============================================================================
+ * Settings Parse Empty Payload
+ * ============================================================================
+ */
+
+TEST (h3_settings_parse_empty)
+{
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  int ret = SocketHTTP3_Settings_parse (NULL, 0, &settings);
+  ASSERT_EQ (0, ret);
+  /* All defaults preserved */
+  ASSERT_EQ (UINT64_MAX, settings.max_field_section_size);
+  ASSERT_EQ (0ULL, settings.qpack_max_table_capacity);
+  ASSERT_EQ (0ULL, settings.qpack_blocked_streams);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary
- Implement parsing and serialization for all 7 HTTP/3 frame types (DATA, HEADERS, CANCEL_PUSH, SETTINGS, PUSH_PROMISE, GOAWAY, MAX_PUSH_ID)
- SETTINGS parse with duplicate detection, reserved HTTP/2 ID rejection (0x02-0x05), and GREASE handling
- Frame validation per stream context (control/request/push) with first-frame-must-be-SETTINGS enforcement
- 58 test cases covering round-trips, boundary varints, error paths, and validation rules

Fixes #3560

## Test plan
- [x] All 58 new tests pass
- [x] Full test suite (179 tests) passes with ASan + UBSan
- [x] clang-format applied to all new files