### PR TITLE
fix(security): harden DNS/TLS/HTTP3 and pool cleanup paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -107,3 +107,4 @@ clean.md
 .claude/
 CLAUDE.md
 GEMINI.md
+AGENTS.md

--- a/include/pool/SocketPool-private.h
+++ b/include/pool/SocketPool-private.h
@@ -539,6 +539,7 @@ struct T
   Connection_T active_head;       /**< Head of active connection list */
   Connection_T active_tail;       /**< Tail of active connection list */
   Socket_T *cleanup_buffer;       /**< Buffer for cleanup operations */
+  size_t cleanup_buffer_capacity; /**< Allocated entries in cleanup_buffer */
   size_t maxconns;                /**< Maximum connections */
   size_t bufsize;                 /**< Buffer size per connection */
   size_t count;                   /**< Active connection count */


### PR DESCRIPTION
## Summary
- validate DNS UDP response source IP/port and query tuple before accepting replies
- enforce HTTP/3 field-section size limits for received headers
- require configured client hostname verification before TLS handshake
- enforce full OCSP verification in Must-Staple path
- make pool cleanup buffer resizable/capacity-checked to prevent overflow after resize
- include local assistant ignore update: add `AGENTS.md` to `.gitignore`

## Validation
- `cmake --build build -j$(nproc)`
- `cd build && ctest -j$(nproc) --output-on-failure -R "test_dns_transport|test_socketpool$|test_tls_ocsp|test_http3_request|test_tls_handshake|test_dns_over_tls"`

## Risk
- Security hardening changes touch DNS transport, TLS verification, HTTP/3 request parsing, and pool resize/cleanup behavior.
- Build and targeted regressions passed locally.