### PR TITLE
docs: add HTTP/3, QUIC, QPACK, and compression guides

### DIFF
--- a/docs/COMPRESSION.md
+++ b/docs/COMPRESSION.md
@@ -1,0 +1,247 @@
+# DEFLATE and gzip Compression
+
+Native DEFLATE (RFC 1951) and gzip (RFC 1952) implementation with no external dependencies. Used for HTTP Content-Encoding and WebSocket permessage-deflate (RFC 7692).
+
+## Build
+
+Compression is built by default:
+
+```bash
+cmake -S . -B build
+cmake --build build -j$(nproc)
+```
+
+Build options:
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `ENABLE_HTTP_COMPRESSION` | ON | HTTP gzip/deflate Content-Encoding |
+| `ENABLE_NATIVE_DEFLATE` | ON | Use native DEFLATE (no zlib dependency) |
+| `ENABLE_WS_NATIVE_DEFLATE` | ON | Use native DEFLATE for WebSocket |
+
+## Headers
+
+```c
+#include "deflate/SocketDeflate.h"
+```
+
+## Decompression (Inflate)
+
+### Streaming API
+
+```c
+Arena_T arena = Arena_new();
+
+/* Create inflater with bomb protection (max 10MB output) */
+SocketDeflate_Inflater_T inf = SocketDeflate_Inflater_new(arena, 10 * 1024 * 1024);
+
+uint8_t output[4096];
+size_t consumed, written;
+
+SocketDeflate_Result rc = SocketDeflate_Inflater_inflate(inf,
+    compressed_data, compressed_len, &consumed,
+    output, sizeof(output), &written);
+
+switch (rc) {
+case DEFLATE_OK:
+    /* Final block complete — all done */
+    break;
+case DEFLATE_INCOMPLETE:
+    /* Need more input data */
+    break;
+case DEFLATE_OUTPUT_FULL:
+    /* Output buffer full — call again with more space */
+    break;
+case DEFLATE_ERROR_BOMB:
+    /* Decompression bomb detected */
+    break;
+default:
+    fprintf(stderr, "Error: %s\n", SocketDeflate_result_string(rc));
+    break;
+}
+
+/* Query state */
+int done = SocketDeflate_Inflater_finished(inf);
+size_t total_out = SocketDeflate_Inflater_total_out(inf);
+size_t total_in = SocketDeflate_Inflater_total_in(inf);
+
+/* Reset for reuse */
+SocketDeflate_Inflater_reset(inf);
+
+Arena_dispose(&arena);
+```
+
+### Multi-chunk Decompression
+
+```c
+SocketDeflate_Inflater_T inf = SocketDeflate_Inflater_new(arena, 0);
+size_t offset = 0;
+
+while (!SocketDeflate_Inflater_finished(inf) && offset < input_len) {
+    size_t consumed, written;
+    SocketDeflate_Result rc = SocketDeflate_Inflater_inflate(inf,
+        input + offset, input_len - offset, &consumed,
+        output + out_pos, output_cap - out_pos, &written);
+
+    offset += consumed;
+    out_pos += written;
+
+    if (rc == DEFLATE_ERROR || rc == DEFLATE_ERROR_BOMB)
+        break;
+}
+```
+
+## Compression (Deflate)
+
+### Compression Levels
+
+| Level | Enum | Strategy | Block Type |
+|-------|------|----------|------------|
+| 0 | `DEFLATE_LEVEL_STORE` | No compression | Stored blocks only |
+| 1 | `DEFLATE_LEVEL_FASTEST` | Fastest | Fixed Huffman |
+| 3 | `DEFLATE_LEVEL_FAST` | Fast | Fixed Huffman |
+| 6 | `DEFLATE_LEVEL_DEFAULT` | Balanced | Dynamic Huffman |
+| 9 | `DEFLATE_LEVEL_BEST` | Best compression | Dynamic Huffman |
+
+### Streaming API
+
+```c
+Arena_T arena = Arena_new();
+
+/* Create deflater at default level */
+SocketDeflate_Deflater_T def = SocketDeflate_Deflater_new(arena, DEFLATE_LEVEL_DEFAULT);
+
+uint8_t output[8192];
+size_t consumed, written;
+
+/* Compress data */
+SocketDeflate_Deflater_deflate(def,
+    input_data, input_len, &consumed,
+    output, sizeof(output), &written);
+
+/* Finish (flush remaining data as final block) */
+SocketDeflate_Deflater_finish(def, output + written, sizeof(output) - written, &written);
+
+/* Reset for reuse */
+SocketDeflate_Deflater_reset(def);
+
+Arena_dispose(&arena);
+```
+
+### Buffer Sizing
+
+```c
+/* Compute maximum compressed size for buffer allocation */
+size_t max_size = SocketDeflate_compress_bound(input_len);
+uint8_t *buf = Arena_alloc(arena, max_size);
+```
+
+### Sync Flush (WebSocket)
+
+For WebSocket permessage-deflate with context takeover:
+
+```c
+/* Compress message without final block marker */
+SocketDeflate_Deflater_deflate(def, message, msg_len, &consumed,
+    output, output_cap, &written);
+
+/* Flush with sync marker (0x00 0x00 0xFF 0xFF) */
+size_t flush_written;
+SocketDeflate_Deflater_sync_flush(def,
+    output + written, output_cap - written, &flush_written);
+written += flush_written;
+
+/* Strip 4-byte trailer for WebSocket transmission */
+written -= 4;
+
+/* Deflater state preserved — next message reuses LZ77 dictionary */
+```
+
+## gzip (RFC 1952)
+
+gzip wraps DEFLATE with a header (metadata) and trailer (CRC-32 + size).
+
+### Parse Header
+
+```c
+SocketDeflate_GzipHeader header;
+SocketDeflate_Result rc = SocketDeflate_gzip_parse_header(data, len, &header);
+
+if (rc == DEFLATE_OK) {
+    printf("Method: %d\n", header.method);        /* 8 = DEFLATE */
+    printf("OS: %s\n", SocketDeflate_gzip_os_string(header.os));
+    if (header.filename)
+        printf("Filename: %s\n", header.filename);
+    printf("DEFLATE data starts at offset %zu\n", header.header_size);
+}
+```
+
+### Verify Trailer
+
+```c
+/* After decompression, verify the 8-byte trailer */
+uint32_t crc = SocketDeflate_crc32(0, decompressed_data, decompressed_len);
+
+SocketDeflate_Result rc = SocketDeflate_gzip_verify_trailer(
+    trailer_bytes,     /* 8 bytes: CRC32 + ISIZE (little-endian) */
+    crc,               /* Computed CRC-32 */
+    (uint32_t)decompressed_len);  /* Original size mod 2^32 */
+```
+
+### CRC-32
+
+```c
+/* Single-pass CRC */
+uint32_t crc = SocketDeflate_crc32(0, data, len);
+
+/* Incremental CRC */
+uint32_t crc = 0;
+crc = SocketDeflate_crc32(crc, chunk1, chunk1_len);
+crc = SocketDeflate_crc32(crc, chunk2, chunk2_len);
+
+/* Combine two CRCs (for parallel computation) */
+uint32_t combined = SocketDeflate_crc32_combine(crc_a, crc_b, len_b);
+```
+
+## HTTP Content-Encoding
+
+When `ENABLE_HTTP_COMPRESSION` is ON, the HTTP client/server layers handle Content-Encoding automatically:
+
+- **Client**: Sends `Accept-Encoding: gzip, deflate` and decompresses responses
+- **Server**: Compresses responses when client supports it
+
+## WebSocket permessage-deflate (RFC 7692)
+
+When `ENABLE_WS_NATIVE_DEFLATE` is ON, WebSocket compression uses this native DEFLATE implementation:
+
+| Mode | Compression | LZ77 Dictionary |
+|------|-------------|-----------------|
+| Context takeover (default) | `sync_flush()` (BFINAL=0) | Preserved across messages |
+| No context takeover | `finish()` (BFINAL=1) | Reset between messages |
+
+The 4-byte trailer (`0x00 0x00 0xFF 0xFF`) is automatically stripped on send and restored on receive per RFC 7692 Section 7.2.1.
+
+## Error Codes
+
+| Code | Description |
+|------|-------------|
+| `DEFLATE_OK` | Success |
+| `DEFLATE_INCOMPLETE` | Need more input |
+| `DEFLATE_OUTPUT_FULL` | Output buffer full |
+| `DEFLATE_ERROR` | General error |
+| `DEFLATE_ERROR_INVALID_BTYPE` | Invalid block type (BTYPE=11) |
+| `DEFLATE_ERROR_INVALID_CODE` | Invalid Huffman code |
+| `DEFLATE_ERROR_INVALID_DISTANCE` | Invalid distance code (30-31) |
+| `DEFLATE_ERROR_DISTANCE_TOO_FAR` | Distance exceeds window |
+| `DEFLATE_ERROR_HUFFMAN_TREE` | Invalid Huffman tree |
+| `DEFLATE_ERROR_BOMB` | Decompression bomb detected |
+| `DEFLATE_ERROR_GZIP_MAGIC` | Invalid gzip magic bytes |
+| `DEFLATE_ERROR_GZIP_METHOD` | Unsupported compression method |
+| `DEFLATE_ERROR_GZIP_CRC` | CRC-32 mismatch |
+| `DEFLATE_ERROR_GZIP_SIZE` | Original size mismatch |
+
+## See Also
+
+- [WebSocket](WEBSOCKET.md) — WebSocket permessage-deflate
+- [HTTP](HTTP.md) — HTTP Content-Encoding
+- [HTTP/3](HTTP3.md) — HTTP/3 (uses QPACK, not DEFLATE for headers)

