### PR TITLE
feat(grpc): implement unary HTTP/2 client transport

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -378,6 +378,7 @@ set(LIB_SOURCES
 
     # gRPC module (public scaffolding)
     src/grpc/SocketGRPC-core.c
+    src/grpc/SocketGRPCClient-h2.c
     src/grpc/SocketGRPCWire.c
     src/grpc/SocketProto-varint.c
     src/grpc/SocketProto-wire.c
@@ -951,6 +952,7 @@ set(TEST_SOURCES
     test_grpc_api_surface
     test_grpc_wire
     test_grpc_metadata
+    test_grpc_unary_h2
     test_proto_varint
     test_proto_wire
     test_proto_message

--- a/include/grpc/SocketGRPC-private.h
+++ b/include/grpc/SocketGRPC-private.h
@@ -33,6 +33,8 @@ struct SocketGRPC_Channel
   SocketGRPC_Client_T client;
   SocketGRPC_ChannelConfig config;
   char *target;
+  char *authority_override;
+  char *user_agent;
   SocketGRPC_Status last_status;
 };
 
@@ -41,6 +43,8 @@ struct SocketGRPC_Call
   SocketGRPC_Channel_T channel;
   SocketGRPC_CallConfig config;
   char *full_method;
+  SocketGRPC_Metadata_T request_metadata;
+  SocketGRPC_Trailers_T response_trailers;
   SocketGRPC_Status last_status;
 };
 

--- a/include/grpc/SocketGRPCConfig.h
+++ b/include/grpc/SocketGRPCConfig.h
@@ -16,6 +16,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#if SOCKET_HAS_TLS
+#include "tls/SocketTLSContext.h"
+#else
+typedef struct SocketTLSContext_T *SocketTLSContext_T;
+#endif
+
 #ifndef SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CHANNELS
 #define SOCKET_GRPC_DEFAULT_MAX_CONCURRENT_CHANNELS 64U
 #endif
@@ -38,6 +44,18 @@
 
 #ifndef SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES
 #define SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES 64U
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_VERIFY_PEER
+#define SOCKET_GRPC_DEFAULT_VERIFY_PEER 1
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_ALLOW_HTTP2_CLEARTEXT
+#define SOCKET_GRPC_DEFAULT_ALLOW_HTTP2_CLEARTEXT 0
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_USER_AGENT
+#define SOCKET_GRPC_DEFAULT_USER_AGENT "tetsuo-grpc/0.1"
 #endif
 
 #ifndef SOCKET_GRPC_DEFAULT_ENABLE_RETRY
@@ -79,6 +97,11 @@ typedef struct
   size_t max_inbound_message_bytes;
   size_t max_outbound_message_bytes;
   uint32_t max_metadata_entries;
