### PR TITLE
feat(grpc): add unary retry/backoff policy support

### DIFF
--- a/include/grpc/SocketGRPC-private.h
+++ b/include/grpc/SocketGRPC-private.h
@@ -64,6 +64,8 @@ struct SocketGRPC_Call
   SocketGRPC_Status last_status;
   void *h2_stream_ctx;
   SocketGRPC_CallStreamState h2_stream_state;
+  int retry_in_progress;
+  uint32_t retry_attempt;
 };
 
 extern void SocketGRPC_status_set (SocketGRPC_Status *status,


### PR DESCRIPTION
## Summary
- add unary retry policy config (defaults, validation, strict service-config subset parsing)
- implement unary HTTP/2 retry loop with capped jittered backoff, overall deadline preservation, and grpc-previous-rpc-attempts propagation
- add retry-focused integration coverage for unavailable-then-success, non-retryable no-retry, and deadline cutoff behavior
- harden retry policy parsing tests for invalid numeric values

Fixes #3589

## Test Plan
- cmake --build build -j"$(nproc)" --target test_grpc_api_surface test_grpc_unary_h2 test_grpc_unary_server_h2
- ctest --test-dir build --output-on-failure -R "test_grpc_api_surface|test_grpc_unary_h2|test_grpc_unary_server_h2"
- ctest --test-dir build --output-on-failure -R "test_grpc_(wire|metadata|api_surface|unary_h2|unary_server_h2|codegen_streaming)"