### PR TITLE
feat(http3): add HTTP/3 client API with QUIC transport layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,7 @@ set(LIB_SOURCES
     src/http/client/SocketHTTPClient-headers.c
     src/http/client/SocketHTTPClient-http1.c
     src/http/client/SocketHTTPClient-http2.c
+    src/http/client/SocketHTTP3Client.c
 
     # HTTP Server API
     src/http/SocketHTTPServer.c
@@ -475,6 +476,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICAck.c
     src/quic/SocketQUICLoss.c
     src/quic/SocketQUICTLS.c
+    src/quic/SocketQUICTransport.c
 
     # DEFLATE compression module (RFC 1951)
     src/deflate/SocketDeflate-static.c
@@ -1016,6 +1018,8 @@ if(SOCKET_HAS_TLS)
         test_dns_over_tls
         # DNS-over-HTTPS (RFC 8484)
         test_dns_over_https
+        # HTTP/3 client (requires TLS for QUIC transport)
+        test_http3_client
     )
 endif()
 

--- a/include/http/SocketHTTP3-client.h
+++ b/include/http/SocketHTTP3-client.h
@@ -1,0 +1,197 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-client.h
+ * @brief HTTP/3 client API (RFC 9114).
+ *
+ * High-level HTTP/3 client that wraps the QUIC transport and HTTP/3
+ * connection layer. Provides both synchronous request/response and
+ * streaming APIs.
+ *
+ * Architecture: SocketHTTP3_Client_T owns a SocketQUICTransport_T
+ * (QUIC/UDP) and a SocketHTTP3_Conn_T (HTTP/3 framing). The output
+ * queue model bridges them: H3 generates wire data, client flushes
+ * it through the transport, transport delivers received data back
+ * to H3 via stream callback.
+ */
+
+#ifndef SOCKETHTTP3_CLIENT_INCLUDED
+#define SOCKETHTTP3_CLIENT_INCLUDED
+
+#ifdef SOCKET_HAS_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP3.h"
+#include "http/SocketHTTP3-frame.h"
+#include "http/SocketHTTP3-request.h"
+
+/**
+ * @brief HTTP/3 client configuration.
+ */
+typedef struct
+{
+  /* QUIC transport settings */
+  uint64_t idle_timeout_ms;          /**< default: 30000 */
+  uint64_t max_stream_data;          /**< default: 262144 (256KB) */
+  uint64_t initial_max_streams_bidi; /**< default: 100 */
+
+  /* HTTP/3 settings */
+  SocketHTTP3_Settings h3_settings;
+
+  /* TLS */
+  const char *ca_file; /**< NULL for system CAs */
+  int verify_peer;     /**< default: 1 */
+
+  /* Timeouts */
+  uint32_t connect_timeout_ms; /**< default: 5000 */
+  uint32_t request_timeout_ms; /**< default: 30000 */
+} SocketHTTP3_ClientConfig;
+
+/** Opaque client handle. */
+typedef struct SocketHTTP3_Client *SocketHTTP3_Client_T;
+
+/**
+ * @brief Initialize config to defaults.
+ *
+ * @param config  Output config structure.
+ */
+void SocketHTTP3_ClientConfig_defaults (SocketHTTP3_ClientConfig *config);
+
+/**
+ * @brief Create a new HTTP/3 client.
+ *
+ * @param arena   Memory arena for all allocations.
+ * @param config  Client configuration (NULL for defaults).
+ * @return New client, or NULL on error.
+ */
+SocketHTTP3_Client_T
+SocketHTTP3_Client_new (Arena_T arena, const SocketHTTP3_ClientConfig *config);
+
+/**
+ * @brief Connect to a remote HTTP/3 server (blocking).
+ *
+ * Performs the full QUIC handshake, then opens H3 critical streams
+ * and sends SETTINGS.
+ *
+ * @param client  Client handle.
+ * @param host    Remote hostname or IP.
+ * @param port    Remote port.
+ * @return 0 on success, -1 on error.
+ */
+int SocketHTTP3_Client_connect (SocketHTTP3_Client_T client,
+                                const char *host,
+                                int port);
+
+/**
+ * @brief Close the client (send GOAWAY + CONNECTION_CLOSE).
+ *
+ * @param client  Client handle.
+ * @return 0 on success, -1 on error.
+ */
+int SocketHTTP3_Client_close (SocketHTTP3_Client_T client);
+
+/**
+ * @brief Synchronous HTTP request/response.
+ *
+ * Sends request headers + optional body, then polls for the complete
+ * response. All output memory is arena-owned.
+ *
+ * @param client         Client handle.
+ * @param method         HTTP method (e.g., HTTP_METHOD_GET).
+ * @param path           Request path (e.g., "/index.html").
+ * @param headers        Additional request headers (may be NULL).
+ * @param body           Request body (may be NULL).
+ * @param body_len       Body length.
+ * @param[out] resp_headers  Output: response headers.
+ * @param[out] status_code   Output: HTTP status code (may be NULL).
+ * @param[out] resp_body     Output: response body (may be NULL).
+ * @param[out] resp_body_len Output: response body length (may be NULL).
+ * @return 0 on success, -1 on error or timeout.
+ */
+int SocketHTTP3_Client_request (SocketHTTP3_Client_T client,
+                                SocketHTTP_Method method,
+                                const char *path,
+                                const SocketHTTP_Headers_T headers,
+                                const void *body,
+                                size_t body_len,
+                                SocketHTTP_Headers_T *resp_headers,
+                                int *status_code,
+                                void **resp_body,
+                                size_t *resp_body_len);
+
+/**
+ * @brief Create a new streaming request on the connection.
+ *
+ * For callers who need fine-grained control over send/recv.
+ *
+ * @param client  Client handle.
+ * @return New request, or NULL on error.
+ */
+SocketHTTP3_Request_T
+SocketHTTP3_Client_new_request (SocketHTTP3_Client_T client);
+
+/**
+ * @brief Flush H3 output queue through the transport.
+ *
+ * Sends all pending H3 output entries via the QUIC transport.
+ * Called automatically during request(), but available for
+ * manual use with the streaming API.
+ *
+ * @param client  Client handle.
+ * @return 0 on success, -1 on error.
+ */
+int SocketHTTP3_Client_flush (SocketHTTP3_Client_T client);
+
+/**
+ * @brief Poll for incoming data (blocking with timeout).
+ *
+ * Receives QUIC data and delivers it to the H3 connection layer.
+ *
+ * @param client      Client handle.
+ * @param timeout_ms  Poll timeout in milliseconds (-1 for infinite).
+ * @return Number of events processed (>=0), or -1 on error.
+ */
+int SocketHTTP3_Client_poll (SocketHTTP3_Client_T client, int timeout_ms);
+
+/**
+ * @brief Get the underlying H3 connection handle.
+ *
+ * @param client  Client handle.
+ * @return H3 connection, or NULL.
+ */
+SocketHTTP3_Conn_T SocketHTTP3_Client_conn (SocketHTTP3_Client_T client);
+
+/**
+ * @brief Check if connected.
+ *
+ * @param client  Client handle.
+ * @return 1 if connected, 0 otherwise.
+ */
+int SocketHTTP3_Client_is_connected (SocketHTTP3_Client_T client);
+
+/**
+ * @brief Parse Alt-Svc header for h3 support (RFC 7838).
+ *
+ * Extracts the port for "h3" protocol from an Alt-Svc header value.
+ * Optionally extracts the alternate host.
+ *
+ * @param alt_svc_value  Alt-Svc header value string.
+ * @param host_out       Output buffer for alternate host (may be NULL).
+ * @param host_len       Size of host_out buffer.
+ * @return Port number if h3 found, 0 otherwise.
+ */
+uint16_t SocketHTTP3_parse_alt_svc (const char *alt_svc_value,
+                                    char *host_out,
+                                    size_t host_len);
+
+#endif /* SOCKET_HAS_TLS */
+
+#endif /* SOCKETHTTP3_CLIENT_INCLUDED */

--- a/include/quic/SocketQUICTLS.h
+++ b/include/quic/SocketQUICTLS.h
@@ -261,6 +261,27 @@ extern SocketQUICTLS_Result
 SocketQUICTLS_derive_keys (SocketQUICHandshake_T handshake,
                            SocketQUICCryptoLevel level);
 