+  const char *authority_override;
+  const char *user_agent;
+  SocketTLSContext_T tls_context;
+  int verify_peer;
+  int allow_http2_cleartext;
 } SocketGRPC_ChannelConfig;
 
 /**

--- a/src/grpc/SocketGRPCClient-h2.c
+++ b/src/grpc/SocketGRPCClient-h2.c
@@ -1,0 +1,864 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file SocketGRPCClient-h2.c
+ * @brief Unary gRPC client transport integration over HTTP/2.
+ */
+
+#include "grpc/SocketGRPC-private.h"
+#include "grpc/SocketGRPCWire.h"
+#include "http/SocketHTTPClient-private.h"
+
+#include "core/SocketCrypto.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdint.h>
+
+#define GRPC_CONTENT_TYPE "application/grpc"
+#define GRPC_TIMEOUT_HEADER_MAX 32U
+#define GRPC_RESPONSE_CHUNK 4096U
+
+static int
+str_has_prefix (const char *str, const char *prefix)
+{
+  size_t prefix_len;
+  if (str == NULL || prefix == NULL)
+    return 0;
+  prefix_len = strlen (prefix);
+  return strncmp (str, prefix, prefix_len) == 0;
+}
+
+static SocketGRPC_StatusCode
+grpc_map_httpclient_error (SocketHTTPClient_Error error)
+{
+  switch (error)
+    {
+    case HTTPCLIENT_ERROR_TIMEOUT:
+      return SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED;
+    case HTTPCLIENT_ERROR_DNS:
+    case HTTPCLIENT_ERROR_CONNECT:
+      return SOCKET_GRPC_STATUS_UNAVAILABLE;
+    case HTTPCLIENT_ERROR_TLS:
+      return SOCKET_GRPC_STATUS_UNAUTHENTICATED;
+    case HTTPCLIENT_ERROR_RESPONSE_TOO_LARGE:
+    case HTTPCLIENT_ERROR_LIMIT_EXCEEDED:
+      return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+    case HTTPCLIENT_ERROR_CANCELLED:
+      return SOCKET_GRPC_STATUS_CANCELLED;
+    case HTTPCLIENT_ERROR_PROTOCOL:
+    case HTTPCLIENT_ERROR_TOO_MANY_REDIRECTS:
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    case HTTPCLIENT_ERROR_OUT_OF_MEMORY:
+      return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+    default:
+      return SOCKET_GRPC_STATUS_UNKNOWN;
+    }
+}
+
+static void
+grpc_call_status_set (SocketGRPC_Call_T call,
+                      SocketGRPC_StatusCode code,
+                      const char *message)
+{
+  SocketGRPC_status_set (&call->last_status, code, message);
+}
+
+static int
+grpc_has_metadata_slot (SocketGRPC_Call_T call)
+{
+  SocketGRPC_Metadata_T metadata;
+
+  if (call == NULL || call->response_trailers == NULL || call->channel == NULL)
+    return 0;
+  metadata = SocketGRPC_Trailers_metadata (call->response_trailers);
+  if (metadata == NULL)
+    return 0;
+  return SocketGRPC_Metadata_count (metadata)
+         < call->channel->config.max_metadata_entries;
+}
+
+static char *
+grpc_build_call_url (SocketGRPC_Call_T call)
+{
+  const char *target = call->channel->target;
+  const char *path = call->full_method;
+  const char *base = NULL;
+  const char *scheme = NULL;
+  size_t base_len;
+  size_t path_len;
+  size_t trim_len;
+  size_t add_slash;
+  char *url;
+
+  if (target == NULL || path == NULL)
+    return NULL;
+
+  if (str_has_prefix (target, "http://") || str_has_prefix (target, "https://"))
+    {
+      base = target;
+    }
+  else if (str_has_prefix (target, "dns:///"))
+    {
+      base = target + strlen ("dns:///");
+      if (base[0] == '\0')
+        return NULL;
+      scheme = call->channel->config.allow_http2_cleartext ? "http://" : "https://";
+    }
+  else
+    {
+      base = target;
+      scheme = call->channel->config.allow_http2_cleartext ? "http://" : "https://";
+    }
+
+  base_len = strlen (base);
+  trim_len = base_len;
+  while (trim_len > 0 && base[trim_len - 1U] == '/')
+    trim_len--;
+
+  path_len = strlen (path);
+  add_slash = (path_len > 0 && path[0] == '/') ? 0U : 1U;
+
+  if (scheme != NULL)
+    {
+      size_t scheme_len = strlen (scheme);
+      url = (char *)malloc (scheme_len + trim_len + add_slash + path_len + 1U);
+      if (url == NULL)
+        return NULL;
+      memcpy (url, scheme, scheme_len);
+      memcpy (url + scheme_len, base, trim_len);
+      if (add_slash)
+        url[scheme_len + trim_len] = '/';
+      memcpy (url + scheme_len + trim_len + add_slash, path, path_len);
+      url[scheme_len + trim_len + add_slash + path_len] = '\0';
+      return url;
+    }
+
+  url = (char *)malloc (trim_len + add_slash + path_len + 1U);
+  if (url == NULL)
+    return NULL;
+  memcpy (url, base, trim_len);
+  if (add_slash)
+    url[trim_len] = '/';
+  memcpy (url + trim_len + add_slash, path, path_len);
+  url[trim_len + add_slash + path_len] = '\0';
+  return url;
+}
+
+static int
+grpc_request_add_metadata (SocketGRPC_Call_T call,
+                           SocketHTTPClient_Request_T req,
+                           SocketGRPC_Metadata_T metadata)
+{
+  size_t i;
+  size_t count;
+
+  if (call == NULL || call->channel == NULL || req == NULL || metadata == NULL)
+    return 0;
+
+  count = SocketGRPC_Metadata_count (metadata);
+  if (count > call->channel->config.max_metadata_entries)
+    return -1;
+
+  for (i = 0; i < count; i++)
+    {
+      const SocketGRPC_MetadataEntry *entry = SocketGRPC_Metadata_at (metadata, i);
+      if (entry == NULL || entry->key == NULL)
+        continue;
+
+      if (entry->is_binary)
+        {
+          size_t encoded_cap = SocketCrypto_base64_encoded_size (entry->value_len);
+          char *encoded = (char *)malloc (encoded_cap);
+          ssize_t encoded_len;
+          if (encoded == NULL)
+            return -1;
+          encoded_len = SocketCrypto_base64_encode (
+              entry->value, entry->value_len, encoded, encoded_cap);
+          if (encoded_len < 0)
+            {
+              free (encoded);
+              return -1;
+            }
+          if (SocketHTTPClient_Request_header (req, entry->key, encoded) != 0)
+            {
+              free (encoded);
+              return -1;
+            }
+          free (encoded);
+        }
+      else
+        {
+          char *value = (char *)malloc (entry->value_len + 1U);
+          if (value == NULL)
+            return -1;
+          if (entry->value_len > 0)
+            memcpy (value, entry->value, entry->value_len);
+          value[entry->value_len] = '\0';
+          if (SocketHTTPClient_Request_header (req, entry->key, value) != 0)
+            {
+              free (value);
+              return -1;
+            }
+          free (value);
+        }
+    }
+  return 0;
+}
+
+static int
+grpc_request_add_required_headers (SocketGRPC_Call_T call,
+                                   SocketHTTPClient_Request_T req)
+{
+  char timeout_buf[GRPC_TIMEOUT_HEADER_MAX];
+
+  if (SocketHTTPClient_Request_header (req, "content-type", GRPC_CONTENT_TYPE)
+      != 0)
+    return -1;
+  if (SocketHTTPClient_Request_header (req, "te", "trailers") != 0)
+    return -1;
+  if (call->channel->user_agent != NULL
+      && SocketHTTPClient_Request_header (
+             req, "user-agent", call->channel->user_agent)
+             != 0)
+    return -1;
+  if (call->channel->authority_override != NULL
+      && SocketHTTPClient_Request_header (
+             req, "host", call->channel->authority_override)
+             != 0)
+    return -1;
+
+  if (call->config.deadline_ms > 0)
+    {
+      int len
+          = snprintf (timeout_buf, sizeof (timeout_buf), "%dm", call->config.deadline_ms);
+      if (len <= 0 || (size_t)len >= sizeof (timeout_buf))
+        return -1;
+      if (SocketHTTPClient_Request_header (req, "grpc-timeout", timeout_buf) != 0)
+        return -1;
+    }
+
+  return grpc_request_add_metadata (call, req, call->request_metadata);
+}
+
+static int
+grpc_decode_base64 (const char *value,
+                    size_t value_len,
+                    uint8_t **decoded_out,
+                    size_t *decoded_len_out)
+{
+  size_t decoded_cap;
+  uint8_t *decoded;
+  ssize_t decoded_len;
+
+  if (value == NULL || decoded_out == NULL || decoded_len_out == NULL)
+    return -1;
+
+  decoded_cap = SocketCrypto_base64_decoded_size (value_len);
+  decoded = (uint8_t *)malloc (decoded_cap > 0 ? decoded_cap : 1U);
+  if (decoded == NULL)
+    return -1;
+
+  decoded_len = SocketCrypto_base64_decode (
+      value, value_len, decoded, decoded_cap > 0 ? decoded_cap : 1U);
+  if (decoded_len < 0)
+    {
+      free (decoded);
+      return -1;
+    }
+
+  *decoded_out = decoded;
+  *decoded_len_out = (size_t)decoded_len;
+  return 0;
+}
+
+static int
+grpc_trailer_ingest_kv (SocketGRPC_Call_T call,
+                        const char *name,
+                        size_t name_len,
+                        const char *value,
+                        size_t value_len)
+{
+  SocketGRPC_Trailers_T trailers;
+  char *lower_name;
+  size_t i;
+
+  if (call == NULL || call->response_trailers == NULL || name == NULL
+      || value == NULL)
+    return -1;
+  trailers = call->response_trailers;
+
+  lower_name = (char *)malloc (name_len + 1U);
+  if (lower_name == NULL)
+    return -1;
+  for (i = 0; i < name_len; i++)
+    lower_name[i] = (char)tolower ((unsigned char)name[i]);
+  lower_name[name_len] = '\0';
+
+  if (strcmp (lower_name, "grpc-status") == 0)
+    {
+      int status = 0;
+      for (i = 0; i < value_len; i++)
+        {
+          if (!isdigit ((unsigned char)value[i]))
+            {
+              free (lower_name);
+              return -1;
+            }
+          status = status * 10 + (int)(value[i] - '0');
+        }
+      free (lower_name);
+      return SocketGRPC_Trailers_set_status (trailers, status) == SOCKET_GRPC_WIRE_OK ? 0 : -1;
+    }
+  if (strcmp (lower_name, "grpc-message") == 0)
+    {
+      char *message = (char *)malloc (value_len + 1U);
+      int rc;
+      if (message == NULL)
+        {
+          free (lower_name);
+          return -1;
+        }
+      memcpy (message, value, value_len);
+      message[value_len] = '\0';
+      rc = (SocketGRPC_Trailers_set_message (trailers, message)
+            == SOCKET_GRPC_WIRE_OK)
+               ? 0
+               : -1;
+      free (message);
+      free (lower_name);
+      return rc;
+    }
+  if (strcmp (lower_name, "grpc-status-details-bin") == 0)
+    {
+      uint8_t *decoded = NULL;
+      size_t decoded_len = 0;
+      int ok = grpc_decode_base64 (value, value_len, &decoded, &decoded_len);
+      int rc;
+      if (ok != 0)
+        {
+          free (lower_name);
+          return -1;
+        }
+      rc = (SocketGRPC_Trailers_set_status_details_bin (
+                trailers, decoded, decoded_len)
+            == SOCKET_GRPC_WIRE_OK)
+               ? 0
+               : -1;
+      free (decoded);
+      free (lower_name);
+      return rc;
+    }
+
+  if (name_len >= 4 && strcmp (lower_name + (name_len - 4), "-bin") == 0)
+    {
+      uint8_t *decoded = NULL;
+      size_t decoded_len = 0;
+      int rc;
+      if (!grpc_has_metadata_slot (call))
+        {
+          free (lower_name);
+          return -1;
+        }
+      if (grpc_decode_base64 (value, value_len, &decoded, &decoded_len) != 0)
+        {
+          free (lower_name);
+          return -1;
+        }
+      rc = (SocketGRPC_Metadata_add_binary (
+                SocketGRPC_Trailers_metadata (trailers),
+                lower_name,
+                decoded,
+                decoded_len)
+            == SOCKET_GRPC_WIRE_OK)
+               ? 0
+               : -1;
+      free (decoded);
+      free (lower_name);
+      return rc;
+    }
+  else
+    {
+      char *ascii = (char *)malloc (value_len + 1U);
+      int rc;
+      if (!grpc_has_metadata_slot (call))
+        {
+          free (lower_name);
+          return -1;
+        }
+      if (ascii == NULL)
+        {
+          free (lower_name);
+          return -1;
+        }
+      memcpy (ascii, value, value_len);
+      ascii[value_len] = '\0';
+      rc = (SocketGRPC_Metadata_add_ascii (
+                SocketGRPC_Trailers_metadata (trailers), lower_name, ascii)
+            == SOCKET_GRPC_WIRE_OK)
+               ? 0
+               : -1;
+      free (ascii);
+      free (lower_name);
+      return rc;
+    }
+}
+
+static int
+grpc_ingest_response_headers (SocketGRPC_Call_T call,
+                              SocketHTTP_Headers_T headers,
+                              int allow_reserved)
+{
+  size_t i;
+  for (i = 0; i < SocketHTTP_Headers_count (headers); i++)
+    {
+      const SocketHTTP_Header *h = SocketHTTP_Headers_at (headers, i);
+      if (h == NULL || h->name == NULL || h->value == NULL)
+        continue;
+      if (h->name_len > 0 && h->name[0] == ':')
+        continue;
+      if (!allow_reserved
+          && (strncasecmp (h->name, "grpc-status", h->name_len) == 0
+              || strncasecmp (h->name, "grpc-message", h->name_len) == 0
+              || strncasecmp (h->name, "grpc-status-details-bin", h->name_len)
+                     == 0))
+        continue;
+
+      if (grpc_trailer_ingest_kv (
+              call, h->name, h->name_len, h->value, h->value_len)
+          != 0)
+        return -1;
+    }
+  return 0;
+}
+
+static int
+grpc_ingest_stream_trailers (SocketGRPC_Call_T call,
+                             const SocketHPACK_Header *trailers,
+                             size_t trailer_count)
+{
+  size_t i;
+  for (i = 0; i < trailer_count; i++)
+    {
+      if (trailers[i].name == NULL || trailers[i].value == NULL)
+        continue;
+      if (trailers[i].name_len > 0 && trailers[i].name[0] == ':')
+        continue;
+      if (grpc_trailer_ingest_kv (call,
+                                  trailers[i].name,
+                                  trailers[i].name_len,
+                                  trailers[i].value,
+                                  trailers[i].value_len)
+          != 0)
+        return -1;
+    }
+  return 0;
+}
+
+static int
+grpc_receive_body_and_trailers (SocketGRPC_Call_T call,
+                                SocketHTTP2_Stream_T stream,
+                                SocketHTTP2_Conn_T conn,
+                                unsigned char **body_out,
+                                size_t *body_len_out)
+{
+  unsigned char *body = NULL;
+  size_t total = 0;
+  size_t cap = 0;
+
+  if (body_out == NULL || body_len_out == NULL)
+    return -1;
+
+  for (;;)
+    {
+      unsigned char chunk[GRPC_RESPONSE_CHUNK];
+      int end_stream = 0;
+      ssize_t n = SocketHTTP2_Stream_recv_data (
+          stream, chunk, sizeof (chunk), &end_stream);
+      if (n < 0)
+        {
+          free (body);
+          return -1;
+        }
+
+      if (n > 0)
+        {
+          size_t needed = total + (size_t)n;
+          if (needed > call->channel->config.max_inbound_message_bytes)
+            {
+              free (body);
+              return -1;
+            }
+          if (needed > cap)
+            {
+              size_t new_cap = cap == 0 ? GRPC_RESPONSE_CHUNK : cap * 2U;
+              unsigned char *tmp;
+              while (new_cap < needed)
+                new_cap *= 2U;
+              tmp = (unsigned char *)realloc (body, new_cap);
+              if (tmp == NULL)
+                {
+                  free (body);
+                  return -1;
+                }
+              body = tmp;
+              cap = new_cap;
+            }
+          memcpy (body + total, chunk, (size_t)n);
+          total += (size_t)n;
+        }
+
+      {
+        SocketHPACK_Header trailers[SOCKETHTTP2_MAX_DECODED_HEADERS];
+        size_t trailer_count = 0;
+        int tr = SocketHTTP2_Stream_recv_trailers (
+            stream, trailers, SOCKETHTTP2_MAX_DECODED_HEADERS, &trailer_count);
+        if (tr < 0)
+          {
+            free (body);
+            return -1;
+          }
+        if (tr == 1 && trailer_count > 0)
+          {
+            if (grpc_ingest_stream_trailers (call, trailers, trailer_count) != 0)
+              {
+                free (body);
+                return -1;
+              }
+          }
+      }
+
+      if (end_stream)
+        break;
+
+      if (n == 0 && SocketHTTP2_Conn_process (conn, 0) < 0)
+        {
+          free (body);
+          return -1;
+        }
+    }
+
+  *body_out = body;
+  *body_len_out = total;
+  return 0;
+}
+
+int
+SocketGRPC_Call_metadata_add_ascii (SocketGRPC_Call_T call,
+                                    const char *key,
+                                    const char *value)
+{
+  if (call == NULL || key == NULL || value == NULL || call->request_metadata == NULL)
+    return -1;
+  if (SocketGRPC_Metadata_count (call->request_metadata)
+      >= call->channel->config.max_metadata_entries)
+    return -1;
+  return SocketGRPC_Metadata_add_ascii (call->request_metadata, key, value)
+         == SOCKET_GRPC_WIRE_OK
+             ? 0
+             : -1;
+}
+
+int
+SocketGRPC_Call_metadata_add_binary (SocketGRPC_Call_T call,
+                                     const char *key,
+                                     const uint8_t *value,
+                                     size_t value_len)
+{
+  if (call == NULL || key == NULL || (value == NULL && value_len != 0)
+      || call->request_metadata == NULL)
+    return -1;
+  if (SocketGRPC_Metadata_count (call->request_metadata)
+      >= call->channel->config.max_metadata_entries)
+    return -1;
+  return SocketGRPC_Metadata_add_binary (
+             call->request_metadata, key, value, value_len)
+         == SOCKET_GRPC_WIRE_OK
+             ? 0
+             : -1;
+}
+
+void
+SocketGRPC_Call_metadata_clear (SocketGRPC_Call_T call)
+{
+  if (call == NULL || call->request_metadata == NULL)
+    return;
+  SocketGRPC_Metadata_clear (call->request_metadata);
+}
+
+SocketGRPC_Trailers_T
+SocketGRPC_Call_trailers (SocketGRPC_Call_T call)
+{
+  if (call == NULL)
+    return NULL;
+  return call->response_trailers;
+}
+
+SocketGRPC_Status
+SocketGRPC_Call_status (SocketGRPC_Call_T call)
+{
+  SocketGRPC_Status status = { SOCKET_GRPC_STATUS_INTERNAL, "Status unavailable" };
+  if (call == NULL)
+    return status;
+  return call->last_status;
+}
+
+int
+SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
+                          const uint8_t *request_payload,
+                          size_t request_payload_len,
+                          Arena_T arena,
+                          uint8_t **response_payload,
+                          size_t *response_payload_len)
+{
+  SocketHTTPClient_Config cfg;
+  SocketHTTPClient_T http_client = NULL;
+  SocketHTTPClient_Request_T req = NULL;
+  SocketHTTPClient_Response response = { 0 };
+  HTTPPoolEntry *conn = NULL;
+  SocketHTTP_Request http_req;
+  SocketHTTP2_Conn_T h2conn;
+  SocketHTTP2_Stream_T stream = NULL;
+  unsigned char *framed = NULL;
+  size_t framed_cap = 0;
+  size_t framed_len = 0;
+  unsigned char *raw_response = NULL;
+  size_t raw_response_len = 0;
+  char *url = NULL;
+  int status_code = -1;
+  int transport_success = 0;
+
+  if (call == NULL || request_payload == NULL || arena == NULL
+      || response_payload == NULL || response_payload_len == NULL)
+    return -1;
+  if (request_payload_len > call->channel->config.max_outbound_message_bytes
+      || request_payload_len > (size_t)UINT32_MAX
+      || request_payload_len > (SIZE_MAX - SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE))
+    {
+      grpc_call_status_set (call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
+      return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+    }
+  framed_cap = SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE + request_payload_len;
+
+  *response_payload = NULL;
+  *response_payload_len = 0;
+  SocketGRPC_Trailers_clear (call->response_trailers);
+
+  url = grpc_build_call_url (call);
+  if (url == NULL)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INVALID_ARGUMENT, "Invalid channel target");
+      goto cleanup;
+    }
+
+  SocketHTTPClient_config_defaults (&cfg);
+  cfg.max_version = HTTP_VERSION_2;
+  cfg.allow_http2_cleartext = call->channel->config.allow_http2_cleartext;
+  cfg.verify_ssl = call->channel->config.verify_peer;
+  cfg.tls_context = call->channel->config.tls_context;
+  cfg.request_timeout_ms = call->config.deadline_ms;
+  cfg.max_response_size = call->channel->config.max_inbound_message_bytes;
+
+  http_client = SocketHTTPClient_new (&cfg);
+  if (http_client == NULL)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INTERNAL, "HTTP client allocation failed");
+      goto cleanup;
+    }
+
+  req = SocketHTTPClient_Request_new (http_client, HTTP_METHOD_POST, url);
+  if (req == NULL)
+    {
+      grpc_call_status_set (
+          call,
+          grpc_map_httpclient_error (SocketHTTPClient_last_error (http_client)),
+          "Request initialization failed");
+      goto cleanup;
+    }
+
+  SocketHTTPClient_Request_timeout (req, call->config.deadline_ms);
+  if (grpc_request_add_required_headers (call, req) != 0)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INTERNAL, "Failed to set request headers");
+      goto cleanup;
+    }
+
+  framed = (unsigned char *)malloc (framed_cap);
+  if (framed == NULL)
+    {
+      grpc_call_status_set (call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
+      goto cleanup;
+    }
+  if (SocketGRPC_Frame_encode (0,
+                               request_payload,
+                               (uint32_t)request_payload_len,
+                               framed,
+                               framed_cap,
+                               &framed_len)
+      != SOCKET_GRPC_WIRE_OK)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INTERNAL, "Failed to frame request payload");
+      goto cleanup;
+    }
+
+  if (SocketHTTPClient_Request_body (req, framed, framed_len) != 0)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INTERNAL, "Failed to attach request body");
+      goto cleanup;
+    }
+
+  conn = httpclient_connect (http_client, &req->uri);
+  if (conn == NULL)
+    {
+      grpc_call_status_set (call,
+                            grpc_map_httpclient_error (
+                                SocketHTTPClient_last_error (http_client)),
+                            "Connection failed");
+      goto cleanup;
+    }
+
+  httpclient_headers_prepare_request (http_client, req);
+
+  if (conn->version != HTTP_VERSION_2 || conn->proto.h2.conn == NULL)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INTERNAL, "HTTP/2 transport not negotiated");
+      goto cleanup;
+    }
+
+  h2conn = conn->proto.h2.conn;
+  stream = SocketHTTP2_Stream_new (h2conn);
+  if (stream == NULL)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_INTERNAL, "Failed to open HTTP/2 stream");
+      goto cleanup;
+    }
+  conn->proto.h2.active_streams++;
+
+  httpclient_http2_build_request (req, &http_req);
+  if (httpclient_http2_send_request (
+          stream, h2conn, &http_req, req->body, req->body_len)
+      < 0)
+    {
+      grpc_call_status_set (
+          call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to send HTTP/2 request");
+      goto cleanup;
+    }
+
+  {
+    int end_stream = 0;
+    if (httpclient_http2_recv_headers (stream, h2conn, &response, &end_stream)
+        < 0)
+      {
+        grpc_call_status_set (
+            call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to receive response headers");
+        goto cleanup;
+      }
+
+    if (grpc_ingest_response_headers (call, response.headers, end_stream) != 0)
+      {
+        grpc_call_status_set (
+            call, SOCKET_GRPC_STATUS_INTERNAL, "Invalid response header metadata");
+        goto cleanup;
+      }
+
+    if (!end_stream)
+      {
+        if (grpc_receive_body_and_trailers (
+                call, stream, h2conn, &raw_response, &raw_response_len)
+            != 0)
+          {
+            grpc_call_status_set (
+                call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to receive response body");
+            goto cleanup;
+          }
+      }
+  }
+
+  if (!SocketGRPC_Trailers_has_status (call->response_trailers))
+    {
+      SocketGRPC_StatusCode mapped
+          = SocketGRPC_http_status_to_grpc (response.status_code);
+      (void)SocketGRPC_Trailers_set_status (call->response_trailers, mapped);
+    }
+
+  status_code = SocketGRPC_Trailers_status (call->response_trailers);
+  grpc_call_status_set (
+      call,
+      (SocketGRPC_StatusCode)status_code,
+      SocketGRPC_Trailers_message (call->response_trailers));
+
+  if (raw_response != NULL && raw_response_len > 0)
+    {
+      SocketGRPC_FrameView frame;
+      size_t consumed = 0;
+      if (SocketGRPC_Frame_parse (raw_response,
+                                  raw_response_len,
+                                  call->channel->config.max_inbound_message_bytes,
+                                  &frame,
+                                  &consumed)
+          != SOCKET_GRPC_WIRE_OK
+          || consumed != raw_response_len || frame.compressed != 0)
+        {
+          if (status_code == SOCKET_GRPC_STATUS_OK)
+            {
+              (void)SocketGRPC_Trailers_set_status (
+                  call->response_trailers, SOCKET_GRPC_STATUS_INTERNAL);
+              (void)SocketGRPC_Trailers_set_message (
+                  call->response_trailers, "Malformed gRPC response frame");
+              grpc_call_status_set (
+                  call,
+                  SOCKET_GRPC_STATUS_INTERNAL,
+                  "Malformed gRPC response frame");
+              status_code = SOCKET_GRPC_STATUS_INTERNAL;
+            }
+          goto cleanup;
+        }
+      if (frame.payload_len > 0)
+        {
+          uint8_t *out = (uint8_t *)ALLOC (arena, frame.payload_len);
+          if (out == NULL)
+            {
+              grpc_call_status_set (
+                  call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
+              status_code = SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+              goto cleanup;
+            }
+          memcpy (out, frame.payload, frame.payload_len);
+          *response_payload = out;
+          *response_payload_len = frame.payload_len;
+        }
+    }
+
+  transport_success = 1;
+
+cleanup:
+  if (conn != NULL && stream != NULL)
+    {
+      conn->proto.h2.active_streams--;
+      if (!transport_success)
+        SocketHTTP2_Stream_close (stream, HTTP2_CANCEL);
+    }
+  if (conn != NULL)
+    httpclient_release_connection (http_client, conn, transport_success);
+  free (raw_response);
+  free (framed);
+  free (url);
+  SocketHTTPClient_Response_free (&response);
+  SocketHTTPClient_Request_free (&req);
+  SocketHTTPClient_free (&http_client);
+
+  return status_code;
+}

--- a/src/http/h2/SocketHTTP2-connection.c
+++ b/src/http/h2/SocketHTTP2-connection.c
@@ -1051,7 +1051,8 @@ process_settings_ack (SocketHTTP2_Conn_T conn)
   if (conn->settings_ack_pending)
     {
       conn->settings_ack_pending = 0;
-      if (conn->state == HTTP2_CONN_STATE_SETTINGS_SENT)
+      if (conn->state == HTTP2_CONN_STATE_SETTINGS_SENT
+          || conn->state == HTTP2_CONN_STATE_SETTINGS_RECV)
         conn->state = HTTP2_CONN_STATE_READY;
       http2_emit_conn_event (conn, HTTP2_EVENT_SETTINGS_ACK);
     }

--- a/src/http/h2/SocketHTTP2-stream.c
+++ b/src/http/h2/SocketHTTP2-stream.c
@@ -1091,7 +1091,7 @@ http2_validate_headers (SocketHTTP2_Conn_T conn,
                         size_t count,
                         int is_trailer)
 {
-  int is_request = (conn->role == HTTP2_ROLE_CLIENT ? 1 : 0);
+  int is_request = (conn->role == HTTP2_ROLE_SERVER ? 1 : 0);
   int pseudo_headers_seen = 0;
   HTTP2_PseudoHeaderState state = { 0 };
   int has_te = 0;

--- a/src/test/test_grpc_unary_h2.c
+++ b/src/test/test_grpc_unary_h2.c
@@ -1,0 +1,747 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+#include "grpc/SocketGRPC.h"
+#include "grpc/SocketGRPCWire.h"
+#include "test/Test.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+TEST (grpc_call_metadata_enforces_channel_limit)
+{
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  uint8_t binv[] = { 0x01, 0x02 };
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.max_metadata_entries = 1;
+
+  client = SocketGRPC_Client_new (NULL);
+  ASSERT_NOT_NULL (client);
+  channel = SocketGRPC_Channel_new (client, "dns:///example.test", &channel_cfg);
+  ASSERT_NOT_NULL (channel);
+  call = SocketGRPC_Call_new (channel, "/test.Service/Ping", NULL);
+  ASSERT_NOT_NULL (call);
+
+  ASSERT_EQ (0, SocketGRPC_Call_metadata_add_ascii (call, "x-client-id", "abc"));
+  ASSERT_EQ (-1,
+             SocketGRPC_Call_metadata_add_binary (
+                 call, "trace-bin", binv, sizeof (binv)));
+
+  SocketGRPC_Call_metadata_clear (call);
+  ASSERT_EQ (0,
+             SocketGRPC_Call_metadata_add_binary (
+                 call, "trace-bin", binv, sizeof (binv)));
+  ASSERT_NOT_NULL (SocketGRPC_Call_trailers (call));
+  ASSERT_EQ (SOCKET_GRPC_STATUS_OK, SocketGRPC_Call_status (call).code);
+
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+}
+
+TEST (grpc_unary_h2_rejects_oversized_outbound_payload_without_network)
+{
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketGRPC_CallConfig call_cfg;
+  Arena_T arena = NULL;
+  uint8_t request_payload[] = { 1, 2, 3, 4, 5 };
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  int rc;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.max_outbound_message_bytes = 4;
+  SocketGRPC_CallConfig_defaults (&call_cfg);
+  call_cfg.deadline_ms = 5;
+
+  client = SocketGRPC_Client_new (NULL);
+  ASSERT_NOT_NULL (client);
+  channel
+      = SocketGRPC_Channel_new (client, "https://127.0.0.1:1", &channel_cfg);
+  ASSERT_NOT_NULL (channel);
+  call = SocketGRPC_Call_new (channel, "/test.Service/Ping", &call_cfg);
+  ASSERT_NOT_NULL (call);
+
+  arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  rc = SocketGRPC_Call_unary_h2 (call,
+                                 request_payload,
+                                 sizeof (request_payload),
+                                 arena,
+                                 &response_payload,
+                                 &response_payload_len);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, rc);
+  ASSERT_NULL (response_payload);
+  ASSERT_EQ (0U, response_payload_len);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED,
+             SocketGRPC_Call_status (call).code);
+
+  Arena_dispose (&arena);
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+}
+
+#if SOCKET_HAS_TLS
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <signal.h>
+#include <stdlib.h>
+
+#include "http/SocketHPACK.h"
+#include "http/SocketHTTP2.h"
+#include "socket/Socket.h"
+#include "tls/SocketTLS.h"
+#include "tls/SocketTLSContext.h"
+
+#define H2_CLIENT_PREFACE "PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n"
+#define H2_CLIENT_PREFACE_LEN 24
+
+typedef enum
+{
+  GRPC_H2_SCENARIO_SUCCESS = 0,
+  GRPC_H2_SCENARIO_HTTP503_BAD_BODY = 1
+} GRPC_H2_Scenario;
+
+typedef struct
+{
+  Socket_T listen_socket;
+  SocketTLSContext_T tls_ctx;
+  pthread_t thread;
+  volatile int started;
+  int port;
+  GRPC_H2_Scenario scenario;
+} GRPC_H2_Server;
+
+static char cert_path[160];
+static char key_path[160];
+
+static int
+create_temp_cert_files (void)
+{
+  char cmd[640];
+
+  snprintf (
+      cert_path, sizeof (cert_path), "/tmp/test_grpc_h2_cert_%d.pem", getpid ());
+  snprintf (
+      key_path, sizeof (key_path), "/tmp/test_grpc_h2_key_%d.pem", getpid ());
+
+  snprintf (cmd,
+            sizeof (cmd),
+            "openssl req -x509 -newkey rsa:2048 -nodes -sha256 "
+            "-days 1 -subj /CN=127.0.0.1 "
+            "-addext subjectAltName=IP:127.0.0.1 "
+            "-keyout %s -out %s >/dev/null 2>&1",
+            key_path,
+            cert_path);
+  if (system (cmd) != 0)
+    {
+      unlink (cert_path);
+      unlink (key_path);
+      return -1;
+    }
+  return 0;
+}
+
+static void
+cleanup_temp_cert_files (void)
+{
+  unlink (cert_path);
+  unlink (key_path);
+}
+
+static int
+tls_send_all (Socket_T socket, const unsigned char *data, size_t len)
+{
+  size_t off = 0;
+  while (off < len)
+    {
+      ssize_t n = SocketTLS_send (socket, data + off, len - off);
+      if (n <= 0)
+        return -1;
+      off += (size_t)n;
+    }
+  return 0;
+}
+
+static int
+tls_recv_exact (Socket_T socket, unsigned char *buf, size_t len)
+{
+  size_t off = 0;
+  while (off < len)
+    {
+      ssize_t n = SocketTLS_recv (socket, buf + off, len - off);
+      if (n <= 0)
+        return -1;
+      off += (size_t)n;
+    }
+  return 0;
+}
+
+static int
+send_h2_frame (Socket_T socket,
+               uint8_t type,
+               uint8_t flags,
+               uint32_t stream_id,
+               const unsigned char *payload,
+               size_t payload_len)
+{
+  SocketHTTP2_FrameHeader fh;
+  unsigned char header[HTTP2_FRAME_HEADER_SIZE];
+
+  if (payload_len > 0xFFFFFFU)
+    return -1;
+
+  fh.length = (uint32_t)payload_len;
+  fh.type = (SocketHTTP2_FrameType)type;
+  fh.flags = flags;
+  fh.stream_id = stream_id;
+  SocketHTTP2_frame_header_serialize (&fh, header);
+
+  if (tls_send_all (socket, header, sizeof (header)) != 0)
+    return -1;
+  if (payload_len > 0 && tls_send_all (socket, payload, payload_len) != 0)
+    return -1;
+  return 0;
+}
+
+static int
+recv_h2_frame (Socket_T socket,
+               SocketHTTP2_FrameHeader *header_out,
+               unsigned char **payload_out)
+{
+  unsigned char raw_header[HTTP2_FRAME_HEADER_SIZE];
+  unsigned char *payload = NULL;
+  size_t payload_len;
+
+  if (header_out == NULL || payload_out == NULL)
+    return -1;
+
+  *payload_out = NULL;
+  if (tls_recv_exact (socket, raw_header, sizeof (raw_header)) != 0)
+    return -1;
+  if (SocketHTTP2_frame_header_parse (
+          raw_header, sizeof (raw_header), header_out)
+      != 0)
+    return -1;
+
+  payload_len = header_out->length;
+  if (payload_len > (1024U * 1024U))
+    return -1;
+
+  if (payload_len > 0)
+    {
+      payload = (unsigned char *)malloc (payload_len);
+      if (payload == NULL)
+        return -1;
+      if (tls_recv_exact (socket, payload, payload_len) != 0)
+        {
+          free (payload);
+          return -1;
+        }
+    }
+  *payload_out = payload;
+  return 0;
+}
+
+static int
+encode_hpack_block (const SocketHPACK_Header *headers,
+                    size_t header_count,
+                    unsigned char *out,
+                    size_t out_cap,
+                    size_t *written_out)
+{
+  SocketHPACK_EncoderConfig cfg;
+  SocketHPACK_Encoder_T enc;
+  Arena_T arena = NULL;
+  ssize_t written;
+
+  if (headers == NULL || out == NULL || written_out == NULL)
+    return -1;
+
+  SocketHPACK_encoder_config_defaults (&cfg);
+  cfg.use_indexing = 0;
+  arena = Arena_new ();
+  if (arena == NULL)
+    return -1;
+  enc = SocketHPACK_Encoder_new (&cfg, arena);
+  if (enc == NULL)
+    {
+      Arena_dispose (&arena);
+      return -1;
+    }
+
+  written = SocketHPACK_Encoder_encode (enc, headers, header_count, out, out_cap);
+  SocketHPACK_Encoder_free (&enc);
+  Arena_dispose (&arena);
+  if (written < 0)
+    return -1;
+  *written_out = (size_t)written;
+  return 0;
+}
+
+static int
+consume_client_request (Socket_T client)
+{
+  int got_headers = 0;
+  int loops = 0;
+
+  while (loops++ < 64)
+    {
+      SocketHTTP2_FrameHeader fh;
+      unsigned char *payload = NULL;
+
+      if (recv_h2_frame (client, &fh, &payload) != 0)
+        return -1;
+
+      if (fh.type == HTTP2_FRAME_SETTINGS && (fh.flags & HTTP2_FLAG_ACK) == 0)
+        {
+          if (send_h2_frame (client,
+                             HTTP2_FRAME_SETTINGS,
+                             HTTP2_FLAG_ACK,
+                             0,
+                             NULL,
+                             0)
+              != 0)
+            {
+              free (payload);
+              return -1;
+            }
+        }
+      else if (fh.stream_id == 1U && fh.type == HTTP2_FRAME_HEADERS)
+        {
+          got_headers = 1;
+          free (payload);
+          break;
+        }
+
+      free (payload);
+    }
+
+  return got_headers ? 0 : -1;
+}
+
+static int
+send_success_response (Socket_T client)
+{
+  static const uint8_t response_payload[] = { 0x08, 0x2A };
+  SocketHPACK_Header response_headers[] = {
+    { ":status", 7, "200", 3, 0 },
+    { "content-type", 12, "application/grpc", 16, 0 },
+    { "x-trace-id", 10, "trace-123", 9, 0 },
+  };
+  unsigned char header_block[512];
+  unsigned char grpc_frame[128];
+  size_t header_block_len = 0;
+  size_t frame_len = 0;
+
+  if (encode_hpack_block (response_headers,
+                          sizeof (response_headers) / sizeof (response_headers[0]),
+                          header_block,
+                          sizeof (header_block),
+                          &header_block_len)
+      != 0)
+    return -1;
+  if (SocketGRPC_Frame_encode (0,
+                               response_payload,
+                               sizeof (response_payload),
+                               grpc_frame,
+                               sizeof (grpc_frame),
+                               &frame_len)
+      != SOCKET_GRPC_WIRE_OK)
+    return -1;
+
+  if (send_h2_frame (client,
+                     HTTP2_FRAME_HEADERS,
+                     HTTP2_FLAG_END_HEADERS,
+                     1,
+                     header_block,
+                     header_block_len)
+      != 0)
+    return -1;
+  if (send_h2_frame (client,
+                     HTTP2_FRAME_DATA,
+                     HTTP2_FLAG_END_STREAM,
+                     1,
+                     grpc_frame,
+                     frame_len)
+      != 0)
+    return -1;
+  return 0;
+}
+
+static int
+send_http503_bad_body_response (Socket_T client)
+{
+  SocketHPACK_Header response_headers[] = {
+    { ":status", 7, "503", 3, 0 },
+    { "content-type", 12, "text/plain", 10, 0 },
+  };
+  unsigned char header_block[256];
+  unsigned char body[] = { 'n', 'o', 't', '-', 'g', 'r', 'p', 'c' };
+  size_t header_block_len = 0;
+
+  if (encode_hpack_block (response_headers,
+                          sizeof (response_headers) / sizeof (response_headers[0]),
+                          header_block,
+                          sizeof (header_block),
+                          &header_block_len)
+      != 0)
+    return -1;
+  if (send_h2_frame (client,
+                     HTTP2_FRAME_HEADERS,
+                     HTTP2_FLAG_END_HEADERS,
+                     1,
+                     header_block,
+                     header_block_len)
+      != 0)
+    return -1;
+  if (send_h2_frame (client,
+                     HTTP2_FRAME_DATA,
+                     HTTP2_FLAG_END_STREAM,
+                     1,
+                     body,
+                     sizeof (body))
+      != 0)
+    return -1;
+  return 0;
+}
+
+static void *
+grpc_h2_server_thread (void *arg)
+{
+  GRPC_H2_Server *server = (GRPC_H2_Server *)arg;
+  Socket_T client = NULL;
+  unsigned char preface[H2_CLIENT_PREFACE_LEN];
+  TLSHandshakeState hs_state;
+  int hs_loops = 0;
+
+  server->started = 1;
+
+  client = Socket_accept (server->listen_socket);
+  if (client == NULL)
+    return NULL;
+
+  SocketTLS_enable (client, server->tls_ctx);
+  do
+    {
+      hs_state = SocketTLS_handshake (client);
+      if (++hs_loops > 1000)
+        {
+          hs_state = TLS_HANDSHAKE_ERROR;
+          break;
+        }
+      usleep (1000);
+    }
+  while (hs_state == TLS_HANDSHAKE_WANT_READ
+         || hs_state == TLS_HANDSHAKE_WANT_WRITE);
+
+  if (hs_state != TLS_HANDSHAKE_COMPLETE)
+    {
+      Socket_free (&client);
+      return NULL;
+    }
+
+  {
+    const char *alpn = SocketTLS_get_alpn_selected (client);
+    if (alpn == NULL || strcmp (alpn, "h2") != 0)
+      {
+        Socket_free (&client);
+        return NULL;
+      }
+  }
+
+  if (tls_recv_exact (client, preface, sizeof (preface)) != 0
+      || memcmp (preface, H2_CLIENT_PREFACE, sizeof (preface)) != 0)
+    {
+      Socket_free (&client);
+      return NULL;
+    }
+
+  if (send_h2_frame (client, HTTP2_FRAME_SETTINGS, 0, 0, NULL, 0) != 0)
+    {
+      Socket_free (&client);
+      return NULL;
+    }
+
+  if (consume_client_request (client) != 0)
+    {
+      Socket_free (&client);
+      return NULL;
+    }
+
+  if (server->scenario == GRPC_H2_SCENARIO_SUCCESS)
+    (void)send_success_response (client);
+  else
+    (void)send_http503_bad_body_response (client);
+
+  usleep (20000);
+  Socket_free (&client);
+  return NULL;
+}
+
+static int
+grpc_h2_server_start (GRPC_H2_Server *server, GRPC_H2_Scenario scenario)
+{
+  struct sockaddr_in addr;
+  socklen_t len = sizeof (addr);
+  const char *alpn_protos[] = { "h2", "http/1.1" };
+
+  memset (server, 0, sizeof (*server));
+  server->scenario = scenario;
+
+  TRY server->tls_ctx = SocketTLSContext_new_server (cert_path, key_path, NULL);
+  EXCEPT (SocketTLS_Failed)
+  return -1;
+  END_TRY;
+
+  if (server->tls_ctx == NULL)
+    return -1;
+
+  SocketTLSContext_set_alpn_protos (server->tls_ctx, alpn_protos, 2);
+  server->listen_socket = Socket_new (AF_INET, SOCK_STREAM, 0);
+  if (server->listen_socket == NULL)
+    {
+      SocketTLSContext_free (&server->tls_ctx);
+      return -1;
+    }
+
+  TRY
+      Socket_setreuseaddr (server->listen_socket);
+  Socket_bind (server->listen_socket, "127.0.0.1", 0);
+  Socket_listen (server->listen_socket, 8);
+  EXCEPT (Socket_Failed)
+  Socket_free (&server->listen_socket);
+  SocketTLSContext_free (&server->tls_ctx);
+  return -1;
+  END_TRY;
+
+  getsockname (
+      Socket_fd (server->listen_socket), (struct sockaddr *)&addr, &len);
+
+  server->port = ntohs (addr.sin_port);
+
+  if (pthread_create (&server->thread, NULL, grpc_h2_server_thread, server) != 0)
+    {
+      Socket_free (&server->listen_socket);
+      SocketTLSContext_free (&server->tls_ctx);
+      return -1;
+    }
+
+  while (!server->started)
+    usleep (1000);
+
+  return 0;
+}
+
+static void
+grpc_h2_server_stop (GRPC_H2_Server *server)
+{
+  if (server->listen_socket != NULL)
+    Socket_free (&server->listen_socket);
+  pthread_join (server->thread, NULL);
+  if (server->tls_ctx != NULL)
+    SocketTLSContext_free (&server->tls_ctx);
+}
+
+static int
+metadata_contains_ascii (SocketGRPC_Metadata_T metadata,
+                         const char *key,
+                         const char *value)
+{
+  size_t i;
+
+  if (metadata == NULL || key == NULL || value == NULL)
+    return 0;
+  for (i = 0; i < SocketGRPC_Metadata_count (metadata); i++)
+    {
+      const SocketGRPC_MetadataEntry *entry = SocketGRPC_Metadata_at (metadata, i);
+      if (entry == NULL || entry->key == NULL || entry->is_binary != 0)
+        continue;
+      if (strcmp (entry->key, key) == 0 && entry->value_len == strlen (value)
+          && memcmp (entry->value, value, entry->value_len) == 0)
+        return 1;
+    }
+  return 0;
+}
+
+TEST (grpc_unary_h2_success_integration_roundtrip)
+{
+  GRPC_H2_Server server;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  Arena_T arena = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  uint8_t request_payload[] = { 0x08, 0x01 };
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  int rc;
+  char target[128];
+
+  signal (SIGPIPE, SIG_IGN);
+
+  if (create_temp_cert_files () != 0)
+    {
+      printf ("  [SKIP] Could not generate TLS cert fixtures\n");
+      return;
+    }
+  if (grpc_h2_server_start (&server, GRPC_H2_SCENARIO_SUCCESS) != 0)
+    {
+      printf ("  [SKIP] Could not start gRPC/HTTP2 test server\n");
+      cleanup_temp_cert_files ();
+      return;
+    }
+
+  SocketTLSContext_T tls_client_ctx = SocketTLSContext_new_client (cert_path);
+  ASSERT_NOT_NULL (tls_client_ctx);
+  {
+    const char *alpn[] = { "h2" };
+    SocketTLSContext_set_alpn_protos (tls_client_ctx, alpn, 1);
+  }
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.verify_peer = 1;
+  channel_cfg.tls_context = tls_client_ctx;
+  channel_cfg.max_metadata_entries = 8;
+
+  client = SocketGRPC_Client_new (NULL);
+  ASSERT_NOT_NULL (client);
+  snprintf (target, sizeof (target), "https://127.0.0.1:%d", server.port);
+  channel = SocketGRPC_Channel_new (client, target, &channel_cfg);
+  ASSERT_NOT_NULL (channel);
+  call = SocketGRPC_Call_new (channel, "/test.EchoService/Ping", NULL);
+  ASSERT_NOT_NULL (call);
+  ASSERT_EQ (0, SocketGRPC_Call_metadata_add_ascii (call, "x-client-id", "abc"));
+
+  arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  rc = SocketGRPC_Call_unary_h2 (call,
+                                 request_payload,
+                                 sizeof (request_payload),
+                                 arena,
+                                 &response_payload,
+                                 &response_payload_len);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_OK, rc);
+  ASSERT_NOT_NULL (response_payload);
+  ASSERT_EQ (2U, response_payload_len);
+  ASSERT_EQ (0x08, response_payload[0]);
+  ASSERT_EQ (0x2A, response_payload[1]);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_OK, SocketGRPC_Call_status (call).code);
+
+  {
+    SocketGRPC_Trailers_T trailers = SocketGRPC_Call_trailers (call);
+    ASSERT_NOT_NULL (trailers);
+    ASSERT (SocketGRPC_Trailers_has_status (trailers));
+    ASSERT_EQ (SOCKET_GRPC_STATUS_OK, SocketGRPC_Trailers_status (trailers));
+    ASSERT (metadata_contains_ascii (
+        SocketGRPC_Trailers_metadata (trailers), "x-trace-id", "trace-123"));
+  }
+
+  Arena_dispose (&arena);
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  SocketTLSContext_free (&tls_client_ctx);
+  grpc_h2_server_stop (&server);
+  cleanup_temp_cert_files ();
+}
+
+TEST (grpc_unary_h2_http_status_fallback_on_non_grpc_body)
+{
+  GRPC_H2_Server server;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  Arena_T arena = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  uint8_t request_payload[] = { 0x08, 0x09 };
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  int rc;
+  char target[128];
+
+  signal (SIGPIPE, SIG_IGN);
+
+  if (create_temp_cert_files () != 0)
+    {
+      printf ("  [SKIP] Could not generate TLS cert fixtures\n");
+      return;
+    }
+  if (grpc_h2_server_start (&server, GRPC_H2_SCENARIO_HTTP503_BAD_BODY) != 0)
+    {
+      printf ("  [SKIP] Could not start gRPC/HTTP2 test server\n");
+      cleanup_temp_cert_files ();
+      return;
+    }
+
+  SocketTLSContext_T tls_client_ctx = SocketTLSContext_new_client (cert_path);
+  ASSERT_NOT_NULL (tls_client_ctx);
+  {
+    const char *alpn[] = { "h2" };
+    SocketTLSContext_set_alpn_protos (tls_client_ctx, alpn, 1);
+  }
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.verify_peer = 1;
+  channel_cfg.tls_context = tls_client_ctx;
+
+  client = SocketGRPC_Client_new (NULL);
+  ASSERT_NOT_NULL (client);
+  snprintf (target, sizeof (target), "https://127.0.0.1:%d", server.port);
+  channel = SocketGRPC_Channel_new (client, target, &channel_cfg);
+  ASSERT_NOT_NULL (channel);
+  call = SocketGRPC_Call_new (channel, "/test.EchoService/Ping", NULL);
+  ASSERT_NOT_NULL (call);
+  arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  rc = SocketGRPC_Call_unary_h2 (call,
+                                 request_payload,
+                                 sizeof (request_payload),
+                                 arena,
+                                 &response_payload,
+                                 &response_payload_len);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_UNAVAILABLE, rc);
+  ASSERT_NULL (response_payload);
+  ASSERT_EQ (0U, response_payload_len);
+  {
+    SocketGRPC_Status status = SocketGRPC_Call_status (call);
+    ASSERT_EQ (SOCKET_GRPC_STATUS_UNAVAILABLE, status.code);
+    ASSERT_EQ (0,
+               strcmp (
+                   SocketGRPC_Status_message (&status), "Service unavailable"));
+  }
+
+  Arena_dispose (&arena);
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  SocketTLSContext_free (&tls_client_ctx);
+  grpc_h2_server_stop (&server);
+  cleanup_temp_cert_files ();
+}
+
+#endif /* SOCKET_HAS_TLS */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- add unary gRPC over HTTP/2 transport via `SocketGRPC_Call_unary_h2`
- expose call-level request metadata APIs and status/trailer accessors
- enforce outbound message size and metadata entry limits in client path
- preserve mapped HTTP fallback status when non-gRPC bodies are returned
- add `test_grpc_unary_h2` coverage for success path, HTTP fallback path, metadata limits, and oversized outbound payloads
- wire new transport/test into `CMakeLists.txt`

## Related Fixes
- fix HTTP/2 client handshake progression to avoid preface/SETTINGS deadlock
- fix HTTP/2 incoming header validation role check for client-side responses

## Validation
- `ctest --test-dir build-3585 --output-on-failure -R "test_http2$|test_http2_(integration|server_push|priority|rate_limit)$|test_http_client$|test_grpc_(api_surface|wire|metadata|unary_h2)$"`