### PR TITLE
feat(quic): add RFC 9002 §7 NewReno congestion control

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -476,6 +476,7 @@ set(LIB_SOURCES
     src/quic/SocketQUICFlow.c
     src/quic/SocketQUICAck.c
     src/quic/SocketQUICLoss.c
+    src/quic/SocketQUICCongestion.c
     src/quic/SocketQUICTLS.c
     src/quic/SocketQUICTransport.c
     src/quic/SocketQUICServer.c
@@ -745,6 +746,7 @@ set(QUIC_HEADERS
     include/quic/SocketQUICHandshake.h
     include/quic/SocketQUICAck.h
     include/quic/SocketQUICLoss.h
+    include/quic/SocketQUICCongestion.h
     include/quic/SocketQUICTLS.h
 )
 
@@ -989,6 +991,7 @@ list(APPEND TEST_SOURCES
     test_quic_crypto_frame_encode
     test_quic_ack
     test_quic_loss
+    test_quic_congestion
     test_quic_key_discard
     test_quic_0rtt
 )

--- a/include/quic/SocketQUICCongestion.h
+++ b/include/quic/SocketQUICCongestion.h
@@ -1,0 +1,198 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICCongestion.h
+ * @brief QUIC NewReno Congestion Control (RFC 9002 Section 7).
+ *
+ * Implements NewReno congestion control for QUIC:
+ *   - Slow start with exponential growth
+ *   - Congestion avoidance with linear growth
+ *   - Recovery phase with halved window
+ *   - Persistent congestion detection (Section 7.6)
+ *   - ECN-CE congestion signal handling
+ *
+ * The congestion controller is stateless with respect to bytes_in_flight;
+ * the loss module (SocketQUICLoss) tracks bytes_in_flight. The transport
+ * layer queries both to make send decisions.
+ *
+ * @defgroup quic_congestion QUIC Congestion Control
+ * @{
+ * @see https://www.rfc-editor.org/rfc/rfc9002#section-7
+ */
+
+#ifndef SOCKETQUICCONGESTION_INCLUDED
+#define SOCKETQUICCONGESTION_INCLUDED
+
+#include "core/Arena.h"
+#include "quic/SocketQUICLoss.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* ============================================================================
+ * Types
+ * ============================================================================
+ */
+
+/**
+ * @brief Congestion control phase.
+ */
+typedef enum
+{
+  QUIC_CC_SLOW_START,      /**< Exponential window growth */
+  QUIC_CC_RECOVERY,        /**< Window halved, waiting for recovery */
+  QUIC_CC_CONGESTION_AVOID /**< Linear window growth */
+} SocketQUICCongestion_Phase;
+
+/**
+ * @brief Opaque congestion controller handle.
+ */
+typedef struct SocketQUICCongestion *SocketQUICCongestion_T;
+
+/* ============================================================================
+ * Lifecycle
+ * ============================================================================
+ */
+
+/**
+ * @brief Create a new congestion controller.
+ *
+ * @param arena             Memory arena for allocations.
+ * @param max_datagram_size Maximum datagram size (typically 1200).
+ *
+ * @return New controller, or NULL on failure.
+ */
+extern SocketQUICCongestion_T
+SocketQUICCongestion_new (Arena_T arena, size_t max_datagram_size);
+
+/**
+ * @brief Reset congestion state to initial values.
+ *
+ * @param cc Controller to reset.
+ */
+extern void SocketQUICCongestion_reset (SocketQUICCongestion_T cc);
+
+/* ============================================================================
+ * Sending Gate
+ * ============================================================================
+ */
+
+/**
+ * @brief Check whether a packet can be sent under the congestion window.
+ *
+ * @param cc              Controller to query.
+ * @param bytes_in_flight Current bytes in flight (from loss module).
+ * @param packet_size     Size of packet to send.
+ *
+ * @return Non-zero if the packet can be sent, 0 if blocked.
+ */
+extern int SocketQUICCongestion_can_send (const SocketQUICCongestion_T cc,
+                                          size_t bytes_in_flight,
+                                          size_t packet_size);
+
+/* ============================================================================
+ * Event Notifications
+ * ============================================================================
+ */
+
+/**
+ * @brief Notify controller of acknowledged packets.
+ *
+ * @param cc                  Controller to update.
+ * @param acked_bytes         Total in-flight bytes acknowledged.
+ * @param latest_sent_time_us Sent time of the most recent acked packet.
+ */
+extern void
+SocketQUICCongestion_on_packets_acked (SocketQUICCongestion_T cc,
+                                       size_t acked_bytes,
+                                       uint64_t latest_sent_time_us);
+
+/**
+ * @brief Notify controller of lost packets.
+ *
+ * @param cc                  Controller to update.
+ * @param lost_bytes          Total in-flight bytes lost.
+ * @param latest_sent_time_us Sent time of the most recent lost packet.
+ */
+extern void SocketQUICCongestion_on_packets_lost (SocketQUICCongestion_T cc,
+                                                  size_t lost_bytes,
+                                                  uint64_t latest_sent_time_us);
+
+/**
+ * @brief Notify controller of ECN Congestion Experienced signal.
+ *
+ * @param cc           Controller to update.
+ * @param sent_time_us Sent time of the packet that triggered ECN-CE.
+ */
+extern void SocketQUICCongestion_on_ecn_ce (SocketQUICCongestion_T cc,
+                                            uint64_t sent_time_us);
+
+/**
+ * @brief Notify controller of persistent congestion detection.
+ *
+ * Resets cwnd to minimum (RFC 9002 Section 7.6.2).
+ *
+ * @param cc Controller to update.
+ */
+extern void
+SocketQUICCongestion_on_persistent_congestion (SocketQUICCongestion_T cc);
+
+/* ============================================================================
+ * Query
+ * ============================================================================
+ */
+
+/**
+ * @brief Get current congestion window.
+ */
+extern size_t SocketQUICCongestion_cwnd (const SocketQUICCongestion_T cc);
+
+/**
+ * @brief Get current slow start threshold.
+ */
+extern size_t SocketQUICCongestion_ssthresh (const SocketQUICCongestion_T cc);
+
+/**
+ * @brief Get current congestion control phase.
+ */
+extern SocketQUICCongestion_Phase
+SocketQUICCongestion_phase (const SocketQUICCongestion_T cc);
+
+/* ============================================================================
+ * Persistent Congestion Helper
+ * ============================================================================
+ */
+
+/**
+ * @brief Compute the persistent congestion duration (RFC 9002 Section 7.6.1).
+ *
+ * Duration = (smoothed_rtt + max(4*rttvar, granularity) + max_ack_delay)
+ *            * QUIC_PERSISTENT_CONGESTION_THRESHOLD
+ *
+ * @param rtt              RTT estimation state.
+ * @param max_ack_delay_us Peer's max_ack_delay in microseconds.
+ *
+ * @return Duration in microseconds.
+ */
+extern uint64_t
+SocketQUICCongestion_persistent_duration (const SocketQUICLossRTT_T *rtt,
+                                          uint64_t max_ack_delay_us);
+
+/* ============================================================================
+ * Utilities
+ * ============================================================================
+ */
+
+/**
+ * @brief Get human-readable name for a congestion control phase.
+ */
+extern const char *
+SocketQUICCongestion_phase_name (SocketQUICCongestion_Phase phase);
+
+/** @} */
+
+#endif /* SOCKETQUICCONGESTION_INCLUDED */

--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -157,6 +157,28 @@
 #define QUIC_MAX_CWND (1024 * 1024)
 
 /**
+ * @brief Minimum congestion window in bytes (RFC 9002 Section 7.2).
+ *
+ * 2 * max_datagram_size = 2400 bytes.
+ */
+#define QUIC_MIN_CWND (2 * QUIC_MAX_DATAGRAM_SIZE)
+
+/**
+ * @brief Loss reduction factor numerator (RFC 9002 Section 7.3.2).
+ *
+ * NewReno halves the window on loss: factor = 1/2.
+ */
+#define QUIC_LOSS_REDUCTION_FACTOR_NUM 1
+#define QUIC_LOSS_REDUCTION_FACTOR_DEN 2
+
+/**
+ * @brief Persistent congestion threshold (RFC 9002 Section 7.6).
+ *
+ * Duration = (smoothed_rtt + max(4*rttvar, granularity) + max_ack_delay) * 3.
+ */
+#define QUIC_PERSISTENT_CONGESTION_THRESHOLD 3
+
+/**
  * @brief Initial RTT estimate in microseconds (RFC 9002 Section 6.2.2).
  *
  * Before any RTT measurement, use 333ms as initial estimate.

--- a/include/quic/SocketQUICServer.h
+++ b/include/quic/SocketQUICServer.h
@@ -14,7 +14,7 @@
  *
  * V1 Simplifications (same as client transport):
  * - No Retry/Version Negotiation
- * - No congestion control, retransmission, 0-RTT, migration
+ * - No retransmission, 0-RTT, migration
  * - Fixed 4-byte packet numbers, immediate ACK
  */
 

--- a/include/quic/SocketQUICTransport.h
+++ b/include/quic/SocketQUICTransport.h
@@ -17,7 +17,6 @@
  * frames, and delivers stream data via callback.
  *
  * V1 Simplifications:
- * - No congestion control (send immediately)
  * - No retransmission (detect losses but don't retransmit)
  * - No 0-RTT (always full handshake)
  * - No connection migration (fixed path)

--- a/src/quic/SocketQUICCongestion.c
+++ b/src/quic/SocketQUICCongestion.c
@@ -1,0 +1,318 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketQUICCongestion.c
+ * @brief QUIC NewReno Congestion Control (RFC 9002 Section 7).
+ *
+ * Appendix B of RFC 9002 provides the reference pseudocode.
+ */
+
+#ifdef SOCKET_HAS_TLS
+
+#include "quic/SocketQUICCongestion.h"
+#include "quic/SocketQUICConstants.h"
+#include "core/SocketUtil.h"
+
+#include <string.h>
+#include <time.h>
+
+#undef SOCKET_LOG_COMPONENT
+#define SOCKET_LOG_COMPONENT "QUIC-CC"
+
+/* ============================================================================
+ * Internal Structure
+ * ============================================================================
+ */
+
+struct SocketQUICCongestion
+{
+  Arena_T arena;
+  size_t cwnd;
+  size_t ssthresh;
+  size_t max_datagram_size;
+  SocketQUICCongestion_Phase phase;
+  uint64_t recovery_start_time_us; /**< 0 when not in recovery */
+};
+
+/* ============================================================================
+ * Time Helper
+ * ============================================================================
+ */
+
+static uint64_t
+now_us (void)
+{
+  struct timespec ts;
+  clock_gettime (CLOCK_MONOTONIC, &ts);
+  return (uint64_t)ts.tv_sec * 1000000ULL + (uint64_t)ts.tv_nsec / 1000ULL;
+}
+
+/* ============================================================================
+ * Internal Helpers
+ * ============================================================================
+ */
+
+/**
+ * Check if sent_time falls within the current recovery period.
+ */
+static int
+in_congestion_recovery (const SocketQUICCongestion_T cc, uint64_t sent_time_us)
+{
+  return cc->recovery_start_time_us > 0
+         && sent_time_us <= cc->recovery_start_time_us;
+}
+
+/**
+ * Enter recovery: halve cwnd, set ssthresh, record recovery start.
+ * RFC 9002 Appendix B.6 (OnCongestionEvent).
+ */
+static void
+enter_recovery (SocketQUICCongestion_T cc)
+{
+  size_t new_ssthresh = cc->cwnd * QUIC_LOSS_REDUCTION_FACTOR_NUM
+                        / QUIC_LOSS_REDUCTION_FACTOR_DEN;
+
+  if (new_ssthresh < QUIC_MIN_CWND)
+    new_ssthresh = QUIC_MIN_CWND;
+
+  cc->ssthresh = new_ssthresh;
+  cc->cwnd = new_ssthresh;
+  cc->recovery_start_time_us = now_us ();
+  cc->phase = QUIC_CC_RECOVERY;
+}
+
+/* ============================================================================
+ * Lifecycle
+ * ============================================================================
+ */
+
+SocketQUICCongestion_T
+SocketQUICCongestion_new (Arena_T arena, size_t max_datagram_size)
+{
+  SocketQUICCongestion_T cc;
+
+  if (arena == NULL)
+    return NULL;
+
+  cc = CALLOC (arena, 1, sizeof (*cc));
+  if (cc == NULL)
+    return NULL;
+
+  cc->arena = arena;
+  cc->max_datagram_size
+      = max_datagram_size > 0 ? max_datagram_size : QUIC_MAX_DATAGRAM_SIZE;
+  cc->cwnd = QUIC_INITIAL_CWND;
+  cc->ssthresh = QUIC_MAX_CWND;
+  cc->phase = QUIC_CC_SLOW_START;
+  cc->recovery_start_time_us = 0;
+
+  return cc;
+}
+
+void
+SocketQUICCongestion_reset (SocketQUICCongestion_T cc)
+{
+  if (cc == NULL)
+    return;
+
+  cc->cwnd = QUIC_INITIAL_CWND;
+  cc->ssthresh = QUIC_MAX_CWND;
+  cc->phase = QUIC_CC_SLOW_START;
+  cc->recovery_start_time_us = 0;
+}
+
+/* ============================================================================
+ * Sending Gate
+ * ============================================================================
+ */
+
+int
+SocketQUICCongestion_can_send (const SocketQUICCongestion_T cc,
+                               size_t bytes_in_flight,
+                               size_t packet_size)
+{
+  if (cc == NULL)
+    return 1; /* No CC = allow send */
+
+  return bytes_in_flight + packet_size <= cc->cwnd;
+}
+
+/* ============================================================================
+ * Event Notifications
+ * ============================================================================
+ */
+
+void
+SocketQUICCongestion_on_packets_acked (SocketQUICCongestion_T cc,
+                                       size_t acked_bytes,
+                                       uint64_t latest_sent_time_us)
+{
+  if (cc == NULL || acked_bytes == 0)
+    return;
+
+  /* If in recovery, check if we can exit */
+  if (cc->phase == QUIC_CC_RECOVERY)
+    {
+      if (latest_sent_time_us > cc->recovery_start_time_us)
+        {
+          /* ACK of packet sent after recovery started → exit recovery */
+          cc->recovery_start_time_us = 0;
+          cc->phase = QUIC_CC_CONGESTION_AVOID;
+        }
+      else
+        {
+          /* Still in recovery — no cwnd growth */
+          return;
+        }
+    }
+
+  /* Grow cwnd based on phase */
+  if (cc->phase == QUIC_CC_SLOW_START)
+    {
+      /* Exponential growth: cwnd += acked_bytes */
+      cc->cwnd += acked_bytes;
+
+      /* Cap at ssthresh to transition to congestion avoidance */
+      if (cc->cwnd >= cc->ssthresh)
+        {
+          cc->cwnd = cc->ssthresh;
+          cc->phase = QUIC_CC_CONGESTION_AVOID;
+        }
+    }
+  else
+    {
+      /* Congestion avoidance: linear growth
+       * cwnd += max_datagram_size * acked_bytes / cwnd
+       * (RFC 9002 Appendix B.5)
+       */
+      size_t increment = cc->max_datagram_size * acked_bytes / cc->cwnd;
+      if (increment == 0)
+        increment = 1; /* Ensure at least 1 byte growth */
+      cc->cwnd += increment;
+    }
+
+  /* Cap at maximum */
+  if (cc->cwnd > QUIC_MAX_CWND)
+    cc->cwnd = QUIC_MAX_CWND;
+}
+
+void
+SocketQUICCongestion_on_packets_lost (SocketQUICCongestion_T cc,
+                                      size_t lost_bytes,
+                                      uint64_t latest_sent_time_us)
+{
+  if (cc == NULL || lost_bytes == 0)
+    return;
+
+  /* If the lost packet was sent during recovery, don't re-enter */
+  if (in_congestion_recovery (cc, latest_sent_time_us))
+    return;
+
+  enter_recovery (cc);
+}
+
+void
+SocketQUICCongestion_on_ecn_ce (SocketQUICCongestion_T cc,
+                                uint64_t sent_time_us)
+{
+  if (cc == NULL)
+    return;
+
+  /* ECN-CE treated same as loss for congestion signal */
+  if (in_congestion_recovery (cc, sent_time_us))
+    return;
+
+  enter_recovery (cc);
+}
+
+void
+SocketQUICCongestion_on_persistent_congestion (SocketQUICCongestion_T cc)
+{
+  if (cc == NULL)
+    return;
+
+  /* RFC 9002 Section 7.6.2: reset to minimum window */
+  cc->cwnd = QUIC_MIN_CWND;
+  cc->ssthresh = QUIC_MAX_CWND;
+  cc->recovery_start_time_us = 0;
+  cc->phase = QUIC_CC_SLOW_START;
+}
+
+/* ============================================================================
+ * Query
+ * ============================================================================
+ */
+
+size_t
+SocketQUICCongestion_cwnd (const SocketQUICCongestion_T cc)
+{
+  if (cc == NULL)
+    return 0;
+  return cc->cwnd;
+}
+
+size_t
+SocketQUICCongestion_ssthresh (const SocketQUICCongestion_T cc)
+{
+  if (cc == NULL)
+    return 0;
+  return cc->ssthresh;
+}
+
+SocketQUICCongestion_Phase
+SocketQUICCongestion_phase (const SocketQUICCongestion_T cc)
+{
+  if (cc == NULL)
+    return QUIC_CC_SLOW_START;
+  return cc->phase;
+}
+
+/* ============================================================================
+ * Persistent Congestion Helper
+ * ============================================================================
+ */
+
+uint64_t
+SocketQUICCongestion_persistent_duration (const SocketQUICLossRTT_T *rtt,
+                                          uint64_t max_ack_delay_us)
+{
+  uint64_t pto;
+  uint64_t rttvar_term;
+
+  if (rtt == NULL || !rtt->has_sample)
+    return 0;
+
+  /* PTO base = smoothed_rtt + max(4 * rttvar, granularity) + max_ack_delay */
+  rttvar_term = rtt->rtt_var * 4;
+  if (rttvar_term < QUIC_LOSS_GRANULARITY_US)
+    rttvar_term = QUIC_LOSS_GRANULARITY_US;
+
+  pto = rtt->smoothed_rtt + rttvar_term + max_ack_delay_us;
+
+  return pto * QUIC_PERSISTENT_CONGESTION_THRESHOLD;
+}
+
+/* ============================================================================
+ * Utilities
+ * ============================================================================
+ */
+
+static const char *phase_names[] = {
+  [QUIC_CC_SLOW_START] = "SLOW_START",
+  [QUIC_CC_RECOVERY] = "RECOVERY",
+  [QUIC_CC_CONGESTION_AVOID] = "CONGESTION_AVOIDANCE",
+};
+
+const char *
+SocketQUICCongestion_phase_name (SocketQUICCongestion_Phase phase)
+{
+  if (phase > QUIC_CC_CONGESTION_AVOID)
+    return "UNKNOWN";
+  return phase_names[phase];
+}
+
+#endif /* SOCKET_HAS_TLS */

--- a/src/test/test_quic_congestion.c
+++ b/src/test/test_quic_congestion.c
@@ -1,0 +1,528 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_quic_congestion.c
+ * @brief Unit tests for QUIC NewReno Congestion Control (RFC 9002 §7).
+ */
+
+#include "quic/SocketQUICCongestion.h"
+#include "quic/SocketQUICConstants.h"
+#include "quic/SocketQUICLoss.h"
+#include "core/Arena.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+/* ============================================================================
+ * Initialization Tests
+ * ============================================================================
+ */
+
+TEST (cc_init)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+  ASSERT (cc != NULL);
+
+  ASSERT_EQ (QUIC_INITIAL_CWND, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (QUIC_MAX_CWND, SocketQUICCongestion_ssthresh (cc));
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  Arena_dispose (&arena);
+}
+
+TEST (cc_init_null)
+{
+  SocketQUICCongestion_T cc = SocketQUICCongestion_new (NULL, 1200);
+  ASSERT (cc == NULL);
+
+  /* NULL cc should not crash */
+  ASSERT_EQ (0, SocketQUICCongestion_cwnd (NULL));
+  ASSERT_EQ (0, SocketQUICCongestion_ssthresh (NULL));
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (NULL));
+}
+
+/* ============================================================================
+ * Sending Gate Tests
+ * ============================================================================
+ */
+
+TEST (cc_can_send_under_cwnd)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Initial cwnd = 12000. With 0 bytes in flight, should allow send. */
+  ASSERT (SocketQUICCongestion_can_send (cc, 0, 1200));
+  ASSERT (SocketQUICCongestion_can_send (cc, 10800, 1200));
+
+  Arena_dispose (&arena);
+}
+
+TEST (cc_can_send_blocked)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* bytes_in_flight + packet_size > cwnd → blocked */
+  ASSERT (!SocketQUICCongestion_can_send (cc, QUIC_INITIAL_CWND, 1));
+  ASSERT (!SocketQUICCongestion_can_send (cc, 11000, 1200));
+
+  /* NULL cc → allow (no CC = always allow) */
+  ASSERT (SocketQUICCongestion_can_send (NULL, 999999, 1200));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Slow Start Tests
+ * ============================================================================
+ */
+
+TEST (cc_slow_start_growth)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  size_t initial_cwnd = SocketQUICCongestion_cwnd (cc);
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  /* ACK 1200 bytes — cwnd should increase by 1200 */
+  SocketQUICCongestion_on_packets_acked (cc, 1200, 1000);
+  ASSERT_EQ (initial_cwnd + 1200, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  /* ACK another 2400 bytes */
+  SocketQUICCongestion_on_packets_acked (cc, 2400, 2000);
+  ASSERT_EQ (initial_cwnd + 1200 + 2400, SocketQUICCongestion_cwnd (cc));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Loss / Recovery Tests
+ * ============================================================================
+ */
+
+TEST (cc_slow_start_exit_on_loss)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Initial cwnd = 12000 */
+  size_t cwnd_before = SocketQUICCongestion_cwnd (cc);
+
+  /* Report loss — should enter recovery, halve cwnd */
+  SocketQUICCongestion_on_packets_lost (cc, 1200, 500);
+
+  ASSERT_EQ (QUIC_CC_RECOVERY, SocketQUICCongestion_phase (cc));
+
+  /* cwnd should be cwnd_before / 2, but at least QUIC_MIN_CWND */
+  size_t expected_cwnd = cwnd_before / 2;
+  if (expected_cwnd < QUIC_MIN_CWND)
+    expected_cwnd = QUIC_MIN_CWND;
+  ASSERT_EQ (expected_cwnd, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (expected_cwnd, SocketQUICCongestion_ssthresh (cc));
+
+  Arena_dispose (&arena);
+}
+
+TEST (cc_recovery_no_cwnd_change)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Enter recovery */
+  SocketQUICCongestion_on_packets_lost (cc, 1200, 500);
+  size_t cwnd_in_recovery = SocketQUICCongestion_cwnd (cc);
+  ASSERT_EQ (QUIC_CC_RECOVERY, SocketQUICCongestion_phase (cc));
+
+  /* Further losses during recovery (sent before recovery) don't reduce cwnd */
+  SocketQUICCongestion_on_packets_lost (cc, 1200, 400);
+  ASSERT_EQ (cwnd_in_recovery, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (QUIC_CC_RECOVERY, SocketQUICCongestion_phase (cc));
+
+  /* ACKs of pre-recovery packets don't grow cwnd */
+  SocketQUICCongestion_on_packets_acked (cc, 1200, 300);
+  ASSERT_EQ (cwnd_in_recovery, SocketQUICCongestion_cwnd (cc));
+
+  Arena_dispose (&arena);
+}
+
+TEST (cc_recovery_exit)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Enter recovery at time ~now */
+  SocketQUICCongestion_on_packets_lost (cc, 1200, 500);
+  ASSERT_EQ (QUIC_CC_RECOVERY, SocketQUICCongestion_phase (cc));
+  size_t recovery_cwnd = SocketQUICCongestion_cwnd (cc);
+
+  /* ACK of packet sent AFTER recovery start → exit to congestion avoidance */
+  /* Use a very large time that is guaranteed to be after recovery_start */
+  uint64_t future_sent_time = UINT64_MAX / 2;
+  SocketQUICCongestion_on_packets_acked (cc, 1200, future_sent_time);
+
+  ASSERT_EQ (QUIC_CC_CONGESTION_AVOID, SocketQUICCongestion_phase (cc));
+  /* cwnd should have grown linearly from recovery_cwnd */
+  ASSERT (SocketQUICCongestion_cwnd (cc) > recovery_cwnd);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Congestion Avoidance Tests
+ * ============================================================================
+ */
+
+TEST (cc_congestion_avoidance_linear)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Force into congestion avoidance: loss then ack of post-recovery packet */
+  SocketQUICCongestion_on_packets_lost (cc, 1200, 100);
+  SocketQUICCongestion_on_packets_acked (cc, 1200, UINT64_MAX / 2);
+  ASSERT_EQ (QUIC_CC_CONGESTION_AVOID, SocketQUICCongestion_phase (cc));
+
+  size_t cwnd_before = SocketQUICCongestion_cwnd (cc);
+
+  /* ACK one full cwnd worth of data */
+  SocketQUICCongestion_on_packets_acked (cc, cwnd_before, UINT64_MAX / 2 + 1);
+
+  /* Linear growth: cwnd += max_datagram_size * acked_bytes / cwnd
+   * = 1200 * cwnd / cwnd = 1200 */
+  ASSERT_EQ (cwnd_before + QUIC_MAX_DATAGRAM_SIZE,
+             SocketQUICCongestion_cwnd (cc));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * ECN Tests
+ * ============================================================================
+ */
+
+TEST (cc_ecn_triggers_recovery)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  size_t cwnd_before = SocketQUICCongestion_cwnd (cc);
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  /* ECN-CE signal → same as loss */
+  SocketQUICCongestion_on_ecn_ce (cc, 500);
+
+  ASSERT_EQ (QUIC_CC_RECOVERY, SocketQUICCongestion_phase (cc));
+  ASSERT_EQ (cwnd_before / 2, SocketQUICCongestion_cwnd (cc));
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Persistent Congestion Tests
+ * ============================================================================
+ */
+
+TEST (cc_persistent_congestion)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Grow cwnd first */
+  SocketQUICCongestion_on_packets_acked (cc, 12000, 1000);
+  ASSERT (SocketQUICCongestion_cwnd (cc) > QUIC_MIN_CWND);
+
+  /* Persistent congestion → minimum window */
+  SocketQUICCongestion_on_persistent_congestion (cc);
+  ASSERT_EQ (QUIC_MIN_CWND, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  Arena_dispose (&arena);
+}
+
+TEST (cc_min_cwnd)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Repeatedly lose packets to drive cwnd down */
+  for (int i = 0; i < 20; i++)
+    {
+      /* Each loss triggers recovery if not already in recovery.
+       * Use increasing sent_time to ensure we're past recovery_start. */
+      uint64_t t = (uint64_t)(i + 1) * 1000000000ULL;
+      SocketQUICCongestion_on_packets_lost (cc, 1200, t);
+      /* Exit recovery by acking a post-recovery packet */
+      SocketQUICCongestion_on_packets_acked (cc, 1200, t + 1000000000ULL);
+    }
+
+  /* cwnd should never go below QUIC_MIN_CWND */
+  ASSERT (SocketQUICCongestion_cwnd (cc) >= QUIC_MIN_CWND);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Persistent Duration Calculation Tests
+ * ============================================================================
+ */
+
+TEST (cc_persistent_duration)
+{
+  SocketQUICLossRTT_T rtt;
+  SocketQUICLoss_init_rtt (&rtt);
+
+  /* Set known RTT values */
+  SocketQUICLoss_update_rtt (&rtt, 100000, 0, 0);
+  /* After first sample: smoothed_rtt=100000, rtt_var=50000 */
+
+  uint64_t max_ack_delay = 25000; /* 25ms */
+
+  uint64_t duration
+      = SocketQUICCongestion_persistent_duration (&rtt, max_ack_delay);
+
+  /* PTO = smoothed_rtt + max(4*rtt_var, granularity) + max_ack_delay
+   *     = 100000 + max(200000, 1000) + 25000
+   *     = 100000 + 200000 + 25000 = 325000
+   * persistent = PTO * 3 = 975000 */
+  ASSERT_EQ (975000, duration);
+
+  /* No RTT sample → returns 0 */
+  SocketQUICLossRTT_T no_sample;
+  SocketQUICLoss_init_rtt (&no_sample);
+  ASSERT_EQ (0, SocketQUICCongestion_persistent_duration (&no_sample, 25000));
+
+  /* NULL → returns 0 */
+  ASSERT_EQ (0, SocketQUICCongestion_persistent_duration (NULL, 25000));
+}
+
+/* ============================================================================
+ * Reset Tests
+ * ============================================================================
+ */
+
+TEST (cc_reset)
+{
+  Arena_T arena = Arena_new ();
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+
+  /* Modify state */
+  SocketQUICCongestion_on_packets_acked (cc, 12000, 1000);
+  SocketQUICCongestion_on_packets_lost (cc, 1200, 500);
+
+  /* Reset */
+  SocketQUICCongestion_reset (cc);
+  ASSERT_EQ (QUIC_INITIAL_CWND, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (QUIC_MAX_CWND, SocketQUICCongestion_ssthresh (cc));
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  /* Reset NULL should not crash */
+  SocketQUICCongestion_reset (NULL);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Phase Name Tests
+ * ============================================================================
+ */
+
+TEST (cc_phase_name)
+{
+  ASSERT_EQ (0,
+             strcmp ("SLOW_START",
+                     SocketQUICCongestion_phase_name (QUIC_CC_SLOW_START)));
+  ASSERT_EQ (
+      0,
+      strcmp ("RECOVERY", SocketQUICCongestion_phase_name (QUIC_CC_RECOVERY)));
+  ASSERT_EQ (
+      0,
+      strcmp ("CONGESTION_AVOIDANCE",
+              SocketQUICCongestion_phase_name (QUIC_CC_CONGESTION_AVOID)));
+  ASSERT_EQ (0, strcmp ("UNKNOWN", SocketQUICCongestion_phase_name (99)));
+}
+
+/* ============================================================================
+ * Integration Test: Loss + Congestion Wired Together
+ * ============================================================================
+ */
+
+static size_t integration_acked_bytes;
+static uint64_t integration_latest_acked_time;
+static size_t integration_lost_bytes;
+static uint64_t integration_latest_lost_time;
+
+static void
+integration_acked_cb (const SocketQUICLossSentPacket_T *pkt, void *ctx)
+{
+  (void)ctx;
+  if (pkt->in_flight)
+    integration_acked_bytes += pkt->sent_bytes;
+  if (pkt->sent_time_us > integration_latest_acked_time)
+    integration_latest_acked_time = pkt->sent_time_us;
+}
+
+static void
+integration_lost_cb (const SocketQUICLossSentPacket_T *pkt, void *ctx)
+{
+  (void)ctx;
+  if (pkt->in_flight)
+    integration_lost_bytes += pkt->sent_bytes;
+  if (pkt->sent_time_us > integration_latest_lost_time)
+    integration_latest_lost_time = pkt->sent_time_us;
+}
+
+TEST (cc_integration_send_ack_cycle)
+{
+  Arena_T arena = Arena_new ();
+
+  /* Create loss state and congestion controller */
+  SocketQUICLossState_T loss = SocketQUICLoss_new (arena, 0, 25000);
+  ASSERT (loss != NULL);
+
+  SocketQUICCongestion_T cc
+      = SocketQUICCongestion_new (arena, QUIC_MAX_DATAGRAM_SIZE);
+  ASSERT (cc != NULL);
+
+  SocketQUICLossRTT_T rtt;
+  SocketQUICLoss_init_rtt (&rtt);
+
+  uint64_t base_time = 1000000;
+
+  /* Send 5 packets */
+  for (uint64_t i = 0; i < 5; i++)
+    {
+      SocketQUICLoss_on_packet_sent (
+          loss, i, base_time + i * 10000, 1200, 1, 1, 0);
+    }
+
+  ASSERT_EQ (6000, SocketQUICLoss_bytes_in_flight (loss));
+  size_t initial_cwnd = SocketQUICCongestion_cwnd (cc);
+
+  /* ACK packets 0-4 */
+  integration_acked_bytes = 0;
+  integration_latest_acked_time = 0;
+  integration_lost_bytes = 0;
+  integration_latest_lost_time = 0;
+
+  SocketQUICFrameAck_T ack;
+  memset (&ack, 0, sizeof (ack));
+  ack.largest_ack = 4;
+  ack.ack_delay = 1000;
+  ack.first_range = 4; /* Range [0, 4] */
+
+  size_t acked_count = 0, lost_count = 0;
+  SocketQUICLoss_on_ack_received (loss,
+                                  &rtt,
+                                  &ack,
+                                  base_time + 100000,
+                                  integration_acked_cb,
+                                  integration_lost_cb,
+                                  NULL,
+                                  &acked_count,
+                                  &lost_count);
+
+  ASSERT_EQ (5, acked_count);
+  ASSERT_EQ (6000, integration_acked_bytes);
+  ASSERT_EQ (0, SocketQUICLoss_bytes_in_flight (loss));
+
+  /* Notify congestion controller */
+  if (integration_acked_bytes > 0)
+    SocketQUICCongestion_on_packets_acked (
+        cc, integration_acked_bytes, integration_latest_acked_time);
+
+  /* In slow start, cwnd should have grown by acked_bytes */
+  ASSERT_EQ (initial_cwnd + 6000, SocketQUICCongestion_cwnd (cc));
+  ASSERT_EQ (QUIC_CC_SLOW_START, SocketQUICCongestion_phase (cc));
+
+  /* Now send more packets and simulate loss */
+  for (uint64_t i = 5; i < 15; i++)
+    {
+      SocketQUICLoss_on_packet_sent (
+          loss, i, base_time + 200000 + i * 10000, 1200, 1, 1, 0);
+    }
+
+  size_t cwnd_before_loss = SocketQUICCongestion_cwnd (cc);
+
+  /* ACK packet 14 only (skip 5-11 → they become lost by packet threshold) */
+  integration_acked_bytes = 0;
+  integration_latest_acked_time = 0;
+  integration_lost_bytes = 0;
+  integration_latest_lost_time = 0;
+
+  memset (&ack, 0, sizeof (ack));
+  ack.largest_ack = 14;
+  ack.ack_delay = 1000;
+  ack.first_range = 2; /* ACK range [12, 14] */
+
+  SocketQUICLoss_on_ack_received (loss,
+                                  &rtt,
+                                  &ack,
+                                  base_time + 400000,
+                                  integration_acked_cb,
+                                  integration_lost_cb,
+                                  NULL,
+                                  &acked_count,
+                                  &lost_count);
+
+  /* Some packets should be declared lost (pn <= 14 - 3 = 11 and not acked) */
+  ASSERT (lost_count > 0);
+  ASSERT (integration_lost_bytes > 0);
+
+  /* Notify CC of acked and lost */
+  if (integration_acked_bytes > 0)
+    SocketQUICCongestion_on_packets_acked (
+        cc, integration_acked_bytes, integration_latest_acked_time);
+  if (integration_lost_bytes > 0)
+    SocketQUICCongestion_on_packets_lost (
+        cc, integration_lost_bytes, integration_latest_lost_time);
+
+  /* Should have entered recovery and halved cwnd */
+  ASSERT_EQ (QUIC_CC_RECOVERY, SocketQUICCongestion_phase (cc));
+  ASSERT (SocketQUICCongestion_cwnd (cc) < cwnd_before_loss);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Main
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures ();
+}


### PR DESCRIPTION
## Summary

- Implement NewReno congestion control (RFC 9002 §7) for both client and server QUIC transports
- Wire `on_packet_sent` into transport send paths so the loss module tracks `bytes_in_flight`
- Add full ACK range processing to loss module (previously only handled `largest_acked`)
- Congestion window gate in 1-RTT send paths blocks sends when cwnd is exceeded

## Details

**New module** (`SocketQUICCongestion`):
- Slow start: cwnd += acked_bytes
- Congestion avoidance: cwnd += mds * acked_bytes / cwnd
- Recovery: cwnd halved on loss, no further reduction until recovery exit
- Persistent congestion (§7.6): cwnd reset to QUIC_MIN_CWND
- ECN-CE: triggers recovery same as packet loss

**Loss module changes** (`SocketQUICLoss`):
- `on_ack_received` now takes full `SocketQUICFrameAck_T` and processes all ACK ranges
- Added `acked_callback` for CC notification of acknowledged packets
- Added `first_rtt_sample_time` to RTT state for persistent congestion calculation

**Transport integration** (client + server):
- `on_packet_sent` called after every successful send
- ACK-only packets use `in_flight=0` (RFC 9002 §7)
- ACK handler notifies CC of acked/lost bytes and checks ECN-CE/persistent congestion

## Test plan

- [x] 16 new tests in `test_quic_congestion` (init, can_send, slow start, loss/recovery, congestion avoidance, ECN, persistent congestion, reset, integration)
- [x] Existing `test_quic_loss` updated for new signature — all pass
- [x] Full suite: 186/186 tests pass with ASan + UBSan

Fixes #3574