### PR TITLE
feat(grpc): implement protobuf runtime with hardened parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -364,6 +364,9 @@ set(LIB_SOURCES
 
     # gRPC module (public scaffolding)
     src/grpc/SocketGRPC-core.c
+    src/grpc/SocketProto-varint.c
+    src/grpc/SocketProto-wire.c
+    src/grpc/SocketProto-message.c
     
     # HTTP module (RFC 9110/3986)
     src/http/SocketHTTP-core.c
@@ -780,6 +783,8 @@ set(GRPC_HEADERS
     include/grpc/SocketGRPC.h
     include/grpc/SocketGRPC-private.h
     include/grpc/SocketGRPCConfig.h
+    include/grpc/SocketProto.h
+    include/grpc/SocketProto-private.h
 )
 
 install(TARGETS socket_static socket_shared
@@ -928,6 +933,9 @@ set(TEST_SOURCES
     test_http3_request
     test_http3_compliance
     test_grpc_api_surface
+    test_proto_varint
+    test_proto_wire
+    test_proto_message
 )
 
 if(ENABLE_H3_PUSH)
@@ -1368,6 +1376,8 @@ if(ENABLE_FUZZING)
         fuzz_quic_connection
         fuzz_quic_handshake
         fuzz_quic_tls
+        fuzz_proto_wire
+        fuzz_proto_message
         # QPACK fuzzers (RFC 9204 - HTTP/3 header compression)
         fuzz_qpack_index
         fuzz_qpack_prefix

--- a/include/grpc/SocketProto-private.h
+++ b/include/grpc/SocketProto-private.h
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketProto-private.h
+ * @brief Internal protobuf runtime definitions.
+ */
+
+#ifndef SOCKETPROTO_PRIVATE_INCLUDED
+#define SOCKETPROTO_PRIVATE_INCLUDED
+
+#include "grpc/SocketProto.h"
+
+struct SocketProto_Message
+{
+  Arena_T arena;
+  int owns_arena;
+  SocketProto_Limits limits;
+  const SocketProto_Schema *schema;
+  SocketProto_Field *fields;
+  size_t field_count;
+  size_t field_capacity;
+  size_t unknown_count;
+};
+
+static inline int
+socketproto_size_add (size_t a, size_t b, size_t *out)
+{
+  return __builtin_add_overflow (a, b, out);
+}
+
+static inline int
+socketproto_size_mul (size_t a, size_t b, size_t *out)
+{
+  return __builtin_mul_overflow (a, b, out);
+}
+
+#endif /* SOCKETPROTO_PRIVATE_INCLUDED */

--- a/include/grpc/SocketProto.h
+++ b/include/grpc/SocketProto.h
@@ -1,0 +1,314 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketProto.h
+ * @brief Protobuf wire/runtime primitives for gRPC payloads.
+ * @ingroup grpc
+ */
+
+#ifndef SOCKETPROTO_INCLUDED
+#define SOCKETPROTO_INCLUDED
+
+#include "core/Arena.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+/** Maximum varint width in bytes for protobuf uint64 values. */
+#define SOCKET_PROTO_MAX_VARINT_LEN 10U
+
+/** Maximum allowed protobuf field number (29 bits). */
+#define SOCKET_PROTO_MAX_FIELD_NUMBER 0x1FFFFFFFU
+
+/** Default parser guardrail: max message size in bytes. */
+#ifndef SOCKET_PROTO_DEFAULT_MAX_MESSAGE_SIZE
+#define SOCKET_PROTO_DEFAULT_MAX_MESSAGE_SIZE (4U * 1024U * 1024U)
+#endif
+
+/** Default parser guardrail: max decoded fields per message. */
+#ifndef SOCKET_PROTO_DEFAULT_MAX_FIELDS
+#define SOCKET_PROTO_DEFAULT_MAX_FIELDS 1024U
+#endif
+
+/** Default parser guardrail: max nested message depth. */
+#ifndef SOCKET_PROTO_DEFAULT_MAX_NESTING_DEPTH
+#define SOCKET_PROTO_DEFAULT_MAX_NESTING_DEPTH 16U
+#endif
+
+/**
+ * @brief Result codes for protobuf runtime operations.
+ */
+typedef enum
+{
+  SOCKET_PROTO_OK = 0,
+  SOCKET_PROTO_INCOMPLETE,
+  SOCKET_PROTO_OVERFLOW,
+  SOCKET_PROTO_INVALID_ARGUMENT,
+  SOCKET_PROTO_INVALID_TAG,
+  SOCKET_PROTO_INVALID_WIRE_TYPE,
+  SOCKET_PROTO_TYPE_MISMATCH,
+  SOCKET_PROTO_LIMIT_MESSAGE_SIZE,
+  SOCKET_PROTO_LIMIT_FIELD_COUNT,
+  SOCKET_PROTO_LIMIT_NESTING_DEPTH,
+  SOCKET_PROTO_BUFFER_TOO_SMALL,
+  SOCKET_PROTO_MALFORMED
+} SocketProto_Result;
+
+/**
+ * @brief Wire types from protobuf encoding.
+ */
+typedef enum
+{
+  SOCKET_PROTO_WIRE_VARINT = 0,
+  SOCKET_PROTO_WIRE_FIXED64 = 1,
+  SOCKET_PROTO_WIRE_LENGTH_DELIMITED = 2,
+  SOCKET_PROTO_WIRE_START_GROUP = 3,
+  SOCKET_PROTO_WIRE_END_GROUP = 4,
+  SOCKET_PROTO_WIRE_FIXED32 = 5
+} SocketProto_WireType;
+
+/**
+ * @brief Schema-level field kinds for descriptor validation.
+ */
+typedef enum
+{
+  SOCKET_PROTO_KIND_VARINT = 0,
+  SOCKET_PROTO_KIND_FIXED64,
+  SOCKET_PROTO_KIND_LENGTH_DELIMITED,
+  SOCKET_PROTO_KIND_FIXED32,
+  SOCKET_PROTO_KIND_MESSAGE
+} SocketProto_FieldKind;
+
+struct SocketProto_Schema;
+
+/**
+ * @brief Descriptor for one protobuf field in a schema.
+ */
+typedef struct
+{
+  uint32_t field_number;
+  SocketProto_FieldKind kind;
+  const struct SocketProto_Schema *message_schema;
+} SocketProto_SchemaField;
+
+/**
+ * @brief Schema descriptor table for validation/classification.
+ */
+typedef struct SocketProto_Schema
+{
+  const SocketProto_SchemaField *fields;
+  size_t field_count;
+} SocketProto_Schema;
+
+/**
+ * @brief Parser/encoder limits used for fail-closed behavior.
+ */
+typedef struct
+{
+  size_t max_message_size;
+  size_t max_fields;
+  size_t max_nesting_depth;
+} SocketProto_Limits;
+
+/**
+ * @brief Parsed field view with raw payload/encoding spans.
+ *
+ * `encoded` preserves the exact bytes for roundtrip emission.
+ */
+typedef struct
+{
+  uint32_t field_number;
+  uint8_t wire_type;
+  const uint8_t *value;
+  size_t value_len;
+  const uint8_t *encoded;
+  size_t encoded_len;
+  int known;
+} SocketProto_Field;
+
+/** Opaque decoded message handle. */
+typedef struct SocketProto_Message *SocketProto_Message_T;
+
+/**
+ * @brief Convert result code to human-readable constant string.
+ * @threadsafe Yes
+ */
+extern const char *SocketProto_result_string (SocketProto_Result result);
+
+/**
+ * @brief Populate protobuf limits with secure defaults.
+ * @threadsafe Yes
+ */
+extern void SocketProto_limits_defaults (SocketProto_Limits *limits);
+
+/**
+ * @brief Find a field descriptor by number in a schema.
+ * @return Pointer to descriptor, or NULL if not declared.
+ * @threadsafe Yes
+ */
+extern const SocketProto_SchemaField *
+SocketProto_Schema_find_field (const SocketProto_Schema *schema,
+                               uint32_t field_number);
+
+/**
+ * @brief Encode/decode unsigned varints.
+ */
+extern SocketProto_Result
+SocketProto_varint_encode_u64 (uint64_t value,
+                               uint8_t *out,
+                               size_t out_len,
+                               size_t *written);
+extern SocketProto_Result
+SocketProto_varint_decode_u64 (const uint8_t *in,
+                               size_t in_len,
+                               uint64_t *value,
+                               size_t *consumed);
+extern SocketProto_Result
+SocketProto_varint_encode_u32 (uint32_t value,
+                               uint8_t *out,
+                               size_t out_len,
+                               size_t *written);
+extern SocketProto_Result
+SocketProto_varint_decode_u32 (const uint8_t *in,
+                               size_t in_len,
+                               uint32_t *value,
+                               size_t *consumed);
+
+/**
+ * @brief ZigZag conversions for signed protobuf integers.
+ */
+extern uint64_t SocketProto_zigzag_encode_s64 (int64_t value);
+extern int64_t SocketProto_zigzag_decode_s64 (uint64_t value);
+extern uint32_t SocketProto_zigzag_encode_s32 (int32_t value);
+extern int32_t SocketProto_zigzag_decode_s32 (uint32_t value);
+
+/**
+ * @brief fixed32/fixed64 little-endian encode/decode.
+ */
+extern SocketProto_Result
+SocketProto_fixed32_encode (uint32_t value, uint8_t *out, size_t out_len);
+extern SocketProto_Result
+SocketProto_fixed32_decode (const uint8_t *in, size_t in_len, uint32_t *value);
+extern SocketProto_Result
+SocketProto_fixed64_encode (uint64_t value, uint8_t *out, size_t out_len);
+extern SocketProto_Result
+SocketProto_fixed64_decode (const uint8_t *in, size_t in_len, uint64_t *value);
+
+/**
+ * @brief Wire-level helpers.
+ */
+extern SocketProto_Result
+SocketProto_wire_make_tag (uint32_t field_number, uint8_t wire_type, uint64_t *tag);
+extern SocketProto_Result
+SocketProto_wire_write_tag (uint32_t field_number,
+                            uint8_t wire_type,
+                            uint8_t *out,
+                            size_t out_len,
+                            size_t *written);
+extern SocketProto_Result
+SocketProto_wire_write_length_delimited (uint32_t field_number,
+                                         const uint8_t *value,
+                                         size_t value_len,
+                                         uint8_t *out,
+                                         size_t out_len,
+                                         size_t *written);
+extern SocketProto_Result
+SocketProto_wire_read_field (const uint8_t *data,
+                             size_t len,
+                             SocketProto_Field *field,
+                             size_t *consumed);
+
+/**
+ * @brief Create/destroy message handle.
+ *
+ * If `arena` is NULL, the message allocates an internal arena and owns it.
+ */
+extern SocketProto_Message_T
+SocketProto_Message_new (Arena_T arena,
+                         const SocketProto_Limits *limits,
+                         const SocketProto_Schema *schema);
+extern void SocketProto_Message_free (SocketProto_Message_T *message);
+extern void SocketProto_Message_clear (SocketProto_Message_T message);
+
+/**
+ * @brief Parse/encode whole messages while preserving unknown fields.
+ */
+extern SocketProto_Result
+SocketProto_Message_parse (SocketProto_Message_T message,
+                           const uint8_t *data,
+                           size_t len);
+extern SocketProto_Result
+SocketProto_Message_encode (const SocketProto_Message_T message,
+                            uint8_t *out,
+                            size_t out_len,
+                            size_t *written);
+
+/**
+ * @brief Validate wire payload against limits/schema without storing fields.
+ */
+extern SocketProto_Result
+SocketProto_Message_validate (const uint8_t *data,
+                              size_t len,
+                              const SocketProto_Schema *schema,
+                              const SocketProto_Limits *limits);
+
+/**
+ * @brief Field accessors.
+ */
+extern size_t SocketProto_Message_field_count (const SocketProto_Message_T message);
+extern const SocketProto_Field *
+SocketProto_Message_field_at (const SocketProto_Message_T message, size_t index);
+extern size_t
+SocketProto_Message_unknown_count (const SocketProto_Message_T message);
+extern const SocketProto_Field *
+SocketProto_Message_unknown_at (const SocketProto_Message_T message, size_t index);
+
+/**
+ * @brief Message builders.
+ */
+extern SocketProto_Result
+SocketProto_Message_append_varint (SocketProto_Message_T message,
+                                   uint32_t field_number,
+                                   uint64_t value);
+extern SocketProto_Result
+SocketProto_Message_append_sint64 (SocketProto_Message_T message,
+                                   uint32_t field_number,
+                                   int64_t value);
+extern SocketProto_Result
+SocketProto_Message_append_fixed32 (SocketProto_Message_T message,
+                                    uint32_t field_number,
+                                    uint32_t value);
+extern SocketProto_Result
+SocketProto_Message_append_fixed64 (SocketProto_Message_T message,
+                                    uint32_t field_number,
+                                    uint64_t value);
+extern SocketProto_Result
+SocketProto_Message_append_bytes (SocketProto_Message_T message,
+                                  uint32_t field_number,
+                                  const uint8_t *value,
+                                  size_t value_len);
+extern SocketProto_Result
+SocketProto_Message_append_embedded (SocketProto_Message_T message,
+                                     uint32_t field_number,
+                                     const uint8_t *encoded_message,
+                                     size_t encoded_len);
+
+/**
+ * @brief Decode typed values from parsed fields.
+ */
+extern SocketProto_Result
+SocketProto_Field_decode_u64 (const SocketProto_Field *field, uint64_t *value);
+extern SocketProto_Result
+SocketProto_Field_decode_s64 (const SocketProto_Field *field, int64_t *value);
+extern SocketProto_Result
+SocketProto_Field_decode_fixed32 (const SocketProto_Field *field,
+                                  uint32_t *value);
+extern SocketProto_Result
+SocketProto_Field_decode_fixed64 (const SocketProto_Field *field,
+                                  uint64_t *value);
+
+#endif /* SOCKETPROTO_INCLUDED */

--- a/src/fuzz/fuzz_proto_message.c
+++ b/src/fuzz/fuzz_proto_message.c
@@ -1,0 +1,71 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_proto_message.c - libFuzzer harness for protobuf message runtime
+ */
+
+#include "grpc/SocketProto.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+static const SocketProto_SchemaField fuzz_schema_fields[] = {
+  { 1, SOCKET_PROTO_KIND_VARINT, NULL },
+  { 2, SOCKET_PROTO_KIND_LENGTH_DELIMITED, NULL },
+  { 3, SOCKET_PROTO_KIND_FIXED32, NULL },
+};
+
+static const SocketProto_Schema fuzz_schema = {
+  .fields = fuzz_schema_fields,
+  .field_count = sizeof (fuzz_schema_fields) / sizeof (fuzz_schema_fields[0]),
+};
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  SocketProto_Limits limits;
+  SocketProto_Message_T msg;
+
+  SocketProto_limits_defaults (&limits);
+  if (size > 0)
+    {
+      limits.max_fields = (size_t)((data[0] % 64U) + 1U);
+      limits.max_nesting_depth = (size_t)((data[0] % 8U) + 1U);
+      limits.max_message_size = size + 8U;
+    }
+
+  msg = SocketProto_Message_new (NULL, &limits, &fuzz_schema);
+  if (msg == NULL)
+    return 0;
+
+  (void)SocketProto_Message_parse (msg, data, size);
+  (void)SocketProto_Message_validate (data, size, &fuzz_schema, &limits);
+
+  uint8_t out[512];
+  size_t written = 0;
+  (void)SocketProto_Message_encode (msg, out, sizeof (out), &written);
+
+  if (size >= 8)
+    {
+      uint64_t v = ((uint64_t)data[0] << 56) | ((uint64_t)data[1] << 48)
+                   | ((uint64_t)data[2] << 40) | ((uint64_t)data[3] << 32)
+                   | ((uint64_t)data[4] << 24) | ((uint64_t)data[5] << 16)
+                   | ((uint64_t)data[6] << 8) | (uint64_t)data[7];
+      (void)SocketProto_Message_append_varint (msg, 1, v);
+    }
+  if (size >= 4)
+    {
+      uint32_t v
+          = ((uint32_t)data[0] << 24) | ((uint32_t)data[1] << 16)
+            | ((uint32_t)data[2] << 8) | (uint32_t)data[3];
+      (void)SocketProto_Message_append_fixed32 (msg, 3, v);
+    }
+  (void)SocketProto_Message_append_bytes (msg, 2, data, size);
+
+  SocketProto_Message_free (&msg);
+  return 0;
+}

