### PR TITLE
feat(http3): add server push support (RFC 9114 §4.6)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,6 +548,14 @@ elseif(ZLIB_FOUND)
     message(STATUS "WebSocket permessage-deflate compression enabled (zlib)")
 endif()
 
+# HTTP/3 Server Push support (RFC 9114 §4.6)
+option(ENABLE_H3_PUSH "Enable HTTP/3 server push support (RFC 9114 §4.6)" OFF)
+if(ENABLE_H3_PUSH)
+    add_compile_definitions(SOCKET_HAS_H3_PUSH)
+    list(APPEND LIB_SOURCES src/http/h3/SocketHTTP3-push.c)
+    message(STATUS "HTTP/3 server push enabled")
+endif()
+
 # Object library for reuse in tests (avoids static library constructor issues)
 add_library(socket_objects OBJECT ${LIB_SOURCES})
 target_include_directories(socket_objects PRIVATE ${CMAKE_SOURCE_DIR}/include)
@@ -906,6 +914,13 @@ set(TEST_SOURCES
     test_http3_stream
     test_http3_connection
     test_http3_request
+)
+
+if(ENABLE_H3_PUSH)
+    list(APPEND TEST_SOURCES test_http3_push)
+endif()
+
+list(APPEND TEST_SOURCES
     test_http_integration
     test_ws_integration
     test_http2_integration

--- a/include/http/SocketHTTP3-push.h
+++ b/include/http/SocketHTTP3-push.h
@@ -1,0 +1,129 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-push.h
+ * @brief HTTP/3 server push support (RFC 9114 Section 4.6).
+ *
+ * Server push allows a server to pre-emptively send responses to a client.
+ * The server sends a PUSH_PROMISE on an existing request stream, then
+ * opens a unidirectional push stream to deliver the promised response.
+ *
+ * Build with -DENABLE_H3_PUSH=ON to enable. Disabled by default since
+ * server push is rarely used in practice.
+ *
+ * Output model: Same as connection — push operations enqueue entries into
+ * the connection's output queue. Caller must drain_output() between
+ * push operations to avoid exhausting the output queue.
+ */
+
+#ifndef SOCKETHTTP3_PUSH_INCLUDED
+#define SOCKETHTTP3_PUSH_INCLUDED
+
+#ifdef SOCKET_HAS_H3_PUSH
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "http/SocketHTTP.h"
+#include "http/SocketHTTP3.h"
+#include "http/SocketHTTP3-request.h"
+
+/**
+ * @brief Callback invoked when a client receives a PUSH_PROMISE.
+ */
+typedef void (*SocketHTTP3_PushCallback) (SocketHTTP3_Conn_T conn,
+                                          uint64_t push_id,
+                                          SocketHTTP_Headers_T promised_headers,
+                                          void *userdata);
+
+/**
+ * @brief Allocate the next push ID.
+ *
+ * Monotonically increments the server's push ID counter. Fails if the
+ * client hasn't sent MAX_PUSH_ID or the allocated ID would exceed it.
+ *
+ * @param conn          Server connection handle.
+ * @param[out] out_push_id  Output: allocated push ID.
+ * @return 0 on success, negative H3 error code on failure.
+ */
+int SocketHTTP3_Conn_allocate_push_id (SocketHTTP3_Conn_T conn,
+                                       uint64_t *out_push_id);
+
+/**
+ * @brief Send PUSH_PROMISE on a request stream.
+ *
+ * QPACK-encodes the promised request headers and sends a PUSH_PROMISE
+ * frame on the specified request stream. The push entry transitions to
+ * PROMISED state.
+ *
+ * @param conn              Server connection handle.
+ * @param request_stream_id Bidirectional stream to send promise on.
+ * @param push_id           Previously allocated push ID.
+ * @param headers           Promised request headers.
+ * @return 0 on success, negative H3 error code on failure.
+ */
+int SocketHTTP3_Conn_send_push_promise (SocketHTTP3_Conn_T conn,
+                                        uint64_t request_stream_id,
+                                        uint64_t push_id,
+                                        const SocketHTTP_Headers_T headers);
+
+/**
+ * @brief Open a push stream for a previously promised push ID.
+ *
+ * Allocates a server-initiated unidirectional stream, writes the push
+ * stream header (type byte + push ID), and returns a request handle.
+ * The caller uses send_headers + send_data on the returned handle to
+ * deliver the pushed response.
+ *
+ * @param conn     Server connection handle.
+ * @param push_id  Previously promised push ID (must be in PROMISED state).
+ * @return Request handle for the push stream, or NULL on error.
+ */
+SocketHTTP3_Request_T
+SocketHTTP3_Conn_open_push_stream (SocketHTTP3_Conn_T conn, uint64_t push_id);
+
+/**
+ * @brief Register a push promise callback (client only).
+ *
+ * The callback is invoked when the client receives a PUSH_PROMISE frame.
+ *
+ * @param conn      Client connection handle.
+ * @param cb        Callback function (NULL to clear).
+ * @param userdata  User context passed to callback.
+ */
+void SocketHTTP3_Conn_on_push (SocketHTTP3_Conn_T conn,
+                                SocketHTTP3_PushCallback cb,
+                                void *userdata);
+
+/**
+ * @brief Send MAX_PUSH_ID on the control stream (client only).
+ *
+ * Tells the server the maximum push ID it may use. The value must not
+ * decrease from previously sent values.
+ *
+ * @param conn         Client connection handle.
+ * @param max_push_id  Maximum push ID the server may use.
+ * @return 0 on success, negative H3 error code on failure.
+ */
+int SocketHTTP3_Conn_send_max_push_id (SocketHTTP3_Conn_T conn,
+                                       uint64_t max_push_id);
+
+/**
+ * @brief Cancel a push (both roles).
+ *
+ * Sends a CANCEL_PUSH frame on the control stream. Server: cancels a
+ * promised or open push. Client: rejects a promised push.
+ *
+ * @param conn     Connection handle.
+ * @param push_id  Push ID to cancel.
+ * @return 0 on success, negative H3 error code on failure.
+ */
+int SocketHTTP3_Conn_cancel_push (SocketHTTP3_Conn_T conn, uint64_t push_id);
+
+#endif /* SOCKET_HAS_H3_PUSH */
+
+#endif /* SOCKETHTTP3_PUSH_INCLUDED */

--- a/include/http/SocketHTTP3-request.h
+++ b/include/http/SocketHTTP3-request.h
@@ -219,4 +219,22 @@ int SocketHTTP3_Request_feed (SocketHTTP3_Request_T req,
                               size_t len,
                               int fin);
 
+#ifdef SOCKET_HAS_H3_PUSH
+/**
+ * @brief Create a request for a server push stream.
+ *
+ * Used internally by the push module. Does not register in conn->requests[]
+ * since push streams use a separate tracking array.
+ *
+ * @param conn       Connection handle (must be in OPEN state).
+ * @param stream_id  Server-initiated unidirectional stream ID.
+ * @param push_id    Push ID for this push stream.
+ * @return New request, or NULL on error.
+ */
+SocketHTTP3_Request_T
+SocketHTTP3_Request_new_push (SocketHTTP3_Conn_T conn,
+                               uint64_t stream_id,
+                               uint64_t push_id);
+#endif /* SOCKET_HAS_H3_PUSH */
+
 #endif /* SOCKETHTTP3_REQUEST_INCLUDED */

--- a/src/http/h3/SocketHTTP3-push.c
+++ b/src/http/h3/SocketHTTP3-push.c
@@ -1,0 +1,460 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketHTTP3-push.c
+ * @brief HTTP/3 server push implementation (RFC 9114 Section 4.6).
+ */
+
+#ifdef SOCKET_HAS_H3_PUSH
+
+#include "http/SocketHTTP3-push.h"
+#include "http/SocketHTTP3-constants.h"
+#include "http/SocketHTTP3-frame.h"
+#include "http/SocketHTTP3-private.h"
+#include "http/SocketHTTP3-request.h"
+#include "http/SocketHTTP3-stream.h"
+#include "quic/SocketQUICVarInt.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * Internal Helpers
+ * ============================================================================
+ */
+
+static H3_PushEntry *
+find_push_entry (SocketHTTP3_Conn_T conn, uint64_t push_id)
+{
+  for (size_t i = 0; i < conn->push_count; i++)
+    {
+      if (conn->pushes[i].push_id == push_id)
+        return &conn->pushes[i];
+    }
+  return NULL;
+}
+
+/**
+ * @brief Append a frame to the control stream output buffer and queue it.
+ */
+static int
+send_control_frame (SocketHTTP3_Conn_T conn,
+                    uint64_t frame_type,
+                    const uint8_t *payload,
+                    size_t payload_len)
+{
+  uint8_t frame_hdr[16];
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      frame_type, payload_len, frame_hdr, sizeof (frame_hdr));
+  if (hdr_len < 0)
+    return -(int)H3_INTERNAL_ERROR;
+
+  stream_buf_reset (&conn->control_out);
+  stream_buf_append (
+      &conn->control_out, conn->arena, frame_hdr, (size_t)hdr_len);
+  if (payload_len > 0)
+    stream_buf_append (&conn->control_out, conn->arena, payload, payload_len);
+
+  return h3_output_queue_push (&conn->output,
+                                conn->local_control_id,
+                                conn->control_out.data,
+                                conn->control_out.len);
+}
+
+/* ============================================================================
+ * Server-Side Push
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_Conn_allocate_push_id (SocketHTTP3_Conn_T conn,
+                                   uint64_t *out_push_id)
+{
+  if (conn == NULL || out_push_id == NULL)
+    return -1;
+  if (conn->role != H3_ROLE_SERVER)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+  if (conn->state != H3_CONN_STATE_OPEN)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+  if (!conn->max_push_id_received)
+    return -(int)H3_ID_ERROR;
+  if (conn->next_push_id > conn->max_push_id)
+    return -(int)H3_ID_ERROR;
+  if (conn->push_count >= H3_MAX_PUSH_STREAMS)
+    return -(int)H3_ID_ERROR;
+
+  *out_push_id = conn->next_push_id;
+  conn->next_push_id++;
+  return 0;
+}
+
+int
+SocketHTTP3_Conn_send_push_promise (SocketHTTP3_Conn_T conn,
+                                    uint64_t request_stream_id,
+                                    uint64_t push_id,
+                                    const SocketHTTP_Headers_T headers)
+{
+  if (conn == NULL || headers == NULL)
+    return -1;
+  if (conn->role != H3_ROLE_SERVER)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+  if (conn->state != H3_CONN_STATE_OPEN)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+
+  /* Validate push_id isn't already tracked */
+  if (find_push_entry (conn, push_id) != NULL)
+    return -(int)H3_ID_ERROR;
+
+  /* push_id must be within max_push_id */
+  if (!conn->max_push_id_received || push_id > conn->max_push_id)
+    return -(int)H3_ID_ERROR;
+
+  if (conn->push_count >= H3_MAX_PUSH_STREAMS)
+    return -(int)H3_ID_ERROR;
+
+  /* QPACK-encode the promised headers */
+  uint8_t *qpack_data;
+  size_t qpack_len;
+  int rc = h3_qpack_encode_headers (conn->arena, headers, &qpack_data,
+                                     &qpack_len);
+  if (rc != 0)
+    return rc;
+
+  /* Build PUSH_PROMISE payload: push_id(varint) + qpack_data */
+  uint8_t push_id_buf[SOCKETQUICVARINT_MAX_SIZE];
+  size_t push_id_len
+      = SocketQUICVarInt_encode (push_id, push_id_buf, sizeof (push_id_buf));
+  if (push_id_len == 0)
+    return -(int)H3_INTERNAL_ERROR;
+
+  size_t payload_len = push_id_len + qpack_len;
+
+  /* Build frame header */
+  uint8_t frame_hdr[16];
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_PUSH_PROMISE, payload_len, frame_hdr, sizeof (frame_hdr));
+  if (hdr_len < 0)
+    return -(int)H3_INTERNAL_ERROR;
+
+  /* Build promise frame in a temporary buffer */
+  H3_StreamBuf promise_buf;
+  stream_buf_init (&promise_buf, conn->arena, request_stream_id);
+  stream_buf_append (&promise_buf, conn->arena, frame_hdr, (size_t)hdr_len);
+  stream_buf_append (&promise_buf, conn->arena, push_id_buf, push_id_len);
+  stream_buf_append (&promise_buf, conn->arena, qpack_data, qpack_len);
+
+  h3_output_queue_push (&conn->output,
+                         request_stream_id,
+                         promise_buf.data,
+                         promise_buf.len);
+
+  /* Create push entry */
+  H3_PushEntry *entry = &conn->pushes[conn->push_count++];
+  entry->push_id = push_id;
+  entry->request_stream_id = request_stream_id;
+  entry->push_stream_id = 0;
+  entry->state = H3_PUSH_PROMISED;
+  entry->promised_headers = NULL;
+  entry->request = NULL;
+
+  return 0;
+}
+
+SocketHTTP3_Request_T
+SocketHTTP3_Conn_open_push_stream (SocketHTTP3_Conn_T conn, uint64_t push_id)
+{
+  if (conn == NULL)
+    return NULL;
+  if (conn->role != H3_ROLE_SERVER)
+    return NULL;
+  if (conn->state != H3_CONN_STATE_OPEN)
+    return NULL;
+
+  H3_PushEntry *entry = find_push_entry (conn, push_id);
+  if (entry == NULL)
+    return NULL;
+  if (entry->state != H3_PUSH_PROMISED)
+    return NULL;
+
+  /* Allocate server-initiated unidi stream ID */
+  uint64_t stream_id = conn->next_server_unidi_id;
+  conn->next_server_unidi_id += 4;
+
+  /* Create push request */
+  SocketHTTP3_Request_T req
+      = SocketHTTP3_Request_new_push (conn, stream_id, push_id);
+  if (req == NULL)
+    return NULL;
+
+  /* Build push stream header: type(0x01) + push_id(varint) */
+  uint8_t type_byte = (uint8_t)H3_STREAM_TYPE_PUSH;
+  uint8_t push_id_buf[SOCKETQUICVARINT_MAX_SIZE];
+  size_t push_id_len
+      = SocketQUICVarInt_encode (push_id, push_id_buf, sizeof (push_id_buf));
+  if (push_id_len == 0)
+    return NULL;
+
+  /* Build stream header in a temporary buffer */
+  H3_StreamBuf stream_hdr;
+  stream_buf_init (&stream_hdr, conn->arena, stream_id);
+  stream_buf_append (&stream_hdr, conn->arena, &type_byte, 1);
+  stream_buf_append (&stream_hdr, conn->arena, push_id_buf, push_id_len);
+
+  h3_output_queue_push (&conn->output,
+                         stream_id,
+                         stream_hdr.data,
+                         stream_hdr.len);
+
+  /* Register in stream map */
+  SocketHTTP3_StreamMap_register (conn->stream_map, stream_id,
+                                  H3_STREAM_TYPE_PUSH);
+
+  /* Update entry */
+  entry->push_stream_id = stream_id;
+  entry->state = H3_PUSH_STREAM_OPENED;
+  entry->request = req;
+
+  return req;
+}
+
+/* ============================================================================
+ * Client-Side Push
+ * ============================================================================
+ */
+
+void
+SocketHTTP3_Conn_on_push (SocketHTTP3_Conn_T conn,
+                           SocketHTTP3_PushCallback cb,
+                           void *userdata)
+{
+  if (conn == NULL)
+    return;
+  conn->push_cb = cb;
+  conn->push_cb_userdata = userdata;
+}
+
+int
+SocketHTTP3_Conn_send_max_push_id (SocketHTTP3_Conn_T conn,
+                                   uint64_t max_push_id)
+{
+  if (conn == NULL)
+    return -1;
+  if (conn->role != H3_ROLE_CLIENT)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+  if (conn->state != H3_CONN_STATE_OPEN)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+
+  /* Must not decrease */
+  if (conn->local_max_push_id_sent && max_push_id < conn->local_max_push_id)
+    return -(int)H3_ID_ERROR;
+
+  uint8_t payload[SOCKETQUICVARINT_MAX_SIZE];
+  int payload_len
+      = SocketHTTP3_MaxPushId_write (max_push_id, payload, sizeof (payload));
+  if (payload_len < 0)
+    return -(int)H3_INTERNAL_ERROR;
+
+  int rc = send_control_frame (conn, HTTP3_FRAME_MAX_PUSH_ID,
+                                payload, (size_t)payload_len);
+  if (rc < 0)
+    return rc;
+
+  conn->local_max_push_id = max_push_id;
+  conn->local_max_push_id_sent = 1;
+  return 0;
+}
+
+/* ============================================================================
+ * Both Roles — Cancel Push
+ * ============================================================================
+ */
+
+int
+SocketHTTP3_Conn_cancel_push (SocketHTTP3_Conn_T conn, uint64_t push_id)
+{
+  if (conn == NULL)
+    return -1;
+  if (conn->state != H3_CONN_STATE_OPEN)
+    return -(int)H3_GENERAL_PROTOCOL_ERROR;
+
+  /* Send CANCEL_PUSH frame on control stream */
+  uint8_t payload[SOCKETQUICVARINT_MAX_SIZE];
+  int payload_len
+      = SocketHTTP3_CancelPush_write (push_id, payload, sizeof (payload));
+  if (payload_len < 0)
+    return -(int)H3_INTERNAL_ERROR;
+
+  int rc = send_control_frame (conn, HTTP3_FRAME_CANCEL_PUSH,
+                                payload, (size_t)payload_len);
+  if (rc < 0)
+    return rc;
+
+  /* Update local push entry if it exists */
+  H3_PushEntry *entry = find_push_entry (conn, push_id);
+  if (entry != NULL)
+    {
+      entry->state = H3_PUSH_CANCELLED;
+      if (entry->request != NULL)
+        SocketHTTP3_Request_cancel (entry->request);
+    }
+
+  return 0;
+}
+
+/* ============================================================================
+ * Internal: Handle CANCEL_PUSH from peer
+ * ============================================================================
+ */
+
+void
+h3_handle_cancel_push (SocketHTTP3_Conn_T conn, uint64_t push_id)
+{
+  H3_PushEntry *entry = find_push_entry (conn, push_id);
+  if (entry == NULL)
+    return; /* Unknown push_id: silently ignore per RFC 9114 §7.2.3 */
+
+  entry->state = H3_PUSH_CANCELLED;
+  if (entry->request != NULL)
+    SocketHTTP3_Request_cancel (entry->request);
+}
+
+/* ============================================================================
+ * Internal: Receive PUSH_PROMISE (client side)
+ * ============================================================================
+ */
+
+int
+h3_conn_recv_push_promise (SocketHTTP3_Conn_T conn,
+                            uint64_t request_stream_id,
+                            const uint8_t *payload,
+                            size_t payload_len)
+{
+  if (conn == NULL)
+    return -1;
+  if (conn->role != H3_ROLE_CLIENT)
+    return -(int)H3_FRAME_UNEXPECTED;
+
+  /* Parse push_id from payload start */
+  uint64_t push_id;
+  size_t push_id_offset;
+  int rc = SocketHTTP3_PushPromise_parse_id (
+      payload, payload_len, &push_id, &push_id_offset);
+  if (rc != 0)
+    return -(int)H3_FRAME_ERROR;
+
+  /* Duplicate check */
+  if (find_push_entry (conn, push_id) != NULL)
+    return -(int)H3_ID_ERROR;
+
+  if (conn->push_count >= H3_MAX_PUSH_STREAMS)
+    return -(int)H3_ID_ERROR;
+
+  /* Decode promised headers from remaining payload */
+  const uint8_t *qpack_data = payload + push_id_offset;
+  size_t qpack_len = payload_len - push_id_offset;
+
+  SocketHTTP_Headers_T promised_headers = NULL;
+  if (qpack_len > 0)
+    {
+      rc = h3_qpack_decode_headers (
+          conn->arena, qpack_data, qpack_len, &promised_headers);
+      if (rc != 0)
+        return rc;
+    }
+
+  /* Create push entry */
+  H3_PushEntry *entry = &conn->pushes[conn->push_count++];
+  entry->push_id = push_id;
+  entry->request_stream_id = request_stream_id;
+  entry->push_stream_id = 0;
+  entry->state = H3_PUSH_PROMISED;
+  entry->promised_headers = promised_headers;
+  entry->request = NULL;
+
+  /* Invoke callback if registered */
+  if (conn->push_cb != NULL)
+    conn->push_cb (conn, push_id, promised_headers, conn->push_cb_userdata);
+
+  return 0;
+}
+
+/* ============================================================================
+ * Internal: Feed push stream data (client side)
+ * ============================================================================
+ */
+
+int
+h3_feed_push_stream (SocketHTTP3_Conn_T conn,
+                      uint64_t stream_id,
+                      const uint8_t *data,
+                      size_t len,
+                      int fin)
+{
+  if (conn == NULL)
+    return -1;
+
+  /* Find push entry by stream_id */
+  H3_PushEntry *entry = NULL;
+  for (size_t i = 0; i < conn->push_count; i++)
+    {
+      if (conn->pushes[i].push_stream_id == stream_id
+          && conn->pushes[i].state == H3_PUSH_STREAM_OPENED)
+        {
+          entry = &conn->pushes[i];
+          break;
+        }
+    }
+
+  if (entry == NULL)
+    {
+      /* First data on push stream: decode push_id varint */
+      if (len == 0)
+        return 0;
+
+      uint64_t push_id;
+      size_t consumed;
+      SocketQUICVarInt_Result vres
+          = SocketQUICVarInt_decode (data, len, &push_id, &consumed);
+      if (vres == QUIC_VARINT_INCOMPLETE)
+        return 0;
+      if (vres != QUIC_VARINT_OK)
+        return -(int)H3_GENERAL_PROTOCOL_ERROR;
+
+      entry = find_push_entry (conn, push_id);
+      if (entry == NULL)
+        return -(int)H3_ID_ERROR;
+      if (entry->state == H3_PUSH_CANCELLED)
+        return 0;
+
+      /* Create request for receiving push response */
+      SocketHTTP3_Request_T req
+          = SocketHTTP3_Request_new_push (conn, stream_id, push_id);
+      if (req == NULL)
+        return -(int)H3_INTERNAL_ERROR;
+
+      entry->push_stream_id = stream_id;
+      entry->state = H3_PUSH_STREAM_OPENED;
+      entry->request = req;
+
+      /* Feed remaining data after push_id */
+      if (consumed < len)
+        return SocketHTTP3_Request_feed (
+            req, data + consumed, len - consumed, fin);
+
+      if (fin)
+        return SocketHTTP3_Request_feed (req, NULL, 0, fin);
+
+      return 0;
+    }
+
+  /* Subsequent calls: feed to existing request */
+  if (entry->request == NULL)
+    return -(int)H3_INTERNAL_ERROR;
+
+  return SocketHTTP3_Request_feed (entry->request, data, len, fin);
+}
+
+#endif /* SOCKET_HAS_H3_PUSH */