+/**
+ * @brief Get traffic secrets for an encryption level.
+ *
+ * Returns the raw TLS traffic secrets needed for packet key derivation
+ * via SocketQUICCrypto_derive_packet_keys().
+ *
+ * @param handshake   Handshake context.
+ * @param level       Encryption level.
+ * @param write_secret Output: write secret buffer (SOCKET_CRYPTO_SHA256_SIZE).
+ * @param read_secret  Output: read secret buffer (SOCKET_CRYPTO_SHA256_SIZE).
+ * @param secret_len   Output: actual secret length.
+ *
+ * @return QUIC_TLS_OK on success, error code otherwise.
+ */
+extern SocketQUICTLS_Result
+SocketQUICTLS_get_traffic_secrets (SocketQUICHandshake_T handshake,
+                                   SocketQUICCryptoLevel level,
+                                   uint8_t *write_secret,
+                                   uint8_t *read_secret,
+                                   size_t *secret_len);
+
 /* ============================================================================
  * Alert Handling
  * ============================================================================

--- a/include/quic/SocketQUICTransport.h
+++ b/include/quic/SocketQUICTransport.h
@@ -1,0 +1,179 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICTransport.h
+ * @brief QUIC transport layer over UDP (RFC 9000).
+ *
+ * Drives the QUIC handshake and stream I/O over a UDP socket, integrating
+ * the existing packet protection, frame encoding, handshake state machine,
+ * ACK generation, and loss detection modules.
+ *
+ * Output model: send_stream() builds STREAM frames into 1-RTT packets and
+ * sends them immediately. poll() receives UDP datagrams, decrypts, parses
+ * frames, and delivers stream data via callback.
+ *
+ * V1 Simplifications:
+ * - No congestion control (send immediately)
+ * - No retransmission (detect losses but don't retransmit)
+ * - No 0-RTT (always full handshake)
+ * - No connection migration (fixed path)
+ * - No PMTU discovery (assume 1200-byte minimum)
+ * - Fixed 4-byte packet numbers
+ * - Immediate ACK (no delayed ACK)
+ * - No coalesced packets (one QUIC packet per UDP datagram)
+ * - No CID rotation
+ */
+
+#ifndef SOCKETQUICTRANSPORT_INCLUDED
+#define SOCKETQUICTRANSPORT_INCLUDED
+
+#ifdef SOCKET_HAS_TLS
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/Arena.h"
+
+/**
+ * @brief QUIC transport configuration.
+ */
+typedef struct
+{
+  uint64_t idle_timeout_ms;          /**< default: 30000 */
+  uint64_t max_stream_data;          /**< default: 262144 (256KB) */
+  uint64_t initial_max_data;         /**< default: 1048576 (1MB) */
+  uint64_t initial_max_streams_bidi; /**< default: 100 */
+  uint32_t connect_timeout_ms;       /**< default: 5000 */
+  const char *alpn;                  /**< default: "h3" */
+  const char *ca_file;               /**< NULL for system CAs */
+  int verify_peer;                   /**< default: 1 */
+} SocketQUICTransportConfig;
+
+/** Opaque transport handle. */
+typedef struct SocketQUICTransport *SocketQUICTransport_T;
+
+/**
+ * @brief Callback for received stream data during poll().
+ *
+ * @param stream_id  QUIC stream ID.
+ * @param data       Received data.
+ * @param len        Data length.
+ * @param fin        1 if this is the final data on the stream.
+ * @param userdata   User-supplied context pointer.
+ */
+typedef void (*SocketQUICTransport_StreamCB) (uint64_t stream_id,
+                                              const uint8_t *data,
+                                              size_t len,
+                                              int fin,
+                                              void *userdata);
+
+/**
+ * @brief Initialize config to defaults.
+ *
+ * @param config  Output config structure.
+ */
+void SocketQUICTransportConfig_defaults (SocketQUICTransportConfig *config);
+
+/**
+ * @brief Create a new QUIC transport.
+ *
+ * @param arena   Memory arena for all allocations.
+ * @param config  Transport configuration (NULL for defaults).
+ * @return New transport, or NULL on error.
+ */
+SocketQUICTransport_T
+SocketQUICTransport_new (Arena_T arena,
+                         const SocketQUICTransportConfig *config);
+
+/**
+ * @brief Connect to a remote QUIC server (blocking).
+ *
+ * Performs the full QUIC handshake over UDP:
+ * 1. Creates and connects UDP socket
+ * 2. Derives Initial keys, sends ClientHello
+ * 3. Processes server responses, derives Handshake/1-RTT keys
+ * 4. Completes TLS handshake
+ *
+ * @param t     Transport handle.
+ * @param host  Remote hostname or IP.
+ * @param port  Remote port.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_connect (SocketQUICTransport_T t,
+                                 const char *host,
+                                 int port);
+
+/**
+ * @brief Close the transport (send CONNECTION_CLOSE).
+ *
+ * @param t  Transport handle.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_close (SocketQUICTransport_T t);
+
+/**
+ * @brief Send data on a QUIC stream.
+ *
+ * Builds a STREAM frame, wraps in a 1-RTT packet, encrypts, and sends.
+ *
+ * @param t          Transport handle.
+ * @param stream_id  QUIC stream ID.
+ * @param data       Payload data.
+ * @param len        Payload length.
+ * @param fin        1 to signal end-of-stream.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_send_stream (SocketQUICTransport_T t,
+                                     uint64_t stream_id,
+                                     const uint8_t *data,
+                                     size_t len,
+                                     int fin);
+
+/**
+ * @brief Poll for incoming data (blocking with timeout).
+ *
+ * Receives a UDP datagram, decrypts, parses frames, and delivers
+ * stream data via the registered callback. Also handles ACK generation.
+ *
+ * @param t           Transport handle.
+ * @param timeout_ms  Poll timeout in milliseconds (-1 for infinite).
+ * @return Number of events processed (>=0), or -1 on error.
+ */
+int SocketQUICTransport_poll (SocketQUICTransport_T t, int timeout_ms);
+
+/**
+ * @brief Set stream data receive callback.
+ *
+ * @param t         Transport handle.
+ * @param cb        Callback function.
+ * @param userdata  User context passed to callback.
+ */
+void SocketQUICTransport_set_stream_callback (SocketQUICTransport_T t,
+                                              SocketQUICTransport_StreamCB cb,
+                                              void *userdata);
+
+/**
+ * @brief Check if connected.
+ *
+ * @param t  Transport handle.
+ * @return 1 if connected, 0 otherwise.
+ */
+int SocketQUICTransport_is_connected (SocketQUICTransport_T t);
+
+/**
+ * @brief Allocate the next client bidirectional stream ID.
+ *
+ * Client bidi stream IDs: 0, 4, 8, 12, ...
+ *
+ * @param t  Transport handle.
+ * @return Stream ID, or UINT64_MAX on error.
+ */
+uint64_t SocketQUICTransport_open_bidi_stream (SocketQUICTransport_T t);
+
+#endif /* SOCKET_HAS_TLS */
+
+#endif /* SOCKETQUICTRANSPORT_INCLUDED */

