### PR TITLE
fix: comprehensive security audit fixes across 16 files

### DIFF
--- a/include/core/SocketSecurity.h
+++ b/include/core/SocketSecurity.h
@@ -378,7 +378,8 @@ SocketSecurity_has_compression (void)
 static inline int
 SocketSecurity_has_control_chars (const char *data, size_t len)
 {
-  assert (data != NULL);
+  if (data == NULL)
+    return 1; /* NULL is unsafe — treat as containing control chars */
   for (size_t i = 0; i < len; i++)
     {
       unsigned char c = (unsigned char)data[i];

--- a/src/http/h2/SocketHTTP2-connection.c
+++ b/src/http/h2/SocketHTTP2-connection.c
@@ -656,7 +656,9 @@ SocketHTTP2_Conn_settings (SocketHTTP2_Conn_T conn,
 
   assert (conn);
 
-  payload_len = count * HTTP2_SETTING_ENTRY_SIZE;
+  if (__builtin_mul_overflow (
+          count, (size_t)HTTP2_SETTING_ENTRY_SIZE, &payload_len))
+    return -1;
   payload = Arena_alloc (conn->arena, payload_len, __FILE__, __LINE__);
   if (!payload)
     return -1;
@@ -735,7 +737,9 @@ SocketHTTP2_Conn_goaway (SocketHTTP2_Conn_T conn,
 
   assert (conn);
 
-  payload_len = HTTP2_GOAWAY_HEADER_SIZE + debug_len;
+  if (__builtin_add_overflow (
+          (size_t)HTTP2_GOAWAY_HEADER_SIZE, debug_len, &payload_len))
+    return -1;
   payload = Arena_alloc (conn->arena, payload_len, __FILE__, __LINE__);
   if (!payload)
     return -1;

--- a/src/http/h3/SocketHTTP3-frame.c
+++ b/src/http/h3/SocketHTTP3-frame.c
@@ -140,6 +140,8 @@ SocketHTTP3_Settings_parse (const uint8_t *buf,
         }
       if (seen_count < MAX_SETTINGS_IDS)
         seen_ids[seen_count++] = id;
+      else
+        return -(int)H3_SETTINGS_ERROR; /* too many settings to track */
 
       /* GREASE values: silently ignore (RFC 9114 §7.2.4.1) */
       if (H3_IS_GREASE (id))

--- a/src/pool/SocketPool-core.c
+++ b/src/pool/SocketPool-core.c
@@ -903,14 +903,11 @@ SocketPool_enable_reconnect (T pool,
   {
     create_reconnect_context (conn, host, port, policy);
   }
-  EXCEPT (SocketReconnect_Failed)
+  FINALLY
   {
     POOL_UNLOCK (pool);
-    RERAISE;
   }
   END_TRY;
-
-  POOL_UNLOCK (pool);
 
   log_reconnect_enabled (host, port);
 }

--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -358,6 +358,10 @@ encrypt_aead_payload (const uint8_t *packet,
   int outlen;
   SocketQUICInitial_Result result = QUIC_INITIAL_ERROR_CRYPTO;
 
+  /* Validate sizes before casting to int for OpenSSL */
+  if (header_len > INT_MAX || payload_len > INT_MAX)
+    return QUIC_INITIAL_ERROR_BUFFER;
+
   /* Create cipher context for encryption */
   ctx = EVP_CIPHER_CTX_new ();
   if (ctx == NULL)
@@ -426,6 +430,10 @@ decrypt_aead_payload (const uint8_t *packet,
   EVP_CIPHER_CTX *ctx = NULL;
   int outlen;
   SocketQUICInitial_Result result = QUIC_INITIAL_ERROR_CRYPTO;
+
+  /* Validate sizes before casting to int for OpenSSL */
+  if (header_len > INT_MAX || payload_len > INT_MAX)
+    return QUIC_INITIAL_ERROR_BUFFER;
 
   /* Create cipher context for decryption */
   ctx = EVP_CIPHER_CTX_new ();

--- a/src/tls/SocketTLSContext-verify.c
+++ b/src/tls/SocketTLSContext-verify.c
@@ -42,7 +42,7 @@ SOCKET_DECLARE_MODULE_EXCEPTION (SocketTLSContext);
  */
 #ifndef SOCKET_TLS_LEGACY_CIPHER_LIST
 #define SOCKET_TLS_LEGACY_CIPHER_LIST \
-  "HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA"
+  "HIGH:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!SRP:!CAMELLIA:!CBC"
 #endif
 
 static int internal_verify_callback (int pre_ok, X509_STORE_CTX *x509_ctx);


### PR DESCRIPTION
## Summary

Comprehensive security hardening from a full codebase audit. Fixes 25+ findings across all major modules:

- **HTTP/1.1 request smuggling**: CL+TE conflict detection now unconditional; proper token-boundary TE parsing
- **HPACK bomb protection**: check runs before output buffer write; fixed missing return (UB)
- **DEFLATE hardening**: bomb ratio uses overflow-safe multiplication; fixed RFC 1951 canonical code bug; thread-safe fixed table init via pthread_once; gzip FEXTRA overflow fix
- **HTTP/3 buffer overflow**: overflow guards on stream_buf_append/h3_growbuf_append; allocation cap at 256MB
- **QUIC crypto**: packet number bounds check (62-bit max); INT_MAX validation for OpenSSL casts
- **DNS cache UAF**: hold mutex during result copy instead of copy-then-unlock
- **HTTP/2 overflow**: safe arithmetic for SETTINGS and GOAWAY frame sizes
- **Pool mutex leak**: FINALLY block catches all exception types, not just SocketReconnect_Failed
- **TLS**: exclude CBC cipher modes from legacy list
- **Core**: reduce base64 scan to 4KB; volatile secure_compare; rate limit clock jump rejection; NULL-safe control char check

16 files changed, 330 insertions, 182 deletions. All 188 tests pass with ASan+UBSan.

Fixes #3578

## Test plan
- [x] Full test suite passes (188/188) with ASAN_OPTIONS=detect_leaks=1:abort_on_error=1
- [x] All sanitizers enabled (AddressSanitizer + UndefinedBehaviorSanitizer)
- [x] No new warnings introduced
- [x] clang-format applied to all modified files