--- a/src/test/test_http3_push.c
+++ b/src/test/test_http3_push.c
@@ -1,0 +1,865 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_http3_push.c
+ * @brief Unit tests for HTTP/3 server push (RFC 9114 Section 4.6).
+ */
+
+#ifdef SOCKET_HAS_H3_PUSH
+
+#include "core/Arena.h"
+#include "http/SocketHTTP3.h"
+#include "http/SocketHTTP3-constants.h"
+#include "http/SocketHTTP3-frame.h"
+#include "http/SocketHTTP3-private.h"
+#include "http/SocketHTTP3-push.h"
+#include "http/SocketHTTP3-request.h"
+#include "http/SocketHTTP3-stream.h"
+#include "quic/SocketQUICVarInt.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * Test Helpers
+ * ============================================================================
+ */
+
+static size_t
+build_settings_frame (uint8_t *buf,
+                      size_t buflen,
+                      const SocketHTTP3_Settings *settings)
+{
+  size_t pos = 0;
+  uint8_t payload[HTTP3_SETTINGS_MAX_WRITE_SIZE];
+  int payload_len
+      = SocketHTTP3_Settings_write (settings, payload, sizeof (payload));
+  if (payload_len < 0)
+    payload_len = 0;
+
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_SETTINGS, (uint64_t)payload_len, buf + pos, buflen - pos);
+  if (hdr_len < 0)
+    return 0;
+  pos += (size_t)hdr_len;
+
+  if (payload_len > 0)
+    {
+      memcpy (buf + pos, payload, (size_t)payload_len);
+      pos += (size_t)payload_len;
+    }
+  return pos;
+}
+
+static size_t
+build_max_push_id_frame (uint8_t *buf, size_t buflen, uint64_t push_id)
+{
+  size_t pos = 0;
+  uint8_t payload[SOCKETQUICVARINT_MAX_SIZE];
+  int payload_len
+      = SocketHTTP3_MaxPushId_write (push_id, payload, sizeof (payload));
+  if (payload_len < 0)
+    return 0;
+
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_MAX_PUSH_ID, (uint64_t)payload_len, buf + pos, buflen - pos);
+  if (hdr_len < 0)
+    return 0;
+  pos += (size_t)hdr_len;
+
+  memcpy (buf + pos, payload, (size_t)payload_len);
+  pos += (size_t)payload_len;
+  return pos;
+}
+
+static size_t
+build_cancel_push_frame (uint8_t *buf, size_t buflen, uint64_t push_id)
+{
+  size_t pos = 0;
+  uint8_t payload[SOCKETQUICVARINT_MAX_SIZE];
+  int payload_len
+      = SocketHTTP3_CancelPush_write (push_id, payload, sizeof (payload));
+  if (payload_len < 0)
+    return 0;
+
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_CANCEL_PUSH, (uint64_t)payload_len, buf + pos, buflen - pos);
+  if (hdr_len < 0)
+    return 0;
+  pos += (size_t)hdr_len;
+
+  memcpy (buf + pos, payload, (size_t)payload_len);
+  pos += (size_t)payload_len;
+  return pos;
+}
+
+/**
+ * @brief Create and init a server conn with peer control registered +
+ *        SETTINGS received + MAX_PUSH_ID received.
+ */
+static SocketHTTP3_Conn_T
+make_server_conn_push_ready (Arena_T arena, uint64_t max_push_id)
+{
+  SocketHTTP3_ConnConfig config;
+  SocketHTTP3_ConnConfig_defaults (&config, H3_ROLE_SERVER);
+
+  SocketHTTP3_Conn_T conn = SocketHTTP3_Conn_new (arena, NULL, &config);
+  SocketHTTP3_Conn_init (conn);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Register peer control stream (client-initiated unidi stream 2) */
+  SocketHTTP3_StreamMap_register (conn->stream_map, 2,
+                                  H3_STREAM_TYPE_CONTROL);
+
+  /* Feed SETTINGS */
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  uint8_t sbuf[64];
+  size_t slen = build_settings_frame (sbuf, sizeof (sbuf), &settings);
+  SocketHTTP3_Conn_feed_stream (conn, 2, sbuf, slen, 0);
+
+  /* Feed MAX_PUSH_ID */
+  uint8_t mbuf[16];
+  size_t mlen = build_max_push_id_frame (mbuf, sizeof (mbuf), max_push_id);
+  SocketHTTP3_Conn_feed_stream (conn, 2, mbuf, mlen, 0);
+
+  SocketHTTP3_Conn_drain_output (conn);
+  return conn;
+}
+
+/**
+ * @brief Create a server conn with a client request registered at stream 0.
+ */
+static SocketHTTP3_Conn_T
+make_server_conn_with_request (Arena_T arena, uint64_t max_push_id)
+{
+  SocketHTTP3_Conn_T conn = make_server_conn_push_ready (arena, max_push_id);
+
+  /* Simulate an incoming client request on bidi stream 0 */
+  SocketHTTP3_Request_T req
+      = SocketHTTP3_Request_new_incoming (conn, 0);
+  (void)req;
+
+  return conn;
+}
+
+static SocketHTTP3_Conn_T
+make_client_conn_with_peer_control (Arena_T arena)
+{
+  SocketHTTP3_ConnConfig config;
+  SocketHTTP3_ConnConfig_defaults (&config, H3_ROLE_CLIENT);
+
+  SocketHTTP3_Conn_T conn = SocketHTTP3_Conn_new (arena, NULL, &config);
+  SocketHTTP3_Conn_init (conn);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Register peer control stream (server-initiated unidi stream 3) */
+  SocketHTTP3_StreamMap_register (conn->stream_map, 3,
+                                  H3_STREAM_TYPE_CONTROL);
+  return conn;
+}
+
+static SocketHTTP_Headers_T
+make_push_promise_headers (Arena_T arena)
+{
+  SocketHTTP_Headers_T h = SocketHTTP_Headers_new (arena);
+  SocketHTTP_Headers_add_pseudo_n (h, ":method", 7, "GET", 3);
+  SocketHTTP_Headers_add_pseudo_n (h, ":scheme", 7, "https", 5);
+  SocketHTTP_Headers_add_pseudo_n (h, ":path", 5, "/style.css", 10);
+  SocketHTTP_Headers_add_pseudo_n (h, ":authority", 10, "example.com", 11);
+  return h;
+}
+
+static SocketHTTP_Headers_T
+make_response_headers (Arena_T arena)
+{
+  SocketHTTP_Headers_T h = SocketHTTP_Headers_new (arena);
+  SocketHTTP_Headers_add_pseudo_n (h, ":status", 7, "200", 3);
+  SocketHTTP_Headers_add_n (h, "content-type", 12, "text/css", 8);
+  return h;
+}
+
+/* ============================================================================
+ * Push ID Allocation Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_allocate_id)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_push_ready (arena, 5);
+
+  uint64_t id0, id1, id2;
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &id0));
+  ASSERT_EQ (0ULL, id0);
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &id1));
+  ASSERT_EQ (1ULL, id1);
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &id2));
+  ASSERT_EQ (2ULL, id2);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_allocate_without_max)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_ConnConfig config;
+  SocketHTTP3_ConnConfig_defaults (&config, H3_ROLE_SERVER);
+
+  SocketHTTP3_Conn_T conn = SocketHTTP3_Conn_new (arena, NULL, &config);
+  SocketHTTP3_Conn_init (conn);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* No MAX_PUSH_ID received — allocate must fail */
+  uint64_t id;
+  ASSERT_EQ (-(int)H3_ID_ERROR, SocketHTTP3_Conn_allocate_push_id (conn, &id));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * PUSH_PROMISE Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_promise_basic)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+  ASSERT_EQ (0ULL, push_id);
+
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+  ASSERT_EQ (0, SocketHTTP3_Conn_send_push_promise (conn, 0, push_id,
+                                                      headers));
+
+  /* Output queue should have the PUSH_PROMISE frame */
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+  const SocketHTTP3_Output *out = SocketHTTP3_Conn_get_output (conn, 0);
+  ASSERT_NOT_NULL (out);
+  ASSERT_EQ (0ULL, out->stream_id); /* On request stream 0 */
+
+  /* Verify frame starts with PUSH_PROMISE type (0x05) */
+  ASSERT (out->len >= 2);
+  ASSERT_EQ (0x05, out->data[0]);
+
+  /* Verify push entry state */
+  ASSERT_EQ ((size_t)1, conn->push_count);
+  ASSERT_EQ (H3_PUSH_PROMISED, conn->pushes[0].state);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_promise_exceeds_max)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 0);
+
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+
+  /* Allocate push_id 0 (within max_push_id=0) */
+  uint64_t push_id;
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+  ASSERT_EQ (0ULL, push_id);
+  ASSERT_EQ (0, SocketHTTP3_Conn_send_push_promise (conn, 0, push_id,
+                                                      headers));
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Try push_id 1 — exceeds max_push_id=0 */
+  ASSERT_EQ (-(int)H3_ID_ERROR,
+             SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_promise_duplicate)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+
+  uint64_t push_id;
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+  ASSERT_EQ (0, SocketHTTP3_Conn_send_push_promise (conn, 0, push_id,
+                                                      headers));
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Same push_id again → error */
+  ASSERT_EQ (-(int)H3_ID_ERROR,
+             SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, headers));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_promise_client_send)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_client_conn_with_peer_control (arena);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+
+  /* Client cannot send PUSH_PROMISE */
+  ASSERT_EQ (-(int)H3_GENERAL_PROTOCOL_ERROR,
+             SocketHTTP3_Conn_send_push_promise (conn, 0, 0, headers));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Push Stream Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_open_stream)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  SocketHTTP3_Conn_allocate_push_id (conn, &push_id);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+  SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, headers);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  SocketHTTP3_Request_T req
+      = SocketHTTP3_Conn_open_push_stream (conn, push_id);
+  ASSERT_NOT_NULL (req);
+
+  /* Output queue should have push stream header */
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+  const SocketHTTP3_Output *out = SocketHTTP3_Conn_get_output (conn, 0);
+  ASSERT_NOT_NULL (out);
+
+  /* First byte should be stream type 0x01 (push) */
+  ASSERT (out->len >= 2);
+  ASSERT_EQ (0x01, out->data[0]);
+
+  /* Push entry should be STREAM_OPENED */
+  ASSERT_EQ (H3_PUSH_STREAM_OPENED, conn->pushes[0].state);
+
+  /* Stream ID should be server unidi starting at 15 */
+  ASSERT_EQ (15ULL, out->stream_id);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_open_unpromised)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_push_ready (arena, 5);
+
+  /* Try to open stream for push_id 0 that was never promised */
+  SocketHTTP3_Request_T req = SocketHTTP3_Conn_open_push_stream (conn, 0);
+  ASSERT_NULL (req);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_open_cancelled)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  SocketHTTP3_Conn_allocate_push_id (conn, &push_id);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+  SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, headers);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Cancel the push */
+  SocketHTTP3_Conn_cancel_push (conn, push_id);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Try to open — should fail */
+  SocketHTTP3_Request_T req
+      = SocketHTTP3_Conn_open_push_stream (conn, push_id);
+  ASSERT_NULL (req);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_response)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  SocketHTTP3_Conn_allocate_push_id (conn, &push_id);
+  SocketHTTP_Headers_T promise = make_push_promise_headers (arena);
+  SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, promise);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  SocketHTTP3_Request_T req
+      = SocketHTTP3_Conn_open_push_stream (conn, push_id);
+  ASSERT_NOT_NULL (req);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Send response headers */
+  SocketHTTP_Headers_T resp = make_response_headers (arena);
+  int rc = SocketHTTP3_Request_send_headers (req, resp, 0);
+  ASSERT_EQ (0, rc);
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Send response data */
+  const char *body = "body { color: red; }";
+  rc = SocketHTTP3_Request_send_data (req, body, strlen (body), 1);
+  ASSERT_EQ (0, rc);
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Cancel Push Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_cancel_before_open)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  SocketHTTP3_Conn_allocate_push_id (conn, &push_id);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+  SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, headers);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  int rc = SocketHTTP3_Conn_cancel_push (conn, push_id);
+  ASSERT_EQ (0, rc);
+
+  /* Output should have CANCEL_PUSH frame on control stream */
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+  const SocketHTTP3_Output *out = SocketHTTP3_Conn_get_output (conn, 0);
+  ASSERT_NOT_NULL (out);
+  ASSERT_EQ (conn->local_control_id, out->stream_id);
+
+  /* Push entry should be CANCELLED */
+  ASSERT_EQ (H3_PUSH_CANCELLED, conn->pushes[0].state);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_cancel_after_open)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  SocketHTTP3_Conn_allocate_push_id (conn, &push_id);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+  SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, headers);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  SocketHTTP3_Conn_open_push_stream (conn, push_id);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  int rc = SocketHTTP3_Conn_cancel_push (conn, push_id);
+  ASSERT_EQ (0, rc);
+  ASSERT_EQ (H3_PUSH_CANCELLED, conn->pushes[0].state);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_cancel_server_recv)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  uint64_t push_id;
+  SocketHTTP3_Conn_allocate_push_id (conn, &push_id);
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+  SocketHTTP3_Conn_send_push_promise (conn, 0, push_id, headers);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Simulate client sending CANCEL_PUSH via control stream */
+  uint8_t buf[16];
+  size_t len = build_cancel_push_frame (buf, sizeof (buf), push_id);
+  ASSERT (len > 0);
+
+  int rc = SocketHTTP3_Conn_feed_stream (conn, 2, buf, len, 0);
+  ASSERT_EQ (0, rc);
+  ASSERT_EQ (H3_PUSH_CANCELLED, conn->pushes[0].state);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * MAX_PUSH_ID Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_max_push_id_send)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_client_conn_with_peer_control (arena);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  int rc = SocketHTTP3_Conn_send_max_push_id (conn, 10);
+  ASSERT_EQ (0, rc);
+
+  /* Output should have MAX_PUSH_ID on control stream */
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+  const SocketHTTP3_Output *out = SocketHTTP3_Conn_get_output (conn, 0);
+  ASSERT_NOT_NULL (out);
+  ASSERT_EQ (conn->local_control_id, out->stream_id);
+
+  /* Verify tracked locally */
+  ASSERT_EQ (10ULL, conn->local_max_push_id);
+  ASSERT_EQ (1, conn->local_max_push_id_sent);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_max_push_id_decrease)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_client_conn_with_peer_control (arena);
+
+  SocketHTTP3_Conn_send_max_push_id (conn, 10);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Decrease should fail */
+  ASSERT_EQ (-(int)H3_ID_ERROR,
+             SocketHTTP3_Conn_send_max_push_id (conn, 5));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Client Receive Tests
+ * ============================================================================
+ */
+
+/**
+ * @brief Build a PUSH_PROMISE frame payload: push_id(varint) + QPACK data.
+ *
+ * Uses static-table-only encoding for the promised headers.
+ */
+static size_t
+build_push_promise_payload (Arena_T arena,
+                            uint64_t push_id,
+                            const SocketHTTP_Headers_T headers,
+                            uint8_t *buf,
+                            size_t buflen)
+{
+  size_t pos = 0;
+
+  /* Push ID varint */
+  size_t vid_len
+      = SocketQUICVarInt_encode (push_id, buf + pos, buflen - pos);
+  if (vid_len == 0)
+    return 0;
+  pos += vid_len;
+
+  /* QPACK encode headers */
+  uint8_t *qpack_data;
+  size_t qpack_len;
+  int rc
+      = h3_qpack_encode_headers (arena, headers, &qpack_data, &qpack_len);
+  if (rc != 0)
+    return 0;
+
+  if (pos + qpack_len > buflen)
+    return 0;
+  memcpy (buf + pos, qpack_data, qpack_len);
+  pos += qpack_len;
+
+  return pos;
+}
+
+/**
+ * @brief Build a complete PUSH_PROMISE frame (frame header + payload).
+ */
+static size_t
+build_push_promise_frame (Arena_T arena,
+                          uint64_t push_id,
+                          const SocketHTTP_Headers_T headers,
+                          uint8_t *buf,
+                          size_t buflen)
+{
+  /* Build payload first in temp buffer */
+  uint8_t payload[4096];
+  size_t payload_len = build_push_promise_payload (
+      arena, push_id, headers, payload, sizeof (payload));
+  if (payload_len == 0)
+    return 0;
+
+  /* Frame header */
+  size_t pos = 0;
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_PUSH_PROMISE, payload_len, buf + pos, buflen - pos);
+  if (hdr_len < 0)
+    return 0;
+  pos += (size_t)hdr_len;
+
+  memcpy (buf + pos, payload, payload_len);
+  pos += payload_len;
+  return pos;
+}
+
+/* Callback state for push promise tests */
+static int push_cb_called;
+static uint64_t push_cb_push_id;
+
+static void
+push_callback (SocketHTTP3_Conn_T conn,
+               uint64_t push_id,
+               SocketHTTP_Headers_T promised_headers,
+               void *userdata)
+{
+  (void)conn;
+  (void)promised_headers;
+  (void)userdata;
+  push_cb_called = 1;
+  push_cb_push_id = push_id;
+}
+
+TEST (h3_push_client_recv_promise)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_client_conn_with_peer_control (arena);
+
+  /* Feed SETTINGS from server on peer control stream 3 */
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  uint8_t sbuf[64];
+  size_t slen = build_settings_frame (sbuf, sizeof (sbuf), &settings);
+  SocketHTTP3_Conn_feed_stream (conn, 3, sbuf, slen, 0);
+
+  /* Register push callback */
+  push_cb_called = 0;
+  push_cb_push_id = UINT64_MAX;
+  SocketHTTP3_Conn_on_push (conn, push_callback, NULL);
+
+  /* Create a client request on stream 0 */
+  SocketHTTP3_Request_T req = SocketHTTP3_Request_new (conn);
+  ASSERT_NOT_NULL (req);
+
+  /* Build a response with PUSH_PROMISE before the actual response headers */
+  SocketHTTP_Headers_T promise = make_push_promise_headers (arena);
+  uint8_t pp_frame[4096];
+  size_t pp_len = build_push_promise_frame (arena, 0, promise, pp_frame,
+                                             sizeof (pp_frame));
+  ASSERT (pp_len > 0);
+
+  /* Feed PUSH_PROMISE on request stream 0 */
+  int rc = SocketHTTP3_Conn_feed_stream (conn, 0, pp_frame, pp_len, 0);
+  ASSERT_EQ (0, rc);
+
+  /* Callback should have been invoked */
+  ASSERT_EQ (1, push_cb_called);
+  ASSERT_EQ (0ULL, push_cb_push_id);
+
+  /* Push entry should exist */
+  ASSERT_EQ ((size_t)1, conn->push_count);
+  ASSERT_EQ (H3_PUSH_PROMISED, conn->pushes[0].state);
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_client_recv_stream)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_client_conn_with_peer_control (arena);
+
+  /* Feed SETTINGS */
+  SocketHTTP3_Settings settings;
+  SocketHTTP3_Settings_init (&settings);
+  uint8_t sbuf[64];
+  size_t slen = build_settings_frame (sbuf, sizeof (sbuf), &settings);
+  SocketHTTP3_Conn_feed_stream (conn, 3, sbuf, slen, 0);
+
+  /* Create request + send PUSH_PROMISE for push_id=0 */
+  SocketHTTP3_Request_T req = SocketHTTP3_Request_new (conn);
+  ASSERT_NOT_NULL (req);
+
+  SocketHTTP_Headers_T promise = make_push_promise_headers (arena);
+  uint8_t pp_frame[4096];
+  size_t pp_len = build_push_promise_frame (arena, 0, promise, pp_frame,
+                                             sizeof (pp_frame));
+  SocketHTTP3_Conn_feed_stream (conn, 0, pp_frame, pp_len, 0);
+
+  /* Simulate server push stream (server unidi stream 15): type(0x01) */
+  uint8_t stream_type = 0x01;
+  int rc = SocketHTTP3_Conn_feed_stream (conn, 15, &stream_type, 1, 0);
+  ASSERT_EQ (0, rc);
+
+  /* Feed push_id varint (0) + a HEADERS frame */
+  uint8_t push_data[4096];
+  size_t pos = 0;
+  pos += SocketQUICVarInt_encode (0, push_data + pos,
+                                   sizeof (push_data) - pos);
+
+  /* Build response HEADERS frame */
+  SocketHTTP_Headers_T resp = make_response_headers (arena);
+  uint8_t *qpack_data;
+  size_t qpack_len;
+  h3_qpack_encode_headers (arena, resp, &qpack_data, &qpack_len);
+
+  uint8_t frame_hdr[16];
+  int hdr_len = SocketHTTP3_Frame_write_header (
+      HTTP3_FRAME_HEADERS, qpack_len, frame_hdr, sizeof (frame_hdr));
+  ASSERT (hdr_len > 0);
+  memcpy (push_data + pos, frame_hdr, (size_t)hdr_len);
+  pos += (size_t)hdr_len;
+  memcpy (push_data + pos, qpack_data, qpack_len);
+  pos += qpack_len;
+
+  rc = SocketHTTP3_Conn_feed_stream (conn, 15, push_data, pos, 1);
+  ASSERT_EQ (0, rc);
+
+  /* Push entry should be STREAM_OPENED with a request */
+  ASSERT_EQ (H3_PUSH_STREAM_OPENED, conn->pushes[0].state);
+  ASSERT_NOT_NULL (conn->pushes[0].request);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Full Lifecycle Test
+ * ============================================================================
+ */
+
+TEST (h3_push_full_lifecycle)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  /* Allocate push ID */
+  uint64_t push_id;
+  ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+  ASSERT_EQ (0ULL, push_id);
+
+  /* Send PUSH_PROMISE */
+  SocketHTTP_Headers_T promise = make_push_promise_headers (arena);
+  ASSERT_EQ (0, SocketHTTP3_Conn_send_push_promise (conn, 0, push_id,
+                                                      promise));
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Open push stream */
+  SocketHTTP3_Request_T req
+      = SocketHTTP3_Conn_open_push_stream (conn, push_id);
+  ASSERT_NOT_NULL (req);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Send response headers */
+  SocketHTTP_Headers_T resp = make_response_headers (arena);
+  ASSERT_EQ (0, SocketHTTP3_Request_send_headers (req, resp, 0));
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Send response body */
+  const char *body = "body{}";
+  ASSERT_EQ (0, SocketHTTP3_Request_send_data (req, body, strlen (body), 1));
+  ASSERT (SocketHTTP3_Conn_output_count (conn) > 0);
+
+  /* Verify send state is complete */
+  ASSERT_EQ (H3_REQ_SEND_DONE, SocketHTTP3_Request_send_state (req));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Edge Case Tests
+ * ============================================================================
+ */
+
+TEST (h3_push_null_params)
+{
+  ASSERT_EQ (-1, SocketHTTP3_Conn_allocate_push_id (NULL, NULL));
+  ASSERT_EQ (-1, SocketHTTP3_Conn_send_push_promise (NULL, 0, 0, NULL));
+  ASSERT_NULL (SocketHTTP3_Conn_open_push_stream (NULL, 0));
+  ASSERT_EQ (-1, SocketHTTP3_Conn_cancel_push (NULL, 0));
+  ASSERT_EQ (-1, SocketHTTP3_Conn_send_max_push_id (NULL, 0));
+}
+
+TEST (h3_push_after_goaway)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_with_request (arena, 5);
+
+  /* Shutdown the connection */
+  SocketHTTP3_Conn_shutdown (conn, 0);
+  SocketHTTP3_Conn_drain_output (conn);
+
+  /* Push operations should fail after GOAWAY */
+  uint64_t push_id;
+  ASSERT_NE (0, SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_count_exhaustion)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn
+      = make_server_conn_with_request (arena, H3_MAX_PUSH_STREAMS + 10);
+
+  SocketHTTP_Headers_T headers = make_push_promise_headers (arena);
+
+  /* Allocate and promise all push IDs up to max */
+  for (size_t i = 0; i < H3_MAX_PUSH_STREAMS; i++)
+    {
+      uint64_t push_id;
+      ASSERT_EQ (0, SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+      ASSERT_EQ (0, SocketHTTP3_Conn_send_push_promise (conn, 0, push_id,
+                                                          headers));
+      SocketHTTP3_Conn_drain_output (conn);
+    }
+
+  /* Next allocation should fail */
+  uint64_t push_id;
+  ASSERT_EQ (-(int)H3_ID_ERROR,
+             SocketHTTP3_Conn_allocate_push_id (conn, &push_id));
+
+  Arena_dispose (&arena);
+}
+
+TEST (h3_push_cancel_unknown)
+{
+  Arena_T arena = Arena_new ();
+  SocketHTTP3_Conn_T conn = make_server_conn_push_ready (arena, 5);
+
+  /* Register peer control */
+  SocketHTTP3_StreamMap_register (conn->stream_map, 2,
+                                  H3_STREAM_TYPE_CONTROL);
+
+  /* Feed CANCEL_PUSH for unknown push_id on already-registered control */
+  uint8_t buf[16];
+  size_t len = build_cancel_push_frame (buf, sizeof (buf), 99);
+  ASSERT (len > 0);
+
+  /* Should be silently ignored (no error) */
+  int rc = SocketHTTP3_Conn_feed_stream (conn, 2, buf, len, 0);
+  ASSERT_EQ (0, rc);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}
+
+#else /* !SOCKET_HAS_H3_PUSH */
+
+int
+main (void)
+{
+  return 0;
+}
+
+#endif /* SOCKET_HAS_H3_PUSH */


### PR DESCRIPTION
## Summary
- Implement HTTP/3 server push behind compile-time flag `ENABLE_H3_PUSH` (default OFF)
- Add PUSH_PROMISE frames on request streams, push streams (type 0x01), MAX_PUSH_ID, CANCEL_PUSH
- 22 unit tests covering server push, client reception, cancellation, and edge cases
- All code behind `#ifdef SOCKET_HAS_H3_PUSH` guards — zero impact when disabled

Fixes #3554

## Test plan
- [x] 22 push tests pass with ASan+UBSan+LeakSanitizer
- [x] Full suite (185 tests) passes with push ON
- [x] Full suite (184 tests) passes with push OFF (default)
- [x] No memory leaks detected