### PR TITLE
feat: implement HTTP/3 stream mapping (RFC 9114 §6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -400,6 +400,9 @@ set(LIB_SOURCES
     # HTTP/3 Framing (RFC 9114 Section 7)
     src/http/h3/SocketHTTP3-frame.c
 
+    # HTTP/3 Stream Mapping (RFC 9114 Section 6)
+    src/http/h3/SocketHTTP3-stream.c
+
     # HTTP/2 Protocol (RFC 9113)
     src/http/h2/SocketHTTP2-frame.c
     src/http/h2/SocketHTTP2-connection.c
@@ -889,6 +892,7 @@ set(TEST_SOURCES
     test_qpack_vectors
     test_http3_constants
     test_http3_frame
+    test_http3_stream
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/SocketHTTP3-stream.h
+++ b/include/http/SocketHTTP3-stream.h
@@ -1,0 +1,145 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-stream.h
+ * @brief HTTP/3 stream mapping and classification (RFC 9114 Section 6).
+ *
+ * Maps QUIC stream IDs to HTTP/3 roles and manages unidirectional stream
+ * registration. Enforces critical stream uniqueness: exactly one control
+ * stream, one QPACK encoder stream, and one QPACK decoder stream per
+ * connection direction.
+ *
+ * Bidirectional streams are classified as request streams via O(1) bitmask
+ * check. Push streams are tracked in a dynamic array.
+ */
+
+#ifndef SOCKETHTTP3_STREAM_INCLUDED
+#define SOCKETHTTP3_STREAM_INCLUDED
+
+#include <stdint.h>
+
+#include "core/Arena.h"
+
+/**
+ * @brief HTTP/3 stream roles.
+ *
+ * Classifies a QUIC stream by its HTTP/3 function.
+ */
+typedef enum
+{
+  H3_STREAM_ROLE_REQUEST,       /**< Bidirectional request stream */
+  H3_STREAM_ROLE_CONTROL,       /**< Control stream (type 0x00) */
+  H3_STREAM_ROLE_PUSH,          /**< Push stream (type 0x01) */
+  H3_STREAM_ROLE_QPACK_ENCODER, /**< QPACK encoder stream (type 0x02) */
+  H3_STREAM_ROLE_QPACK_DECODER, /**< QPACK decoder stream (type 0x03) */
+  H3_STREAM_ROLE_UNKNOWN        /**< Unknown or unregistered unidi stream */
+} SocketHTTP3_StreamRole;
+
+/** Sentinel value indicating no stream ID assigned. */
+#define H3_STREAM_ID_NONE ((int64_t) - 1)
+
+/** Opaque stream map handle. */
+typedef struct SocketHTTP3_StreamMap *SocketHTTP3_StreamMap_T;
+
+/**
+ * @brief Create a new stream map.
+ *
+ * All critical stream slots are initialized to H3_STREAM_ID_NONE.
+ *
+ * @param arena  Memory arena for allocations.
+ * @return New stream map, or NULL if arena is NULL.
+ */
+SocketHTTP3_StreamMap_T SocketHTTP3_StreamMap_new (Arena_T arena);
+
+/**
+ * @brief Register a peer-initiated unidirectional stream.
+ *
+ * Called after reading the stream type byte from a peer-initiated
+ * unidirectional stream. Validates stream ID directionality, enforces
+ * critical stream uniqueness, and stores the mapping.
+ *
+ * @param map         Stream map.
+ * @param stream_id   QUIC stream ID (must be unidirectional).
+ * @param stream_type HTTP/3 stream type byte (0x00-0x03, GREASE, etc.).
+ * @return 0 on success, H3 error code on violation.
+ */
+uint64_t SocketHTTP3_StreamMap_register (SocketHTTP3_StreamMap_T map,
+                                         uint64_t stream_id,
+                                         uint64_t stream_type);
+
+/**
+ * @brief Classify a stream by its HTTP/3 role.
+ *
+ * Bidirectional streams return H3_STREAM_ROLE_REQUEST (O(1) bitmask).
+ * Registered unidirectional streams return their assigned role.
+ * Unregistered unidirectional streams return H3_STREAM_ROLE_UNKNOWN.
+ *
+ * @param map        Stream map.
+ * @param stream_id  QUIC stream ID.
+ * @return Stream role.
+ */
+SocketHTTP3_StreamRole
+SocketHTTP3_StreamMap_role (SocketHTTP3_StreamMap_T map, uint64_t stream_id);
+
+/**
+ * @brief Check if all three peer critical streams have been opened.
+ *
+ * @param map  Stream map.
+ * @return 1 if control, QPACK encoder, and QPACK decoder are all registered.
+ */
+int SocketHTTP3_StreamMap_critical_streams_ready (SocketHTTP3_StreamMap_T map);
+
+/**
+ * @brief Get the peer control stream ID.
+ * @return Stream ID, or H3_STREAM_ID_NONE if not yet opened.
+ */
+int64_t SocketHTTP3_StreamMap_get_control (SocketHTTP3_StreamMap_T map);
+
+/**
+ * @brief Get the peer QPACK encoder stream ID.
+ * @return Stream ID, or H3_STREAM_ID_NONE if not yet opened.
+ */
+int64_t SocketHTTP3_StreamMap_get_qpack_encoder (SocketHTTP3_StreamMap_T map);
+
+/**
+ * @brief Get the peer QPACK decoder stream ID.
+ * @return Stream ID, or H3_STREAM_ID_NONE if not yet opened.
+ */
+int64_t SocketHTTP3_StreamMap_get_qpack_decoder (SocketHTTP3_StreamMap_T map);
+
+/**
+ * @brief Set the locally-opened control stream ID.
+ * @param map  Stream map.
+ * @param id   Stream ID.
+ */
+void SocketHTTP3_StreamMap_set_local_control (SocketHTTP3_StreamMap_T map,
+                                              uint64_t id);
+
+/**
+ * @brief Set the locally-opened QPACK encoder stream ID.
+ * @param map  Stream map.
+ * @param id   Stream ID.
+ */
+void SocketHTTP3_StreamMap_set_local_qpack_encoder (SocketHTTP3_StreamMap_T map,
+                                                    uint64_t id);
+
+/**
+ * @brief Set the locally-opened QPACK decoder stream ID.
+ * @param map  Stream map.
+ * @param id   Stream ID.
+ */
+void SocketHTTP3_StreamMap_set_local_qpack_decoder (SocketHTTP3_StreamMap_T map,
+                                                    uint64_t id);
+
+/**
+ * @brief Return human-readable name for a stream role.
+ * @param role  Stream role.
+ * @return Static string.
+ */
+const char *SocketHTTP3_StreamRole_name (SocketHTTP3_StreamRole role);
+
+#endif /* SOCKETHTTP3_STREAM_INCLUDED */

--- a/src/http/h3/SocketHTTP3-stream.c
+++ b/src/http/h3/SocketHTTP3-stream.c
@@ -1,0 +1,267 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-stream.c
+ * @brief HTTP/3 stream mapping implementation (RFC 9114 Section 6).
+ */
+
+#include "http/SocketHTTP3-stream.h"
+#include "http/SocketHTTP3-constants.h"
+#include "quic/SocketQUICStream.h"
+
+#include <string.h>
+
+#define H3_PUSH_STREAMS_INITIAL_CAP 8
+#define H3_MAX_PUSH_STREAMS 256
+
+struct SocketHTTP3_StreamMap
+{
+  Arena_T arena;
+
+  /* Peer-initiated critical streams (exactly 1 each, or -1) */
+  int64_t peer_control_id;
+  int64_t peer_qpack_encoder_id;
+  int64_t peer_qpack_decoder_id;
+
+  /* Locally-opened critical streams (set by connection layer) */
+  int64_t local_control_id;
+  int64_t local_qpack_encoder_id;
+  int64_t local_qpack_decoder_id;
+
+  /* Push streams (server-initiated unidi type 0x01) */
+  uint64_t *push_ids;
+  size_t push_count;
+  size_t push_capacity;
+};
+
+SocketHTTP3_StreamMap_T
+SocketHTTP3_StreamMap_new (Arena_T arena)
+{
+  if (arena == NULL)
+    return NULL;
+
+  SocketHTTP3_StreamMap_T map
+      = CALLOC (arena, 1, sizeof (struct SocketHTTP3_StreamMap));
+  map->arena = arena;
+
+  map->peer_control_id = H3_STREAM_ID_NONE;
+  map->peer_qpack_encoder_id = H3_STREAM_ID_NONE;
+  map->peer_qpack_decoder_id = H3_STREAM_ID_NONE;
+
+  map->local_control_id = H3_STREAM_ID_NONE;
+  map->local_qpack_encoder_id = H3_STREAM_ID_NONE;
+  map->local_qpack_decoder_id = H3_STREAM_ID_NONE;
+
+  map->push_ids
+      = CALLOC (arena, H3_PUSH_STREAMS_INITIAL_CAP, sizeof (uint64_t));
+  map->push_count = 0;
+  map->push_capacity = H3_PUSH_STREAMS_INITIAL_CAP;
+
+  return map;
+}
+
+/**
+ * @brief Grow the push stream array by doubling capacity.
+ */
+static int
+push_array_grow (SocketHTTP3_StreamMap_T map)
+{
+  size_t new_cap = map->push_capacity * 2;
+  if (new_cap > H3_MAX_PUSH_STREAMS)
+    new_cap = H3_MAX_PUSH_STREAMS;
+
+  if (new_cap <= map->push_capacity)
+    return -1;
+
+  uint64_t *new_ids = CALLOC (map->arena, new_cap, sizeof (uint64_t));
+  memcpy (new_ids, map->push_ids, map->push_count * sizeof (uint64_t));
+  map->push_ids = new_ids;
+  map->push_capacity = new_cap;
+  return 0;
+}
+
+uint64_t
+SocketHTTP3_StreamMap_register (SocketHTTP3_StreamMap_T map,
+                                uint64_t stream_id,
+                                uint64_t stream_type)
+{
+  if (map == NULL)
+    return H3_STREAM_CREATION_ERROR;
+
+  /* Only unidirectional streams carry a type byte */
+  if (SocketQUICStream_is_bidirectional (stream_id))
+    return H3_STREAM_CREATION_ERROR;
+
+  /* GREASE stream types: silently ignore */
+  if (H3_IS_GREASE (stream_type))
+    return 0;
+
+  switch (stream_type)
+    {
+    case H3_STREAM_TYPE_CONTROL:
+      if (map->peer_control_id != H3_STREAM_ID_NONE)
+        return H3_STREAM_CREATION_ERROR;
+      map->peer_control_id = (int64_t)stream_id;
+      return 0;
+
+    case H3_STREAM_TYPE_QPACK_ENCODER:
+      if (map->peer_qpack_encoder_id != H3_STREAM_ID_NONE)
+        return H3_STREAM_CREATION_ERROR;
+      map->peer_qpack_encoder_id = (int64_t)stream_id;
+      return 0;
+
+    case H3_STREAM_TYPE_QPACK_DECODER:
+      if (map->peer_qpack_decoder_id != H3_STREAM_ID_NONE)
+        return H3_STREAM_CREATION_ERROR;
+      map->peer_qpack_decoder_id = (int64_t)stream_id;
+      return 0;
+
+    case H3_STREAM_TYPE_PUSH:
+      /* Push streams must be server-initiated */
+      if (SocketQUICStream_is_client_initiated (stream_id))
+        return H3_STREAM_CREATION_ERROR;
+
+      if (map->push_count >= map->push_capacity)
+        {
+          if (push_array_grow (map) < 0)
+            return H3_STREAM_CREATION_ERROR;
+        }
+      map->push_ids[map->push_count++] = stream_id;
+      return 0;
+
+    default:
+      /* Unknown non-GREASE type: RFC §6.2.3 requires ignore */
+      return 0;
+    }
+}
+
+SocketHTTP3_StreamRole
+SocketHTTP3_StreamMap_role (SocketHTTP3_StreamMap_T map, uint64_t stream_id)
+{
+  if (map == NULL)
+    return H3_STREAM_ROLE_UNKNOWN;
+
+  /* Bidirectional streams are always request streams */
+  if (SocketQUICStream_is_bidirectional (stream_id))
+    return H3_STREAM_ROLE_REQUEST;
+
+  /* Check peer critical streams */
+  if (map->peer_control_id != H3_STREAM_ID_NONE
+      && (uint64_t)map->peer_control_id == stream_id)
+    return H3_STREAM_ROLE_CONTROL;
+
+  if (map->peer_qpack_encoder_id != H3_STREAM_ID_NONE
+      && (uint64_t)map->peer_qpack_encoder_id == stream_id)
+    return H3_STREAM_ROLE_QPACK_ENCODER;
+
+  if (map->peer_qpack_decoder_id != H3_STREAM_ID_NONE
+      && (uint64_t)map->peer_qpack_decoder_id == stream_id)
+    return H3_STREAM_ROLE_QPACK_DECODER;
+
+  /* Check local critical streams */
+  if (map->local_control_id != H3_STREAM_ID_NONE
+      && (uint64_t)map->local_control_id == stream_id)
+    return H3_STREAM_ROLE_CONTROL;
+
+  if (map->local_qpack_encoder_id != H3_STREAM_ID_NONE
+      && (uint64_t)map->local_qpack_encoder_id == stream_id)
+    return H3_STREAM_ROLE_QPACK_ENCODER;
+
+  if (map->local_qpack_decoder_id != H3_STREAM_ID_NONE
+      && (uint64_t)map->local_qpack_decoder_id == stream_id)
+    return H3_STREAM_ROLE_QPACK_DECODER;
+
+  /* Check push streams */
+  for (size_t i = 0; i < map->push_count; i++)
+    {
+      if (map->push_ids[i] == stream_id)
+        return H3_STREAM_ROLE_PUSH;
+    }
+
+  return H3_STREAM_ROLE_UNKNOWN;
+}
+
+int
+SocketHTTP3_StreamMap_critical_streams_ready (SocketHTTP3_StreamMap_T map)
+{
+  if (map == NULL)
+    return 0;
+
+  return map->peer_control_id != H3_STREAM_ID_NONE
+         && map->peer_qpack_encoder_id != H3_STREAM_ID_NONE
+         && map->peer_qpack_decoder_id != H3_STREAM_ID_NONE;
+}
+
+int64_t
+SocketHTTP3_StreamMap_get_control (SocketHTTP3_StreamMap_T map)
+{
+  if (map == NULL)
+    return H3_STREAM_ID_NONE;
+  return map->peer_control_id;
+}
+
+int64_t
+SocketHTTP3_StreamMap_get_qpack_encoder (SocketHTTP3_StreamMap_T map)
+{
+  if (map == NULL)
+    return H3_STREAM_ID_NONE;
+  return map->peer_qpack_encoder_id;
+}
+
+int64_t
+SocketHTTP3_StreamMap_get_qpack_decoder (SocketHTTP3_StreamMap_T map)
+{
+  if (map == NULL)
+    return H3_STREAM_ID_NONE;
+  return map->peer_qpack_decoder_id;
+}
+
+void
+SocketHTTP3_StreamMap_set_local_control (SocketHTTP3_StreamMap_T map,
+                                         uint64_t id)
+{
+  if (map != NULL)
+    map->local_control_id = (int64_t)id;
+}
+
+void
+SocketHTTP3_StreamMap_set_local_qpack_encoder (SocketHTTP3_StreamMap_T map,
+                                               uint64_t id)
+{
+  if (map != NULL)
+    map->local_qpack_encoder_id = (int64_t)id;
+}
+
+void
+SocketHTTP3_StreamMap_set_local_qpack_decoder (SocketHTTP3_StreamMap_T map,
+                                               uint64_t id)
+{
+  if (map != NULL)
+    map->local_qpack_decoder_id = (int64_t)id;
+}
+
+const char *
+SocketHTTP3_StreamRole_name (SocketHTTP3_StreamRole role)
+{
+  switch (role)
+    {
+    case H3_STREAM_ROLE_REQUEST:
+      return "REQUEST";
+    case H3_STREAM_ROLE_CONTROL:
+      return "CONTROL";
+    case H3_STREAM_ROLE_PUSH:
+      return "PUSH";
+    case H3_STREAM_ROLE_QPACK_ENCODER:
+      return "QPACK_ENCODER";
+    case H3_STREAM_ROLE_QPACK_DECODER:
+      return "QPACK_DECODER";
+    case H3_STREAM_ROLE_UNKNOWN:
+      return "UNKNOWN";
+    default:
+      return "UNKNOWN";
+    }
+}

--- a/src/test/test_http3_stream.c
+++ b/src/test/test_http3_stream.c
@@ -1,0 +1,402 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_http3_stream.c
+ * @brief Unit tests for HTTP/3 stream mapping (RFC 9114 Section 6).
+ */
+
+#include "core/Arena.h"
+#include "http/SocketHTTP3-constants.h"
+#include "http/SocketHTTP3-stream.h"
+#include "test/Test.h"
+
+/* ============================================================================
+ * Stream ID Reference (RFC 9000 §2.1)
+ *
+ *   0, 4, 8  — Client-initiated bidi  (id & 0x03 == 0x00)
+ *   1, 5, 9  — Server-initiated bidi  (id & 0x03 == 0x01)
+ *   2, 6, 10 — Client-initiated unidi (id & 0x03 == 0x02)
+ *   3, 7, 11 — Server-initiated unidi (id & 0x03 == 0x03)
+ * ============================================================================
+ */
+
+/* ============================================================================
+ * Registration Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_register_control)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+  ASSERT_NOT_NULL (map);
+
+  /* Register stream 2 (client-initiated unidi) as control */
+  uint64_t err
+      = SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_CONTROL);
+  ASSERT_EQ (0ULL, err);
+  ASSERT_EQ (H3_STREAM_ROLE_CONTROL, SocketHTTP3_StreamMap_role (map, 2));
+  ASSERT_EQ (2LL, SocketHTTP3_StreamMap_get_control (map));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_register_qpack_encoder)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  uint64_t err
+      = SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_QPACK_ENCODER);
+  ASSERT_EQ (0ULL, err);
+  ASSERT_EQ (H3_STREAM_ROLE_QPACK_ENCODER, SocketHTTP3_StreamMap_role (map, 6));
+  ASSERT_EQ (6LL, SocketHTTP3_StreamMap_get_qpack_encoder (map));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_register_qpack_decoder)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  uint64_t err
+      = SocketHTTP3_StreamMap_register (map, 10, H3_STREAM_TYPE_QPACK_DECODER);
+  ASSERT_EQ (0ULL, err);
+  ASSERT_EQ (H3_STREAM_ROLE_QPACK_DECODER,
+             SocketHTTP3_StreamMap_role (map, 10));
+  ASSERT_EQ (10LL, SocketHTTP3_StreamMap_get_qpack_decoder (map));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_register_push)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Stream 3 is server-initiated unidi */
+  uint64_t err = SocketHTTP3_StreamMap_register (map, 3, H3_STREAM_TYPE_PUSH);
+  ASSERT_EQ (0ULL, err);
+  ASSERT_EQ (H3_STREAM_ROLE_PUSH, SocketHTTP3_StreamMap_role (map, 3));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_register_unknown_type)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Unknown type 0xFF on unidi stream 2: silently ignored */
+  uint64_t err = SocketHTTP3_StreamMap_register (map, 2, 0xFF);
+  ASSERT_EQ (0ULL, err);
+  ASSERT_EQ (H3_STREAM_ROLE_UNKNOWN, SocketHTTP3_StreamMap_role (map, 2));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_register_grease)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* GREASE value 0x21 (0x1f*0 + 0x21) on unidi stream 6 */
+  uint64_t err = SocketHTTP3_StreamMap_register (map, 6, 0x21);
+  ASSERT_EQ (0ULL, err);
+  ASSERT_EQ (H3_STREAM_ROLE_UNKNOWN, SocketHTTP3_StreamMap_role (map, 6));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Duplicate Critical Stream Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_duplicate_control)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_CONTROL));
+  /* Second control stream must fail */
+  ASSERT_EQ (H3_STREAM_CREATION_ERROR,
+             SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_CONTROL));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_duplicate_qpack_encoder)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  ASSERT_EQ (
+      0ULL,
+      SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_QPACK_ENCODER));
+  ASSERT_EQ (
+      H3_STREAM_CREATION_ERROR,
+      SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_QPACK_ENCODER));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_duplicate_qpack_decoder)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  ASSERT_EQ (
+      0ULL,
+      SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_QPACK_DECODER));
+  ASSERT_EQ (
+      H3_STREAM_CREATION_ERROR,
+      SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_QPACK_DECODER));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Error Condition Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_register_bidi_rejected)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Stream 0 is client-initiated bidi — cannot register a stream type */
+  ASSERT_EQ (H3_STREAM_CREATION_ERROR,
+             SocketHTTP3_StreamMap_register (map, 0, H3_STREAM_TYPE_CONTROL));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_register_null_map)
+{
+  ASSERT_EQ (H3_STREAM_CREATION_ERROR,
+             SocketHTTP3_StreamMap_register (NULL, 2, H3_STREAM_TYPE_CONTROL));
+}
+
+TEST (h3_stream_push_from_client_rejected)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Stream 2 is client-initiated unidi — push must be server-initiated */
+  ASSERT_EQ (H3_STREAM_CREATION_ERROR,
+             SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_PUSH));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Role Classification Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_role_bidi_is_request)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Client-initiated bidi: 0, 4, 8 */
+  ASSERT_EQ (H3_STREAM_ROLE_REQUEST, SocketHTTP3_StreamMap_role (map, 0));
+  ASSERT_EQ (H3_STREAM_ROLE_REQUEST, SocketHTTP3_StreamMap_role (map, 4));
+  ASSERT_EQ (H3_STREAM_ROLE_REQUEST, SocketHTTP3_StreamMap_role (map, 8));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_role_server_bidi_is_request)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Server-initiated bidi: 1, 5 */
+  ASSERT_EQ (H3_STREAM_ROLE_REQUEST, SocketHTTP3_StreamMap_role (map, 1));
+  ASSERT_EQ (H3_STREAM_ROLE_REQUEST, SocketHTTP3_StreamMap_role (map, 5));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_role_unregistered_unidi)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Unidi stream 2 not registered */
+  ASSERT_EQ (H3_STREAM_ROLE_UNKNOWN, SocketHTTP3_StreamMap_role (map, 2));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Critical Streams Ready Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_critical_not_ready_initially)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  ASSERT_EQ (0, SocketHTTP3_StreamMap_critical_streams_ready (map));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_critical_ready_after_all_three)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_CONTROL);
+  SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_QPACK_ENCODER);
+  SocketHTTP3_StreamMap_register (map, 10, H3_STREAM_TYPE_QPACK_DECODER);
+
+  ASSERT_EQ (1, SocketHTTP3_StreamMap_critical_streams_ready (map));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_critical_partial_not_ready)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_CONTROL);
+  SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_QPACK_ENCODER);
+  /* Missing QPACK decoder */
+
+  ASSERT_EQ (0, SocketHTTP3_StreamMap_critical_streams_ready (map));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Getter Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_get_before_register)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  ASSERT_EQ (H3_STREAM_ID_NONE, SocketHTTP3_StreamMap_get_control (map));
+  ASSERT_EQ (H3_STREAM_ID_NONE, SocketHTTP3_StreamMap_get_qpack_encoder (map));
+  ASSERT_EQ (H3_STREAM_ID_NONE, SocketHTTP3_StreamMap_get_qpack_decoder (map));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_get_after_register)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  SocketHTTP3_StreamMap_register (map, 2, H3_STREAM_TYPE_CONTROL);
+  SocketHTTP3_StreamMap_register (map, 6, H3_STREAM_TYPE_QPACK_ENCODER);
+  SocketHTTP3_StreamMap_register (map, 10, H3_STREAM_TYPE_QPACK_DECODER);
+
+  ASSERT_EQ (2LL, SocketHTTP3_StreamMap_get_control (map));
+  ASSERT_EQ (6LL, SocketHTTP3_StreamMap_get_qpack_encoder (map));
+  ASSERT_EQ (10LL, SocketHTTP3_StreamMap_get_qpack_decoder (map));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Local Stream Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_set_local_control)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Stream 2 is our local control stream */
+  SocketHTTP3_StreamMap_set_local_control (map, 2);
+  ASSERT_EQ (H3_STREAM_ROLE_CONTROL, SocketHTTP3_StreamMap_role (map, 2));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_stream_local_and_peer_distinct)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Peer control on stream 3 (server-initiated unidi) */
+  SocketHTTP3_StreamMap_register (map, 3, H3_STREAM_TYPE_CONTROL);
+  /* Local control on stream 2 (client-initiated unidi) */
+  SocketHTTP3_StreamMap_set_local_control (map, 2);
+
+  ASSERT_EQ (H3_STREAM_ROLE_CONTROL, SocketHTTP3_StreamMap_role (map, 3));
+  ASSERT_EQ (H3_STREAM_ROLE_CONTROL, SocketHTTP3_StreamMap_role (map, 2));
+  /* get_control returns peer, not local */
+  ASSERT_EQ (3LL, SocketHTTP3_StreamMap_get_control (map));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Push Stream Tests
+ * ============================================================================
+ */
+
+TEST (h3_stream_multiple_push_streams)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_StreamMap_T map = SocketHTTP3_StreamMap_new (arena);
+
+  /* Server-initiated unidi streams: 3, 7, 11 */
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_StreamMap_register (map, 3, H3_STREAM_TYPE_PUSH));
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_StreamMap_register (map, 7, H3_STREAM_TYPE_PUSH));
+  ASSERT_EQ (0ULL,
+             SocketHTTP3_StreamMap_register (map, 11, H3_STREAM_TYPE_PUSH));
+
+  ASSERT_EQ (H3_STREAM_ROLE_PUSH, SocketHTTP3_StreamMap_role (map, 3));
+  ASSERT_EQ (H3_STREAM_ROLE_PUSH, SocketHTTP3_StreamMap_role (map, 7));
+  ASSERT_EQ (H3_STREAM_ROLE_PUSH, SocketHTTP3_StreamMap_role (map, 11));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Role Name Test
+ * ============================================================================
+ */
+
+TEST (h3_stream_role_name)
+{
+  ASSERT (SocketHTTP3_StreamRole_name (H3_STREAM_ROLE_REQUEST) != NULL);
+  ASSERT (SocketHTTP3_StreamRole_name (H3_STREAM_ROLE_CONTROL) != NULL);
+  ASSERT (SocketHTTP3_StreamRole_name (H3_STREAM_ROLE_PUSH) != NULL);
+  ASSERT (SocketHTTP3_StreamRole_name (H3_STREAM_ROLE_QPACK_ENCODER) != NULL);
+  ASSERT (SocketHTTP3_StreamRole_name (H3_STREAM_ROLE_QPACK_DECODER) != NULL);
+  ASSERT (SocketHTTP3_StreamRole_name (H3_STREAM_ROLE_UNKNOWN) != NULL);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary
- Add `SocketHTTP3_StreamMap_T` for mapping QUIC stream IDs to HTTP/3 roles (control, QPACK encoder/decoder, push, request)
- Enforce critical stream uniqueness: exactly one control, one QPACK encoder, one QPACK decoder per direction
- O(1) bidirectional stream classification via bitmask, direct field lookup for critical streams, linear array for push streams
- 23 test cases covering registration, duplication errors, role classification, critical readiness, and local/peer distinction

Fixes #3562

## Test plan
- [x] All 23 new tests pass with ASan + UBSan
- [x] Full test suite passes (180/180)
- [x] clang-format applied to all new files