### PR TITLE
feat(grpc): scaffold phase-0 public API and module integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -361,6 +361,9 @@ set(LIB_SOURCES
     src/pool/SocketPool-ratelimit.c
     src/pool/SocketPool-drain.c
     src/pool/SocketPool-health.c
+
+    # gRPC module (public scaffolding)
+    src/grpc/SocketGRPC-core.c
     
     # HTTP module (RFC 9110/3986)
     src/http/SocketHTTP-core.c
@@ -773,6 +776,12 @@ set(DEFLATE_HEADERS
     include/deflate/SocketDeflate.h
 )
 
+set(GRPC_HEADERS
+    include/grpc/SocketGRPC.h
+    include/grpc/SocketGRPC-private.h
+    include/grpc/SocketGRPCConfig.h
+)
+
 install(TARGETS socket_static socket_shared
     ARCHIVE DESTINATION lib
     LIBRARY DESTINATION lib
@@ -790,6 +799,7 @@ install(FILES ${TEST_HEADERS} DESTINATION include/test)
 install(FILES ${QUIC_HEADERS} DESTINATION include/quic)
 install(FILES ${SIMPLE_HEADERS} DESTINATION include/simple)
 install(FILES ${DEFLATE_HEADERS} DESTINATION include/deflate)
+install(FILES ${GRPC_HEADERS} DESTINATION include/grpc)
 
 # Print build configuration
 message(STATUS "Socket Library Configuration:")
@@ -917,6 +927,7 @@ set(TEST_SOURCES
     test_http3_connection
     test_http3_request
     test_http3_compliance
+    test_grpc_api_surface
 )
 
 if(ENABLE_H3_PUSH)

--- a/include/grpc/SocketGRPC-private.h
+++ b/include/grpc/SocketGRPC-private.h
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketGRPC-private.h
+ * @brief Internal gRPC scaffolding structures.
+ *
+ * Not part of the public API stability contract.
+ */
+
+#ifndef SOCKETGRPC_PRIVATE_INCLUDED
+#define SOCKETGRPC_PRIVATE_INCLUDED
+
+#include "grpc/SocketGRPC.h"
+
+struct SocketGRPC_Client
+{
+  SocketGRPC_ClientConfig config;
+  SocketGRPC_Status last_status;
+};
+
+struct SocketGRPC_Server
+{
+  SocketGRPC_ServerConfig config;
+  SocketGRPC_Status last_status;
+};
+
+struct SocketGRPC_Channel
+{
+  SocketGRPC_Client_T client;
+  SocketGRPC_ChannelConfig config;
+  char *target;
+  SocketGRPC_Status last_status;
+};
+
+struct SocketGRPC_Call
+{
+  SocketGRPC_Channel_T channel;
+  SocketGRPC_CallConfig config;
+  char *full_method;
+  SocketGRPC_Status last_status;
+};
+
+extern void SocketGRPC_status_set (SocketGRPC_Status *status,
+                                   SocketGRPC_StatusCode code,
+                                   const char *message);
+
+extern const char *
+SocketGRPC_status_default_message (SocketGRPC_StatusCode code);
+
+#endif /* SOCKETGRPC_PRIVATE_INCLUDED */

--- a/include/grpc/SocketGRPC.h
+++ b/include/grpc/SocketGRPC.h
@@ -1,0 +1,223 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @defgroup grpc gRPC Module
+ * @brief gRPC public API scaffolding and status model.
+ * @{
+ */
+
+/**
+ * @file SocketGRPC.h
+ * @ingroup grpc
+ * @brief Public gRPC API surface for client, server, channel, and call types.
+ *
+ * Phase-0 guarantees:
+ * - Stable opaque handles for gRPC object lifecycles.
+ * - Canonical gRPC status codes and message helpers.
+ * - No global mutable runtime state.
+ *
+ * Behavior in this phase is intentionally minimal; transport, protobuf, and
+ * streaming semantics land in follow-up phases.
+ */
+
+#ifndef SOCKETGRPC_INCLUDED
+#define SOCKETGRPC_INCLUDED
+
+#include "core/Except.h"
+#include "grpc/SocketGRPCConfig.h"
+
+/**
+ * @brief Module-level exception for fatal gRPC runtime failures.
+ */
+extern const Except_T SocketGRPC_Failed;
+
+/**
+ * @brief Exception for invalid API usage (NULL/invalid parameters).
+ */
+extern const Except_T SocketGRPC_InvalidArgument;
+
+/**
+ * @brief Exception for memory allocation failures in gRPC helpers.
+ */
+extern const Except_T SocketGRPC_OutOfMemory;
+
+/**
+ * @brief Canonical gRPC status codes (grpc-status values).
+ *
+ * Matches gRPC core status space exactly (0-16).
+ */
+typedef enum
+{
+  SOCKET_GRPC_STATUS_OK = 0,
+  SOCKET_GRPC_STATUS_CANCELLED = 1,
+  SOCKET_GRPC_STATUS_UNKNOWN = 2,
+  SOCKET_GRPC_STATUS_INVALID_ARGUMENT = 3,
+  SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED = 4,
+  SOCKET_GRPC_STATUS_NOT_FOUND = 5,
+  SOCKET_GRPC_STATUS_ALREADY_EXISTS = 6,
+  SOCKET_GRPC_STATUS_PERMISSION_DENIED = 7,
+  SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED = 8,
+  SOCKET_GRPC_STATUS_FAILED_PRECONDITION = 9,
+  SOCKET_GRPC_STATUS_ABORTED = 10,
+  SOCKET_GRPC_STATUS_OUT_OF_RANGE = 11,
+  SOCKET_GRPC_STATUS_UNIMPLEMENTED = 12,
+  SOCKET_GRPC_STATUS_INTERNAL = 13,
+  SOCKET_GRPC_STATUS_UNAVAILABLE = 14,
+  SOCKET_GRPC_STATUS_DATA_LOSS = 15,
+  SOCKET_GRPC_STATUS_UNAUTHENTICATED = 16
+} SocketGRPC_StatusCode;
+
+/**
+ * @brief gRPC status payload used by simple/non-throwing APIs.
+ *
+ * message may reference static storage or module-owned memory.
+ */
+typedef struct
+{
+  SocketGRPC_StatusCode code;
+  const char *message;
+} SocketGRPC_Status;
+
+/** Opaque gRPC client handle. */
+typedef struct SocketGRPC_Client *SocketGRPC_Client_T;
+
+/** Opaque gRPC server handle. */
+typedef struct SocketGRPC_Server *SocketGRPC_Server_T;
+
+/** Opaque gRPC channel handle. */
+typedef struct SocketGRPC_Channel *SocketGRPC_Channel_T;
+
+/** Opaque gRPC call handle. */
+typedef struct SocketGRPC_Call *SocketGRPC_Call_T;
+
+/**
+ * @brief Create a gRPC client object.
+ *
+ * @param config Optional runtime configuration (NULL for defaults).
+ * @return Client handle or NULL on error.
+ *
+ * @threadsafe Yes
+ */
+extern SocketGRPC_Client_T
+SocketGRPC_Client_new (const SocketGRPC_ClientConfig *config);
+
+/**
+ * @brief Destroy a gRPC client object.
+ *
+ * Safe to call with NULL or *client == NULL.
+ *
+ * @param client Pointer to client handle; set to NULL on return.
+ * @threadsafe No
+ */
+extern void SocketGRPC_Client_free (SocketGRPC_Client_T *client);
+
+/**
+ * @brief Create a gRPC server object.
+ *
+ * @param config Optional runtime configuration (NULL for defaults).
+ * @return Server handle or NULL on error.
+ *
+ * @threadsafe Yes
+ */
+extern SocketGRPC_Server_T
+SocketGRPC_Server_new (const SocketGRPC_ServerConfig *config);
+
+/**
+ * @brief Destroy a gRPC server object.
+ *
+ * Safe to call with NULL or *server == NULL.
+ *
+ * @param server Pointer to server handle; set to NULL on return.
+ * @threadsafe No
+ */
+extern void SocketGRPC_Server_free (SocketGRPC_Server_T *server);
+
+/**
+ * @brief Create a logical channel owned by a client.
+ *
+ * @param client Parent client (required).
+ * @param target Authority/endpoint target string (required).
+ * @param config Optional channel configuration (NULL for defaults).
+ * @return Channel handle or NULL on error.
+ *
+ * @threadsafe Yes
+ */
+extern SocketGRPC_Channel_T
+SocketGRPC_Channel_new (SocketGRPC_Client_T client,
+                        const char *target,
+                        const SocketGRPC_ChannelConfig *config);
+
+/**
+ * @brief Destroy a channel.
+ *
+ * Safe to call with NULL or *channel == NULL.
+ *
+ * @param channel Pointer to channel handle; set to NULL on return.
+ * @threadsafe No
+ */
+extern void SocketGRPC_Channel_free (SocketGRPC_Channel_T *channel);
+
+/**
+ * @brief Create a call bound to a channel and fully qualified method path.
+ *
+ * @param channel Parent channel (required).
+ * @param full_method Method path, e.g. "/pkg.Service/Method" (required).
+ * @param config Optional call configuration (NULL for defaults).
+ * @return Call handle or NULL on error.
+ *
+ * @threadsafe Yes
+ */
+extern SocketGRPC_Call_T
+SocketGRPC_Call_new (SocketGRPC_Channel_T channel,
+                     const char *full_method,
+                     const SocketGRPC_CallConfig *config);
+
+/**
+ * @brief Destroy a call.
+ *
+ * Safe to call with NULL or *call == NULL.
+ *
+ * @param call Pointer to call handle; set to NULL on return.
+ * @threadsafe No
+ */
+extern void SocketGRPC_Call_free (SocketGRPC_Call_T *call);
+
+/**
+ * @brief Extract numeric status code from a status payload.
+ *
+ * NULL-safe: returns INTERNAL for a NULL status pointer.
+ *
+ * @param status Status payload pointer.
+ * @return gRPC status code.
+ * @threadsafe Yes
+ */
+extern SocketGRPC_StatusCode
+SocketGRPC_Status_code (const SocketGRPC_Status *status);
+
+/**
+ * @brief Extract human-readable status message.
+ *
+ * If status->message is NULL/empty, a canonical default message is returned.
+ *
+ * @param status Status payload pointer.
+ * @return Static or owned string, never NULL.
+ * @threadsafe Yes
+ */
+extern const char *SocketGRPC_Status_message (const SocketGRPC_Status *status);
+
+/**
+ * @brief Convert status code to symbolic constant name.
+ *
+ * @param code gRPC status code.
+ * @return Static string (e.g., "UNAVAILABLE"), or "UNKNOWN_CODE".
+ * @threadsafe Yes
+ */
+extern const char *SocketGRPC_Status_code_name (SocketGRPC_StatusCode code);
+
+/** @} */
+
+#endif /* SOCKETGRPC_INCLUDED */

--- a/include/grpc/SocketGRPCConfig.h
+++ b/include/grpc/SocketGRPCConfig.h
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketGRPCConfig.h
+ * @brief Compile-time defaults and runtime config structs for gRPC scaffolding.
+ * @ingroup grpc
+ */
+
+#ifndef SOCKETGRPCCONFIG_INCLUDED
+#define SOCKETGRPCCONFIG_INCLUDED
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CHANNELS
+#define SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CHANNELS 64U
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_OUTSTANDING_CALLS
+#define SOCKET_GRPC_DEFAULT_MAX_OUTSTANDING_CALLS 512U
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CONNECTIONS
+#define SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CONNECTIONS 1024U
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_INBOUND_MESSAGE_BYTES
+#define SOCKET_GRPC_DEFAULT_MAX_INBOUND_MESSAGE_BYTES (4U * 1024U * 1024U)
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_OUTBOUND_MESSAGE_BYTES
+#define SOCKET_GRPC_DEFAULT_MAX_OUTBOUND_MESSAGE_BYTES (4U * 1024U * 1024U)
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES
+#define SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES 64U
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_ENABLE_RETRY
+#define SOCKET_GRPC_DEFAULT_ENABLE_RETRY 0
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_DEADLINE_MS
+#define SOCKET_GRPC_DEFAULT_DEADLINE_MS 30000
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_WAIT_FOR_READY
+#define SOCKET_GRPC_DEFAULT_WAIT_FOR_READY 0
+#endif
+
+/**
+ * @brief Runtime client configuration for future channel/call management.
+ */
+typedef struct
+{
+  uint32_t max_concurrent_channels;
+  uint32_t max_outstanding_calls;
+  int enable_retry;
+} SocketGRPC_ClientConfig;
+
+/**
+ * @brief Runtime server configuration for listener/dispatch scaffolding.
+ */
+typedef struct
+{
+  uint32_t max_concurrent_connections;
+  uint32_t max_outstanding_calls;
+} SocketGRPC_ServerConfig;
+
+/**
+ * @brief Runtime channel configuration.
+ */
+typedef struct
+{
+  size_t max_inbound_message_bytes;
+  size_t max_outbound_message_bytes;
+  uint32_t max_metadata_entries;
+} SocketGRPC_ChannelConfig;
+
+/**
+ * @brief Runtime per-call configuration.
+ */
+typedef struct
+{
+  int deadline_ms;
+  int wait_for_ready;
+} SocketGRPC_CallConfig;
+
+/**
+ * @brief Populate client config with default values.
+ * @threadsafe Yes
+ */
+extern void SocketGRPC_ClientConfig_defaults (SocketGRPC_ClientConfig *config);
+
+/**
+ * @brief Populate server config with default values.
+ * @threadsafe Yes
+ */
+extern void SocketGRPC_ServerConfig_defaults (SocketGRPC_ServerConfig *config);
+
+/**
+ * @brief Populate channel config with default values.
+ * @threadsafe Yes
+ */
+extern void
+SocketGRPC_ChannelConfig_defaults (SocketGRPC_ChannelConfig *config);
+
+/**
+ * @brief Populate call config with default values.
+ * @threadsafe Yes
+ */
+extern void SocketGRPC_CallConfig_defaults (SocketGRPC_CallConfig *config);
+
+#endif /* SOCKETGRPCCONFIG_INCLUDED */

--- a/libsocket.pc.in
+++ b/libsocket.pc.in
@@ -4,7 +4,7 @@ libdir=${prefix}/lib
 includedir=${prefix}/include
 
 Name: libsocket
-Description: High-performance C socket library with TLS, HTTP/2, and WebSocket support
+Description: High-performance C socket library with TLS, HTTP/2, HTTP/3, WebSocket, and gRPC support
 Version: @PROJECT_VERSION@
 Libs: -L${libdir} -lsocket
 Libs.private: @PC_LIBS_PRIVATE@

--- a/src/grpc/SocketGRPC-core.c
+++ b/src/grpc/SocketGRPC-core.c
@@ -1,0 +1,373 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketGRPC-core.c
+ * @brief Phase-0 gRPC lifecycle and status helper implementation.
+ */
+
+#include "grpc/SocketGRPC-private.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+const Except_T SocketGRPC_Failed
+    = { &SocketGRPC_Failed, "gRPC operation failed" };
+const Except_T SocketGRPC_InvalidArgument
+    = { &SocketGRPC_InvalidArgument, "gRPC invalid argument" };
+const Except_T SocketGRPC_OutOfMemory
+    = { &SocketGRPC_OutOfMemory, "gRPC out of memory" };
+
+static const char *grpc_status_code_names[]
+    = { "OK",
+        "CANCELLED",
+        "UNKNOWN",
+        "INVALID_ARGUMENT",
+        "DEADLINE_EXCEEDED",
+        "NOT_FOUND",
+        "ALREADY_EXISTS",
+        "PERMISSION_DENIED",
+        "RESOURCE_EXHAUSTED",
+        "FAILED_PRECONDITION",
+        "ABORTED",
+        "OUT_OF_RANGE",
+        "UNIMPLEMENTED",
+        "INTERNAL",
+        "UNAVAILABLE",
+        "DATA_LOSS",
+        "UNAUTHENTICATED" };
+
+static const char *grpc_status_default_messages[]
+    = { "Success",
+        "Operation cancelled",
+        "Unknown error",
+        "Invalid argument",
+        "Deadline exceeded",
+        "Requested entity was not found",
+        "Entity already exists",
+        "Permission denied",
+        "Resource exhausted",
+        "Operation rejected due to current system state",
+        "Operation aborted",
+        "Operation out of range",
+        "Operation not implemented",
+        "Internal error",
+        "Service unavailable",
+        "Unrecoverable data loss",
+        "Unauthenticated request" };
+
+_Static_assert (sizeof (grpc_status_code_names)
+                        / sizeof (grpc_status_code_names[0])
+                    == SOCKET_GRPC_STATUS_UNAUTHENTICATED + 1,
+                "grpc_status_code_names must map all canonical gRPC codes");
+
+_Static_assert (sizeof (grpc_status_default_messages)
+                        / sizeof (grpc_status_default_messages[0])
+                    == SOCKET_GRPC_STATUS_UNAUTHENTICATED + 1,
+                "grpc_status_default_messages must map all canonical gRPC "
+                "codes");
+
+static int
+grpc_status_is_valid (SocketGRPC_StatusCode code)
+{
+  return code >= SOCKET_GRPC_STATUS_OK
+         && code <= SOCKET_GRPC_STATUS_UNAUTHENTICATED;
+}
+
+const char *
+SocketGRPC_status_default_message (SocketGRPC_StatusCode code)
+{
+  if (grpc_status_is_valid (code))
+    return grpc_status_default_messages[code];
+  return "Unknown gRPC status code";
+}
+
+void
+SocketGRPC_status_set (SocketGRPC_Status *status,
+                       SocketGRPC_StatusCode code,
+                       const char *message)
+{
+  if (status == NULL)
+    return;
+
+  status->code = code;
+  if (message != NULL && message[0] != '\0')
+    status->message = message;
+  else
+    status->message = SocketGRPC_status_default_message (code);
+}
+
+SocketGRPC_StatusCode
+SocketGRPC_Status_code (const SocketGRPC_Status *status)
+{
+  if (status == NULL)
+    return SOCKET_GRPC_STATUS_INTERNAL;
+  return status->code;
+}
+
+const char *
+SocketGRPC_Status_message (const SocketGRPC_Status *status)
+{
+  if (status == NULL)
+    return "Status unavailable";
+
+  if (status->message != NULL && status->message[0] != '\0')
+    return status->message;
+
+  return SocketGRPC_status_default_message (status->code);
+}
+
+const char *
+SocketGRPC_Status_code_name (SocketGRPC_StatusCode code)
+{
+  if (grpc_status_is_valid (code))
+    return grpc_status_code_names[code];
+  return "UNKNOWN_CODE";
+}
+
+void
+SocketGRPC_ClientConfig_defaults (SocketGRPC_ClientConfig *config)
+{
+  if (config == NULL)
+    return;
+
+  config->max_concurrent_channels = SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CHANNELS;
+  config->max_outstanding_calls = SOCKET_GRPC_DEFAULT_MAX_OUTSTANDING_CALLS;
+  config->enable_retry = SOCKET_GRPC_DEFAULT_ENABLE_RETRY;
+}
+
+void
+SocketGRPC_ServerConfig_defaults (SocketGRPC_ServerConfig *config)
+{
+  if (config == NULL)
+    return;
+
+  config->max_concurrent_connections
+      = SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CONNECTIONS;
+  config->max_outstanding_calls = SOCKET_GRPC_DEFAULT_MAX_OUTSTANDING_CALLS;
+}
+
+void
+SocketGRPC_ChannelConfig_defaults (SocketGRPC_ChannelConfig *config)
+{
+  if (config == NULL)
+    return;
+
+  config->max_inbound_message_bytes
+      = SOCKET_GRPC_DEFAULT_MAX_INBOUND_MESSAGE_BYTES;
+  config->max_outbound_message_bytes
+      = SOCKET_GRPC_DEFAULT_MAX_OUTBOUND_MESSAGE_BYTES;
+  config->max_metadata_entries = SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES;
+}
+
+void
+SocketGRPC_CallConfig_defaults (SocketGRPC_CallConfig *config)
+{
+  if (config == NULL)
+    return;
+
+  config->deadline_ms = SOCKET_GRPC_DEFAULT_DEADLINE_MS;
+  config->wait_for_ready = SOCKET_GRPC_DEFAULT_WAIT_FOR_READY;
+}
+
+static void
+grpc_sanitize_client_config (SocketGRPC_ClientConfig *config)
+{
+  if (config->max_concurrent_channels == 0)
+    config->max_concurrent_channels = SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CHANNELS;
+  if (config->max_outstanding_calls == 0)
+    config->max_outstanding_calls = SOCKET_GRPC_DEFAULT_MAX_OUTSTANDING_CALLS;
+  config->enable_retry = config->enable_retry ? 1 : 0;
+}
+
+static void
+grpc_sanitize_server_config (SocketGRPC_ServerConfig *config)
+{
+  if (config->max_concurrent_connections == 0)
+    config->max_concurrent_connections
+        = SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CONNECTIONS;
+  if (config->max_outstanding_calls == 0)
+    config->max_outstanding_calls = SOCKET_GRPC_DEFAULT_MAX_OUTSTANDING_CALLS;
+}
+
+static void
+grpc_sanitize_channel_config (SocketGRPC_ChannelConfig *config)
+{
+  if (config->max_inbound_message_bytes == 0)
+    config->max_inbound_message_bytes
+        = SOCKET_GRPC_DEFAULT_MAX_INBOUND_MESSAGE_BYTES;
+  if (config->max_outbound_message_bytes == 0)
+    config->max_outbound_message_bytes
+        = SOCKET_GRPC_DEFAULT_MAX_OUTBOUND_MESSAGE_BYTES;
+  if (config->max_metadata_entries == 0)
+    config->max_metadata_entries = SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES;
+}
+
+static void
+grpc_sanitize_call_config (SocketGRPC_CallConfig *config)
+{
+  if (config->deadline_ms < 0)
+    config->deadline_ms = SOCKET_GRPC_DEFAULT_DEADLINE_MS;
+  config->wait_for_ready = config->wait_for_ready ? 1 : 0;
+}
+
+static char *
+grpc_strdup_required (const char *src)
+{
+  if (src == NULL || src[0] == '\0')
+    return NULL;
+  return strdup (src);
+}
+
+SocketGRPC_Client_T
+SocketGRPC_Client_new (const SocketGRPC_ClientConfig *config)
+{
+  SocketGRPC_Client_T client = calloc (1, sizeof (*client));
+  if (client == NULL)
+    return NULL;
+
+  if (config != NULL)
+    client->config = *config;
+  else
+    SocketGRPC_ClientConfig_defaults (&client->config);
+
+  grpc_sanitize_client_config (&client->config);
+  SocketGRPC_status_set (
+      &client->last_status, SOCKET_GRPC_STATUS_OK, "Client initialized");
+  return client;
+}
+
+void
+SocketGRPC_Client_free (SocketGRPC_Client_T *client)
+{
+  if (client == NULL || *client == NULL)
+    return;
+
+  memset (*client, 0, sizeof (**client));
+  free (*client);
+  *client = NULL;
+}
+
+SocketGRPC_Server_T
+SocketGRPC_Server_new (const SocketGRPC_ServerConfig *config)
+{
+  SocketGRPC_Server_T server = calloc (1, sizeof (*server));
+  if (server == NULL)
+    return NULL;
+
+  if (config != NULL)
+    server->config = *config;
+  else
+    SocketGRPC_ServerConfig_defaults (&server->config);
+
+  grpc_sanitize_server_config (&server->config);
+  SocketGRPC_status_set (
+      &server->last_status, SOCKET_GRPC_STATUS_OK, "Server initialized");
+  return server;
+}
+
+void
+SocketGRPC_Server_free (SocketGRPC_Server_T *server)
+{
+  if (server == NULL || *server == NULL)
+    return;
+
+  memset (*server, 0, sizeof (**server));
+  free (*server);
+  *server = NULL;
+}
+
+SocketGRPC_Channel_T
+SocketGRPC_Channel_new (SocketGRPC_Client_T client,
+                        const char *target,
+                        const SocketGRPC_ChannelConfig *config)
+{
+  SocketGRPC_Channel_T channel;
+
+  if (client == NULL || target == NULL || target[0] == '\0')
+    return NULL;
+
+  channel = calloc (1, sizeof (*channel));
+  if (channel == NULL)
+    return NULL;
+
+  channel->target = grpc_strdup_required (target);
+  if (channel->target == NULL)
+    {
+      free (channel);
+      return NULL;
+    }
+
+  if (config != NULL)
+    channel->config = *config;
+  else
+    SocketGRPC_ChannelConfig_defaults (&channel->config);
+
+  grpc_sanitize_channel_config (&channel->config);
+  channel->client = client;
+  SocketGRPC_status_set (
+      &channel->last_status, SOCKET_GRPC_STATUS_OK, "Channel initialized");
+  return channel;
+}
+
+void
+SocketGRPC_Channel_free (SocketGRPC_Channel_T *channel)
+{
+  if (channel == NULL || *channel == NULL)
+    return;
+
+  free ((*channel)->target);
+  (*channel)->target = NULL;
+  memset (*channel, 0, sizeof (**channel));
+  free (*channel);
+  *channel = NULL;
+}
+
+SocketGRPC_Call_T
+SocketGRPC_Call_new (SocketGRPC_Channel_T channel,
+                     const char *full_method,
+                     const SocketGRPC_CallConfig *config)
+{
+  SocketGRPC_Call_T call;
+
+  if (channel == NULL || full_method == NULL || full_method[0] == '\0')
+    return NULL;
+
+  call = calloc (1, sizeof (*call));
+  if (call == NULL)
+    return NULL;
+
+  call->full_method = grpc_strdup_required (full_method);
+  if (call->full_method == NULL)
+    {
+      free (call);
+      return NULL;
+    }
+
+  if (config != NULL)
+    call->config = *config;
+  else
+    SocketGRPC_CallConfig_defaults (&call->config);
+
+  grpc_sanitize_call_config (&call->config);
+  call->channel = channel;
+  SocketGRPC_status_set (
+      &call->last_status, SOCKET_GRPC_STATUS_OK, "Call initialized");
+  return call;
+}
+
+void
+SocketGRPC_Call_free (SocketGRPC_Call_T *call)
+{
+  if (call == NULL || *call == NULL)
+    return;
+
+  free ((*call)->full_method);
+  (*call)->full_method = NULL;
+  memset (*call, 0, sizeof (**call));
+  free (*call);
+  *call = NULL;
+}

--- a/src/test/test_grpc_api_surface.c
+++ b/src/test/test_grpc_api_surface.c
@@ -1,0 +1,114 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_grpc_api_surface.c
+ * @brief Compile/link smoke tests for gRPC API scaffolding.
+ */
+
+#include "grpc/SocketGRPC.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+TEST (grpc_status_code_names_cover_canonical_space)
+{
+  for (int i = SOCKET_GRPC_STATUS_OK; i <= SOCKET_GRPC_STATUS_UNAUTHENTICATED;
+       i++)
+    {
+      const char *name = SocketGRPC_Status_code_name ((SocketGRPC_StatusCode)i);
+      ASSERT_NOT_NULL (name);
+      ASSERT_NE (0, strcmp (name, "UNKNOWN_CODE"));
+    }
+}
+
+TEST (grpc_status_accessors_are_null_safe)
+{
+  ASSERT_EQ (SOCKET_GRPC_STATUS_INTERNAL, SocketGRPC_Status_code (NULL));
+  ASSERT_NOT_NULL (SocketGRPC_Status_message (NULL));
+  ASSERT_EQ (
+      0,
+      strcmp (SocketGRPC_Status_code_name ((SocketGRPC_StatusCode)1024),
+              "UNKNOWN_CODE"));
+}
+
+TEST (grpc_status_accessors_support_custom_and_default_messages)
+{
+  SocketGRPC_Status custom
+      = { SOCKET_GRPC_STATUS_UNAVAILABLE, "upstream reset by peer" };
+  SocketGRPC_Status fallback = { SOCKET_GRPC_STATUS_NOT_FOUND, NULL };
+
+  ASSERT_EQ (SOCKET_GRPC_STATUS_UNAVAILABLE, SocketGRPC_Status_code (&custom));
+  ASSERT_EQ (0, strcmp (SocketGRPC_Status_message (&custom),
+                        "upstream reset by peer"));
+
+  ASSERT_EQ (SOCKET_GRPC_STATUS_NOT_FOUND, SocketGRPC_Status_code (&fallback));
+  ASSERT_EQ (0, strcmp (SocketGRPC_Status_message (&fallback),
+                        "Requested entity was not found"));
+}
+
+TEST (grpc_handle_lifecycle_smoke)
+{
+  SocketGRPC_ClientConfig client_cfg;
+  SocketGRPC_ServerConfig server_cfg;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketGRPC_CallConfig call_cfg;
+
+  SocketGRPC_ClientConfig_defaults (&client_cfg);
+  SocketGRPC_ServerConfig_defaults (&server_cfg);
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  SocketGRPC_CallConfig_defaults (&call_cfg);
+
+  SocketGRPC_Client_T client = SocketGRPC_Client_new (&client_cfg);
+  SocketGRPC_Server_T server = SocketGRPC_Server_new (&server_cfg);
+  SocketGRPC_Channel_T channel
+      = SocketGRPC_Channel_new (client, "dns:///example.grpc.local", NULL);
+  SocketGRPC_Call_T call
+      = SocketGRPC_Call_new (channel, "/example.Service/Ping", &call_cfg);
+
+  ASSERT_NOT_NULL (client);
+  ASSERT_NOT_NULL (server);
+  ASSERT_NOT_NULL (channel);
+  ASSERT_NOT_NULL (call);
+
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Server_free (&server);
+  SocketGRPC_Client_free (&client);
+
+  ASSERT_NULL (call);
+  ASSERT_NULL (channel);
+  ASSERT_NULL (server);
+  ASSERT_NULL (client);
+}
+
+TEST (grpc_invalid_inputs_fail_without_crash)
+{
+  SocketGRPC_Client_T client = SocketGRPC_Client_new (NULL);
+  ASSERT_NOT_NULL (client);
+
+  ASSERT_NULL (SocketGRPC_Channel_new (NULL, "dns:///x", NULL));
+  ASSERT_NULL (SocketGRPC_Channel_new (client, NULL, NULL));
+  ASSERT_NULL (SocketGRPC_Channel_new (client, "", NULL));
+
+  SocketGRPC_Channel_T channel
+      = SocketGRPC_Channel_new (client, "dns:///x", NULL);
+  ASSERT_NOT_NULL (channel);
+
+  ASSERT_NULL (SocketGRPC_Call_new (NULL, "/svc/method", NULL));
+  ASSERT_NULL (SocketGRPC_Call_new (channel, NULL, NULL));
+  ASSERT_NULL (SocketGRPC_Call_new (channel, "", NULL));
+
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- add phase-0 gRPC scaffolding module with public/private/config headers
- add canonical gRPC status model helpers and opaque lifecycle handles (client/server/channel/call)
- wire gRPC source + headers into CMake build/install and update pkg-config description
- add `test_grpc_api_surface` compile/link smoke coverage for API surface and lifecycle

Fixes #3581

## Test plan
- [x] `cmake -S . -B build && cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure -R '^(test_grpc_api_surface|test_http3_connection|test_http3_request|test_dns_transport|test_tls_handshake)$'`