--- a/src/http/client/SocketHTTP3Client.c
+++ b/src/http/client/SocketHTTP3Client.c
@@ -1,0 +1,536 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3Client.c
+ * @brief HTTP/3 client implementation (RFC 9114).
+ *
+ * Wraps SocketQUICTransport_T and SocketHTTP3_Conn_T into a user-facing
+ * HTTP/3 client API. The output queue model bridges H3 framing with
+ * QUIC transport: H3 generates wire data -> flush sends via transport ->
+ * transport delivers received data back to H3 via stream callback.
+ */
+
+#ifdef SOCKET_HAS_TLS
+
+#include "http/SocketHTTP3-client.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#include "core/Arena.h"
+#include "http/SocketHTTP3-private.h"
+#include "quic/SocketQUICTransport.h"
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+#define H3_CLIENT_RESP_BUF_INIT 4096
+
+/* ============================================================================
+ * Internal structure
+ * ============================================================================
+ */
+
+struct SocketHTTP3_Client
+{
+  Arena_T arena;
+  SocketHTTP3_ClientConfig config;
+
+  /* QUIC transport */
+  SocketQUICTransport_T transport;
+
+  /* HTTP/3 connection */
+  SocketHTTP3_Conn_T h3_conn;
+
+  /* State */
+  char *connected_host;
+  int connected_port;
+  int connected;
+};
+
+/* ============================================================================
+ * Time helpers
+ * ============================================================================
+ */
+
+static uint64_t
+now_us (void)
+{
+  struct timespec ts;
+  clock_gettime (CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000ULL + (uint64_t)ts.tv_nsec / 1000ULL;
+}
+
+/* ============================================================================
+ * Flush H3 output queue through transport
+ * ============================================================================
+ */
+
+static int
+flush_h3_output (SocketHTTP3_Client_T client)
+{
+  size_t count = SocketHTTP3_Conn_output_count (client->h3_conn);
+  for (size_t i = 0; i < count; i++)
+    {
+      const SocketHTTP3_Output *entry
+          = SocketHTTP3_Conn_get_output (client->h3_conn, i);
+      if (!entry)
+        continue;
+      if (SocketQUICTransport_send_stream (
+              client->transport, entry->stream_id, entry->data, entry->len, 0)
+          < 0)
+        {
+          SocketHTTP3_Conn_drain_output (client->h3_conn);
+          return -1;
+        }
+    }
+  SocketHTTP3_Conn_drain_output (client->h3_conn);
+  return 0;
+}
+
+/* ============================================================================
+ * Stream callback: receives QUIC stream data, feeds to H3
+ * ============================================================================
+ */
+
+static void
+h3_stream_callback (uint64_t stream_id,
+                    const uint8_t *data,
+                    size_t len,
+                    int fin,
+                    void *userdata)
+{
+  SocketHTTP3_Client_T client = userdata;
+  if (!client || !client->h3_conn)
+    return;
+
+  SocketHTTP3_Conn_feed_stream (client->h3_conn, stream_id, data, len, fin);
+  flush_h3_output (client);
+}
+
+/* ============================================================================
+ * Config defaults
+ * ============================================================================
+ */
+
+void
+SocketHTTP3_ClientConfig_defaults (SocketHTTP3_ClientConfig *config)
+{
+  if (!config)
+    return;
+  memset (config, 0, sizeof (*config));
+  config->idle_timeout_ms = 30000;
+  config->max_stream_data = 262144;
+  config->initial_max_streams_bidi = 100;
+  SocketHTTP3_Settings_init (&config->h3_settings);
+  config->ca_file = NULL;
+  config->verify_peer = 1;
+  config->connect_timeout_ms = 5000;
+  config->request_timeout_ms = 30000;
+}
+
+/* ============================================================================
+ * New
+ * ============================================================================
+ */
+
+SocketHTTP3_Client_T
+SocketHTTP3_Client_new (Arena_T arena, const SocketHTTP3_ClientConfig *config)
+{
+  if (!arena)
+    return NULL;
+
+  SocketHTTP3_Client_T client
+      = Arena_alloc (arena, sizeof (*client), __FILE__, __LINE__);
+  memset (client, 0, sizeof (*client));
+  client->arena = arena;
+
+  if (config)
+    client->config = *config;
+  else
+    SocketHTTP3_ClientConfig_defaults (&client->config);
+
+  /* Create QUIC transport */
+  SocketQUICTransportConfig transport_config;
+  SocketQUICTransportConfig_defaults (&transport_config);
+  transport_config.idle_timeout_ms = client->config.idle_timeout_ms;
+  transport_config.max_stream_data = client->config.max_stream_data;
+  transport_config.initial_max_streams_bidi
+      = client->config.initial_max_streams_bidi;
+  transport_config.connect_timeout_ms = client->config.connect_timeout_ms;
+  transport_config.ca_file = client->config.ca_file;
+  transport_config.verify_peer = client->config.verify_peer;
+
+  client->transport = SocketQUICTransport_new (arena, &transport_config);
+  if (!client->transport)
+    return NULL;
+
+  /* Create H3 connection */
+  SocketHTTP3_ConnConfig h3_config;
+  SocketHTTP3_ConnConfig_defaults (&h3_config, H3_ROLE_CLIENT);
+  h3_config.local_settings = client->config.h3_settings;
+
+  client->h3_conn = SocketHTTP3_Conn_new (arena, NULL, &h3_config);
+  if (!client->h3_conn)
+    return NULL;
+
+  /* Set stream callback on transport pointing to h3_stream_callback */
+  SocketQUICTransport_set_stream_callback (
+      client->transport, h3_stream_callback, client);
+
+  return client;
+}
+
+/* ============================================================================
+ * Connect
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_Client_connect (SocketHTTP3_Client_T client,
+                            const char *host,
+                            int port)
+{
+  if (!client || !host || client->connected)
+    return -1;
+
+  /* Blocking QUIC handshake */
+  if (SocketQUICTransport_connect (client->transport, host, port) < 0)
+    return -1;
+
+  /* Initialize H3 connection (opens critical streams, sends SETTINGS) */
+  if (SocketHTTP3_Conn_init (client->h3_conn) < 0)
+    return -1;
+
+  /* Flush H3 output (SETTINGS on control stream, type bytes on all) */
+  if (flush_h3_output (client) < 0)
+    return -1;
+
+  /* Store connection info */
+  size_t host_len = strlen (host);
+  client->connected_host
+      = Arena_alloc (client->arena, host_len + 1, __FILE__, __LINE__);
+  memcpy (client->connected_host, host, host_len + 1);
+  client->connected_port = port;
+  client->connected = 1;
+
+  return 0;
+}
+
+/* ============================================================================
+ * Close
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_Client_close (SocketHTTP3_Client_T client)
+{
+  if (!client)
+    return -1;
+
+  if (client->connected && client->h3_conn)
+    {
+      /* Send GOAWAY */
+      SocketHTTP3_Conn_shutdown (client->h3_conn, UINT64_MAX);
+      flush_h3_output (client);
+    }
+
+  /* Close QUIC transport */
+  if (client->transport)
+    SocketQUICTransport_close (client->transport);
+
+  client->connected = 0;
+  return 0;
+}
+
+/* ============================================================================
+ * Synchronous request/response
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_Client_request (SocketHTTP3_Client_T client,
+                            SocketHTTP_Method method,
+                            const char *path,
+                            const SocketHTTP_Headers_T headers,
+                            const void *body,
+                            size_t body_len,
+                            SocketHTTP_Headers_T *resp_headers,
+                            int *status_code,
+                            void **resp_body,
+                            size_t *resp_body_len)
+{
+  if (!client || !client->connected || !path)
+    return -1;
+
+  /* Create request */
+  SocketHTTP3_Request_T req = SocketHTTP3_Request_new (client->h3_conn);
+  if (!req)
+    return -1;
+
+  /* Build request headers with pseudo-headers */
+  SocketHTTP_Headers_T req_headers = SocketHTTP_Headers_new (client->arena);
+  if (!req_headers)
+    return -1;
+
+  const char *method_str = SocketHTTP_method_name (method);
+  if (!method_str)
+    method_str = "GET";
+
+  SocketHTTP_Headers_add (req_headers, ":method", method_str);
+  SocketHTTP_Headers_add (req_headers, ":scheme", "https");
+
+  /* Build :authority from connected host and port */
+  char authority[256];
+  if (client->connected_port == 443)
+    snprintf (authority, sizeof (authority), "%s", client->connected_host);
+  else
+    snprintf (authority,
+              sizeof (authority),
+              "%s:%d",
+              client->connected_host,
+              client->connected_port);
+  SocketHTTP_Headers_add (req_headers, ":authority", authority);
+  SocketHTTP_Headers_add (req_headers, ":path", path);
+
+  /* Copy caller-supplied headers (skip pseudo-headers) */
+  if (headers)
+    {
+      size_t count = SocketHTTP_Headers_count (headers);
+      for (size_t i = 0; i < count; i++)
+        {
+          const SocketHTTP_Header *h = SocketHTTP_Headers_at (headers, i);
+          if (h && h->name && h->name[0] != ':')
+            SocketHTTP_Headers_add_n (
+                req_headers, h->name, h->name_len, h->value, h->value_len);
+        }
+    }
+
+  /* Send HEADERS */
+  int end_stream = (!body || body_len == 0) ? 1 : 0;
+  if (SocketHTTP3_Request_send_headers (req, req_headers, end_stream) < 0)
+    return -1;
+  if (flush_h3_output (client) < 0)
+    return -1;
+
+  /* Send DATA if present */
+  if (body && body_len > 0)
+    {
+      if (SocketHTTP3_Request_send_data (req, body, body_len, 1) < 0)
+        return -1;
+      if (flush_h3_output (client) < 0)
+        return -1;
+    }
+
+  /* Poll for response */
+  uint64_t deadline_us
+      = now_us () + (uint64_t)client->config.request_timeout_ms * 1000;
+
+  while (SocketHTTP3_Request_recv_state (req) != H3_REQ_RECV_COMPLETE)
+    {
+      uint64_t current = now_us ();
+      if (current >= deadline_us)
+        return -1;
+
+      int remaining_ms = (int)((deadline_us - current) / 1000);
+      if (remaining_ms <= 0)
+        remaining_ms = 1;
+
+      int events = SocketQUICTransport_poll (client->transport, remaining_ms);
+      if (events < 0)
+        return -1;
+    }
+
+  /* Extract response headers */
+  if (resp_headers || status_code)
+    {
+      SocketHTTP_Headers_T hdrs = NULL;
+      int code = 0;
+      if (SocketHTTP3_Request_recv_headers (req, &hdrs, &code) == 0)
+        {
+          if (resp_headers)
+            *resp_headers = hdrs;
+          if (status_code)
+            *status_code = code;
+        }
+      else
+        {
+          if (resp_headers)
+            *resp_headers = NULL;
+          if (status_code)
+            *status_code = 0;
+        }
+    }
+
+  /* Extract response body */
+  if (resp_body && resp_body_len)
+    {
+      size_t buf_cap = H3_CLIENT_RESP_BUF_INIT;
+      uint8_t *buf = Arena_alloc (client->arena, buf_cap, __FILE__, __LINE__);
+      size_t total = 0;
+      int end = 0;
+
+      while (!end)
+        {
+          ssize_t n = SocketHTTP3_Request_recv_data (
+              req, buf + total, buf_cap - total, &end);
+          if (n < 0)
+            break;
+          total += (size_t)n;
+          if (n == 0)
+            break;
+
+          /* Grow buffer if needed */
+          if (total >= buf_cap && !end)
+            {
+              size_t new_cap = buf_cap * 2;
+              uint8_t *new_buf
+                  = Arena_alloc (client->arena, new_cap, __FILE__, __LINE__);
+              memcpy (new_buf, buf, total);
+              buf = new_buf;
+              buf_cap = new_cap;
+            }
+        }
+
+      *resp_body = buf;
+      *resp_body_len = total;
+    }
+
+  return 0;
+}
+
+/* ============================================================================
+ * Streaming API
+ * ============================================================================
+ */
+
+SocketHTTP3_Request_T
+SocketHTTP3_Client_new_request (SocketHTTP3_Client_T client)
+{
+  if (!client || !client->connected || !client->h3_conn)
+    return NULL;
+  return SocketHTTP3_Request_new (client->h3_conn);
+}
+
+int
+SocketHTTP3_Client_flush (SocketHTTP3_Client_T client)
+{
+  if (!client || !client->connected)
+    return -1;
+  return flush_h3_output (client);
+}
+
+int
+SocketHTTP3_Client_poll (SocketHTTP3_Client_T client, int timeout_ms)
+{
+  if (!client || !client->connected || !client->transport)
+    return -1;
+  return SocketQUICTransport_poll (client->transport, timeout_ms);
+}
+
+/* ============================================================================
+ * Accessors
+ * ============================================================================
+ */
+
+SocketHTTP3_Conn_T
+SocketHTTP3_Client_conn (SocketHTTP3_Client_T client)
+{
+  if (!client)
+    return NULL;
+  return client->h3_conn;
+}
+
+int
+SocketHTTP3_Client_is_connected (SocketHTTP3_Client_T client)
+{
+  return client && client->connected;
+}
+
+/* ============================================================================
+ * Alt-Svc parsing (RFC 7838)
+ * ============================================================================
+ */
+
+uint16_t
+SocketHTTP3_parse_alt_svc (const char *alt_svc_value,
+                           char *host_out,
+                           size_t host_len)
+{
+  if (!alt_svc_value)
+    return 0;
+
+  /* Look for h3="[host:]port" or h3=":port" */
+  const char *p = alt_svc_value;
+  while (*p)
+    {
+      /* Skip whitespace and commas */
+      while (*p == ' ' || *p == '\t' || *p == ',')
+        p++;
+
+      /* Check for h3= */
+      if (strncmp (p, "h3=\"", 4) == 0)
+        {
+          p += 4;
+
+          /* Parse host:port or :port */
+          const char *start = p;
+          const char *colon = NULL;
+          while (*p && *p != '"')
+            {
+              if (*p == ':')
+                colon = p;
+              p++;
+            }
+
+          if (!colon || *p != '"')
+            return 0;
+
+          /* Extract port */
+          uint16_t port = 0;
+          const char *port_str = colon + 1;
+          while (port_str < p)
+            {
+              if (*port_str < '0' || *port_str > '9')
+                return 0;
+              port = (uint16_t)(port * 10 + (*port_str - '0'));
+              port_str++;
+            }
+
+          if (port == 0)
+            return 0;
+
+          /* Extract host if present (before the last colon) */
+          if (host_out && host_len > 0)
+            {
+              size_t hlen = (size_t)(colon - start);
+              if (hlen > 0 && hlen < host_len)
+                {
+                  memcpy (host_out, start, hlen);
+                  host_out[hlen] = '\0';
+                }
+              else
+                {
+                  host_out[0] = '\0';
+                }
+            }
+
+          return port;
+        }
+
+      /* Skip to next entry */
+      while (*p && *p != ',')
+        p++;
+    }
+
+  return 0;
+}
+
+#endif /* SOCKET_HAS_TLS */