--- a/docs/HTTP3.md
+++ b/docs/HTTP3.md
@@ -1,0 +1,417 @@
+# HTTP/3 (RFC 9114)
+
+HTTP/3 runs HTTP semantics over QUIC (RFC 9000), replacing TCP+TLS with UDP-based transport. This library provides complete client and server APIs.
+
+## Build Requirements
+
+```bash
+cmake -S . -B build -DENABLE_TLS=ON
+cmake --build build -j$(nproc)
+
+# Optional: enable server push (disabled by default)
+cmake -S . -B build -DENABLE_TLS=ON -DENABLE_H3_PUSH=ON
+```
+
+Requires OpenSSL or LibreSSL with TLS 1.3 support.
+
+## Architecture
+
+```
+Application
+    │
+    ├── SocketHTTP3_Client_T  (or SocketHTTP3_Server_T)
+    │       │
+    │       ├── SocketHTTP3_Conn_T      (HTTP/3 framing + connection lifecycle)
+    │       │       ├── Stream Map       (request/control/QPACK streams)
+    │       │       ├── QPACK            (header compression)
+    │       │       └── Output Queue     (wire data staging)
+    │       │
+    │       └── SocketQUICTransport_T    (or SocketQUICServer_T)
+    │               ├── TLS 1.3          (handshake, key derivation)
+    │               ├── Loss Detection   (RTT, PTO, packet tracking)
+    │               ├── Congestion Ctrl  (NewReno cwnd gating)
+    │               └── UDP Socket
+    │
+    └── Arena_T  (memory lifecycle)
+```
+
+The **output queue model** bridges HTTP/3 and QUIC: HTTP/3 operations generate wire data into an output queue; the transport layer drains and sends it over UDP.
+
+## Client API
+
+### Headers
+
+```c
+#include "http/SocketHTTP3-client.h"
+```
+
+### Quick Start
+
+```c
+Arena_T arena = Arena_new();
+
+/* Create client with defaults */
+SocketHTTP3_Client_T client = SocketHTTP3_Client_new(arena, NULL);
+
+/* Connect (blocking QUIC handshake + H3 init) */
+if (SocketHTTP3_Client_connect(client, "example.com", 443) < 0) {
+    fprintf(stderr, "Connect failed\n");
+    Arena_dispose(&arena);
+    return -1;
+}
+
+/* Synchronous GET request */
+SocketHTTP_Headers_T resp_headers;
+int status;
+void *body;
+size_t body_len;
+
+int rc = SocketHTTP3_Client_request(client,
+    HTTP_METHOD_GET, "/index.html",
+    NULL,            /* no extra headers */
+    NULL, 0,         /* no body */
+    &resp_headers, &status, &body, &body_len);
+
+if (rc == 0) {
+    printf("Status: %d\n", status);
+    printf("Body: %.*s\n", (int)body_len, (char *)body);
+}
+
+/* Cleanup */
+SocketHTTP3_Client_close(client);
+Arena_dispose(&arena);
+```
+
+### Configuration
+
+```c
+SocketHTTP3_ClientConfig config;
+SocketHTTP3_ClientConfig_defaults(&config);
+
+/* QUIC transport */
+config.idle_timeout_ms = 30000;           /* Connection idle timeout */
+config.max_stream_data = 262144;          /* 256KB per-stream flow control */
+config.initial_max_streams_bidi = 100;    /* Max concurrent requests */
+
+/* TLS */
+config.ca_file = "/path/to/ca-bundle.crt"; /* NULL = system CAs */
+config.verify_peer = 1;                     /* Verify server certificate */
+
+/* Timeouts */
+config.connect_timeout_ms = 5000;         /* QUIC handshake timeout */
+config.request_timeout_ms = 30000;        /* Per-request timeout */
+
+/* HTTP/3 settings (sent in SETTINGS frame) */
+config.h3_settings.max_field_section_size = 65536;
+config.h3_settings.qpack_max_table_capacity = 4096;
+config.h3_settings.qpack_blocked_streams = 100;
+
+SocketHTTP3_Client_T client = SocketHTTP3_Client_new(arena, &config);
+```
+
+### Streaming API
+
+For fine-grained control over request/response lifecycle:
+
+```c
+/* Create a streaming request */
+SocketHTTP3_Request_T req = SocketHTTP3_Client_new_request(client);
+
+/* Build and send headers */
+SocketHTTP_Headers_T hdrs = SocketHTTP_Headers_new(arena);
+SocketHTTP_Headers_add(hdrs, ":method", "POST");
+SocketHTTP_Headers_add(hdrs, ":path", "/api/data");
+SocketHTTP_Headers_add(hdrs, ":scheme", "https");
+SocketHTTP_Headers_add(hdrs, ":authority", "example.com");
+SocketHTTP_Headers_add(hdrs, "content-type", "application/json");
+
+SocketHTTP3_Request_send_headers(req, hdrs, /*end_stream=*/0);
+SocketHTTP3_Client_flush(client);  /* Send queued data */
+
+/* Send body */
+const char *body = "{\"key\": \"value\"}";
+SocketHTTP3_Request_send_data(req, body, strlen(body), /*end_stream=*/1);
+SocketHTTP3_Client_flush(client);
+
+/* Poll for response */
+while (SocketHTTP3_Request_recv_state(req) < H3_REQ_RECV_HEADERS_RECEIVED) {
+    SocketHTTP3_Client_poll(client, 1000);
+}
+
+/* Read response headers */
+SocketHTTP_Headers_T resp;
+int status;
+SocketHTTP3_Request_recv_headers(req, &resp, &status);
+
+/* Read response body */
+char buf[4096];
+int end = 0;
+while (!end) {
+    SocketHTTP3_Client_poll(client, 1000);
+    ssize_t n = SocketHTTP3_Request_recv_data(req, buf, sizeof(buf), &end);
+    if (n > 0)
+        fwrite(buf, 1, n, stdout);
+}
+```
+
+### Alt-Svc Discovery
+
+Detect HTTP/3 support from HTTP/1.1 or HTTP/2 responses:
+
+```c
+/* Parse Alt-Svc header from prior HTTP response */
+char alt_host[256];
+uint16_t h3_port = SocketHTTP3_parse_alt_svc(
+    "h3=\":443\"; ma=86400", alt_host, sizeof(alt_host));
+
+if (h3_port > 0) {
+    /* Connect via HTTP/3 */
+    SocketHTTP3_Client_connect(client, alt_host[0] ? alt_host : host, h3_port);
+}
+```
+
+## Server API
+
+### Headers
+
+```c
+#include "http/SocketHTTP3-server.h"
+```
+
+### Quick Start
+
+```c
+Arena_T arena = Arena_new();
+
+/* Configure server */
+SocketHTTP3_ServerConfig config;
+SocketHTTP3_ServerConfig_defaults(&config);
+config.bind_addr = "0.0.0.0";
+config.port = 443;
+config.cert_file = "/path/to/cert.pem";
+config.key_file = "/path/to/key.pem";
+
+/* Create and start */
+SocketHTTP3_Server_T server = SocketHTTP3_Server_new(arena, &config);
+
+/* Register request handler */
+SocketHTTP3_Server_on_request(server, handle_request, NULL);
+
+/* Start listening */
+if (SocketHTTP3_Server_start(server) < 0) {
+    fprintf(stderr, "Failed to start server\n");
+    Arena_dispose(&arena);
+    return -1;
+}
+
+/* Event loop */
+while (running) {
+    SocketHTTP3_Server_poll(server, 100);
+}
+
+/* Graceful shutdown */
+SocketHTTP3_Server_shutdown(server);
+SocketHTTP3_Server_close(server);
+Arena_dispose(&arena);
+```
+
+### Request Handler
+
+```c
+static void
+handle_request(SocketHTTP3_Request_T req,
+               const SocketHTTP_Headers_T headers,
+               void *userdata)
+{
+    /* Read request info from headers */
+    const char *method = SocketHTTP_Headers_get(headers, ":method");
+    const char *path = SocketHTTP_Headers_get(headers, ":path");
+
+    /* Build response headers */
+    Arena_T arena = /* get from server context */;
+    SocketHTTP_Headers_T resp = SocketHTTP_Headers_new(arena);
+    SocketHTTP_Headers_add(resp, ":status", "200");
+    SocketHTTP_Headers_add(resp, "content-type", "text/html");
+
+    /* Send response */
+    const char *body = "<h1>Hello from HTTP/3</h1>";
+    SocketHTTP3_Request_send_headers(req, resp, /*end_stream=*/0);
+    SocketHTTP3_Request_send_data(req, body, strlen(body), /*end_stream=*/1);
+}
+```
+
+### Server Configuration
+
+```c
+SocketHTTP3_ServerConfig config;
+SocketHTTP3_ServerConfig_defaults(&config);
+
+config.bind_addr = "0.0.0.0";        /* Bind address */
+config.port = 443;                     /* Listen port */
+config.cert_file = "server.crt";       /* TLS certificate (required) */
+config.key_file = "server.key";        /* TLS private key (required) */
+config.idle_timeout_ms = 30000;        /* Per-connection idle timeout */
+config.initial_max_streams_bidi = 100; /* Max concurrent requests per conn */
+config.max_stream_data = 262144;       /* 256KB per-stream window */
+config.max_connections = 256;          /* Max concurrent connections */
+config.max_header_size = 65536;        /* Max decoded header size */
+```
+
+## Request/Response Lifecycle
+
+Both client and server use `SocketHTTP3_Request_T` for request/response exchange:
+
+### Send State Machine
+
+```
+IDLE → HEADERS_SENT → BODY_SENT → TRAILERS_SENT → DONE
+```
+
+- `send_headers(req, hdrs, end_stream)` — Send initial HEADERS frame
+- `send_data(req, data, len, end_stream)` — Send DATA frame
+- `send_trailers(req, trailers)` — Send trailing HEADERS (implicitly closes)
+
+### Receive State Machine
+
+```
+IDLE → HEADERS_RECEIVED → BODY_RECEIVING → COMPLETE
+```
+
+- `recv_headers(req, &hdrs, &status)` — Read decoded headers
+- `recv_data(req, buf, len, &end_stream)` — Read DATA payload
+
+### Header Validation
+
+Headers are validated per RFC 9114 Section 4.3:
+
+**Request headers** (client → server):
+- Required pseudo-headers: `:method`, `:path`, `:scheme`
+- `:authority` recommended
+- No connection-specific headers (`Connection`, `Transfer-Encoding`, `Upgrade`)
+
+**Response headers** (server → client):
+- Required: `:status`
+- Status `101` (Switching Protocols) is prohibited
+- No connection-specific headers
+
+## Server Push (Optional)
+
+Build with `-DENABLE_H3_PUSH=ON`. Server push allows pre-emptive responses.
+
+```c
+#include "http/SocketHTTP3-push.h"
+
+/* Server: push a resource during request handling */
+static void
+handle_request(SocketHTTP3_Request_T req,
+               const SocketHTTP_Headers_T headers,
+               void *userdata)
+{
+    SocketHTTP3_Conn_T conn = /* get from server context */;
+
+    /* Allocate a push ID */
+    uint64_t push_id;
+    if (SocketHTTP3_Conn_allocate_push_id(conn, &push_id) < 0)
+        return;  /* Client hasn't sent MAX_PUSH_ID */
+
+    /* Send PUSH_PROMISE on the request stream */
+    SocketHTTP_Headers_T promised = SocketHTTP_Headers_new(arena);
+    SocketHTTP_Headers_add(promised, ":method", "GET");
+    SocketHTTP_Headers_add(promised, ":path", "/style.css");
+    SocketHTTP_Headers_add(promised, ":scheme", "https");
+    SocketHTTP_Headers_add(promised, ":authority", "example.com");
+
+    uint64_t req_stream = SocketHTTP3_Request_stream_id(req);
+    SocketHTTP3_Conn_send_push_promise(conn, req_stream, push_id, promised);
+
+    /* Open push stream and send the pushed response */
+    SocketHTTP3_Request_T push = SocketHTTP3_Conn_open_push_stream(conn, push_id);
+
+    SocketHTTP_Headers_T push_resp = SocketHTTP_Headers_new(arena);
+    SocketHTTP_Headers_add(push_resp, ":status", "200");
+    SocketHTTP_Headers_add(push_resp, "content-type", "text/css");
+
+    SocketHTTP3_Request_send_headers(push, push_resp, 0);
+    SocketHTTP3_Request_send_data(push, css_data, css_len, 1);
+
+    /* Continue with the original response... */
+}
+```
+
+**Client-side push handling:**
+
+```c
+/* Register callback for incoming push promises */
+SocketHTTP3_Conn_on_push(conn, on_push_promise, userdata);
+
+/* Send MAX_PUSH_ID to allow server pushes */
+SocketHTTP3_Conn_send_max_push_id(conn, 10);
+
+/* Cancel an unwanted push */
+SocketHTTP3_Conn_cancel_push(conn, push_id);
+```
+
+## Connection Lifecycle
+
+### States
+
+```
+IDLE → OPEN → GOAWAY_SENT/GOAWAY_RECV → CLOSING → CLOSED
+```
+
+- **IDLE**: Created but not initialized
+- **OPEN**: Critical streams opened, SETTINGS exchanged
+- **GOAWAY_SENT/RECV**: Graceful shutdown in progress
+- **CLOSING**: Both sides have sent GOAWAY
+- **CLOSED**: Connection terminated
+
+### Critical Streams
+
+Each HTTP/3 connection opens three unidirectional streams:
+
+| Stream | Client IDs | Server IDs | Purpose |
+|--------|-----------|-----------|---------|
+| Control | 2 | 3 | SETTINGS, GOAWAY, MAX_PUSH_ID |
+| QPACK Encoder | 6 | 7 | Dynamic table updates |
+| QPACK Decoder | 10 | 11 | Acknowledgments |
+
+## Error Codes
+
+| Code | Name | Meaning |
+|------|------|---------|
+| 0x0100 | `H3_NO_ERROR` | Graceful close |
+| 0x0101 | `H3_GENERAL_PROTOCOL_ERROR` | Protocol violation |
+| 0x0102 | `H3_INTERNAL_ERROR` | Internal error |
+| 0x0103 | `H3_STREAM_CREATION_ERROR` | Stream creation failed |
+| 0x0104 | `H3_CLOSED_CRITICAL_STREAM` | Required stream closed |
+| 0x0105 | `H3_FRAME_UNEXPECTED` | Frame on wrong stream |
+| 0x0106 | `H3_FRAME_ERROR` | Malformed frame |
+| 0x0107 | `H3_EXCESSIVE_LOAD` | Resource exhaustion |
+| 0x0108 | `H3_ID_ERROR` | Invalid ID |
+| 0x0109 | `H3_SETTINGS_ERROR` | Bad settings |
+| 0x010A | `H3_MISSING_SETTINGS` | No SETTINGS received |
+| 0x010B | `H3_REQUEST_REJECTED` | Request not processed |
+| 0x010C | `H3_REQUEST_CANCELLED` | Request cancelled |
+| 0x010D | `H3_REQUEST_INCOMPLETE` | Partial request |
+| 0x010E | `H3_MESSAGE_ERROR` | Malformed message |
+| 0x010F | `H3_CONNECT_ERROR` | CONNECT failure |
+| 0x0110 | `H3_VERSION_FALLBACK` | Retry with HTTP/1.1 |
+
+## V1 Simplifications
+
+The transport layer has documented simplifications that don't prevent HTTP/3 from functioning:
+
+- **No retransmission** — Lost packets detected but not retransmitted
+- **No 0-RTT** — Always full QUIC handshake
+- **No connection migration** — Fixed network path
+- **Immediate ACK** — No delayed ACK optimization
+- **Fixed 4-byte packet numbers**
+- **One QUIC packet per UDP datagram** (no coalescing)
+
+## See Also
+
+- [QUIC Transport](QUIC.md) — Underlying QUIC transport layer
+- [QPACK](QPACK.md) — Header compression
+- [COMPRESSION](COMPRESSION.md) — DEFLATE/gzip compression
+- [TLS Configuration](TLS-CONFIG.md) — TLS settings
+- [HTTP/1.1 and HTTP/2](HTTP.md) — Earlier HTTP versions