--- a/src/fuzz/fuzz_proto_wire.c
+++ b/src/fuzz/fuzz_proto_wire.c
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * fuzz_proto_wire.c - libFuzzer harness for protobuf wire field parsing
+ */
+
+#include "grpc/SocketProto.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+int
+LLVMFuzzerTestOneInput (const uint8_t *data, size_t size)
+{
+  if (data == NULL)
+    return 0;
+
+  size_t offset = 0;
+  int fields = 0;
+
+  while (offset < size && fields < 128)
+    {
+      SocketProto_Field field;
+      size_t consumed = 0;
+      SocketProto_Result rc = SocketProto_wire_read_field (
+          data + offset, size - offset, &field, &consumed);
+      if (rc != SOCKET_PROTO_OK || consumed == 0)
+        break;
+
+      uint64_t u64 = 0;
+      uint32_t u32 = 0;
+      uint64_t u64f = 0;
+      (void)SocketProto_Field_decode_u64 (&field, &u64);
+      (void)SocketProto_Field_decode_fixed32 (&field, &u32);
+      (void)SocketProto_Field_decode_fixed64 (&field, &u64f);
+
+      offset += consumed;
+      fields++;
+    }
+
+  if (size > 0)
+    {
+      uint8_t out[32];
+      size_t written = 0;
+      uint32_t field_number = (uint32_t)((data[0] % 30U) + 1U);
+      uint8_t wire_type = (uint8_t)(data[0] % 6U);
+
+      (void)SocketProto_wire_write_tag (
+          field_number, wire_type, out, sizeof (out), &written);
+      (void)SocketProto_wire_write_length_delimited (
+          field_number, data, size, out, sizeof (out), &written);
+    }
+
+  return 0;
+}

