### PR TITLE
refactor: centralize magic numbers into SocketConfig.h

### DIFF
--- a/include/core/SocketConfig.h
+++ b/include/core/SocketConfig.h
@@ -1687,8 +1687,9 @@ typedef struct SocketTimeouts_Extended
  *
  */
 #ifndef SOCKET_DEFAULT_TLS_TIMEOUT_MS
-#define SOCKET_DEFAULT_TLS_TIMEOUT_MS 30000 /**< 30 seconds for TLS handshake \
-                                             */
+#define SOCKET_DEFAULT_TLS_TIMEOUT_MS     \
+  30000 /**< 30 seconds for TLS handshake \
+         */
 #endif
 
 /**
@@ -1816,6 +1817,28 @@ typedef struct SocketTimeouts_Extended
  */
 #ifndef SOCKET_POOL_TOKENS_PER_ACCEPT
 #define SOCKET_POOL_TOKENS_PER_ACCEPT 1
+#endif
+
+/* --- HTTP & Pool hash table tuning --- */
+
+#ifndef SOCKET_POOL_FOREACH_BATCH_SIZE
+#define SOCKET_POOL_FOREACH_BATCH_SIZE 100
+#endif
+
+#ifndef POOL_MAX_HASH_CHAIN_LEN
+#define POOL_MAX_HASH_CHAIN_LEN 1024
+#endif
+
+#ifndef POOL_TARGET_LOAD_FACTOR
+#define POOL_TARGET_LOAD_FACTOR 8
+#endif
+
+#ifndef SOCKETHTTP_MAX_CHAIN_LEN
+#define SOCKETHTTP_MAX_CHAIN_LEN 10
+#endif
+
+#ifndef SOCKETHTTP_MAX_DOS_WARNINGS
+#define SOCKETHTTP_MAX_DOS_WARNINGS 3
 #endif
 
 /* ============================================================================

--- a/src/http/SocketHTTP-headers.c
+++ b/src/http/SocketHTTP-headers.c
@@ -10,6 +10,7 @@
  * O(1) case-insensitive lookup using hash table with separate chaining.
  */
 
+#include "core/SocketConfig.h"
 #include "core/SocketCrypto.h"
 #include "core/SocketSecurity.h"
 #include "core/SocketUtil.h"
@@ -25,9 +26,7 @@
  */
 
 #define HEADER_ENTRY_NULL_OVERHEAD 2
-#define SOCKETHTTP_MAX_CHAIN_LEN 10
 #define SOCKETHTTP_MAX_CHAIN_SEARCH_LEN (SOCKETHTTP_MAX_CHAIN_LEN * 2)
-#define SOCKETHTTP_MAX_DOS_WARNINGS 3 /* Hard fail after this many warnings */
 
 #define VALIDATE_HEADERS_NAME(headers, name, retval) \
   do                                                 \

--- a/src/http/client/SocketHTTPClient-pool.c
+++ b/src/http/client/SocketHTTPClient-pool.c
@@ -42,19 +42,6 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketHTTPClient);
 #define HTTPS_DEFAULT_PORT 443
 #endif
 
-/* SECURITY: Limit to prevent DoS via hash collision attacks */
-#ifndef POOL_MAX_HASH_CHAIN_LEN
-#define POOL_MAX_HASH_CHAIN_LEN 1024
-#endif
-
-/* Hash table load factor for sizing the hash table based on max connections.
- * A load factor of 8 means we size the hash table to ~1/8 the number of
- * max connections, providing a good balance between memory usage and
- * hash lookup performance. */
-#ifndef POOL_TARGET_LOAD_FACTOR
-#define POOL_TARGET_LOAD_FACTOR 8
-#endif
-
 /* Forward declarations */
 static void
 pool_entry_remove_and_recycle (HTTPPool *pool, HTTPPoolEntry *entry);

--- a/src/pool/SocketPool-ops.c
+++ b/src/pool/SocketPool-ops.c
@@ -36,22 +36,6 @@
 
 /* SOCKET_LOG_COMPONENT defined in SocketPool-private.h */
 
-/**
- * Default batch size for SocketPool_foreach iteration.
- * Balances lock contention vs iteration overhead.
- */
-#ifndef SOCKET_POOL_FOREACH_BATCH_SIZE
-#define SOCKET_POOL_FOREACH_BATCH_SIZE 100
-#endif
-
-/**
- * Divisor for converting percentage (0-100) to fraction.
- * Used in SocketPool_prewarm to calculate slot count from percentage.
- */
-#ifndef SOCKET_PERCENTAGE_DIVISOR
-#define SOCKET_PERCENTAGE_DIVISOR 100
-#endif
-
 #define T SocketPool_T
 
 /* Forward declarations for internal functions used by helpers */


### PR DESCRIPTION
## Summary
- Move 5 hash table tuning constants from scattered local `#define` blocks into `SocketConfig.h`
- Remove duplicate `SOCKET_PERCENTAGE_DIVISOR` from `SocketPool-ops.c`
- Add `#include "core/SocketConfig.h"` to `SocketHTTP-headers.c` (wasn't transitively included)

Fixes #3532

## Test plan
- [x] All 180 tests pass with ASan+UBSan enabled
- [x] No behavioral changes — pure constant relocation