--- a/docs/QPACK.md
+++ b/docs/QPACK.md
@@ -1,0 +1,159 @@
+# QPACK Header Compression (RFC 9204)
+
+QPACK compresses HTTP headers for HTTP/3. Unlike HPACK (HTTP/2), QPACK avoids head-of-line blocking by using separate encoder/decoder streams.
+
+## Overview
+
+QPACK uses three components:
+1. **Static table** — 99 pre-defined header entries (RFC 9204 Appendix A)
+2. **Dynamic table** — Connection-scoped table of recently used headers
+3. **Encoder/decoder streams** — Unidirectional QUIC streams for table synchronization
+
+```
+Encoder                              Decoder
+   │                                    │
+   ├── Encoder Stream (type 0x02) ────→ │  (table updates)
+   │                                    │
+   │ ←──── Decoder Stream (type 0x03) ──┤  (acknowledgments)
+   │                                    │
+   ├── HEADERS frame on request ──────→ │  (compressed headers)
+   │                                    │
+```
+
+## Settings
+
+QPACK behavior is negotiated via HTTP/3 SETTINGS:
+
+| Setting | ID | Default | Description |
+|---------|-----|---------|-------------|
+| `QPACK_MAX_TABLE_CAPACITY` | 0x01 | 0 | Maximum dynamic table size in bytes |
+| `QPACK_BLOCKED_STREAMS` | 0x07 | 0 | Max streams that can be blocked on table updates |
+
+```c
+/* Configure via HTTP/3 settings */
+SocketHTTP3_Settings settings;
+SocketHTTP3_Settings_init(&settings);
+settings.qpack_max_table_capacity = 4096;  /* 4KB dynamic table */
+settings.qpack_blocked_streams = 100;       /* Allow 100 blocked streams */
+```
+
+## Index Addressing (RFC 9204 Section 3.2)
+
+QPACK uses four index types:
+
+| Type | Base | Direction | Usage |
+|------|------|-----------|-------|
+| **Absolute** | 0 = first insertion | Monotonically increasing | Internal tracking |
+| **Encoder-relative** | 0 = most recent | Decreasing from insertion point | Encoder stream |
+| **Field-relative** | 0 = Base - 1 | Decreasing from field section Base | Field sections |
+| **Post-base** | 0 = Base | Increasing from Base | Entries added during encoding |
+
+## Encoder Stream Instructions (Section 4.3)
+
+The encoder stream carries table modification instructions:
+
+```c
+/* Set dynamic table capacity */
+SocketQPACK_EncoderStream_write_capacity(enc, 4096);
+
+/* Insert with name reference (static or dynamic) */
+SocketQPACK_EncoderStream_write_insert_nameref(enc,
+    /*is_static=*/1, /*name_index=*/1,
+    "example.com", 11);
+
+/* Insert with literal name */
+SocketQPACK_EncoderStream_write_insert_literal(enc,
+    "x-custom", 8, "value", 5);
+
+/* Duplicate existing entry */
+SocketQPACK_EncoderStream_write_duplicate(enc, /*index=*/0);
+```
+
+## Decoder Stream Instructions (Section 4.4)
+
+The decoder stream carries acknowledgments:
+
+```c
+/* Acknowledge a field section (frees references) */
+SocketQPACK_DecoderStream_write_section_ack(dec, stream_id);
+
+/* Cancel a stream (free references without processing) */
+SocketQPACK_DecoderStream_write_stream_cancel(dec, stream_id);
+
+/* Increment Known Received Count */
+SocketQPACK_DecoderStream_write_insert_count_inc(dec, increment);
+```
+
+## Field Section Encoding (Section 4.5)
+
+### Prefix
+
+Every encoded field section begins with a prefix:
+
+```c
+/* Encode prefix (Required Insert Count + Base) */
+SocketQPACK_encode_prefix(buf, buflen, &written,
+    required_insert_count, base, max_entries);
+
+/* Decode prefix */
+SocketQPACK_decode_prefix(buf, buflen, &consumed,
+    &required_insert_count, &base, max_entries);
+```
+
+### Representation Types
+
+Six encoding modes are available, chosen based on whether the header exists in the static/dynamic table:
+
+| Type | Prefix Bits | Description |
+|------|-------------|-------------|
+| Indexed (static) | `1` + `1` | Reference static table entry |
+| Indexed (dynamic) | `1` + `0` | Reference dynamic table entry |
+| Indexed post-base | `0001` | Entry inserted during this encoding |
+| Literal with name ref (static) | `01` + `N` + `1` | Static name, literal value |
+| Literal with name ref (dynamic) | `01` + `N` + `0` | Dynamic name, literal value |
+| Literal with post-base name | `0000` | Post-base name, literal value |
+| Literal with literal name | `001` | Both name and value are literal |
+
+## Dynamic Table
+
+### Capacity
+
+The dynamic table has a maximum capacity set by `QPACK_MAX_TABLE_CAPACITY`. Each entry occupies:
+
+```
+entry_size = len(name) + len(value) + 32
+```
+
+The 32-byte overhead accounts for internal tracking. When the table is full, oldest entries are evicted.
+
+### Entry Lifecycle
+
+1. **Insertion** — Encoder adds entry via encoder stream instruction
+2. **Reference** — Field sections reference entries by index
+3. **Acknowledgment** — Decoder acknowledges field sections via decoder stream
+4. **Eviction** — Oldest entries removed when capacity exceeded
+
+## Blocked Streams
+
+When a field section references dynamic table entries that haven't been received yet, the stream is "blocked" until the encoder stream delivers the required insertions.
+
+The `QPACK_BLOCKED_STREAMS` setting limits how many streams can be in this state. The encoder respects this limit when choosing whether to use dynamic table references.
+
+## Error Codes
+
+| Code | Name | Trigger |
+|------|------|---------|
+| 0x0200 | `QPACK_DECOMPRESSION_FAILED` | Field section decode failure |
+| 0x0201 | `QPACK_ENCODER_STREAM_ERROR` | Invalid encoder stream instruction |
+| 0x0202 | `QPACK_DECODER_STREAM_ERROR` | Invalid decoder stream instruction |
+
+## Integration with HTTP/3
+
+QPACK is used automatically by `SocketHTTP3_Request_send_headers()` and `SocketHTTP3_Request_recv_headers()`. The connection layer manages encoder/decoder streams transparently.
+
+For most applications, you do not need to interact with QPACK directly — just configure the settings and the HTTP/3 layer handles the rest.
+
+## See Also
+
+- [HTTP/3](HTTP3.md) — HTTP/3 protocol
+- [HTTP/1.1 and HTTP/2](HTTP.md) — HPACK for HTTP/2