--- a/src/grpc/SocketProto-message.c
+++ b/src/grpc/SocketProto-message.c
@@ -1,0 +1,795 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketProto-message.c
+ * @brief Protobuf message parsing/encoding with unknown-field preservation.
+ */
+
+#include "grpc/SocketProto-private.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static uint8_t
+socketproto_kind_wire_type (SocketProto_FieldKind kind)
+{
+  switch (kind)
+    {
+    case SOCKET_PROTO_KIND_VARINT:
+      return SOCKET_PROTO_WIRE_VARINT;
+    case SOCKET_PROTO_KIND_FIXED64:
+      return SOCKET_PROTO_WIRE_FIXED64;
+    case SOCKET_PROTO_KIND_LENGTH_DELIMITED:
+      return SOCKET_PROTO_WIRE_LENGTH_DELIMITED;
+    case SOCKET_PROTO_KIND_FIXED32:
+      return SOCKET_PROTO_WIRE_FIXED32;
+    case SOCKET_PROTO_KIND_MESSAGE:
+      return SOCKET_PROTO_WIRE_LENGTH_DELIMITED;
+    }
+
+  return 0xFFU;
+}
+
+const SocketProto_SchemaField *
+SocketProto_Schema_find_field (const SocketProto_Schema *schema,
+                               uint32_t field_number)
+{
+  if (schema == NULL || schema->fields == NULL || schema->field_count == 0)
+    return NULL;
+
+  for (size_t i = 0; i < schema->field_count; i++)
+    {
+      if (schema->fields[i].field_number == field_number)
+        return &schema->fields[i];
+    }
+
+  return NULL;
+}
+
+void
+SocketProto_limits_defaults (SocketProto_Limits *limits)
+{
+  if (limits == NULL)
+    return;
+
+  limits->max_message_size = SOCKET_PROTO_DEFAULT_MAX_MESSAGE_SIZE;
+  limits->max_fields = SOCKET_PROTO_DEFAULT_MAX_FIELDS;
+  limits->max_nesting_depth = SOCKET_PROTO_DEFAULT_MAX_NESTING_DEPTH;
+}
+
+static void
+socketproto_limits_apply (SocketProto_Limits *out, const SocketProto_Limits *in)
+{
+  SocketProto_limits_defaults (out);
+  if (in == NULL)
+    return;
+
+  if (in->max_message_size != 0)
+    out->max_message_size = in->max_message_size;
+  if (in->max_fields != 0)
+    out->max_fields = in->max_fields;
+  if (in->max_nesting_depth != 0)
+    out->max_nesting_depth = in->max_nesting_depth;
+}
+
+SocketProto_Message_T
+SocketProto_Message_new (Arena_T arena,
+                         const SocketProto_Limits *limits,
+                         const SocketProto_Schema *schema)
+{
+  SocketProto_Message_T message
+      = calloc (1, sizeof (struct SocketProto_Message));
+  if (message == NULL)
+    return NULL;
+
+  if (arena != NULL)
+    {
+      message->arena = arena;
+      message->owns_arena = 0;
+    }
+  else
+    {
+      message->arena = Arena_new ();
+      message->owns_arena = 1;
+    }
+
+  socketproto_limits_apply (&message->limits, limits);
+  message->schema = schema;
+  return message;
+}
+
+void
+SocketProto_Message_free (SocketProto_Message_T *message)
+{
+  if (message == NULL || *message == NULL)
+    return;
+
+  if ((*message)->owns_arena)
+    {
+      Arena_dispose (&(*message)->arena);
+    }
+
+  free (*message);
+  *message = NULL;
+}
+
+void
+SocketProto_Message_clear (SocketProto_Message_T message)
+{
+  if (message == NULL)
+    return;
+  message->field_count = 0;
+  message->unknown_count = 0;
+}
+
+static SocketProto_Result
+socketproto_message_reserve_fields (SocketProto_Message_T message, size_t needed)
+{
+  size_t new_capacity;
+  size_t bytes;
+  SocketProto_Field *new_fields;
+
+  if (message->field_capacity >= needed)
+    return SOCKET_PROTO_OK;
+
+  new_capacity = message->field_capacity ? message->field_capacity : 8U;
+  while (new_capacity < needed)
+    {
+      size_t doubled;
+      if (socketproto_size_mul (new_capacity, 2U, &doubled))
+        return SOCKET_PROTO_OVERFLOW;
+      if (doubled > message->limits.max_fields)
+        {
+          new_capacity = message->limits.max_fields;
+          break;
+        }
+      new_capacity = doubled;
+    }
+
+  if (new_capacity < needed)
+    return SOCKET_PROTO_LIMIT_FIELD_COUNT;
+
+  if (socketproto_size_mul (new_capacity, sizeof (SocketProto_Field), &bytes))
+    return SOCKET_PROTO_OVERFLOW;
+
+  (void)bytes;
+  new_fields = CALLOC (message->arena, new_capacity, sizeof (SocketProto_Field));
+  if (message->fields != NULL && message->field_count > 0)
+    {
+      memcpy (new_fields,
+              message->fields,
+              message->field_count * sizeof (SocketProto_Field));
+    }
+
+  message->fields = new_fields;
+  message->field_capacity = new_capacity;
+  return SOCKET_PROTO_OK;
+}
+
+static SocketProto_Result
+socketproto_validate_message_internal (const uint8_t *data,
+                                       size_t len,
+                                       const SocketProto_Schema *schema,
+                                       const SocketProto_Limits *limits,
+                                       size_t depth)
+{
+  size_t offset = 0;
+  size_t field_count = 0;
+
+  if ((data == NULL && len != 0) || limits == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  if (len > limits->max_message_size)
+    return SOCKET_PROTO_LIMIT_MESSAGE_SIZE;
+
+  if (depth > limits->max_nesting_depth)
+    return SOCKET_PROTO_LIMIT_NESTING_DEPTH;
+
+  while (offset < len)
+    {
+      SocketProto_Field field;
+      size_t consumed = 0;
+      SocketProto_Result rc = SocketProto_wire_read_field (
+          data + offset, len - offset, &field, &consumed);
+      if (rc != SOCKET_PROTO_OK)
+        return rc;
+      if (consumed == 0)
+        return SOCKET_PROTO_MALFORMED;
+
+      field_count++;
+      if (field_count > limits->max_fields)
+        return SOCKET_PROTO_LIMIT_FIELD_COUNT;
+
+      if (schema != NULL)
+        {
+          const SocketProto_SchemaField *decl
+              = SocketProto_Schema_find_field (schema, field.field_number);
+          if (decl != NULL)
+            {
+              uint8_t expected_wire = socketproto_kind_wire_type (decl->kind);
+              if (expected_wire != field.wire_type)
+                return SOCKET_PROTO_TYPE_MISMATCH;
+
+              if (decl->kind == SOCKET_PROTO_KIND_MESSAGE
+                  && decl->message_schema != NULL)
+                {
+                  if (depth + 1 > limits->max_nesting_depth)
+                    return SOCKET_PROTO_LIMIT_NESTING_DEPTH;
+
+                  rc = socketproto_validate_message_internal (
+                      field.value,
+                      field.value_len,
+                      decl->message_schema,
+                      limits,
+                      depth + 1);
+                  if (rc != SOCKET_PROTO_OK)
+                    return rc;
+                }
+            }
+        }
+
+      if (socketproto_size_add (offset, consumed, &offset))
+        return SOCKET_PROTO_OVERFLOW;
+    }
+
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_Message_validate (const uint8_t *data,
+                              size_t len,
+                              const SocketProto_Schema *schema,
+                              const SocketProto_Limits *limits)
+{
+  SocketProto_Limits effective_limits;
+  socketproto_limits_apply (&effective_limits, limits);
+  return socketproto_validate_message_internal (
+      data, len, schema, &effective_limits, 0);
+}
+
+static SocketProto_Result
+socketproto_message_store_encoded (SocketProto_Message_T message,
+                                   uint32_t field_number,
+                                   uint8_t wire_type,
+                                   uint8_t *encoded,
+                                   size_t encoded_len,
+                                   size_t value_offset,
+                                   size_t value_len,
+                                   int known)
+{
+  SocketProto_Result rc;
+  SocketProto_Field *dst;
+  size_t total_size = 0;
+
+  if (message == NULL || encoded == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (value_offset > encoded_len)
+    return SOCKET_PROTO_MALFORMED;
+  if (value_len > encoded_len - value_offset)
+    return SOCKET_PROTO_MALFORMED;
+  if (message->field_count >= message->limits.max_fields)
+    return SOCKET_PROTO_LIMIT_FIELD_COUNT;
+
+  for (size_t i = 0; i < message->field_count; i++)
+    {
+      if (socketproto_size_add (total_size, message->fields[i].encoded_len, &total_size))
+        return SOCKET_PROTO_OVERFLOW;
+    }
+  if (socketproto_size_add (total_size, encoded_len, &total_size))
+    return SOCKET_PROTO_OVERFLOW;
+  if (total_size > message->limits.max_message_size)
+    return SOCKET_PROTO_LIMIT_MESSAGE_SIZE;
+
+  rc = socketproto_message_reserve_fields (message, message->field_count + 1);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  dst = &message->fields[message->field_count++];
+  dst->field_number = field_number;
+  dst->wire_type = wire_type;
+  dst->encoded = encoded;
+  dst->encoded_len = encoded_len;
+  dst->value = encoded + value_offset;
+  dst->value_len = value_len;
+  dst->known = known ? 1 : 0;
+  if (!dst->known)
+    message->unknown_count++;
+
+  return SOCKET_PROTO_OK;
+}
+
+static SocketProto_Result
+socketproto_message_store_from_view (SocketProto_Message_T message,
+                                     const SocketProto_Field *view,
+                                     int known)
+{
+  ptrdiff_t offset;
+  size_t value_offset;
+  uint8_t *encoded_copy;
+
+  if (message == NULL || view == NULL || view->encoded == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  offset = view->value - view->encoded;
+  if (offset < 0)
+    return SOCKET_PROTO_MALFORMED;
+  value_offset = (size_t)offset;
+
+  encoded_copy = ALLOC (message->arena, view->encoded_len);
+  memcpy (encoded_copy, view->encoded, view->encoded_len);
+
+  return socketproto_message_store_encoded (message,
+                                            view->field_number,
+                                            view->wire_type,
+                                            encoded_copy,
+                                            view->encoded_len,
+                                            value_offset,
+                                            view->value_len,
+                                            known);
+}
+
+SocketProto_Result
+SocketProto_Message_parse (SocketProto_Message_T message,
+                           const uint8_t *data,
+                           size_t len)
+{
+  size_t offset = 0;
+
+  if (message == NULL || (data == NULL && len != 0))
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  SocketProto_Message_clear (message);
+
+  if (len > message->limits.max_message_size)
+    return SOCKET_PROTO_LIMIT_MESSAGE_SIZE;
+
+  while (offset < len)
+    {
+      SocketProto_Field field;
+      size_t consumed = 0;
+      int known = 0;
+      const SocketProto_SchemaField *decl = NULL;
+      SocketProto_Result rc
+          = SocketProto_wire_read_field (data + offset,
+                                         len - offset,
+                                         &field,
+                                         &consumed);
+      if (rc != SOCKET_PROTO_OK)
+        return rc;
+      if (consumed == 0)
+        return SOCKET_PROTO_MALFORMED;
+
+      if (message->schema != NULL)
+        {
+          decl = SocketProto_Schema_find_field (
+              message->schema, field.field_number);
+          if (decl != NULL)
+            {
+              uint8_t expected_wire = socketproto_kind_wire_type (decl->kind);
+              if (expected_wire != field.wire_type)
+                return SOCKET_PROTO_TYPE_MISMATCH;
+              known = 1;
+            }
+        }
+
+      if (decl != NULL && decl->kind == SOCKET_PROTO_KIND_MESSAGE
+          && decl->message_schema != NULL)
+        {
+          SocketProto_Result nested_rc = socketproto_validate_message_internal (
+              field.value,
+              field.value_len,
+              decl->message_schema,
+              &message->limits,
+              1);
+          if (nested_rc != SOCKET_PROTO_OK)
+            return nested_rc;
+        }
+
+      rc = socketproto_message_store_from_view (message, &field, known);
+      if (rc != SOCKET_PROTO_OK)
+        return rc;
+
+      if (socketproto_size_add (offset, consumed, &offset))
+        return SOCKET_PROTO_OVERFLOW;
+    }
+
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_Message_encode (const SocketProto_Message_T message,
+                            uint8_t *out,
+                            size_t out_len,
+                            size_t *written)
+{
+  size_t total = 0;
+  size_t pos = 0;
+
+  if (message == NULL || out == NULL || written == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  for (size_t i = 0; i < message->field_count; i++)
+    {
+      if (socketproto_size_add (total, message->fields[i].encoded_len, &total))
+        return SOCKET_PROTO_OVERFLOW;
+    }
+
+  if (out_len < total)
+    return SOCKET_PROTO_BUFFER_TOO_SMALL;
+
+  for (size_t i = 0; i < message->field_count; i++)
+    {
+      memcpy (out + pos, message->fields[i].encoded, message->fields[i].encoded_len);
+      pos += message->fields[i].encoded_len;
+    }
+
+  *written = total;
+  return SOCKET_PROTO_OK;
+}
+
+size_t
+SocketProto_Message_field_count (const SocketProto_Message_T message)
+{
+  return message ? message->field_count : 0;
+}
+
+const SocketProto_Field *
+SocketProto_Message_field_at (const SocketProto_Message_T message, size_t index)
+{
+  if (message == NULL || index >= message->field_count)
+    return NULL;
+  return &message->fields[index];
+}
+
+size_t
+SocketProto_Message_unknown_count (const SocketProto_Message_T message)
+{
+  return message ? message->unknown_count : 0;
+}
+
+const SocketProto_Field *
+SocketProto_Message_unknown_at (const SocketProto_Message_T message, size_t index)
+{
+  size_t seen = 0;
+
+  if (message == NULL)
+    return NULL;
+
+  for (size_t i = 0; i < message->field_count; i++)
+    {
+      if (!message->fields[i].known)
+        {
+          if (seen == index)
+            return &message->fields[i];
+          seen++;
+        }
+    }
+
+  return NULL;
+}
+
+static SocketProto_Result
+socketproto_message_schema_classify (const SocketProto_Message_T message,
+                                     uint32_t field_number,
+                                     uint8_t wire_type,
+                                     int *known,
+                                     const SocketProto_SchemaField **decl_out)
+{
+  if (known == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  *known = 0;
+  if (decl_out != NULL)
+    *decl_out = NULL;
+
+  if (message == NULL || message->schema == NULL)
+    return SOCKET_PROTO_OK;
+
+  const SocketProto_SchemaField *decl
+      = SocketProto_Schema_find_field (message->schema, field_number);
+  if (decl == NULL)
+    return SOCKET_PROTO_OK;
+
+  if (socketproto_kind_wire_type (decl->kind) != wire_type)
+    return SOCKET_PROTO_TYPE_MISMATCH;
+
+  *known = 1;
+  if (decl_out != NULL)
+    *decl_out = decl;
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_Message_append_varint (SocketProto_Message_T message,
+                                   uint32_t field_number,
+                                   uint64_t value)
+{
+  uint8_t tag_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t val_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t *encoded;
+  size_t tag_len = 0;
+  size_t val_len = 0;
+  size_t total = 0;
+  int known = 0;
+  SocketProto_Result rc;
+
+  if (message == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = socketproto_message_schema_classify (
+      message, field_number, SOCKET_PROTO_WIRE_VARINT, &known, NULL);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_wire_write_tag (
+      field_number, SOCKET_PROTO_WIRE_VARINT, tag_buf, sizeof (tag_buf), &tag_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_varint_encode_u64 (value, val_buf, sizeof (val_buf), &val_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  if (socketproto_size_add (tag_len, val_len, &total))
+    return SOCKET_PROTO_OVERFLOW;
+
+  encoded = ALLOC (message->arena, total);
+  memcpy (encoded, tag_buf, tag_len);
+  memcpy (encoded + tag_len, val_buf, val_len);
+
+  return socketproto_message_store_encoded (message,
+                                            field_number,
+                                            SOCKET_PROTO_WIRE_VARINT,
+                                            encoded,
+                                            total,
+                                            tag_len,
+                                            val_len,
+                                            known);
+}
+
+SocketProto_Result
+SocketProto_Message_append_sint64 (SocketProto_Message_T message,
+                                   uint32_t field_number,
+                                   int64_t value)
+{
+  return SocketProto_Message_append_varint (
+      message, field_number, SocketProto_zigzag_encode_s64 (value));
+}
+
+SocketProto_Result
+SocketProto_Message_append_fixed32 (SocketProto_Message_T message,
+                                    uint32_t field_number,
+                                    uint32_t value)
+{
+  uint8_t tag_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t fixed_buf[4];
+  uint8_t *encoded;
+  size_t tag_len = 0;
+  size_t total = 0;
+  int known = 0;
+  SocketProto_Result rc;
+
+  if (message == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = socketproto_message_schema_classify (
+      message, field_number, SOCKET_PROTO_WIRE_FIXED32, &known, NULL);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_wire_write_tag (
+      field_number, SOCKET_PROTO_WIRE_FIXED32, tag_buf, sizeof (tag_buf), &tag_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_fixed32_encode (value, fixed_buf, sizeof (fixed_buf));
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  if (socketproto_size_add (tag_len, sizeof (fixed_buf), &total))
+    return SOCKET_PROTO_OVERFLOW;
+
+  encoded = ALLOC (message->arena, total);
+  memcpy (encoded, tag_buf, tag_len);
+  memcpy (encoded + tag_len, fixed_buf, sizeof (fixed_buf));
+
+  return socketproto_message_store_encoded (message,
+                                            field_number,
+                                            SOCKET_PROTO_WIRE_FIXED32,
+                                            encoded,
+                                            total,
+                                            tag_len,
+                                            sizeof (fixed_buf),
+                                            known);
+}
+
+SocketProto_Result
+SocketProto_Message_append_fixed64 (SocketProto_Message_T message,
+                                    uint32_t field_number,
+                                    uint64_t value)
+{
+  uint8_t tag_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t fixed_buf[8];
+  uint8_t *encoded;
+  size_t tag_len = 0;
+  size_t total = 0;
+  int known = 0;
+  SocketProto_Result rc;
+
+  if (message == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = socketproto_message_schema_classify (
+      message, field_number, SOCKET_PROTO_WIRE_FIXED64, &known, NULL);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_wire_write_tag (
+      field_number, SOCKET_PROTO_WIRE_FIXED64, tag_buf, sizeof (tag_buf), &tag_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_fixed64_encode (value, fixed_buf, sizeof (fixed_buf));
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  if (socketproto_size_add (tag_len, sizeof (fixed_buf), &total))
+    return SOCKET_PROTO_OVERFLOW;
+
+  encoded = ALLOC (message->arena, total);
+  memcpy (encoded, tag_buf, tag_len);
+  memcpy (encoded + tag_len, fixed_buf, sizeof (fixed_buf));
+
+  return socketproto_message_store_encoded (message,
+                                            field_number,
+                                            SOCKET_PROTO_WIRE_FIXED64,
+                                            encoded,
+                                            total,
+                                            tag_len,
+                                            sizeof (fixed_buf),
+                                            known);
+}
+
+SocketProto_Result
+SocketProto_Message_append_bytes (SocketProto_Message_T message,
+                                  uint32_t field_number,
+                                  const uint8_t *value,
+                                  size_t value_len)
+{
+  uint8_t tag_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t len_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  size_t tag_len = 0;
+  size_t len_len = 0;
+  size_t prefix_len = 0;
+  size_t total = 0;
+  uint8_t *encoded;
+  int known = 0;
+  const SocketProto_SchemaField *decl = NULL;
+  SocketProto_Result rc;
+
+  if (message == NULL || (value_len > 0 && value == NULL))
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = socketproto_message_schema_classify (message,
+                                            field_number,
+                                            SOCKET_PROTO_WIRE_LENGTH_DELIMITED,
+                                            &known,
+                                            &decl);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_wire_write_tag (field_number,
+                                   SOCKET_PROTO_WIRE_LENGTH_DELIMITED,
+                                   tag_buf,
+                                   sizeof (tag_buf),
+                                   &tag_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_varint_encode_u64 (
+      (uint64_t)value_len, len_buf, sizeof (len_buf), &len_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  if (socketproto_size_add (tag_len, len_len, &prefix_len))
+    return SOCKET_PROTO_OVERFLOW;
+  if (socketproto_size_add (prefix_len, value_len, &total))
+    return SOCKET_PROTO_OVERFLOW;
+  if (total > message->limits.max_message_size)
+    return SOCKET_PROTO_LIMIT_MESSAGE_SIZE;
+
+  encoded = ALLOC (message->arena, total);
+  memcpy (encoded, tag_buf, tag_len);
+  memcpy (encoded + tag_len, len_buf, len_len);
+  if (value_len > 0)
+    memcpy (encoded + prefix_len, value, value_len);
+
+  if (decl != NULL && decl->kind == SOCKET_PROTO_KIND_MESSAGE
+      && decl->message_schema != NULL)
+    {
+      SocketProto_Result nested_rc = socketproto_validate_message_internal (
+          value, value_len, decl->message_schema, &message->limits, 1);
+      if (nested_rc != SOCKET_PROTO_OK)
+        return nested_rc;
+    }
+
+  return socketproto_message_store_encoded (message,
+                                            field_number,
+                                            SOCKET_PROTO_WIRE_LENGTH_DELIMITED,
+                                            encoded,
+                                            total,
+                                            prefix_len,
+                                            value_len,
+                                            known);
+}
+
+SocketProto_Result
+SocketProto_Message_append_embedded (SocketProto_Message_T message,
+                                     uint32_t field_number,
+                                     const uint8_t *encoded_message,
+                                     size_t encoded_len)
+{
+  return SocketProto_Message_append_bytes (
+      message, field_number, encoded_message, encoded_len);
+}
+
+SocketProto_Result
+SocketProto_Field_decode_u64 (const SocketProto_Field *field, uint64_t *value)
+{
+  size_t consumed = 0;
+  SocketProto_Result rc;
+
+  if (field == NULL || value == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (field->wire_type != SOCKET_PROTO_WIRE_VARINT)
+    return SOCKET_PROTO_TYPE_MISMATCH;
+
+  rc = SocketProto_varint_decode_u64 (
+      field->value, field->value_len, value, &consumed);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+  if (consumed != field->value_len)
+    return SOCKET_PROTO_MALFORMED;
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_Field_decode_s64 (const SocketProto_Field *field, int64_t *value)
+{
+  uint64_t encoded = 0;
+  SocketProto_Result rc;
+
+  if (field == NULL || value == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = SocketProto_Field_decode_u64 (field, &encoded);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  *value = SocketProto_zigzag_decode_s64 (encoded);
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_Field_decode_fixed32 (const SocketProto_Field *field, uint32_t *value)
+{
+  if (field == NULL || value == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (field->wire_type != SOCKET_PROTO_WIRE_FIXED32)
+    return SOCKET_PROTO_TYPE_MISMATCH;
+  return SocketProto_fixed32_decode (field->value, field->value_len, value);
+}
+
+SocketProto_Result
+SocketProto_Field_decode_fixed64 (const SocketProto_Field *field, uint64_t *value)
+{
+  if (field == NULL || value == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (field->wire_type != SOCKET_PROTO_WIRE_FIXED64)
+    return SOCKET_PROTO_TYPE_MISMATCH;
+  return SocketProto_fixed64_decode (field->value, field->value_len, value);
+}

--- a/src/grpc/SocketProto-varint.c
+++ b/src/grpc/SocketProto-varint.c
@@ -1,0 +1,216 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketProto-varint.c
+ * @brief Protobuf varint/zigzag/fixed primitives.
+ */
+
+#include "grpc/SocketProto-private.h"
+
+#include <limits.h>
+
+static const char *socketproto_result_names[]
+    = { "SOCKET_PROTO_OK",
+        "SOCKET_PROTO_INCOMPLETE",
+        "SOCKET_PROTO_OVERFLOW",
+        "SOCKET_PROTO_INVALID_ARGUMENT",
+        "SOCKET_PROTO_INVALID_TAG",
+        "SOCKET_PROTO_INVALID_WIRE_TYPE",
+        "SOCKET_PROTO_TYPE_MISMATCH",
+        "SOCKET_PROTO_LIMIT_MESSAGE_SIZE",
+        "SOCKET_PROTO_LIMIT_FIELD_COUNT",
+        "SOCKET_PROTO_LIMIT_NESTING_DEPTH",
+        "SOCKET_PROTO_BUFFER_TOO_SMALL",
+        "SOCKET_PROTO_MALFORMED" };
+
+_Static_assert (sizeof (socketproto_result_names)
+                        / sizeof (socketproto_result_names[0])
+                    == SOCKET_PROTO_MALFORMED + 1,
+                "socketproto_result_names must map all result codes");
+
+const char *
+SocketProto_result_string (SocketProto_Result result)
+{
+  if (result < SOCKET_PROTO_OK || result > SOCKET_PROTO_MALFORMED)
+    return "SOCKET_PROTO_UNKNOWN_RESULT";
+  return socketproto_result_names[result];
+}
+
+SocketProto_Result
+SocketProto_varint_encode_u64 (uint64_t value,
+                               uint8_t *out,
+                               size_t out_len,
+                               size_t *written)
+{
+  size_t pos = 0;
+
+  if (out == NULL || written == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  while (value >= 0x80U)
+    {
+      if (pos >= out_len)
+        return SOCKET_PROTO_BUFFER_TOO_SMALL;
+      out[pos++] = (uint8_t)((value & 0x7FU) | 0x80U);
+      value >>= 7;
+    }
+
+  if (pos >= out_len)
+    return SOCKET_PROTO_BUFFER_TOO_SMALL;
+
+  out[pos++] = (uint8_t)value;
+  *written = pos;
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_varint_decode_u64 (const uint8_t *in,
+                               size_t in_len,
+                               uint64_t *value,
+                               size_t *consumed)
+{
+  uint64_t result = 0;
+
+  if (in == NULL || value == NULL || consumed == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  for (size_t i = 0; i < in_len && i < SOCKET_PROTO_MAX_VARINT_LEN; i++)
+    {
+      uint8_t byte = in[i];
+      uint64_t payload = (uint64_t)(byte & 0x7FU);
+      unsigned shift = (unsigned)(i * 7U);
+
+      if (i == SOCKET_PROTO_MAX_VARINT_LEN - 1 && (byte & 0xFEU) != 0)
+        return SOCKET_PROTO_OVERFLOW;
+
+      result |= (payload << shift);
+
+      if ((byte & 0x80U) == 0)
+        {
+          *value = result;
+          *consumed = i + 1;
+          return SOCKET_PROTO_OK;
+        }
+    }
+
+  if (in_len < SOCKET_PROTO_MAX_VARINT_LEN)
+    return SOCKET_PROTO_INCOMPLETE;
+
+  return SOCKET_PROTO_OVERFLOW;
+}
+
+SocketProto_Result
+SocketProto_varint_encode_u32 (uint32_t value,
+                               uint8_t *out,
+                               size_t out_len,
+                               size_t *written)
+{
+  return SocketProto_varint_encode_u64 ((uint64_t)value, out, out_len, written);
+}
+
+SocketProto_Result
+SocketProto_varint_decode_u32 (const uint8_t *in,
+                               size_t in_len,
+                               uint32_t *value,
+                               size_t *consumed)
+{
+  uint64_t decoded = 0;
+  SocketProto_Result rc
+      = SocketProto_varint_decode_u64 (in, in_len, &decoded, consumed);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+  if (decoded > UINT32_MAX)
+    return SOCKET_PROTO_OVERFLOW;
+  *value = (uint32_t)decoded;
+  return SOCKET_PROTO_OK;
+}
+
+uint64_t
+SocketProto_zigzag_encode_s64 (int64_t value)
+{
+  return (((uint64_t)value) << 1) ^ (uint64_t)(value >> 63);
+}
+
+int64_t
+SocketProto_zigzag_decode_s64 (uint64_t value)
+{
+  return (int64_t)((value >> 1) ^ (uint64_t)(-(int64_t)(value & 1U)));
+}
+
+uint32_t
+SocketProto_zigzag_encode_s32 (int32_t value)
+{
+  return (((uint32_t)value) << 1) ^ (uint32_t)(value >> 31);
+}
+
+int32_t
+SocketProto_zigzag_decode_s32 (uint32_t value)
+{
+  return (int32_t)((value >> 1) ^ (uint32_t)(-(int32_t)(value & 1U)));
+}
+
+SocketProto_Result
+SocketProto_fixed32_encode (uint32_t value, uint8_t *out, size_t out_len)
+{
+  if (out == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (out_len < 4)
+    return SOCKET_PROTO_BUFFER_TOO_SMALL;
+
+  out[0] = (uint8_t)(value & 0xFFU);
+  out[1] = (uint8_t)((value >> 8) & 0xFFU);
+  out[2] = (uint8_t)((value >> 16) & 0xFFU);
+  out[3] = (uint8_t)((value >> 24) & 0xFFU);
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_fixed32_decode (const uint8_t *in, size_t in_len, uint32_t *value)
+{
+  if (in == NULL || value == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (in_len < 4)
+    return SOCKET_PROTO_INCOMPLETE;
+
+  *value = (uint32_t)in[0] | ((uint32_t)in[1] << 8) | ((uint32_t)in[2] << 16)
+           | ((uint32_t)in[3] << 24);
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_fixed64_encode (uint64_t value, uint8_t *out, size_t out_len)
+{
+  if (out == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (out_len < 8)
+    return SOCKET_PROTO_BUFFER_TOO_SMALL;
+
+  out[0] = (uint8_t)(value & 0xFFU);
+  out[1] = (uint8_t)((value >> 8) & 0xFFU);
+  out[2] = (uint8_t)((value >> 16) & 0xFFU);
+  out[3] = (uint8_t)((value >> 24) & 0xFFU);
+  out[4] = (uint8_t)((value >> 32) & 0xFFU);
+  out[5] = (uint8_t)((value >> 40) & 0xFFU);
+  out[6] = (uint8_t)((value >> 48) & 0xFFU);
+  out[7] = (uint8_t)((value >> 56) & 0xFFU);
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_fixed64_decode (const uint8_t *in, size_t in_len, uint64_t *value)
+{
+  if (in == NULL || value == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+  if (in_len < 8)
+    return SOCKET_PROTO_INCOMPLETE;
+
+  *value = (uint64_t)in[0] | ((uint64_t)in[1] << 8)
+           | ((uint64_t)in[2] << 16) | ((uint64_t)in[3] << 24)
+           | ((uint64_t)in[4] << 32) | ((uint64_t)in[5] << 40)
+           | ((uint64_t)in[6] << 48) | ((uint64_t)in[7] << 56);
+  return SOCKET_PROTO_OK;
+}

--- a/src/grpc/SocketProto-wire.c
+++ b/src/grpc/SocketProto-wire.c
@@ -1,0 +1,204 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketProto-wire.c
+ * @brief Protobuf wire-level field parsing and encoding.
+ */
+
+#include "grpc/SocketProto-private.h"
+
+SocketProto_Result
+SocketProto_wire_make_tag (uint32_t field_number, uint8_t wire_type, uint64_t *tag)
+{
+  if (tag == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  if (field_number == 0 || field_number > SOCKET_PROTO_MAX_FIELD_NUMBER)
+    return SOCKET_PROTO_INVALID_TAG;
+
+  if (wire_type > SOCKET_PROTO_WIRE_FIXED32 || wire_type == SOCKET_PROTO_WIRE_START_GROUP
+      || wire_type == SOCKET_PROTO_WIRE_END_GROUP)
+    return SOCKET_PROTO_INVALID_WIRE_TYPE;
+
+  *tag = ((uint64_t)field_number << 3U) | (uint64_t)wire_type;
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_wire_write_tag (uint32_t field_number,
+                            uint8_t wire_type,
+                            uint8_t *out,
+                            size_t out_len,
+                            size_t *written)
+{
+  uint64_t tag = 0;
+  SocketProto_Result rc
+      = SocketProto_wire_make_tag (field_number, wire_type, &tag);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+  return SocketProto_varint_encode_u64 (tag, out, out_len, written);
+}
+
+SocketProto_Result
+SocketProto_wire_write_length_delimited (uint32_t field_number,
+                                         const uint8_t *value,
+                                         size_t value_len,
+                                         uint8_t *out,
+                                         size_t out_len,
+                                         size_t *written)
+{
+  uint8_t tag_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t len_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  size_t tag_len = 0;
+  size_t len_len = 0;
+  size_t offset = 0;
+  size_t total = 0;
+  SocketProto_Result rc;
+
+  if (out == NULL || written == NULL || (value_len > 0 && value == NULL))
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = SocketProto_wire_write_tag (field_number,
+                                   SOCKET_PROTO_WIRE_LENGTH_DELIMITED,
+                                   tag_buf,
+                                   sizeof (tag_buf),
+                                   &tag_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  rc = SocketProto_varint_encode_u64 (
+      (uint64_t)value_len, len_buf, sizeof (len_buf), &len_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  if (socketproto_size_add (tag_len, len_len, &total)
+      || socketproto_size_add (total, value_len, &total))
+    return SOCKET_PROTO_OVERFLOW;
+
+  if (out_len < total)
+    return SOCKET_PROTO_BUFFER_TOO_SMALL;
+
+  for (size_t i = 0; i < tag_len; i++)
+    out[offset++] = tag_buf[i];
+  for (size_t i = 0; i < len_len; i++)
+    out[offset++] = len_buf[i];
+  for (size_t i = 0; i < value_len; i++)
+    out[offset++] = value[i];
+
+  *written = total;
+  return SOCKET_PROTO_OK;
+}
+
+SocketProto_Result
+SocketProto_wire_read_field (const uint8_t *data,
+                             size_t len,
+                             SocketProto_Field *field,
+                             size_t *consumed)
+{
+  uint64_t tag = 0;
+  size_t tag_len = 0;
+  size_t offset = 0;
+  uint8_t wire_type;
+  uint32_t field_number;
+  SocketProto_Result rc;
+
+  if (data == NULL || field == NULL || consumed == NULL)
+    return SOCKET_PROTO_INVALID_ARGUMENT;
+
+  rc = SocketProto_varint_decode_u64 (data, len, &tag, &tag_len);
+  if (rc != SOCKET_PROTO_OK)
+    return rc;
+
+  wire_type = (uint8_t)(tag & 0x07U);
+  field_number = (uint32_t)(tag >> 3U);
+
+  if (field_number == 0 || field_number > SOCKET_PROTO_MAX_FIELD_NUMBER)
+    return SOCKET_PROTO_INVALID_TAG;
+
+  if (wire_type > SOCKET_PROTO_WIRE_FIXED32
+      || wire_type == SOCKET_PROTO_WIRE_START_GROUP
+      || wire_type == SOCKET_PROTO_WIRE_END_GROUP)
+    return SOCKET_PROTO_INVALID_WIRE_TYPE;
+
+  offset = tag_len;
+  field->field_number = field_number;
+  field->wire_type = wire_type;
+  field->encoded = data;
+  field->known = 0;
+
+  switch (wire_type)
+    {
+    case SOCKET_PROTO_WIRE_VARINT:
+      {
+        uint64_t ignored_value = 0;
+        size_t value_len = 0;
+        rc = SocketProto_varint_decode_u64 (
+            data + offset, len - offset, &ignored_value, &value_len);
+        if (rc != SOCKET_PROTO_OK)
+          return rc;
+
+        field->value = data + offset;
+        field->value_len = value_len;
+        if (socketproto_size_add (offset, value_len, &field->encoded_len))
+          return SOCKET_PROTO_OVERFLOW;
+      }
+      break;
+
+    case SOCKET_PROTO_WIRE_FIXED64:
+      if (len - offset < 8)
+        return SOCKET_PROTO_INCOMPLETE;
+      field->value = data + offset;
+      field->value_len = 8;
+      if (socketproto_size_add (offset, 8, &field->encoded_len))
+        return SOCKET_PROTO_OVERFLOW;
+      break;
+
+    case SOCKET_PROTO_WIRE_LENGTH_DELIMITED:
+      {
+        uint64_t length_u64 = 0;
+        size_t length_len = 0;
+        size_t payload_offset = 0;
+        size_t payload_end = 0;
+
+        rc = SocketProto_varint_decode_u64 (
+            data + offset, len - offset, &length_u64, &length_len);
+        if (rc != SOCKET_PROTO_OK)
+          return rc;
+
+        if (length_u64 > SIZE_MAX)
+          return SOCKET_PROTO_OVERFLOW;
+
+        if (socketproto_size_add (offset, length_len, &payload_offset))
+          return SOCKET_PROTO_OVERFLOW;
+        if (socketproto_size_add (payload_offset, (size_t)length_u64, &payload_end))
+          return SOCKET_PROTO_OVERFLOW;
+
+        if (payload_end > len)
+          return SOCKET_PROTO_INCOMPLETE;
+
+        field->value = data + payload_offset;
+        field->value_len = (size_t)length_u64;
+        field->encoded_len = payload_end;
+      }
+      break;
+
+    case SOCKET_PROTO_WIRE_FIXED32:
+      if (len - offset < 4)
+        return SOCKET_PROTO_INCOMPLETE;
+      field->value = data + offset;
+      field->value_len = 4;
+      if (socketproto_size_add (offset, 4, &field->encoded_len))
+        return SOCKET_PROTO_OVERFLOW;
+      break;
+
+    default:
+      return SOCKET_PROTO_INVALID_WIRE_TYPE;
+    }
+
+  *consumed = field->encoded_len;
+  return SOCKET_PROTO_OK;
+}

--- a/src/test/test_proto_message.c
+++ b/src/test/test_proto_message.c
@@ -1,0 +1,190 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_proto_message.c
+ * @brief Unit tests for protobuf message parse/encode/runtime limits.
+ */
+
+#include "grpc/SocketProto.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+static const SocketProto_SchemaField test_schema_fields[] = {
+  { 1, SOCKET_PROTO_KIND_VARINT, NULL },
+  { 2, SOCKET_PROTO_KIND_LENGTH_DELIMITED, NULL },
+};
+
+static const SocketProto_Schema test_schema = {
+  .fields = test_schema_fields,
+  .field_count = sizeof (test_schema_fields) / sizeof (test_schema_fields[0]),
+};
+
+TEST (proto_message_roundtrip_and_unknown_preservation)
+{
+  SocketProto_Message_T builder = SocketProto_Message_new (NULL, NULL, &test_schema);
+  SocketProto_Message_T parsed = SocketProto_Message_new (NULL, NULL, &test_schema);
+  uint8_t encoded[128];
+  uint8_t reencoded[128];
+  size_t encoded_len = 0;
+  size_t reencoded_len = 0;
+
+  ASSERT_NOT_NULL (builder);
+  ASSERT_NOT_NULL (parsed);
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_Message_append_varint (builder, 1, 42));
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_Message_append_bytes (
+                 builder, 2, (const uint8_t *)"pong", 4));
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_Message_append_varint (builder, 9, 777));
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_Message_encode (
+                 builder, encoded, sizeof (encoded), &encoded_len));
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_Message_parse (parsed, encoded, encoded_len));
+  ASSERT_EQ (3U, SocketProto_Message_field_count (parsed));
+  ASSERT_EQ (1U, SocketProto_Message_unknown_count (parsed));
+
+  const SocketProto_Field *f0 = SocketProto_Message_field_at (parsed, 0);
+  const SocketProto_Field *f1 = SocketProto_Message_field_at (parsed, 1);
+  const SocketProto_Field *unknown = SocketProto_Message_unknown_at (parsed, 0);
+  uint64_t decoded_id = 0;
+
+  ASSERT_NOT_NULL (f0);
+  ASSERT_NOT_NULL (f1);
+  ASSERT_NOT_NULL (unknown);
+  ASSERT_EQ (1U, f0->field_number);
+  ASSERT_EQ (2U, f1->field_number);
+  ASSERT_EQ (9U, unknown->field_number);
+  ASSERT_EQ (SOCKET_PROTO_OK, SocketProto_Field_decode_u64 (f0, &decoded_id));
+  ASSERT_EQ (42ULL, decoded_id);
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_Message_encode (
+                 parsed, reencoded, sizeof (reencoded), &reencoded_len));
+  ASSERT_EQ (encoded_len, reencoded_len);
+  ASSERT_EQ (0, memcmp (encoded, reencoded, encoded_len));
+
+  SocketProto_Message_free (&parsed);
+  SocketProto_Message_free (&builder);
+}
+
+TEST (proto_message_rejects_malformed_wire)
+{
+  SocketProto_Message_T msg = SocketProto_Message_new (NULL, NULL, &test_schema);
+  uint8_t invalid_wire[] = { 0x13, 0x00 };
+  uint8_t truncated[] = { 0x08, 0x80 };
+
+  ASSERT_NOT_NULL (msg);
+  ASSERT_EQ (SOCKET_PROTO_INVALID_WIRE_TYPE,
+             SocketProto_Message_parse (msg, invalid_wire, sizeof (invalid_wire)));
+  ASSERT_EQ (SOCKET_PROTO_INCOMPLETE,
+             SocketProto_Message_parse (msg, truncated, sizeof (truncated)));
+  SocketProto_Message_free (&msg);
+}
+
+TEST (proto_message_enforces_field_and_size_limits)
+{
+  SocketProto_Limits field_limits;
+  SocketProto_Limits size_limits;
+  SocketProto_Message_T limited_by_fields;
+  uint8_t three_fields[] = { 0x08, 0x01, 0x10, 0x02, 0x18, 0x03 };
+
+  SocketProto_limits_defaults (&field_limits);
+  field_limits.max_fields = 2;
+  field_limits.max_message_size = 64;
+
+  SocketProto_limits_defaults (&size_limits);
+  size_limits.max_message_size = 5;
+
+  limited_by_fields = SocketProto_Message_new (NULL, &field_limits, NULL);
+  ASSERT_NOT_NULL (limited_by_fields);
+  ASSERT_EQ (SOCKET_PROTO_LIMIT_FIELD_COUNT,
+             SocketProto_Message_parse (
+                 limited_by_fields, three_fields, sizeof (three_fields)));
+  ASSERT_EQ (SOCKET_PROTO_LIMIT_MESSAGE_SIZE,
+             SocketProto_Message_validate (
+                 three_fields, sizeof (three_fields), &test_schema, &size_limits));
+
+  SocketProto_Message_free (&limited_by_fields);
+}
+
+TEST (proto_message_enforces_nesting_depth)
+{
+  static const SocketProto_SchemaField level2_fields[]
+      = { { 1, SOCKET_PROTO_KIND_VARINT, NULL } };
+  static const SocketProto_Schema level2 = {
+    .fields = level2_fields,
+    .field_count = sizeof (level2_fields) / sizeof (level2_fields[0]),
+  };
+  static const SocketProto_SchemaField level1_fields[]
+      = { { 1, SOCKET_PROTO_KIND_MESSAGE, &level2 } };
+  static const SocketProto_Schema level1 = {
+    .fields = level1_fields,
+    .field_count = sizeof (level1_fields) / sizeof (level1_fields[0]),
+  };
+  static const SocketProto_SchemaField root_fields[]
+      = { { 1, SOCKET_PROTO_KIND_MESSAGE, &level1 } };
+  static const SocketProto_Schema root = {
+    .fields = root_fields,
+    .field_count = sizeof (root_fields) / sizeof (root_fields[0]),
+  };
+
+  SocketProto_Limits shallow_limits;
+  SocketProto_Limits deep_limits;
+  SocketProto_Message_T shallow_msg;
+  SocketProto_Message_T deep_msg;
+  const uint8_t nested_payload[] = {
+    0x0A, 0x04, /* field 1, len 4 */
+    0x0A, 0x02, /* field 1, len 2 */
+    0x08, 0x07  /* field 1, varint 7 */
+  };
+
+  SocketProto_limits_defaults (&shallow_limits);
+  shallow_limits.max_nesting_depth = 1;
+  SocketProto_limits_defaults (&deep_limits);
+  deep_limits.max_nesting_depth = 3;
+
+  shallow_msg = SocketProto_Message_new (NULL, &shallow_limits, &root);
+  deep_msg = SocketProto_Message_new (NULL, &deep_limits, &root);
+  ASSERT_NOT_NULL (shallow_msg);
+  ASSERT_NOT_NULL (deep_msg);
+
+  ASSERT_EQ (SOCKET_PROTO_LIMIT_NESTING_DEPTH,
+             SocketProto_Message_parse (
+                 shallow_msg, nested_payload, sizeof (nested_payload)));
+  ASSERT_EQ (
+      SOCKET_PROTO_OK,
+      SocketProto_Message_parse (deep_msg, nested_payload, sizeof (nested_payload)));
+
+  SocketProto_Message_free (&deep_msg);
+  SocketProto_Message_free (&shallow_msg);
+}
+
+TEST (proto_message_append_type_mismatch_fails_closed)
+{
+  SocketProto_Message_T msg = SocketProto_Message_new (NULL, NULL, &test_schema);
+  ASSERT_NOT_NULL (msg);
+
+  ASSERT_EQ (SOCKET_PROTO_TYPE_MISMATCH,
+             SocketProto_Message_append_fixed64 (msg, 1, 0xABULL));
+  ASSERT_EQ (SOCKET_PROTO_TYPE_MISMATCH,
+             SocketProto_Message_append_varint (msg, 2, 8));
+
+  SocketProto_Message_free (&msg);
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}

--- a/src/test/test_proto_varint.c
+++ b/src/test/test_proto_varint.c
@@ -1,0 +1,133 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_proto_varint.c
+ * @brief Unit tests for protobuf varint/zigzag/fixed primitives.
+ */
+
+#include "grpc/SocketProto.h"
+#include "test/Test.h"
+
+#include <limits.h>
+
+TEST (proto_varint_u64_roundtrip_boundaries)
+{
+  const uint64_t values[] = { 0ULL,
+                              1ULL,
+                              127ULL,
+                              128ULL,
+                              255ULL,
+                              16384ULL,
+                              1048576ULL,
+                              UINT32_MAX,
+                              UINT64_MAX };
+
+  for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    {
+      uint8_t buf[SOCKET_PROTO_MAX_VARINT_LEN];
+      size_t written = 0;
+      uint64_t decoded = 0;
+      size_t consumed = 0;
+
+      ASSERT_EQ (SOCKET_PROTO_OK,
+                 SocketProto_varint_encode_u64 (
+                     values[i], buf, sizeof (buf), &written));
+      ASSERT_EQ (SOCKET_PROTO_OK,
+                 SocketProto_varint_decode_u64 (
+                     buf, written, &decoded, &consumed));
+      ASSERT_EQ (values[i], decoded);
+      ASSERT_EQ (written, consumed);
+    }
+}
+
+TEST (proto_varint_u32_rejects_overflow)
+{
+  uint8_t buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  size_t written = 0;
+  uint32_t decoded = 0;
+  size_t consumed = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_varint_encode_u64 (
+                 (uint64_t)UINT32_MAX + 1ULL, buf, sizeof (buf), &written));
+  ASSERT_EQ (SOCKET_PROTO_OVERFLOW,
+             SocketProto_varint_decode_u32 (buf, written, &decoded, &consumed));
+}
+
+TEST (proto_varint_decode_detects_truncated_and_overflow_encodings)
+{
+  const uint8_t truncated[] = { 0x80 };
+  const uint8_t overflow[] = { 0x80, 0x80, 0x80, 0x80, 0x80,
+                               0x80, 0x80, 0x80, 0x80, 0x02 };
+  uint64_t value = 0;
+  size_t consumed = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_INCOMPLETE,
+             SocketProto_varint_decode_u64 (
+                 truncated, sizeof (truncated), &value, &consumed));
+  ASSERT_EQ (SOCKET_PROTO_OVERFLOW,
+             SocketProto_varint_decode_u64 (
+                 overflow, sizeof (overflow), &value, &consumed));
+}
+
+TEST (proto_varint_encode_detects_small_buffer)
+{
+  uint8_t buf[1];
+  size_t written = 0;
+
+  ASSERT_EQ (
+      SOCKET_PROTO_BUFFER_TOO_SMALL,
+      SocketProto_varint_encode_u64 (300, buf, sizeof (buf), &written));
+}
+
+TEST (proto_zigzag_roundtrip)
+{
+  const int64_t values[] = { 0, 1, -1, 2, -2, INT32_MAX, INT32_MIN };
+
+  for (size_t i = 0; i < sizeof (values) / sizeof (values[0]); i++)
+    {
+      uint64_t encoded = SocketProto_zigzag_encode_s64 (values[i]);
+      int64_t decoded = SocketProto_zigzag_decode_s64 (encoded);
+      ASSERT_EQ (values[i], decoded);
+    }
+}
+
+TEST (proto_fixed32_roundtrip_and_truncation)
+{
+  uint8_t buf[4];
+  uint32_t decoded = 0;
+
+  ASSERT_EQ (
+      SOCKET_PROTO_OK, SocketProto_fixed32_encode (0xA1B2C3D4U, buf, sizeof (buf)));
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_fixed32_decode (buf, sizeof (buf), &decoded));
+  ASSERT_EQ (0xA1B2C3D4U, decoded);
+  ASSERT_EQ (SOCKET_PROTO_INCOMPLETE,
+             SocketProto_fixed32_decode (buf, 3, &decoded));
+}
+
+TEST (proto_fixed64_roundtrip_and_truncation)
+{
+  uint8_t buf[8];
+  uint64_t decoded = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_fixed64_encode (
+                 0x1122334455667788ULL, buf, sizeof (buf)));
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_fixed64_decode (buf, sizeof (buf), &decoded));
+  ASSERT_EQ (0x1122334455667788ULL, decoded);
+  ASSERT_EQ (SOCKET_PROTO_INCOMPLETE,
+             SocketProto_fixed64_decode (buf, 7, &decoded));
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}

--- a/src/test/test_proto_wire.c
+++ b/src/test/test_proto_wire.c
@@ -1,0 +1,144 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_proto_wire.c
+ * @brief Unit tests for protobuf wire-level helpers.
+ */
+
+#include "grpc/SocketProto.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+TEST (proto_wire_make_tag_validation)
+{
+  uint64_t tag = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_make_tag (15, SOCKET_PROTO_WIRE_VARINT, &tag));
+  ASSERT_EQ (((uint64_t)15 << 3U) | SOCKET_PROTO_WIRE_VARINT, tag);
+
+  ASSERT_EQ (SOCKET_PROTO_INVALID_TAG,
+             SocketProto_wire_make_tag (0, SOCKET_PROTO_WIRE_VARINT, &tag));
+  ASSERT_EQ (SOCKET_PROTO_INVALID_WIRE_TYPE,
+             SocketProto_wire_make_tag (1, SOCKET_PROTO_WIRE_START_GROUP, &tag));
+}
+
+TEST (proto_wire_write_and_read_varint_field)
+{
+  uint8_t tag_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t val_buf[SOCKET_PROTO_MAX_VARINT_LEN];
+  uint8_t encoded[SOCKET_PROTO_MAX_VARINT_LEN * 2U];
+  size_t tag_len = 0;
+  size_t val_len = 0;
+  SocketProto_Field field;
+  size_t consumed = 0;
+  uint64_t decoded = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_write_tag (
+                 5, SOCKET_PROTO_WIRE_VARINT, tag_buf, sizeof (tag_buf), &tag_len));
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_varint_encode_u64 (
+                 1500, val_buf, sizeof (val_buf), &val_len));
+
+  memcpy (encoded, tag_buf, tag_len);
+  memcpy (encoded + tag_len, val_buf, val_len);
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_read_field (
+                 encoded, tag_len + val_len, &field, &consumed));
+  ASSERT_EQ (5U, field.field_number);
+  ASSERT_EQ ((uint8_t)SOCKET_PROTO_WIRE_VARINT, field.wire_type);
+  ASSERT_EQ (tag_len + val_len, consumed);
+  ASSERT_EQ (SOCKET_PROTO_OK, SocketProto_Field_decode_u64 (&field, &decoded));
+  ASSERT_EQ (1500ULL, decoded);
+}
+
+TEST (proto_wire_write_and_read_length_delimited_field)
+{
+  const uint8_t payload[] = { 0x41, 0x42, 0x43, 0x44 };
+  uint8_t encoded[64];
+  size_t written = 0;
+  SocketProto_Field field;
+  size_t consumed = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_write_length_delimited (7,
+                                                     payload,
+                                                     sizeof (payload),
+                                                     encoded,
+                                                     sizeof (encoded),
+                                                     &written));
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_read_field (encoded, written, &field, &consumed));
+  ASSERT_EQ (7U, field.field_number);
+  ASSERT_EQ ((uint8_t)SOCKET_PROTO_WIRE_LENGTH_DELIMITED, field.wire_type);
+  ASSERT_EQ (sizeof (payload), field.value_len);
+  ASSERT_EQ (0, memcmp (payload, field.value, sizeof (payload)));
+  ASSERT_EQ (written, consumed);
+}
+
+TEST (proto_wire_read_fixed_fields)
+{
+  uint8_t fixed32_field[] = { 0x0D, 0x44, 0x33, 0x22, 0x11 };
+  uint8_t fixed64_field[] = { 0x11, 0x88, 0x77, 0x66, 0x55,
+                              0x44, 0x33, 0x22, 0x11 };
+  SocketProto_Field field;
+  size_t consumed = 0;
+  uint32_t v32 = 0;
+  uint64_t v64 = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_read_field (
+                 fixed32_field, sizeof (fixed32_field), &field, &consumed));
+  ASSERT_EQ (SOCKET_PROTO_OK, SocketProto_Field_decode_fixed32 (&field, &v32));
+  ASSERT_EQ (0x11223344U, v32);
+
+  ASSERT_EQ (SOCKET_PROTO_OK,
+             SocketProto_wire_read_field (
+                 fixed64_field, sizeof (fixed64_field), &field, &consumed));
+  ASSERT_EQ (SOCKET_PROTO_OK, SocketProto_Field_decode_fixed64 (&field, &v64));
+  ASSERT_EQ (0x1122334455667788ULL, v64);
+}
+
+TEST (proto_wire_rejects_group_wire_types)
+{
+  uint8_t invalid_group_field[] = { 0x13, 0x01 };
+  SocketProto_Field field;
+  size_t consumed = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_INVALID_WIRE_TYPE,
+             SocketProto_wire_read_field (invalid_group_field,
+                                          sizeof (invalid_group_field),
+                                          &field,
+                                          &consumed));
+}
+
+TEST (proto_wire_detects_truncated_payloads)
+{
+  uint8_t truncated_len_delim[] = { 0x0A, 0x05, 0x01, 0x02 };
+  uint8_t truncated_fixed64[] = { 0x11, 0xAA, 0xBB, 0xCC };
+  SocketProto_Field field;
+  size_t consumed = 0;
+
+  ASSERT_EQ (SOCKET_PROTO_INCOMPLETE,
+             SocketProto_wire_read_field (truncated_len_delim,
+                                          sizeof (truncated_len_delim),
+                                          &field,
+                                          &consumed));
+  ASSERT_EQ (SOCKET_PROTO_INCOMPLETE,
+             SocketProto_wire_read_field (
+                 truncated_fixed64, sizeof (truncated_fixed64), &field, &consumed));
+}
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- add protobuf runtime module (`SocketProto`) with varint/zigzag/fixed primitives and strict wire parsing
- add arena-backed message parse/encode with unknown-field preservation, schema-aware validation, and hard message/field/depth limits
- add unit tests for varint/wire/message layers and fuzz harnesses for protobuf wire/message decode paths
- wire sources/headers/tests/fuzz entries into CMake

Fixes #3582

## Test plan
- [x] `cmake -S . -B build && cmake --build build -j$(nproc)`
- [x] `ctest --test-dir build --output-on-failure -R '^(test_proto_varint|test_proto_wire|test_proto_message|test_grpc_api_surface|test_http3_request|test_tls_handshake)$'`