--- a/src/quic/SocketQUICTLS.c
+++ b/src/quic/SocketQUICTLS.c
@@ -891,6 +891,34 @@ SocketQUICTLS_derive_keys (SocketQUICHandshake_T handshake,
   return QUIC_TLS_OK;
 }
 
+SocketQUICTLS_Result
+SocketQUICTLS_get_traffic_secrets (SocketQUICHandshake_T handshake,
+                                   SocketQUICCryptoLevel level,
+                                   uint8_t *write_secret,
+                                   uint8_t *read_secret,
+                                   size_t *secret_len)
+{
+  if (handshake == NULL || write_secret == NULL || read_secret == NULL
+      || secret_len == NULL)
+    return QUIC_TLS_ERROR_NULL;
+
+  if (level >= QUIC_CRYPTO_LEVEL_COUNT)
+    return QUIC_TLS_ERROR_LEVEL;
+
+  TLSState_T *state = get_tls_state (handshake);
+  if (state == NULL)
+    return QUIC_TLS_ERROR_INIT;
+
+  if (!state->secrets_available[level])
+    return QUIC_TLS_ERROR_SECRETS;
+
+  memcpy (write_secret, state->write_secret[level], SOCKET_CRYPTO_SHA256_SIZE);
+  memcpy (read_secret, state->read_secret[level], SOCKET_CRYPTO_SHA256_SIZE);
+  *secret_len = SOCKET_CRYPTO_SHA256_SIZE;
+
+  return QUIC_TLS_OK;
+}
+
 /* ============================================================================
  * Alert Handling
  * ============================================================================
@@ -1467,6 +1495,22 @@ SocketQUICTLS_derive_keys (SocketQUICHandshake_T handshake,
   return QUIC_TLS_ERROR_NO_TLS;
 }
 
+SocketQUICTLS_Result
+SocketQUICTLS_get_traffic_secrets (SocketQUICHandshake_T handshake,
+                                   SocketQUICCryptoLevel level,
+                                   uint8_t *write_secret,
+                                   uint8_t *read_secret,
+                                   size_t *secret_len)
+{
+  (void)level;
+  (void)write_secret;
+  (void)read_secret;
+  (void)secret_len;
+  if (handshake == NULL)
+    return QUIC_TLS_ERROR_NULL;
+  return QUIC_TLS_ERROR_NO_TLS;
+}
+
 uint64_t
 SocketQUICTLS_alert_to_error (uint8_t alert)
 {
@@ -1701,6 +1745,22 @@ SocketQUICTLS_derive_keys (SocketQUICHandshake_T handshake,
                            SocketQUICCryptoLevel level)
 {
   (void)level;
+  if (handshake == NULL)
+    return QUIC_TLS_ERROR_NULL;
+  return QUIC_TLS_ERROR_NO_TLS;
+}
+
+SocketQUICTLS_Result
+SocketQUICTLS_get_traffic_secrets (SocketQUICHandshake_T handshake,
+                                   SocketQUICCryptoLevel level,
+                                   uint8_t *write_secret,
+                                   uint8_t *read_secret,
+                                   size_t *secret_len)
+{
+  (void)level;
+  (void)write_secret;
+  (void)read_secret;
+  (void)secret_len;
   if (handshake == NULL)
     return QUIC_TLS_ERROR_NULL;
   return QUIC_TLS_ERROR_NO_TLS;

--- a/src/quic/SocketQUICTransport.c
+++ b/src/quic/SocketQUICTransport.c
@@ -1,0 +1,1068 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICTransport.c
+ * @brief QUIC transport layer over UDP (RFC 9000).
+ */
+
+#ifdef SOCKET_HAS_TLS
+
+#include "quic/SocketQUICTransport.h"
+
+#include <poll.h>
+#include <string.h>
+#include <time.h>
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "core/SocketCrypto.h"
+#include "quic/SocketQUICAck.h"
+#include "quic/SocketQUICConnection.h"
+#include "quic/SocketQUICCrypto.h"
+#include "quic/SocketQUICFlow.h"
+#include "quic/SocketQUICFrame.h"
+#include "quic/SocketQUICHandshake.h"
+#include "quic/SocketQUICLoss.h"
+#include "quic/SocketQUICPacket.h"
+#include "quic/SocketQUICTLS.h"
+#include "quic/SocketQUICTransportParams.h"
+#include "quic/SocketQUICVarInt.h"
+#include "quic/SocketQUICVersion.h"
+#include "socket/SocketDgram.h"
+
+/* ============================================================================
+ * Constants
+ * ============================================================================
+ */
+
+#define TRANSPORT_SEND_BUF_SIZE 1500
+#define TRANSPORT_RECV_BUF_SIZE 65536
+#define TRANSPORT_MAX_STREAMS 256
+#define TRANSPORT_SCID_LEN 8
+#define TRANSPORT_DCID_LEN 8
+#define TRANSPORT_PN_LEN 4
+
+/* ============================================================================
+ * Per-stream send offset tracking
+ * ============================================================================
+ */
+
+typedef struct
+{
+  uint64_t stream_id;
+  uint64_t send_offset;
+  int active;
+} QUICStreamState;
+
+/* ============================================================================
+ * Internal transport structure
+ * ============================================================================
+ */
+
+struct SocketQUICTransport
+{
+  Arena_T arena;
+  SocketQUICTransportConfig config;
+
+  /* UDP socket */
+  SocketDgram_T socket;
+
+  /* QUIC connection + handshake state */
+  SocketQUICConnection_T conn;
+  SocketQUICHandshake_T handshake;
+  SocketQUICReceive_T recv_ctx;
+  SocketQUICFlow_T flow;
+
+  /* ACK generation (one per PN space) */
+  SocketQUICAckState_T ack[QUIC_PN_SPACE_COUNT];
+
+  /* Loss detection (one per PN space) */
+  SocketQUICLossState_T loss[QUIC_PN_SPACE_COUNT];
+  SocketQUICLossRTT_T rtt;
+
+  /* Packet protection keys (send-side) */
+  SocketQUICInitialKeys_T initial_keys;
+  SocketQUICPacketKeys_T handshake_send_keys;
+  SocketQUICPacketKeys_T app_send_keys;
+  int handshake_keys_valid;
+  int app_keys_valid;
+
+  /* Key update state for 1-RTT */
+  SocketQUICKeyUpdate_T key_update;
+
+  /* Packet number state */
+  uint64_t next_pn[QUIC_PN_SPACE_COUNT];
+
+  /* Packet build/recv buffers (arena-allocated) */
+  uint8_t *send_buf;
+  uint8_t *recv_buf;
+
+  /* Per-stream send offset tracking */
+  QUICStreamState streams[TRANSPORT_MAX_STREAMS];
+  size_t stream_count;
+
+  /* Stream receive callback */
+  SocketQUICTransport_StreamCB stream_cb;
+  void *stream_cb_userdata;
+
+  /* Next bidi stream ID for client: 0, 4, 8, ... */
+  uint64_t next_bidi_id;
+
+  /* Connection IDs */
+  SocketQUICConnectionID_T scid;
+  SocketQUICConnectionID_T dcid;
+
+  /* State */
+  int connected;
+  int closed;
+};
+
+/* ============================================================================
+ * Time helpers
+ * ============================================================================
+ */
+
+static uint64_t
+now_us (void)
+{
+  struct timespec ts;
+  clock_gettime (CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000ULL + (uint64_t)ts.tv_nsec / 1000ULL;
+}
+
+/* ============================================================================
+ * UDP I/O wrappers (exception -> return code)
+ * ============================================================================
+ */
+
+static int
+transport_send_packet (SocketQUICTransport_T t, const uint8_t *data, size_t len)
+{
+  volatile int result = -1;
+  TRY
+  {
+    SocketDgram_send (t->socket, data, len);
+    result = 0;
+  }
+  EXCEPT (SocketDgram_Failed)
+  {
+    result = -1;
+  }
+  END_TRY;
+  return result;
+}
+
+static ssize_t
+transport_recv_packet (SocketQUICTransport_T t, uint8_t *buf, size_t len)
+{
+  volatile ssize_t nbytes = -1;
+  TRY
+  {
+    nbytes = SocketDgram_recv (t->socket, buf, len);
+  }
+  EXCEPT (SocketDgram_Failed)
+  {
+    nbytes = -1;
+  }
+  END_TRY;
+  return nbytes;
+}
+
+/* ============================================================================
+ * Stream state helpers
+ * ============================================================================
+ */
+
+static QUICStreamState *
+find_or_create_stream (SocketQUICTransport_T t, uint64_t stream_id)
+{
+  for (size_t i = 0; i < t->stream_count; i++)
+    {
+      if (t->streams[i].active && t->streams[i].stream_id == stream_id)
+        return &t->streams[i];
+    }
+
+  if (t->stream_count >= TRANSPORT_MAX_STREAMS)
+    return NULL;
+
+  QUICStreamState *s = &t->streams[t->stream_count++];
+  s->stream_id = stream_id;
+  s->send_offset = 0;
+  s->active = 1;
+  return s;
+}
+
+/* ============================================================================
+ * Packet building helpers
+ * ============================================================================
+ */
+
+static int
+build_and_send_1rtt_packet (SocketQUICTransport_T t,
+                            const uint8_t *payload,
+                            size_t payload_len)
+{
+  if (!t->app_keys_valid)
+    return -1;
+
+  uint64_t pn = t->next_pn[QUIC_PN_SPACE_APPLICATION];
+  uint32_t truncated_pn = SocketQUICPacket_encode_pn (pn, TRANSPORT_PN_LEN);
+
+  /* Build short header */
+  SocketQUICPacketHeader_T hdr;
+  SocketQUICPacketHeader_init (&hdr);
+  if (SocketQUICPacketHeader_build_short (&hdr,
+                                          &t->dcid,
+                                          0,
+                                          t->key_update.key_phase,
+                                          TRANSPORT_PN_LEN,
+                                          truncated_pn)
+      != QUIC_PACKET_OK)
+    return -1;
+
+  size_t hdr_len = SocketQUICPacketHeader_serialize (
+      &hdr, t->send_buf, TRANSPORT_SEND_BUF_SIZE);
+  if (hdr_len == 0)
+    return -1;
+
+  size_t pn_offset = hdr_len - TRANSPORT_PN_LEN;
+
+  /* Copy payload after header */
+  if (hdr_len + payload_len + 16 > TRANSPORT_SEND_BUF_SIZE)
+    return -1;
+  memcpy (t->send_buf + hdr_len, payload, payload_len);
+
+  /* Encrypt payload */
+  size_t ciphertext_len = TRANSPORT_SEND_BUF_SIZE - hdr_len;
+  if (SocketQUICCrypto_encrypt_payload (&t->app_send_keys,
+                                        pn,
+                                        t->send_buf,
+                                        hdr_len,
+                                        t->send_buf + hdr_len,
+                                        payload_len,
+                                        t->send_buf + hdr_len,
+                                        &ciphertext_len)
+      != QUIC_CRYPTO_OK)
+    return -1;
+
+  size_t pkt_len = hdr_len + ciphertext_len;
+
+  /* Apply header protection */
+  if (SocketQUICCrypto_protect_header_ex (
+          &t->app_send_keys, t->send_buf, pkt_len, pn_offset)
+      != QUIC_CRYPTO_OK)
+    return -1;
+
+  /* Send */
+  if (transport_send_packet (t, t->send_buf, pkt_len) < 0)
+    return -1;
+
+  t->next_pn[QUIC_PN_SPACE_APPLICATION]++;
+  return 0;
+}
+
+/* ============================================================================
+ * ACK frame sending
+ * ============================================================================
+ */
+
+static int
+send_ack_if_needed (SocketQUICTransport_T t,
+                    SocketQUIC_PNSpace space,
+                    uint64_t now)
+{
+  if (!t->ack[space])
+    return 0;
+  if (!SocketQUICAck_should_send (t->ack[space], now))
+    return 0;
+
+  uint8_t ack_buf[256];
+  size_t ack_len = 0;
+  if (SocketQUICAck_encode (
+          t->ack[space], now, ack_buf, sizeof (ack_buf), &ack_len)
+      != QUIC_ACK_OK)
+    return -1;
+
+  if (ack_len == 0)
+    return 0;
+
+  int rc = -1;
+  if (space == QUIC_PN_SPACE_APPLICATION && t->app_keys_valid)
+    rc = build_and_send_1rtt_packet (t, ack_buf, ack_len);
+
+  if (rc == 0)
+    SocketQUICAck_mark_sent (t->ack[space], now);
+
+  return rc;
+}
+
+/* ============================================================================
+ * Frame processing during poll()
+ * ============================================================================
+ */
+
+static int
+process_frames (SocketQUICTransport_T t,
+                const uint8_t *payload,
+                size_t payload_len,
+                SocketQUIC_PNSpace space,
+                uint64_t now)
+{
+  size_t offset = 0;
+  int events = 0;
+
+  while (offset < payload_len)
+    {
+      SocketQUICFrame_T frame;
+      SocketQUICFrame_init (&frame);
+      size_t consumed = 0;
+      SocketQUICFrame_Result fr = SocketQUICFrame_parse_arena (
+          t->arena, payload + offset, payload_len - offset, &frame, &consumed);
+      if (fr != QUIC_FRAME_OK)
+        break;
+
+      offset += consumed;
+
+      switch (frame.type)
+        {
+        case QUIC_FRAME_PADDING:
+        case QUIC_FRAME_PING:
+          break;
+
+        case QUIC_FRAME_ACK:
+        case QUIC_FRAME_ACK_ECN:
+          if (t->loss[space])
+            {
+              size_t lost_count = 0;
+              SocketQUICLoss_on_ack_received (t->loss[space],
+                                              &t->rtt,
+                                              frame.data.ack.largest_ack,
+                                              frame.data.ack.ack_delay,
+                                              now,
+                                              NULL,
+                                              NULL,
+                                              &lost_count);
+            }
+          break;
+
+        case QUIC_FRAME_CRYPTO:
+          {
+            SocketQUICCryptoLevel level;
+            if (space == QUIC_PN_SPACE_INITIAL)
+              level = QUIC_CRYPTO_LEVEL_INITIAL;
+            else if (space == QUIC_PN_SPACE_HANDSHAKE)
+              level = QUIC_CRYPTO_LEVEL_HANDSHAKE;
+            else
+              level = QUIC_CRYPTO_LEVEL_APPLICATION;
+
+            SocketQUICTLS_provide_data (t->handshake,
+                                        level,
+                                        frame.data.crypto.data,
+                                        (size_t)frame.data.crypto.length);
+          }
+          break;
+
+        case QUIC_FRAME_HANDSHAKE_DONE:
+          SocketQUICHandshake_on_confirmed (t->handshake);
+          break;
+
+        case QUIC_FRAME_CONNECTION_CLOSE:
+        case QUIC_FRAME_CONNECTION_CLOSE_APP:
+          t->closed = 1;
+          return -1;
+
+        case QUIC_FRAME_MAX_DATA:
+          if (t->flow)
+            SocketQUICFlow_update_send_max (t->flow,
+                                            frame.data.max_data.max_data);
+          break;
+
+        default:
+          if (SocketQUICFrame_is_stream (frame.type))
+            {
+              if (t->stream_cb)
+                {
+                  t->stream_cb (frame.data.stream.stream_id,
+                                frame.data.stream.data,
+                                (size_t)frame.data.stream.length,
+                                frame.data.stream.has_fin,
+                                t->stream_cb_userdata);
+                  events++;
+                }
+            }
+          break;
+        }
+    }
+
+  return events;
+}
+
+/* ============================================================================
+ * Handshake: send TLS data at a given crypto level
+ * ============================================================================
+ */
+
+static int
+send_crypto_data (SocketQUICTransport_T t,
+                  SocketQUICCryptoLevel level,
+                  const uint8_t *data,
+                  size_t len,
+                  uint64_t crypto_offset)
+{
+  /* Build CRYPTO frame */
+  uint8_t frame_buf[TRANSPORT_SEND_BUF_SIZE];
+  size_t frame_len = SocketQUICFrame_encode_crypto (
+      crypto_offset, data, len, frame_buf, sizeof (frame_buf));
+  if (frame_len == 0)
+    return -1;
+
+  if (level == QUIC_CRYPTO_LEVEL_INITIAL)
+    {
+      /* Build Initial packet */
+      uint64_t pn = t->next_pn[QUIC_PN_SPACE_INITIAL];
+      uint32_t truncated_pn = SocketQUICPacket_encode_pn (pn, TRANSPORT_PN_LEN);
+
+      SocketQUICPacketHeader_T hdr;
+      SocketQUICPacketHeader_init (&hdr);
+      SocketQUICPacketHeader_build_initial (&hdr,
+                                            QUIC_VERSION_1,
+                                            &t->dcid,
+                                            &t->scid,
+                                            NULL,
+                                            0,
+                                            TRANSPORT_PN_LEN,
+                                            truncated_pn);
+
+      size_t hdr_len = SocketQUICPacketHeader_serialize (
+          &hdr, t->send_buf, TRANSPORT_SEND_BUF_SIZE);
+      if (hdr_len == 0)
+        return -1;
+
+      /* Copy CRYPTO frame into payload area */
+      memcpy (t->send_buf + hdr_len, frame_buf, frame_len);
+      size_t pkt_len = hdr_len + frame_len;
+
+      /* Pad to 1200 bytes minimum for client Initial */
+      size_t pad_needed = SocketQUICInitial_padding_needed (pkt_len + 16);
+      if (pad_needed > 0)
+        {
+          memset (t->send_buf + pkt_len, 0, pad_needed);
+          pkt_len += pad_needed;
+        }
+
+      /* Protect (encrypt + header protection) */
+      if (SocketQUICInitial_protect (
+              t->send_buf, &pkt_len, hdr_len, &t->initial_keys, 1)
+          != QUIC_INITIAL_OK)
+        return -1;
+
+      if (transport_send_packet (t, t->send_buf, pkt_len) < 0)
+        return -1;
+
+      t->next_pn[QUIC_PN_SPACE_INITIAL]++;
+    }
+  else if (level == QUIC_CRYPTO_LEVEL_HANDSHAKE)
+    {
+      if (!t->handshake_keys_valid)
+        return -1;
+
+      uint64_t pn = t->next_pn[QUIC_PN_SPACE_HANDSHAKE];
+      uint32_t truncated_pn = SocketQUICPacket_encode_pn (pn, TRANSPORT_PN_LEN);
+
+      SocketQUICPacketHeader_T hdr;
+      SocketQUICPacketHeader_init (&hdr);
+      SocketQUICPacketHeader_build_handshake (&hdr,
+                                              QUIC_VERSION_1,
+                                              &t->dcid,
+                                              &t->scid,
+                                              TRANSPORT_PN_LEN,
+                                              truncated_pn);
+
+      size_t hdr_len = SocketQUICPacketHeader_serialize (
+          &hdr, t->send_buf, TRANSPORT_SEND_BUF_SIZE);
+      if (hdr_len == 0)
+        return -1;
+
+      size_t pn_offset = hdr_len - TRANSPORT_PN_LEN;
+
+      memcpy (t->send_buf + hdr_len, frame_buf, frame_len);
+
+      /* Encrypt */
+      size_t ciphertext_len = TRANSPORT_SEND_BUF_SIZE - hdr_len;
+      if (SocketQUICCrypto_encrypt_payload (&t->handshake_send_keys,
+                                            pn,
+                                            t->send_buf,
+                                            hdr_len,
+                                            t->send_buf + hdr_len,
+                                            frame_len,
+                                            t->send_buf + hdr_len,
+                                            &ciphertext_len)
+          != QUIC_CRYPTO_OK)
+        return -1;
+
+      size_t pkt_len = hdr_len + ciphertext_len;
+
+      /* Header protection */
+      if (SocketQUICCrypto_protect_header_ex (
+              &t->handshake_send_keys, t->send_buf, pkt_len, pn_offset)
+          != QUIC_CRYPTO_OK)
+        return -1;
+
+      if (transport_send_packet (t, t->send_buf, pkt_len) < 0)
+        return -1;
+
+      /* First Handshake packet sent triggers Initial key discard */
+      SocketQUICHandshake_on_handshake_packet_sent (t->handshake);
+
+      t->next_pn[QUIC_PN_SPACE_HANDSHAKE]++;
+    }
+  else if (level == QUIC_CRYPTO_LEVEL_APPLICATION)
+    {
+      return build_and_send_1rtt_packet (t, frame_buf, frame_len);
+    }
+
+  return 0;
+}
+
+/* ============================================================================
+ * Flush all pending TLS output data
+ * ============================================================================
+ */
+
+static int
+flush_tls_output (SocketQUICTransport_T t)
+{
+  SocketQUICCryptoLevel level;
+  const uint8_t *data;
+  size_t len;
+
+  while (SocketQUICTLS_get_data (t->handshake, &level, &data, &len)
+         == QUIC_TLS_OK)
+    {
+      /* Get the crypto stream offset for this level */
+      uint64_t offset = t->handshake->crypto_streams[level].send_offset;
+
+      if (send_crypto_data (t, level, data, len, offset) < 0)
+        {
+          SocketQUICTLS_consume_data (t->handshake, level, len);
+          return -1;
+        }
+
+      t->handshake->crypto_streams[level].send_offset += len;
+      SocketQUICTLS_consume_data (t->handshake, level, len);
+    }
+
+  return 0;
+}
+
+/* ============================================================================
+ * Try to derive keys from TLS at each level
+ * ============================================================================
+ */
+
+static void
+check_and_derive_keys (SocketQUICTransport_T t)
+{
+  uint8_t write_secret[SOCKET_CRYPTO_SHA256_SIZE];
+  uint8_t read_secret[SOCKET_CRYPTO_SHA256_SIZE];
+  size_t secret_len = 0;
+
+  /* Handshake keys */
+  if (!t->handshake_keys_valid
+      && SocketQUICHandshake_has_keys (t->handshake,
+                                       QUIC_CRYPTO_LEVEL_HANDSHAKE))
+    {
+      if (SocketQUICTLS_get_traffic_secrets (t->handshake,
+                                             QUIC_CRYPTO_LEVEL_HANDSHAKE,
+                                             write_secret,
+                                             read_secret,
+                                             &secret_len)
+          == QUIC_TLS_OK)
+        {
+          SocketQUICPacketKeys_T hs_read_keys;
+          SocketQUICCrypto_derive_packet_keys (write_secret,
+                                               secret_len,
+                                               QUIC_AEAD_AES_128_GCM,
+                                               &t->handshake_send_keys);
+          SocketQUICCrypto_derive_packet_keys (
+              read_secret, secret_len, QUIC_AEAD_AES_128_GCM, &hs_read_keys);
+          SocketQUICReceive_set_handshake_keys (&t->recv_ctx, &hs_read_keys);
+          t->handshake_keys_valid = 1;
+        }
+    }
+
+  /* Application (1-RTT) keys */
+  if (!t->app_keys_valid
+      && SocketQUICHandshake_has_keys (t->handshake,
+                                       QUIC_CRYPTO_LEVEL_APPLICATION))
+    {
+      if (SocketQUICTLS_get_traffic_secrets (t->handshake,
+                                             QUIC_CRYPTO_LEVEL_APPLICATION,
+                                             write_secret,
+                                             read_secret,
+                                             &secret_len)
+          == QUIC_TLS_OK)
+        {
+          SocketQUICCrypto_derive_packet_keys (write_secret,
+                                               secret_len,
+                                               QUIC_AEAD_AES_128_GCM,
+                                               &t->app_send_keys);
+          SocketQUICKeyUpdate_set_initial_keys (&t->key_update,
+                                                write_secret,
+                                                read_secret,
+                                                secret_len,
+                                                QUIC_AEAD_AES_128_GCM);
+          SocketQUICReceive_set_1rtt_keys (&t->recv_ctx, &t->key_update);
+          t->app_keys_valid = 1;
+        }
+    }
+
+  /* Clear secrets from stack */
+  volatile uint8_t *vw = write_secret;
+  volatile uint8_t *vr = read_secret;
+  for (size_t i = 0; i < sizeof (write_secret); i++)
+    vw[i] = 0;
+  for (size_t i = 0; i < sizeof (read_secret); i++)
+    vr[i] = 0;
+}
+
+/* ============================================================================
+ * Config defaults
+ * ============================================================================
+ */
+
+void
+SocketQUICTransportConfig_defaults (SocketQUICTransportConfig *config)
+{
+  if (!config)
+    return;
+  memset (config, 0, sizeof (*config));
+  config->idle_timeout_ms = 30000;
+  config->max_stream_data = 262144;
+  config->initial_max_data = 1048576;
+  config->initial_max_streams_bidi = 100;
+  config->connect_timeout_ms = 5000;
+  config->alpn = "h3";
+  config->ca_file = NULL;
+  config->verify_peer = 1;
+}
+
+/* ============================================================================
+ * New
+ * ============================================================================
+ */
+
+SocketQUICTransport_T
+SocketQUICTransport_new (Arena_T arena, const SocketQUICTransportConfig *config)
+{
+  if (!arena)
+    return NULL;
+
+  SocketQUICTransport_T t
+      = Arena_alloc (arena, sizeof (*t), __FILE__, __LINE__);
+  memset (t, 0, sizeof (*t));
+  t->arena = arena;
+
+  if (config)
+    t->config = *config;
+  else
+    SocketQUICTransportConfig_defaults (&t->config);
+
+  /* Allocate packet buffers */
+  t->send_buf
+      = Arena_alloc (arena, TRANSPORT_SEND_BUF_SIZE, __FILE__, __LINE__);
+  t->recv_buf
+      = Arena_alloc (arena, TRANSPORT_RECV_BUF_SIZE, __FILE__, __LINE__);
+
+  /* Initialize receive context */
+  SocketQUICReceive_init (&t->recv_ctx);
+
+  /* Initialize key update */
+  SocketQUICKeyUpdate_init (&t->key_update);
+
+  /* Initialize RTT state */
+  SocketQUICLoss_init_rtt (&t->rtt);
+
+  return t;
+}
+
+/* ============================================================================
+ * Connect (blocking handshake)
+ * ============================================================================
+ */
+
+int
+SocketQUICTransport_connect (SocketQUICTransport_T t,
+                             const char *host,
+                             int port)
+{
+  if (!t || !host || t->connected || t->closed)
+    return -1;
+
+  /* Phase A: UDP socket setup */
+  volatile int setup_ok = 0;
+  TRY
+  {
+    t->socket = SocketDgram_new (AF_INET, 0);
+    SocketDgram_setnonblocking (t->socket);
+    SocketDgram_connect (t->socket, host, port);
+    setup_ok = 1;
+  }
+  EXCEPT (SocketDgram_Failed)
+  {
+    setup_ok = 0;
+  }
+  END_TRY;
+
+  if (!setup_ok)
+    return -1;
+
+  /* Generate random CIDs */
+  SocketCrypto_random_bytes (t->scid.data, TRANSPORT_SCID_LEN);
+  t->scid.len = TRANSPORT_SCID_LEN;
+  SocketCrypto_random_bytes (t->dcid.data, TRANSPORT_DCID_LEN);
+  t->dcid.len = TRANSPORT_DCID_LEN;
+
+  /* Create QUIC connection */
+  t->conn = SocketQUICConnection_new (t->arena, QUIC_CONN_ROLE_CLIENT);
+  if (!t->conn)
+    return -1;
+
+  SocketQUICConnection_add_local_cid (t->conn, &t->scid);
+  SocketQUICConnection_add_peer_cid (t->conn, &t->dcid);
+  t->conn->initial_dcid = t->dcid;
+
+  /* Create handshake context */
+  t->handshake
+      = SocketQUICHandshake_new (t->arena, t->conn, QUIC_CONN_ROLE_CLIENT);
+  if (!t->handshake)
+    return -1;
+
+  /* Phase B: TLS setup */
+  SocketQUICTransportParams_T local_params;
+  memset (&local_params, 0, sizeof (local_params));
+  local_params.max_idle_timeout = t->config.idle_timeout_ms;
+  local_params.initial_max_data = t->config.initial_max_data;
+  local_params.initial_max_stream_data_bidi_local = t->config.max_stream_data;
+  local_params.initial_max_stream_data_bidi_remote = t->config.max_stream_data;
+  local_params.initial_max_streams_bidi = t->config.initial_max_streams_bidi;
+  local_params.initial_max_streams_uni = 3;
+
+  SocketQUICHandshake_set_transport_params (t->handshake, &local_params);
+
+  SocketQUICTLSConfig_T tls_config;
+  memset (&tls_config, 0, sizeof (tls_config));
+  tls_config.alpn = t->config.alpn ? t->config.alpn : "h3";
+  tls_config.ca_file = t->config.ca_file;
+  tls_config.verify_peer = t->config.verify_peer;
+
+  if (SocketQUICTLS_init_context (t->handshake, &tls_config) != QUIC_TLS_OK)
+    return -1;
+  if (SocketQUICTLS_create_ssl (t->handshake) != QUIC_TLS_OK)
+    return -1;
+  if (SocketQUICTLS_set_local_transport_params (t->handshake) != QUIC_TLS_OK)
+    return -1;
+
+  /* Phase C: Initial packet */
+  if (SocketQUICCrypto_derive_initial_keys (
+          &t->dcid, QUIC_VERSION_1, &t->initial_keys)
+      != QUIC_CRYPTO_OK)
+    return -1;
+
+  SocketQUICReceive_set_initial_keys (&t->recv_ctx, &t->initial_keys);
+
+  /* Init ACK states */
+  t->ack[QUIC_PN_SPACE_INITIAL] = SocketQUICAck_new (t->arena, 1, 0);
+  t->ack[QUIC_PN_SPACE_HANDSHAKE] = SocketQUICAck_new (t->arena, 1, 0);
+  t->ack[QUIC_PN_SPACE_APPLICATION]
+      = SocketQUICAck_new (t->arena, 0, QUIC_ACK_DEFAULT_MAX_DELAY_US);
+
+  /* Init loss detection */
+  t->loss[QUIC_PN_SPACE_INITIAL] = SocketQUICLoss_new (t->arena, 1, 0);
+  t->loss[QUIC_PN_SPACE_HANDSHAKE] = SocketQUICLoss_new (t->arena, 1, 0);
+  t->loss[QUIC_PN_SPACE_APPLICATION]
+      = SocketQUICLoss_new (t->arena, 0, QUIC_ACK_DEFAULT_MAX_DELAY_US);
+
+  /* Drive TLS to produce ClientHello */
+  SocketQUICTLS_do_handshake (t->handshake);
+
+  /* Flush TLS output (sends ClientHello in Initial packet) */
+  if (flush_tls_output (t) < 0)
+    return -1;
+
+  /* Phase D: Handshake loop */
+  uint64_t deadline_us
+      = now_us () + (uint64_t)t->config.connect_timeout_ms * 1000;
+
+  while (!SocketQUICTLS_is_complete (t->handshake))
+    {
+      uint64_t current = now_us ();
+      if (current >= deadline_us)
+        return -1;
+
+      int remaining_ms = (int)((deadline_us - current) / 1000);
+      if (remaining_ms <= 0)
+        remaining_ms = 1;
+
+      /* Poll for UDP data */
+      struct pollfd pfd;
+      pfd.fd = SocketDgram_fd (t->socket);
+      pfd.events = POLLIN;
+      pfd.revents = 0;
+
+      int poll_rc = poll (&pfd, 1, remaining_ms);
+      if (poll_rc <= 0)
+        continue;
+
+      /* Receive packet */
+      ssize_t nbytes
+          = transport_recv_packet (t, t->recv_buf, TRANSPORT_RECV_BUF_SIZE);
+      if (nbytes <= 0)
+        continue;
+
+      /* Decrypt and parse */
+      SocketQUICReceiveResult_T result;
+      memset (&result, 0, sizeof (result));
+      SocketQUICReceive_Result recv_rc = SocketQUICReceive_packet (
+          &t->recv_ctx, t->recv_buf, (size_t)nbytes, t->scid.len, 0, &result);
+
+      if (recv_rc != QUIC_RECEIVE_OK)
+        continue;
+
+      /* Record received PN for ACK generation */
+      if (t->ack[result.pn_space])
+        SocketQUICAck_record_packet (
+            t->ack[result.pn_space], result.packet_number, now_us (), 1);
+
+      /* Process frames */
+      process_frames (
+          t, result.payload, result.payload_len, result.pn_space, now_us ());
+
+      if (t->closed)
+        return -1;
+
+      /* Check and derive keys at new levels */
+      check_and_derive_keys (t);
+
+      /* Advance TLS */
+      SocketQUICTLS_do_handshake (t->handshake);
+
+      /* Flush any generated TLS data */
+      flush_tls_output (t);
+
+      /* Send ACKs */
+      current = now_us ();
+      for (int space = 0; space < QUIC_PN_SPACE_COUNT; space++)
+        send_ack_if_needed (t, (SocketQUIC_PNSpace)space, current);
+    }
+
+  /* Phase E: Post-handshake validation */
+  if (SocketQUICTLS_check_alpn_negotiated (t->handshake) != QUIC_TLS_OK)
+    return -1;
+
+  SocketQUICTLS_get_peer_params (t->handshake);
+
+  /* Ensure we have 1-RTT keys */
+  check_and_derive_keys (t);
+  if (!t->app_keys_valid)
+    return -1;
+
+  /* Initialize flow control from peer params */
+  const SocketQUICTransportParams_T *peer_params
+      = SocketQUICHandshake_get_peer_params (t->handshake);
+  if (peer_params)
+    {
+      t->flow = SocketQUICFlow_new (t->arena);
+      if (t->flow)
+        SocketQUICFlow_init (t->flow,
+                             t->config.initial_max_data,
+                             peer_params->initial_max_data,
+                             peer_params->initial_max_streams_bidi,
+                             peer_params->initial_max_streams_uni);
+    }
+
+  /* Update DCID if server provided a new one */
+  if (t->handshake->conn->peer_cid_count > 0)
+    t->dcid = t->handshake->conn->peer_cids[0];
+
+  t->connected = 1;
+  return 0;
+}
+
+/* ============================================================================
+ * Close
+ * ============================================================================
+ */
+
+int
+SocketQUICTransport_close (SocketQUICTransport_T t)
+{
+  if (!t || t->closed)
+    return -1;
+
+  if (t->app_keys_valid)
+    {
+      /* Send CONNECTION_CLOSE */
+      uint8_t close_buf[64];
+      size_t close_len = SocketQUICFrame_encode_connection_close_app (
+          0, NULL, close_buf, sizeof (close_buf));
+      if (close_len > 0)
+        build_and_send_1rtt_packet (t, close_buf, close_len);
+    }
+
+  t->closed = 1;
+  t->connected = 0;
+
+  /* Clean up UDP socket */
+  if (t->socket)
+    {
+      SocketDgram_free (&t->socket);
+      t->socket = NULL;
+    }
+
+  /* Clear key material */
+  SocketQUICInitialKeys_clear (&t->initial_keys);
+  SocketQUICPacketKeys_clear (&t->handshake_send_keys);
+  SocketQUICPacketKeys_clear (&t->app_send_keys);
+  SocketQUICKeyUpdate_clear (&t->key_update);
+
+  /* Free handshake TLS resources */
+  if (t->handshake)
+    SocketQUICTLS_free (t->handshake);
+
+  return 0;
+}
+
+/* ============================================================================
+ * Send stream data
+ * ============================================================================
+ */
+
+int
+SocketQUICTransport_send_stream (SocketQUICTransport_T t,
+                                 uint64_t stream_id,
+                                 const uint8_t *data,
+                                 size_t len,
+                                 int fin)
+{
+  if (!t || !t->connected || t->closed)
+    return -1;
+  if (!data && len > 0)
+    return -1;
+
+  QUICStreamState *stream = find_or_create_stream (t, stream_id);
+  if (!stream)
+    return -1;
+
+  /* Build STREAM frame */
+  uint8_t frame_buf[TRANSPORT_SEND_BUF_SIZE];
+  size_t frame_len = SocketQUICFrame_encode_stream (stream_id,
+                                                    stream->send_offset,
+                                                    data,
+                                                    len,
+                                                    fin,
+                                                    frame_buf,
+                                                    sizeof (frame_buf));
+  if (frame_len == 0)
+    return -1;
+
+  stream->send_offset += len;
+
+  return build_and_send_1rtt_packet (t, frame_buf, frame_len);
+}
+
+/* ============================================================================
+ * Poll
+ * ============================================================================
+ */
+
+int
+SocketQUICTransport_poll (SocketQUICTransport_T t, int timeout_ms)
+{
+  if (!t || !t->connected || t->closed)
+    return -1;
+
+  struct pollfd pfd;
+  pfd.fd = SocketDgram_fd (t->socket);
+  pfd.events = POLLIN;
+  pfd.revents = 0;
+
+  int poll_rc = poll (&pfd, 1, timeout_ms);
+  if (poll_rc <= 0)
+    return 0;
+
+  ssize_t nbytes
+      = transport_recv_packet (t, t->recv_buf, TRANSPORT_RECV_BUF_SIZE);
+  if (nbytes <= 0)
+    return 0;
+
+  SocketQUICReceiveResult_T result;
+  memset (&result, 0, sizeof (result));
+  SocketQUICReceive_Result recv_rc = SocketQUICReceive_packet (
+      &t->recv_ctx, t->recv_buf, (size_t)nbytes, t->scid.len, 0, &result);
+
+  if (recv_rc != QUIC_RECEIVE_OK)
+    return 0;
+
+  uint64_t current = now_us ();
+
+  /* Record received PN */
+  if (t->ack[result.pn_space])
+    SocketQUICAck_record_packet (
+        t->ack[result.pn_space], result.packet_number, current, 1);
+
+  /* Process frames */
+  int events = process_frames (
+      t, result.payload, result.payload_len, result.pn_space, current);
+
+  /* Send ACK if needed */
+  current = now_us ();
+  for (int space = 0; space < QUIC_PN_SPACE_COUNT; space++)
+    send_ack_if_needed (t, (SocketQUIC_PNSpace)space, current);
+
+  return events >= 0 ? events : 0;
+}
+
+/* ============================================================================
+ * Stream callback
+ * ============================================================================
+ */
+
+void
+SocketQUICTransport_set_stream_callback (SocketQUICTransport_T t,
+                                         SocketQUICTransport_StreamCB cb,
+                                         void *userdata)
+{
+  if (!t)
+    return;
+  t->stream_cb = cb;
+  t->stream_cb_userdata = userdata;
+}
+
+/* ============================================================================
+ * Queries
+ * ============================================================================
+ */
+
+int
+SocketQUICTransport_is_connected (SocketQUICTransport_T t)
+{
+  return t && t->connected && !t->closed;
+}
+
+uint64_t
+SocketQUICTransport_open_bidi_stream (SocketQUICTransport_T t)
+{
+  if (!t || !t->connected || t->closed)
+    return UINT64_MAX;
+
+  uint64_t id = t->next_bidi_id;
+  t->next_bidi_id += 4;
+  return id;
+}
+
+#endif /* SOCKET_HAS_TLS */

--- a/src/test/test_http3_client.c
+++ b/src/test/test_http3_client.c
@@ -1,0 +1,405 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_http3_client.c
+ * @brief Unit tests for HTTP/3 client API (RFC 9114).
+ *
+ * Tests the SocketHTTP3_Client_T wrapper including config defaults,
+ * client lifecycle, state management, Alt-Svc parsing, and the
+ * underlying H3 connection integration.
+ */
+
+#ifdef SOCKET_HAS_TLS
+
+#include "core/Arena.h"
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP3-client.h"
+#include "http/SocketHTTP3-constants.h"
+#include "http/SocketHTTP3.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * Alt-Svc Parsing Tests (RFC 7838)
+ * ============================================================================
+ */
+
+TEST (h3_client_alt_svc_basic_port)
+{
+  char host[256] = { 0 };
+  uint16_t port
+      = SocketHTTP3_parse_alt_svc ("h3=\":443\"", host, sizeof (host));
+  ASSERT_EQ (443, port);
+  ASSERT_EQ ('\0', host[0]);
+}
+
+TEST (h3_client_alt_svc_with_host)
+{
+  char host[256] = { 0 };
+  uint16_t port = SocketHTTP3_parse_alt_svc (
+      "h3=\"alt.example.com:8443\"", host, sizeof (host));
+  ASSERT_EQ (8443, port);
+  ASSERT_EQ (0, strcmp (host, "alt.example.com"));
+}
+
+TEST (h3_client_alt_svc_multiple_entries)
+{
+  char host[256] = { 0 };
+  /* h2 entry first, then h3 */
+  uint16_t port = SocketHTTP3_parse_alt_svc (
+      "h2=\":443\", h3=\":8443\"", host, sizeof (host));
+  ASSERT_EQ (8443, port);
+}
+
+TEST (h3_client_alt_svc_null_input)
+{
+  uint16_t port = SocketHTTP3_parse_alt_svc (NULL, NULL, 0);
+  ASSERT_EQ (0, port);
+}
+
+TEST (h3_client_alt_svc_no_h3)
+{
+  char host[256] = { 0 };
+  uint16_t port
+      = SocketHTTP3_parse_alt_svc ("h2=\":443\"", host, sizeof (host));
+  ASSERT_EQ (0, port);
+}
+
+TEST (h3_client_alt_svc_empty_string)
+{
+  char host[256] = { 0 };
+  uint16_t port = SocketHTTP3_parse_alt_svc ("", host, sizeof (host));
+  ASSERT_EQ (0, port);
+}
+
+TEST (h3_client_alt_svc_invalid_port)
+{
+  char host[256] = { 0 };
+  uint16_t port
+      = SocketHTTP3_parse_alt_svc ("h3=\":abc\"", host, sizeof (host));
+  ASSERT_EQ (0, port);
+}
+
+TEST (h3_client_alt_svc_zero_port)
+{
+  char host[256] = { 0 };
+  uint16_t port = SocketHTTP3_parse_alt_svc ("h3=\":0\"", host, sizeof (host));
+  ASSERT_EQ (0, port);
+}
+
+TEST (h3_client_alt_svc_null_host_buf)
+{
+  /* host_out=NULL should not crash, just return the port */
+  uint16_t port = SocketHTTP3_parse_alt_svc ("h3=\":443\"", NULL, 0);
+  ASSERT_EQ (443, port);
+}
+
+TEST (h3_client_alt_svc_host_too_long)
+{
+  /* Host buffer too small to fit the extracted host */
+  char host[4] = { 0 };
+  uint16_t port = SocketHTTP3_parse_alt_svc (
+      "h3=\"longhost.example.com:443\"", host, sizeof (host));
+  ASSERT_EQ (443, port);
+  /* Host should be empty since it didn't fit */
+  ASSERT_EQ ('\0', host[0]);
+}
+
+/* ============================================================================
+ * Config Defaults Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_config_defaults)
+{
+  SocketHTTP3_ClientConfig config;
+  memset (&config, 0xFF, sizeof (config));
+
+  SocketHTTP3_ClientConfig_defaults (&config);
+
+  ASSERT_EQ (30000ULL, config.idle_timeout_ms);
+  ASSERT_EQ (262144ULL, config.max_stream_data);
+  ASSERT_EQ (100ULL, config.initial_max_streams_bidi);
+  ASSERT_NULL (config.ca_file);
+  ASSERT_EQ (1, config.verify_peer);
+  ASSERT_EQ (5000U, config.connect_timeout_ms);
+  ASSERT_EQ (30000U, config.request_timeout_ms);
+}
+
+TEST (h3_client_config_defaults_null)
+{
+  /* Should not crash */
+  SocketHTTP3_ClientConfig_defaults (NULL);
+}
+
+/* ============================================================================
+ * Client Creation Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_new_with_defaults)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+  ASSERT_EQ (0, SocketHTTP3_Client_is_connected (client));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_new_with_config)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_ClientConfig config;
+  SocketHTTP3_ClientConfig_defaults (&config);
+  config.idle_timeout_ms = 60000;
+  config.request_timeout_ms = 10000;
+
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, &config);
+  ASSERT_NOT_NULL (client);
+  ASSERT_EQ (0, SocketHTTP3_Client_is_connected (client));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_new_null_arena)
+{
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (NULL, NULL);
+  ASSERT_NULL (client);
+}
+
+/* ============================================================================
+ * Client State Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_not_connected_state)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  /* Not connected yet */
+  ASSERT_EQ (0, SocketHTTP3_Client_is_connected (client));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_is_connected_null)
+{
+  ASSERT_EQ (0, SocketHTTP3_Client_is_connected (NULL));
+}
+
+TEST (h3_client_conn_accessor)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  SocketHTTP3_Conn_T conn = SocketHTTP3_Client_conn (client);
+  ASSERT_NOT_NULL (conn);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_conn_null)
+{
+  ASSERT_NULL (SocketHTTP3_Client_conn (NULL));
+}
+
+/* ============================================================================
+ * Request Before Connect Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_request_before_connect)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  /* Request before connect should fail */
+  int status = 0;
+  int rc = SocketHTTP3_Client_request (
+      client, HTTP_METHOD_GET, "/", NULL, NULL, 0, NULL, &status, NULL, NULL);
+  ASSERT_EQ (-1, rc);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_request_null_client)
+{
+  int rc = SocketHTTP3_Client_request (
+      NULL, HTTP_METHOD_GET, "/", NULL, NULL, 0, NULL, NULL, NULL, NULL);
+  ASSERT_EQ (-1, rc);
+}
+
+TEST (h3_client_request_null_path)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  int rc = SocketHTTP3_Client_request (
+      client, HTTP_METHOD_GET, NULL, NULL, NULL, 0, NULL, NULL, NULL, NULL);
+  ASSERT_EQ (-1, rc);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Streaming API Before Connect Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_new_request_before_connect)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  /* Should fail: not connected */
+  SocketHTTP3_Request_T req = SocketHTTP3_Client_new_request (client);
+  ASSERT_NULL (req);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_flush_before_connect)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  int rc = SocketHTTP3_Client_flush (client);
+  ASSERT_EQ (-1, rc);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_poll_before_connect)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  int rc = SocketHTTP3_Client_poll (client, 0);
+  ASSERT_EQ (-1, rc);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Close Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_close_without_connect)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  /* Close without connecting should succeed (no GOAWAY needed) */
+  int rc = SocketHTTP3_Client_close (client);
+  ASSERT_EQ (0, rc);
+  ASSERT_EQ (0, SocketHTTP3_Client_is_connected (client));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_client_close_null)
+{
+  int rc = SocketHTTP3_Client_close (NULL);
+  ASSERT_EQ (-1, rc);
+}
+
+/* ============================================================================
+ * Connect Error Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_connect_null_client)
+{
+  int rc = SocketHTTP3_Client_connect (NULL, "example.com", 443);
+  ASSERT_EQ (-1, rc);
+}
+
+TEST (h3_client_connect_null_host)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  int rc = SocketHTTP3_Client_connect (client, NULL, 443);
+  ASSERT_EQ (-1, rc);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Flush/Poll Null Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_flush_null)
+{
+  int rc = SocketHTTP3_Client_flush (NULL);
+  ASSERT_EQ (-1, rc);
+}
+
+TEST (h3_client_poll_null)
+{
+  int rc = SocketHTTP3_Client_poll (NULL, 0);
+  ASSERT_EQ (-1, rc);
+}
+
+/* ============================================================================
+ * H3 Connection Integration Tests
+ * ============================================================================
+ */
+
+TEST (h3_client_conn_state_idle)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Client_T client = SocketHTTP3_Client_new (arena, NULL);
+  ASSERT_NOT_NULL (client);
+
+  SocketHTTP3_Conn_T conn = SocketHTTP3_Client_conn (client);
+  ASSERT_NOT_NULL (conn);
+
+  /* Before connect, H3 connection should be in IDLE state */
+  ASSERT_EQ (H3_CONN_STATE_IDLE, SocketHTTP3_Conn_state (conn));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Entry point
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}
+
+#else /* !SOCKET_HAS_TLS */
+
+#include <stdio.h>
+
+int
+main (void)
+{
+  printf ("HTTP/3 client tests require TLS support (SOCKET_HAS_TLS)\n");
+  return 0;
+}
+
+#endif /* SOCKET_HAS_TLS */


### PR DESCRIPTION
## Summary
- Implement QUIC UDP transport layer (`SocketQUICTransport`) with full v1 handshake, packet protection at all encryption levels, ACK generation, loss detection, and per-stream offset tracking
- Implement HTTP/3 client API (`SocketHTTP3_Client`) wrapping transport + H3 connection with synchronous request/response, streaming API, Alt-Svc parsing, and graceful shutdown
- Add `SocketQUICTLS_get_traffic_secrets()` for exposing TLS secrets needed by transport key derivation

Fixes #3555

## Test plan
- [x] 32 new unit tests (Alt-Svc parsing, config defaults, client lifecycle, state management, error handling, H3 integration)
- [x] All 183 tests pass with ASan + UBSan + leak detection
- [x] clang-format applied to all new/modified files