--- a/docs/QUIC.md
+++ b/docs/QUIC.md
@@ -1,0 +1,364 @@
+# QUIC Transport (RFC 9000)
+
+QUIC provides reliable, multiplexed transport over UDP with built-in TLS 1.3 encryption. This library implements QUIC v1 with client and server transport APIs.
+
+## Build Requirements
+
+```bash
+cmake -S . -B build -DENABLE_TLS=ON
+cmake --build build -j$(nproc)
+```
+
+Requires OpenSSL or LibreSSL with TLS 1.3 support.
+
+## Architecture
+
+```
+SocketQUICTransport_T / SocketQUICServer_T
+    │
+    ├── Handshake (SocketQUICHandshake + SocketQUICTLS)
+    │       └── TLS 1.3 via OpenSSL (ALPN, transport params)
+    │
+    ├── Packet Protection (SocketQUICCrypto)
+    │       ├── AEAD: AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305
+    │       └── Header Protection: AES-ECB / ChaCha20 masks
+    │
+    ├── Frames (SocketQUICFrame)
+    │       └── 22 standard frame types + DATAGRAM
+    │
+    ├── Streams (SocketQUICStream + SocketQUICFlow)
+    │       ├── Bidirectional / Unidirectional
+    │       └── Connection + stream flow control
+    │
+    ├── Loss Detection (SocketQUICLoss)
+    │       ├── RTT estimation (smoothed_rtt, rttvar, min_rtt)
+    │       ├── Packet/time threshold detection
+    │       └── Probe Timeout (PTO)
+    │
+    ├── Congestion Control (SocketQUICCongestion)
+    │       ├── NewReno: slow start, congestion avoidance, recovery
+    │       ├── Persistent congestion (§7.6)
+    │       └── ECN-CE handling
+    │
+    └── UDP Socket
+```
+
+## Client Transport
+
+### Headers
+
+```c
+#include "quic/SocketQUICTransport.h"
+```
+
+### Quick Start
+
+```c
+Arena_T arena = Arena_new();
+
+/* Create transport with defaults */
+SocketQUICTransport_T t = SocketQUICTransport_new(arena, NULL);
+
+/* Set stream data callback */
+SocketQUICTransport_set_stream_callback(t, on_stream_data, userdata);
+
+/* Connect (blocking QUIC handshake) */
+if (SocketQUICTransport_connect(t, "example.com", 443) < 0) {
+    fprintf(stderr, "QUIC connect failed\n");
+    Arena_dispose(&arena);
+    return -1;
+}
+
+/* Open a bidirectional stream */
+uint64_t stream_id = SocketQUICTransport_open_bidi_stream(t);
+
+/* Send data */
+SocketQUICTransport_send_stream(t, stream_id,
+    (const uint8_t *)"Hello", 5, /*fin=*/0);
+
+/* Poll for responses */
+while (SocketQUICTransport_is_connected(t)) {
+    SocketQUICTransport_poll(t, 1000);
+}
+
+/* Close */
+SocketQUICTransport_close(t);
+Arena_dispose(&arena);
+```
+
+### Configuration
+
+```c
+SocketQUICTransportConfig config;
+SocketQUICTransportConfig_defaults(&config);
+
+config.idle_timeout_ms = 30000;           /* Connection idle timeout */
+config.max_stream_data = 262144;          /* 256KB per-stream window */
+config.initial_max_data = 1048576;        /* 1MB connection window */
+config.initial_max_streams_bidi = 100;    /* Max concurrent bidi streams */
+config.connect_timeout_ms = 5000;         /* Handshake timeout */
+config.alpn = "h3";                       /* ALPN protocol */
+config.ca_file = NULL;                    /* NULL = system CAs */
+config.verify_peer = 1;                   /* Verify server certificate */
+
+SocketQUICTransport_T t = SocketQUICTransport_new(arena, &config);
+```
+
+### Stream Callback
+
+```c
+static void
+on_stream_data(uint64_t stream_id,
+               const uint8_t *data,
+               size_t len,
+               int fin,
+               void *userdata)
+{
+    printf("Stream %lu: %zu bytes%s\n",
+           stream_id, len, fin ? " (FIN)" : "");
+    /* Process data... */
+}
+```
+
+## Server Transport
+
+### Headers
+
+```c
+#include "quic/SocketQUICServer.h"
+```
+
+### Quick Start
+
+```c
+Arena_T arena = Arena_new();
+
+/* Configure server */
+SocketQUICServerConfig config;
+SocketQUICServerConfig_defaults(&config);
+config.bind_addr = "0.0.0.0";
+config.port = 443;
+config.cert_file = "server.crt";
+config.key_file = "server.key";
+
+/* Create and start */
+SocketQUICServer_T server = SocketQUICServer_new(arena, &config);
+
+SocketQUICServer_set_callbacks(server, on_connection, on_stream, userdata);
+
+if (SocketQUICServer_listen(server) < 0) {
+    fprintf(stderr, "Listen failed\n");
+    Arena_dispose(&arena);
+    return -1;
+}
+
+/* Event loop */
+while (running) {
+    SocketQUICServer_poll(server, 100);
+}
+
+SocketQUICServer_close(server);
+Arena_dispose(&arena);
+```
+
+### Server Callbacks
+
+```c
+static void
+on_connection(QUICServerConn_T conn, void *userdata)
+{
+    printf("New QUIC connection\n");
+}
+
+static void
+on_stream(QUICServerConn_T conn,
+          uint64_t stream_id,
+          const uint8_t *data,
+          size_t len,
+          int fin,
+          void *userdata)
+{
+    printf("Stream %lu: %zu bytes\n", stream_id, len);
+
+    /* Echo back */
+    SocketQUICServer_send_stream(conn, stream_id, data, len, fin);
+}
+```
+
+### Server Configuration
+
+```c
+SocketQUICServerConfig config;
+SocketQUICServerConfig_defaults(&config);
+
+config.bind_addr = "0.0.0.0";             /* Bind address */
+config.port = 443;                          /* Listen port */
+config.cert_file = "server.crt";            /* TLS certificate (required) */
+config.key_file = "server.key";             /* TLS private key (required) */
+config.idle_timeout_ms = 30000;             /* Per-connection idle timeout */
+config.max_stream_data = 262144;            /* 256KB per-stream window */
+config.initial_max_data = 1048576;          /* 1MB connection window */
+config.initial_max_streams_bidi = 100;      /* Max concurrent streams */
+config.alpn = "h3";                         /* ALPN protocol */
+config.max_connections = 256;               /* Max concurrent connections */
+```
+
+## Streams
+
+QUIC multiplexes data over independent streams within a single connection.
+
+### Stream Types
+
+| Type | ID Pattern | Initiator | Example IDs |
+|------|-----------|-----------|-------------|
+| Client bidi | 4n | Client | 0, 4, 8, 12 |
+| Server bidi | 4n+1 | Server | 1, 5, 9, 13 |
+| Client unidi | 4n+2 | Client | 2, 6, 10, 14 |
+| Server unidi | 4n+3 | Server | 3, 7, 11, 15 |
+
+### Opening Streams
+
+```c
+/* Client opens bidirectional stream: 0, 4, 8, ... */
+uint64_t id = SocketQUICTransport_open_bidi_stream(t);
+if (id == UINT64_MAX)
+    /* Error: stream limit reached */
+```
+
+### Sending Data
+
+```c
+/* Send with FIN=0 (more data to come) */
+SocketQUICTransport_send_stream(t, stream_id, data, len, 0);
+
+/* Send with FIN=1 (end of stream) */
+SocketQUICTransport_send_stream(t, stream_id, final_data, final_len, 1);
+```
+
+## Flow Control
+
+QUIC enforces flow control at two levels:
+
+- **Connection level**: Total bytes across all streams (controlled by `initial_max_data`)
+- **Stream level**: Bytes per stream (controlled by `max_stream_data`)
+
+Both are configured via transport parameters and updated via `MAX_DATA` / `MAX_STREAM_DATA` frames.
+
+## Loss Detection (RFC 9002)
+
+### RTT Estimation
+
+The loss module tracks:
+- **smoothed_rtt**: Exponentially weighted moving average
+- **rttvar**: RTT variance for timeout calculations
+- **min_rtt**: Minimum observed RTT
+
+### Packet Loss Detection
+
+Two mechanisms detect lost packets:
+- **Packet threshold**: A packet is lost if 3 later packets have been acknowledged
+- **Time threshold**: A packet is lost if 9/8 * max(smoothed_rtt, latest_rtt) has elapsed since it was sent
+
+### Probe Timeout (PTO)
+
+```
+PTO = smoothed_rtt + max(4 * rttvar, 1ms) + max_ack_delay
+```
+
+PTO triggers when no ACK is received, with exponential backoff.
+
+## Congestion Control (RFC 9002 Section 7)
+
+NewReno congestion control gates all 1-RTT packet sends:
+
+### Phases
+
+| Phase | Window Growth | Trigger |
+|-------|--------------|---------|
+| **Slow Start** | cwnd += acked_bytes | Initial phase |
+| **Recovery** | cwnd frozen | Packet loss detected |
+| **Congestion Avoidance** | cwnd += mds * acked / cwnd | Recovery exit |
+
+### Key Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| Initial cwnd | 12000 bytes | 10 * max_datagram_size |
+| Min cwnd | 2400 bytes | 2 * max_datagram_size |
+| Max cwnd | 1MB | Upper bound |
+| Loss reduction | 1/2 | Multiplicative decrease factor |
+| Persistent congestion threshold | 3 | PTO multiplier for persistent detection |
+
+### Persistent Congestion
+
+If lost packets span longer than `3 * (smoothed_rtt + max(4*rttvar, 1ms) + max_ack_delay)` with no ACKs between them, the congestion window resets to minimum (2400 bytes) and returns to slow start.
+
+### ECN Support
+
+The congestion controller handles ECN Congestion Experienced (ECN-CE) signals, which trigger the same recovery entry as packet loss. ACK frames with ECN counts are processed and compared against previous counts.
+
+## Connection ID Management
+
+Each connection uses opaque Connection IDs (CIDs) for routing:
+
+- Default CID length: 8 bytes
+- Multiple CIDs per connection (max 8)
+- NEW_CONNECTION_ID / RETIRE_CONNECTION_ID frames for rotation
+- Server demuxes by Destination CID
+
+## Packet Types
+
+| Type | Header | Encryption Level | Usage |
+|------|--------|-----------------|-------|
+| Initial | Long | Initial keys (from DCID) | Handshake start |
+| Handshake | Long | Handshake keys | TLS completion |
+| 1-RTT | Short | Application keys | Data transfer |
+
+## Frame Types
+
+All 22 standard QUIC frame types are implemented:
+
+| Frame | Type | Purpose |
+|-------|------|---------|
+| PADDING | 0x00 | Padding for amplification protection |
+| PING | 0x01 | Keep-alive / RTT probe |
+| ACK | 0x02-03 | Acknowledge received packets |
+| RESET_STREAM | 0x04 | Abort stream sending |
+| STOP_SENDING | 0x05 | Request stream abort |
+| CRYPTO | 0x06 | TLS handshake data |
+| NEW_TOKEN | 0x07 | Address validation token |
+| STREAM | 0x08-0f | Application data |
+| MAX_DATA | 0x10 | Connection flow control |
+| MAX_STREAM_DATA | 0x11 | Stream flow control |
+| MAX_STREAMS | 0x12-13 | Stream limit |
+| DATA_BLOCKED | 0x14 | Flow control blocked |
+| STREAM_DATA_BLOCKED | 0x15 | Stream flow control blocked |
+| STREAMS_BLOCKED | 0x16-17 | Stream limit blocked |
+| NEW_CONNECTION_ID | 0x18 | Supply new CID |
+| RETIRE_CONNECTION_ID | 0x19 | Retire old CID |
+| PATH_CHALLENGE | 0x1a | Path validation |
+| PATH_RESPONSE | 0x1b | Path validation response |
+| CONNECTION_CLOSE | 0x1c-1d | Close connection |
+| HANDSHAKE_DONE | 0x1e | Server confirms handshake |
+| DATAGRAM | 0x30-31 | Unreliable datagram |
+
+## V1 Simplifications
+
+These are explicitly documented and planned for future versions:
+
+| Feature | Status | Impact |
+|---------|--------|--------|
+| Retransmission | Detect only | Lost packets not retransmitted |
+| 0-RTT | Infrastructure ready | Always full handshake |
+| Connection migration | Module exists | Fixed path only |
+| PMTU discovery | Not implemented | 1200-byte minimum assumed |
+| Delayed ACK | Not implemented | Immediate ACK (more overhead) |
+| Coalesced packets | Not implemented | One QUIC packet per UDP datagram |
+| CID rotation | Implemented | Not used in V1 transport |
+| Version negotiation | Not implemented | QUIC v1 only |
+
+## See Also
+
+- [HTTP/3](HTTP3.md) — HTTP/3 over QUIC
+- [TLS Configuration](TLS-CONFIG.md) — TLS/DTLS settings
+- [QPACK](QPACK.md) — HTTP/3 header compression


### PR DESCRIPTION
## Summary

- Add `docs/HTTP3.md` — HTTP/3 client/server APIs, request lifecycle, server push, error codes
- Add `docs/QUIC.md` — QUIC transport, streams, flow control, loss detection, congestion control  
- Add `docs/QPACK.md` — Header compression, dynamic table, encoder/decoder streams
- Add `docs/COMPRESSION.md` — DEFLATE/gzip APIs, compression levels, HTTP/WebSocket integration

These were the four major gaps identified in user-facing documentation.

## Test plan

- [x] Documentation only — no code changes
- [x] Cross-references between docs verified

Fixes #3576