### PR TITLE
feat(grpc): add h2 streaming call APIs and tests

### DIFF
--- a/include/grpc/SocketGRPC-private.h
+++ b/include/grpc/SocketGRPC-private.h
@@ -18,6 +18,16 @@
 
 typedef struct SocketGRPC_ServerMethod SocketGRPC_ServerMethod;
 
+typedef enum
+{
+  GRPC_CALL_STREAM_IDLE = 0,
+  GRPC_CALL_STREAM_OPEN,
+  GRPC_CALL_STREAM_HALF_CLOSED_LOCAL,
+  GRPC_CALL_STREAM_HALF_CLOSED_REMOTE,
+  GRPC_CALL_STREAM_CLOSED,
+  GRPC_CALL_STREAM_FAILED
+} SocketGRPC_CallStreamState;
+
 struct SocketGRPC_Client
 {
   SocketGRPC_ClientConfig config;
@@ -52,6 +62,8 @@ struct SocketGRPC_Call
   SocketGRPC_Metadata_T request_metadata;
   SocketGRPC_Trailers_T response_trailers;
   SocketGRPC_Status last_status;
+  void *h2_stream_ctx;
+  SocketGRPC_CallStreamState h2_stream_state;
 };
 
 extern void SocketGRPC_status_set (SocketGRPC_Status *status,
@@ -62,5 +74,7 @@ extern const char *
 SocketGRPC_status_default_message (SocketGRPC_StatusCode code);
 
 extern void SocketGRPC_server_methods_clear (SocketGRPC_Server_T server);
+
+extern void SocketGRPC_Call_h2_stream_abort (SocketGRPC_Call_T call);
 
 #endif /* SOCKETGRPC_PRIVATE_INCLUDED */

--- a/include/grpc/SocketGRPC.h
+++ b/include/grpc/SocketGRPC.h
@@ -327,6 +327,43 @@ extern int SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
                                      size_t *response_payload_len);
 
 /**
+ * @brief Send one outbound streaming message on an HTTP/2 gRPC call.
+ *
+ * Lazily opens the stream on first send and emits initial request headers.
+ * Payload is unframed protobuf bytes (gRPC frame prefix is added internally).
+ *
+ * @return 0 on success, -1 on invalid state/argument or transport failure.
+ */
+extern int SocketGRPC_Call_send_message (SocketGRPC_Call_T call,
+                                         const uint8_t *request_payload,
+                                         size_t request_payload_len);
+
+/**
+ * @brief Half-close outbound stream direction for an HTTP/2 gRPC call.
+ *
+ * May be used after zero or more send_message calls. If no stream is active,
+ * this starts the stream and immediately closes outbound direction.
+ *
+ * @return 0 on success, -1 on invalid state or transport failure.
+ */
+extern int SocketGRPC_Call_close_send (SocketGRPC_Call_T call);
+
+/**
+ * @brief Receive next inbound streaming message for an HTTP/2 gRPC call.
+ *
+ * On message delivery: `*done = 0` and output payload fields are populated.
+ * On terminal stream completion: `*done = 1`, payload outputs are cleared, and
+ * final status/trailers are available via SocketGRPC_Call_status/trailers.
+ *
+ * @return 0 on success, -1 on invalid state/argument or transport failure.
+ */
+extern int SocketGRPC_Call_recv_message (SocketGRPC_Call_T call,
+                                         Arena_T arena,
+                                         uint8_t **response_payload,
+                                         size_t *response_payload_len,
+                                         int *done);
+
+/**
  * @brief Per-request metadata (custom headers and trailers).
  */
 extern SocketGRPC_Metadata_T

--- a/src/grpc/SocketGRPC-core.c
+++ b/src/grpc/SocketGRPC-core.c
@@ -398,6 +398,8 @@ SocketGRPC_Call_new (SocketGRPC_Channel_T channel,
   call->channel = channel;
   call->request_metadata = SocketGRPC_Metadata_new (NULL);
   call->response_trailers = SocketGRPC_Trailers_new (NULL);
+  call->h2_stream_ctx = NULL;
+  call->h2_stream_state = GRPC_CALL_STREAM_IDLE;
   if (call->request_metadata == NULL || call->response_trailers == NULL)
     {
       SocketGRPC_Metadata_free (&call->request_metadata);
@@ -418,6 +420,7 @@ SocketGRPC_Call_free (SocketGRPC_Call_T *call)
   if (call == NULL || *call == NULL)
     return;
 
+  SocketGRPC_Call_h2_stream_abort (*call);
   SocketGRPC_Metadata_free (&(*call)->request_metadata);
   SocketGRPC_Trailers_free (&(*call)->response_trailers);
   free ((*call)->full_method);


### PR DESCRIPTION
## Summary
- add HTTP/2 streaming client APIs: `SocketGRPC_Call_send_message`, `SocketGRPC_Call_close_send`, and `SocketGRPC_Call_recv_message`
- add per-call streaming transport/session state with strict lifecycle handling and guaranteed cleanup from `SocketGRPC_Call_free`
- implement robust partial-write send loops, incremental frame parsing, trailer/status ingestion, and terminal state mapping in `SocketGRPCClient-h2.c`
- extend gRPC API surface tests for new streaming calls and invalid-input guards
- upgrade the TLS HTTP/2 integration harness and add streaming integration coverage for client-streaming, server-streaming, and mid-stream error trailers

## Testing
- `cmake --build build -j"$(nproc)" --target test_grpc_api_surface test_grpc_unary_h2`
- `ctest --output-on-failure -R "test_grpc_api_surface|test_grpc_unary_h2"`
- `ctest --output-on-failure -R "test_grpc_(wire|metadata|api_surface|unary_h2|unary_server_h2|codegen_streaming)"`

Closes #3587