### PR TITLE
feat(grpc): add h2 gzip compression and safety limits

### DIFF
--- a/include/grpc/SocketGRPCConfig.h
+++ b/include/grpc/SocketGRPCConfig.h
@@ -42,6 +42,27 @@ typedef struct SocketTLSContext_T *SocketTLSContext_T;
 #define SOCKET_GRPC_DEFAULT_MAX_OUTBOUND_MESSAGE_BYTES (4U * 1024U * 1024U)
 #endif
 
+#ifndef SOCKET_GRPC_DEFAULT_ENABLE_RESPONSE_DECOMPRESSION
+#define SOCKET_GRPC_DEFAULT_ENABLE_RESPONSE_DECOMPRESSION 1
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_ENABLE_REQUEST_COMPRESSION
+#define SOCKET_GRPC_DEFAULT_ENABLE_REQUEST_COMPRESSION 0
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSED_MESSAGE_BYTES
+#define SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSED_MESSAGE_BYTES \
+    (SOCKET_GRPC_DEFAULT_MAX_INBOUND_MESSAGE_BYTES)
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_CUMULATIVE_INFLIGHT_BYTES
+#define SOCKET_GRPC_DEFAULT_MAX_CUMULATIVE_INFLIGHT_BYTES (8U * 1024U * 1024U)
+#endif
+
+#ifndef SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSION_RATIO
+#define SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSION_RATIO 0.0
+#endif
+
 #ifndef SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES
 #define SOCKET_GRPC_DEFAULT_MAX_METADATA_ENTRIES 64U
 #endif
@@ -139,6 +160,11 @@ typedef struct
   SocketTLSContext_T tls_context;
   int verify_peer;
   int allow_http2_cleartext;
+  int enable_response_decompression;
+  int enable_request_compression;
+  size_t max_decompressed_message_bytes;
+  size_t max_cumulative_inflight_bytes;
+  double max_decompression_ratio;
 } SocketGRPC_ChannelConfig;
 
 /**

--- a/src/grpc/SocketGRPC-core.c
+++ b/src/grpc/SocketGRPC-core.c
@@ -480,6 +480,16 @@ SocketGRPC_ChannelConfig_defaults (SocketGRPC_ChannelConfig *config)
   config->tls_context = NULL;
   config->verify_peer = SOCKET_GRPC_DEFAULT_VERIFY_PEER;
   config->allow_http2_cleartext = SOCKET_GRPC_DEFAULT_ALLOW_HTTP2_CLEARTEXT;
+  config->enable_response_decompression
+      = SOCKET_GRPC_DEFAULT_ENABLE_RESPONSE_DECOMPRESSION;
+  config->enable_request_compression
+      = SOCKET_GRPC_DEFAULT_ENABLE_REQUEST_COMPRESSION;
+  config->max_decompressed_message_bytes
+      = SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSED_MESSAGE_BYTES;
+  config->max_cumulative_inflight_bytes
+      = SOCKET_GRPC_DEFAULT_MAX_CUMULATIVE_INFLIGHT_BYTES;
+  config->max_decompression_ratio
+      = SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSION_RATIO;
 }
 
 void
@@ -528,6 +538,21 @@ grpc_sanitize_channel_config (SocketGRPC_ChannelConfig *config)
     config->user_agent = SOCKET_GRPC_DEFAULT_USER_AGENT;
   config->verify_peer = config->verify_peer ? 1 : 0;
   config->allow_http2_cleartext = config->allow_http2_cleartext ? 1 : 0;
+  config->enable_response_decompression
+      = config->enable_response_decompression ? 1 : 0;
+  config->enable_request_compression
+      = config->enable_request_compression ? 1 : 0;
+  if (config->max_decompressed_message_bytes == 0)
+    config->max_decompressed_message_bytes
+        = SOCKET_GRPC_DEFAULT_MAX_DECOMPRESSED_MESSAGE_BYTES;
+  if (config->max_cumulative_inflight_bytes == 0)
+    config->max_cumulative_inflight_bytes
+        = SOCKET_GRPC_DEFAULT_MAX_CUMULATIVE_INFLIGHT_BYTES;
+  if (config->max_decompression_ratio < 0.0)
+    config->max_decompression_ratio = 0.0;
+  else if (config->max_decompression_ratio > 0.0
+           && config->max_decompression_ratio < 1.0)
+    config->max_decompression_ratio = 1.0;
 }
 
 static void

--- a/src/grpc/SocketGRPCClient-h2.c
+++ b/src/grpc/SocketGRPCClient-h2.c
@@ -11,6 +11,7 @@
 
 #include "grpc/SocketGRPC-private.h"
 #include "grpc/SocketGRPCWire.h"
+#include "deflate/SocketDeflate.h"
 #include "core/SocketUtil/Timeout.h"
 #include "http/SocketHTTPClient-private.h"
 #include "http/SocketHTTP2-private.h"
@@ -35,6 +36,16 @@
 #define GRPC_TIMEOUT_HEADER_MAX 32U
 #define GRPC_RESPONSE_CHUNK 4096U
 #define GRPC_STREAM_RECV_BUFFER_INITIAL 4096U
+#define GRPC_ACCEPT_ENCODING_VALUE "identity,gzip"
+#define GRPC_ENCODING_GZIP "gzip"
+#define GRPC_ENCODING_IDENTITY "identity"
+
+typedef enum
+{
+  GRPC_COMPRESSION_IDENTITY = 0,
+  GRPC_COMPRESSION_GZIP = 1,
+  GRPC_COMPRESSION_UNSUPPORTED = 2
+} SocketGRPC_Compression;
 
 typedef struct
 {
@@ -53,6 +64,11 @@ typedef struct
   int active_stream_counted;
   int http_status_code;
   int64_t deadline_ms;
+  Arena_T compression_arena;
+  SocketDeflate_Deflater_T request_deflater;
+  SocketDeflate_Inflater_T response_inflater;
+  SocketGRPC_Compression request_compression;
+  SocketGRPC_Compression response_compression;
 } SocketGRPC_H2CallStream;
 
 static int
@@ -512,6 +528,516 @@ grpc_has_metadata_slot (SocketGRPC_Call_T call)
          < call->channel->config.max_metadata_entries;
 }
 
+static int
+grpc_token_equals_ci (const char *value, size_t value_len, const char *token)
+{
+  size_t token_len;
+
+  if (value == NULL || token == NULL)
+    return 0;
+
+  while (value_len > 0 && isspace ((unsigned char)value[0]))
+    {
+      value++;
+      value_len--;
+    }
+  while (value_len > 0 && isspace ((unsigned char)value[value_len - 1U]))
+    value_len--;
+
+  token_len = strlen (token);
+  if (value_len != token_len)
+    return 0;
+  return strncasecmp (value, token, token_len) == 0;
+}
+
+static SocketGRPC_Compression
+grpc_parse_compression_value (const char *value, size_t value_len)
+{
+  if (grpc_token_equals_ci (value, value_len, GRPC_ENCODING_IDENTITY))
+    return GRPC_COMPRESSION_IDENTITY;
+  if (grpc_token_equals_ci (value, value_len, GRPC_ENCODING_GZIP))
+    return GRPC_COMPRESSION_GZIP;
+  return GRPC_COMPRESSION_UNSUPPORTED;
+}
+
+static SocketGRPC_Compression
+grpc_response_compression_from_headers (SocketHTTP_Headers_T headers)
+{
+  size_t i;
+  SocketGRPC_Compression compression = GRPC_COMPRESSION_IDENTITY;
+  int seen = 0;
+
+  if (headers == NULL)
+    return GRPC_COMPRESSION_IDENTITY;
+
+  for (i = 0; i < SocketHTTP_Headers_count (headers); i++)
+    {
+      const SocketHTTP_Header *h = SocketHTTP_Headers_at (headers, i);
+      SocketGRPC_Compression parsed;
+      if (h == NULL || h->name == NULL || h->value == NULL)
+        continue;
+      if (h->name_len != strlen ("grpc-encoding")
+          || strncasecmp (h->name, "grpc-encoding", h->name_len) != 0)
+        continue;
+
+      parsed = grpc_parse_compression_value (h->value, h->value_len);
+      if (parsed == GRPC_COMPRESSION_UNSUPPORTED)
+        return GRPC_COMPRESSION_UNSUPPORTED;
+      if (seen && parsed != compression)
+        return GRPC_COMPRESSION_UNSUPPORTED;
+      compression = parsed;
+      seen = 1;
+    }
+
+  return compression;
+}
+
+static int
+grpc_grow_heap_buffer_limited (unsigned char **buffer,
+                               size_t *capacity,
+                               size_t min_capacity,
+                               size_t max_capacity)
+{
+  size_t new_capacity;
+  unsigned char *tmp;
+
+  if (buffer == NULL || capacity == NULL || *buffer == NULL
+      || min_capacity > max_capacity)
+    return -1;
+
+  new_capacity = (*capacity == 0) ? 256U : *capacity;
+  if (new_capacity > max_capacity)
+    new_capacity = max_capacity;
+  while (new_capacity < min_capacity)
+    {
+      size_t next;
+      if (new_capacity >= max_capacity)
+        break;
+      next = new_capacity * 2U;
+      if (next <= new_capacity || next > max_capacity)
+        next = max_capacity;
+      new_capacity = next;
+    }
+  if (new_capacity < min_capacity)
+    return -1;
+
+  tmp = (unsigned char *)realloc (*buffer, new_capacity);
+  if (tmp == NULL)
+    return -1;
+  *buffer = tmp;
+  *capacity = new_capacity;
+  return 0;
+}
+
+static size_t
+grpc_write_gzip_header (uint8_t *output, size_t output_len)
+{
+  if (output == NULL || output_len < GZIP_HEADER_MIN_SIZE)
+    return 0;
+
+  output[0] = GZIP_MAGIC_0;
+  output[1] = GZIP_MAGIC_1;
+  output[2] = GZIP_METHOD_DEFLATE;
+  output[3] = 0;
+  output[4] = 0;
+  output[5] = 0;
+  output[6] = 0;
+  output[7] = 0;
+  output[8] = 0;
+  output[9] = GZIP_OS_UNKNOWN;
+  return GZIP_HEADER_MIN_SIZE;
+}
+
+static size_t
+grpc_write_gzip_trailer (uint8_t *output,
+                         size_t output_len,
+                         uint32_t crc,
+                         uint32_t size)
+{
+  if (output == NULL || output_len < GZIP_TRAILER_SIZE)
+    return 0;
+
+  output[0] = (uint8_t)(crc & 0xFFU);
+  output[1] = (uint8_t)((crc >> 8) & 0xFFU);
+  output[2] = (uint8_t)((crc >> 16) & 0xFFU);
+  output[3] = (uint8_t)((crc >> 24) & 0xFFU);
+  output[4] = (uint8_t)(size & 0xFFU);
+  output[5] = (uint8_t)((size >> 8) & 0xFFU);
+  output[6] = (uint8_t)((size >> 16) & 0xFFU);
+  output[7] = (uint8_t)((size >> 24) & 0xFFU);
+  return GZIP_TRAILER_SIZE;
+}
+
+static int
+grpc_stream_context_init_compression (SocketGRPC_Call_T call,
+                                      SocketGRPC_H2CallStream *ctx)
+{
+  int need_request_compression;
+  int need_response_decompression;
+
+  if (call == NULL || call->channel == NULL || ctx == NULL)
+    return -1;
+
+  need_request_compression
+      = call->channel->config.enable_request_compression ? 1 : 0;
+  need_response_decompression
+      = call->channel->config.enable_response_decompression ? 1 : 0;
+
+  ctx->request_compression = need_request_compression
+                                 ? GRPC_COMPRESSION_GZIP
+                                 : GRPC_COMPRESSION_IDENTITY;
+  ctx->response_compression = GRPC_COMPRESSION_IDENTITY;
+
+  if (!need_request_compression && !need_response_decompression)
+    return 0;
+
+  ctx->compression_arena = Arena_new ();
+  if (ctx->compression_arena == NULL)
+    return -1;
+
+  if (need_request_compression)
+    {
+      ctx->request_deflater = SocketDeflate_Deflater_new (
+          ctx->compression_arena, DEFLATE_LEVEL_DEFAULT);
+      if (ctx->request_deflater == NULL)
+        return -1;
+    }
+
+  if (need_response_decompression)
+    {
+      ctx->response_inflater = SocketDeflate_Inflater_new (
+          ctx->compression_arena,
+          call->channel->config.max_decompressed_message_bytes);
+      if (ctx->response_inflater == NULL)
+        return -1;
+    }
+
+  return 0;
+}
+
+static int
+grpc_gzip_compress_payload (SocketDeflate_Deflater_T deflater,
+                            const uint8_t *input,
+                            size_t input_len,
+                            unsigned char **output_out,
+                            size_t *output_len_out)
+{
+  unsigned char *output;
+  size_t output_cap;
+  size_t output_len = 0;
+  const uint8_t *in_ptr = input;
+  size_t in_remaining = input_len;
+  SocketDeflate_Result res;
+  uint32_t crc;
+
+  if (deflater == NULL || output_out == NULL || output_len_out == NULL
+      || (input == NULL && input_len != 0))
+    return -1;
+
+  output_cap = SocketDeflate_compress_bound (input_len);
+  if (output_cap > SIZE_MAX - (GZIP_HEADER_MIN_SIZE + GZIP_TRAILER_SIZE))
+    return -1;
+  output_cap += GZIP_HEADER_MIN_SIZE + GZIP_TRAILER_SIZE;
+  output = (unsigned char *)malloc (output_cap);
+  if (output == NULL)
+    return -1;
+
+  if (grpc_write_gzip_header (output, output_cap) == 0)
+    {
+      free (output);
+      return -1;
+    }
+  output_len = GZIP_HEADER_MIN_SIZE;
+  SocketDeflate_Deflater_reset (deflater);
+
+  while (in_remaining > 0)
+    {
+      size_t consumed = 0;
+      size_t written = 0;
+      res = SocketDeflate_Deflater_deflate (deflater,
+                                            in_ptr,
+                                            in_remaining,
+                                            &consumed,
+                                            output + output_len,
+                                            output_cap - output_len,
+                                            &written);
+      output_len += written;
+      in_ptr += consumed;
+      in_remaining -= consumed;
+
+      if (res == DEFLATE_OUTPUT_FULL)
+        {
+          if (grpc_grow_heap_buffer_limited (
+                  &output, &output_cap, output_len + 1U, SIZE_MAX)
+              != 0)
+            {
+              free (output);
+              return -1;
+            }
+          continue;
+        }
+      if (res != DEFLATE_OK)
+        {
+          free (output);
+          return -1;
+        }
+      if (in_remaining > 0 && consumed == 0 && written == 0)
+        {
+          if (grpc_grow_heap_buffer_limited (
+                  &output, &output_cap, output_len + 1U, SIZE_MAX)
+              != 0)
+            {
+              free (output);
+              return -1;
+            }
+        }
+    }
+
+  for (;;)
+    {
+      size_t written = 0;
+      res = SocketDeflate_Deflater_finish (
+          deflater, output + output_len, output_cap - output_len, &written);
+      output_len += written;
+      if (res == DEFLATE_OUTPUT_FULL)
+        {
+          if (grpc_grow_heap_buffer_limited (
+                  &output, &output_cap, output_len + 1U, SIZE_MAX)
+              != 0)
+            {
+              free (output);
+              return -1;
+            }
+          continue;
+        }
+      if (res != DEFLATE_OK)
+        {
+          free (output);
+          return -1;
+        }
+      break;
+    }
+
+  if (output_cap - output_len < GZIP_TRAILER_SIZE
+      && grpc_grow_heap_buffer_limited (
+             &output, &output_cap, output_len + GZIP_TRAILER_SIZE, SIZE_MAX)
+             != 0)
+    {
+      free (output);
+      return -1;
+    }
+
+  crc = SocketDeflate_crc32 (0, input, input_len);
+  if (grpc_write_gzip_trailer (output + output_len,
+                               output_cap - output_len,
+                               crc,
+                               (uint32_t)input_len)
+      == 0)
+    {
+      free (output);
+      return -1;
+    }
+  output_len += GZIP_TRAILER_SIZE;
+
+  *output_out = output;
+  *output_len_out = output_len;
+  return 0;
+}
+
+static SocketGRPC_StatusCode
+grpc_gzip_decompress_payload (SocketGRPC_Call_T call,
+                              SocketDeflate_Inflater_T inflater,
+                              const uint8_t *input,
+                              size_t input_len,
+                              unsigned char **output_out,
+                              size_t *output_len_out,
+                              const char **message_out)
+{
+  SocketDeflate_GzipHeader header;
+  SocketDeflate_Result res;
+  const uint8_t *deflate_input;
+  size_t deflate_input_len;
+  const uint8_t *trailer;
+  unsigned char *output = NULL;
+  size_t output_cap;
+  size_t output_len = 0;
+  size_t consumed = 0;
+  size_t written = 0;
+  size_t max_output;
+  size_t total_in;
+  size_t total_out;
+  uint32_t crc;
+
+  if (output_out == NULL || output_len_out == NULL || message_out == NULL
+      || call == NULL || call->channel == NULL || inflater == NULL
+      || (input == NULL && input_len != 0))
+    {
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    }
+
+  *output_out = NULL;
+  *output_len_out = 0;
+  *message_out = "Malformed compressed gRPC response frame";
+
+  res = SocketDeflate_gzip_parse_header (input, input_len, &header);
+  if (res != DEFLATE_OK)
+    return SOCKET_GRPC_STATUS_INTERNAL;
+  if (header.header_size > input_len
+      || input_len - header.header_size < GZIP_TRAILER_SIZE)
+    return SOCKET_GRPC_STATUS_INTERNAL;
+
+  deflate_input = input + header.header_size;
+  deflate_input_len = input_len - header.header_size - GZIP_TRAILER_SIZE;
+  trailer = input + input_len - GZIP_TRAILER_SIZE;
+
+  max_output = call->channel->config.max_decompressed_message_bytes;
+  if (max_output == 0)
+    max_output = call->channel->config.max_inbound_message_bytes;
+  if (max_output == 0)
+    return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+
+  output_cap = max_output;
+  if (output_cap == 0)
+    output_cap = 1U;
+  output = (unsigned char *)malloc (output_cap);
+  if (output == NULL)
+    return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+
+  SocketDeflate_Inflater_reset (inflater);
+
+  res = SocketDeflate_Inflater_inflate (inflater,
+                                        deflate_input,
+                                        deflate_input_len,
+                                        &consumed,
+                                        output,
+                                        output_cap,
+                                        &written);
+  output_len = written;
+  if (res == DEFLATE_ERROR_BOMB || res == DEFLATE_OUTPUT_FULL
+      || (res == DEFLATE_INCOMPLETE && output_len >= max_output))
+    {
+      free (output);
+      *message_out = "Compressed response exceeds decompression limits";
+      return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+    }
+  if (res != DEFLATE_OK || consumed != deflate_input_len)
+    {
+      free (output);
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    }
+
+  crc = SocketDeflate_crc32 (0, output, output_len);
+  if (SocketDeflate_gzip_verify_trailer (trailer, crc, (uint32_t)output_len)
+      != DEFLATE_OK)
+    {
+      free (output);
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    }
+
+  if (call->channel->config.max_decompression_ratio > 0.0)
+    {
+      total_in = SocketDeflate_Inflater_total_in (inflater);
+      total_out = SocketDeflate_Inflater_total_out (inflater);
+      if ((total_in == 0 && total_out > 0)
+          || (total_in > 0
+              && ((double)total_out / (double)total_in)
+                     > call->channel->config.max_decompression_ratio))
+        {
+          free (output);
+          *message_out = "Compressed response exceeded decompression ratio";
+          return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+        }
+    }
+
+  *output_out = output;
+  *output_len_out = output_len;
+  return SOCKET_GRPC_STATUS_OK;
+}
+
+static SocketGRPC_StatusCode
+grpc_decode_frame_payload (SocketGRPC_Call_T call,
+                           SocketGRPC_Compression response_compression,
+                           SocketDeflate_Inflater_T inflater,
+                           Arena_T arena,
+                           const SocketGRPC_FrameView *frame,
+                           uint8_t **payload_out,
+                           size_t *payload_len_out,
+                           const char **message_out)
+{
+  if (call == NULL || call->channel == NULL || arena == NULL || frame == NULL
+      || payload_out == NULL || payload_len_out == NULL || message_out == NULL)
+    return SOCKET_GRPC_STATUS_INTERNAL;
+
+  *payload_out = NULL;
+  *payload_len_out = 0;
+  *message_out = "Malformed gRPC response frame";
+
+  if (frame->compressed == 0)
+    {
+      if (frame->payload_len > call->channel->config.max_inbound_message_bytes)
+        {
+          *message_out = "Response message exceeds configured limit";
+          return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+        }
+      if (frame->payload_len > 0)
+        {
+          uint8_t *copy = (uint8_t *)ALLOC (arena, frame->payload_len);
+          if (copy == NULL)
+            return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+          memcpy (copy, frame->payload, frame->payload_len);
+          *payload_out = copy;
+          *payload_len_out = frame->payload_len;
+        }
+      return SOCKET_GRPC_STATUS_OK;
+    }
+
+  if (!call->channel->config.enable_response_decompression)
+    {
+      *message_out = "Response decompression is disabled";
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    }
+  if (response_compression != GRPC_COMPRESSION_GZIP)
+    {
+      *message_out = "Unsupported response compression encoding";
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    }
+  if (inflater == NULL)
+    {
+      *message_out = "Response inflater unavailable";
+      return SOCKET_GRPC_STATUS_INTERNAL;
+    }
+
+  {
+    unsigned char *decoded = NULL;
+    size_t decoded_len = 0;
+    SocketGRPC_StatusCode decode_status
+        = grpc_gzip_decompress_payload (call,
+                                        inflater,
+                                        frame->payload,
+                                        frame->payload_len,
+                                        &decoded,
+                                        &decoded_len,
+                                        message_out);
+    if (decode_status != SOCKET_GRPC_STATUS_OK)
+      return decode_status;
+    if (decoded_len > 0)
+      {
+        uint8_t *copy = (uint8_t *)ALLOC (arena, decoded_len);
+        if (copy == NULL)
+          {
+            free (decoded);
+            return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+          }
+        memcpy (copy, decoded, decoded_len);
+        *payload_out = copy;
+        *payload_len_out = decoded_len;
+      }
+    free (decoded);
+  }
+
+  return SOCKET_GRPC_STATUS_OK;
+}
+
 static char *
 grpc_build_call_url (SocketGRPC_Call_T call, Arena_T arena)
 {
@@ -537,12 +1063,14 @@ grpc_build_call_url (SocketGRPC_Call_T call, Arena_T arena)
       base = target + strlen ("dns:///");
       if (base[0] == '\0')
         return NULL;
-      scheme = call->channel->config.allow_http2_cleartext ? "http://" : "https://";
+      scheme = call->channel->config.allow_http2_cleartext ? "http://"
+                                                           : "https://";
     }
   else
     {
       base = target;
-      scheme = call->channel->config.allow_http2_cleartext ? "http://" : "https://";
+      scheme = call->channel->config.allow_http2_cleartext ? "http://"
+                                                           : "https://";
     }
 
   base_len = strlen (base);
@@ -556,7 +1084,8 @@ grpc_build_call_url (SocketGRPC_Call_T call, Arena_T arena)
   if (scheme != NULL)
     {
       size_t scheme_len = strlen (scheme);
-      url = (char *)ALLOC (arena, scheme_len + trim_len + add_slash + path_len + 1U);
+      url = (char *)ALLOC (arena,
+                           scheme_len + trim_len + add_slash + path_len + 1U);
       if (url == NULL)
         return NULL;
       memcpy (url, scheme, scheme_len);
@@ -596,13 +1125,15 @@ grpc_request_add_metadata (SocketGRPC_Call_T call,
 
   for (i = 0; i < count; i++)
     {
-      const SocketGRPC_MetadataEntry *entry = SocketGRPC_Metadata_at (metadata, i);
+      const SocketGRPC_MetadataEntry *entry
+          = SocketGRPC_Metadata_at (metadata, i);
       if (entry == NULL || entry->key == NULL)
         continue;
 
       if (entry->is_binary)
         {
-          size_t encoded_cap = SocketCrypto_base64_encoded_size (entry->value_len);
+          size_t encoded_cap
+              = SocketCrypto_base64_encoded_size (entry->value_len);
           char *encoded = (char *)malloc (encoded_cap);
           ssize_t encoded_len;
           if (encoded == NULL)
@@ -652,6 +1183,15 @@ grpc_request_add_required_headers (SocketGRPC_Call_T call,
     return -1;
   if (SocketHTTPClient_Request_header (req, "te", "trailers") != 0)
     return -1;
+  if (SocketHTTPClient_Request_header (
+          req, "grpc-accept-encoding", GRPC_ACCEPT_ENCODING_VALUE)
+      != 0)
+    return -1;
+  if (call->channel != NULL && call->channel->config.enable_request_compression
+      && SocketHTTPClient_Request_header (
+             req, "grpc-encoding", GRPC_ENCODING_GZIP)
+             != 0)
+    return -1;
   if (call->channel->user_agent != NULL
       && SocketHTTPClient_Request_header (
              req, "user-agent", call->channel->user_agent)
@@ -665,11 +1205,13 @@ grpc_request_add_required_headers (SocketGRPC_Call_T call,
 
   if (call->config.deadline_ms > 0)
     {
-      if (SocketGRPC_Timeout_format (
-              (int64_t)call->config.deadline_ms, timeout_buf, sizeof (timeout_buf))
+      if (SocketGRPC_Timeout_format ((int64_t)call->config.deadline_ms,
+                                     timeout_buf,
+                                     sizeof (timeout_buf))
           != 0)
         return -1;
-      if (SocketHTTPClient_Request_header (req, "grpc-timeout", timeout_buf) != 0)
+      if (SocketHTTPClient_Request_header (req, "grpc-timeout", timeout_buf)
+          != 0)
         return -1;
     }
 
@@ -755,7 +1297,10 @@ grpc_trailer_ingest_kv (SocketGRPC_Call_T call,
           status = status * 10 + (int)(value[i] - '0');
         }
       free (lower_name);
-      return SocketGRPC_Trailers_set_status (trailers, status) == SOCKET_GRPC_WIRE_OK ? 0 : -1;
+      return SocketGRPC_Trailers_set_status (trailers, status)
+                     == SOCKET_GRPC_WIRE_OK
+                 ? 0
+                 : -1;
     }
   if (strcmp (lower_name, "grpc-message") == 0)
     {
@@ -907,14 +1452,20 @@ grpc_receive_body_and_trailers (SocketGRPC_Call_T call,
                                 SocketHTTP2_Stream_T stream,
                                 SocketHTTP2_Conn_T conn,
                                 unsigned char **body_out,
-                                size_t *body_len_out)
+                                size_t *body_len_out,
+                                SocketGRPC_StatusCode *error_status,
+                                const char **error_message)
 {
   unsigned char *body = NULL;
   size_t total = 0;
   size_t cap = 0;
 
-  if (body_out == NULL || body_len_out == NULL)
+  if (body_out == NULL || body_len_out == NULL || error_status == NULL
+      || error_message == NULL)
     return -1;
+
+  *error_status = SOCKET_GRPC_STATUS_UNAVAILABLE;
+  *error_message = "Failed to receive response body";
 
   for (;;)
     {
@@ -925,15 +1476,19 @@ grpc_receive_body_and_trailers (SocketGRPC_Call_T call,
       if (n < 0)
         {
           free (body);
+          *error_status = SOCKET_GRPC_STATUS_UNAVAILABLE;
+          *error_message = "Failed to receive response body";
           return -1;
         }
 
       if (n > 0)
         {
           size_t needed = total + (size_t)n;
-          if (needed > call->channel->config.max_inbound_message_bytes)
+          if (needed > call->channel->config.max_cumulative_inflight_bytes)
             {
               free (body);
+              *error_status = SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+              *error_message = "Response exceeds configured inflight limit";
               return -1;
             }
           if (needed > cap)
@@ -946,6 +1501,8 @@ grpc_receive_body_and_trailers (SocketGRPC_Call_T call,
               if (tmp == NULL)
                 {
                   free (body);
+                  *error_status = SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+                  *error_message = "Out of memory receiving response body";
                   return -1;
                 }
               body = tmp;
@@ -963,13 +1520,18 @@ grpc_receive_body_and_trailers (SocketGRPC_Call_T call,
         if (tr < 0)
           {
             free (body);
+            *error_status = SOCKET_GRPC_STATUS_UNAVAILABLE;
+            *error_message = "Failed to receive response trailers";
             return -1;
           }
         if (tr == 1 && trailer_count > 0)
           {
-            if (grpc_ingest_stream_trailers (call, trailers, trailer_count) != 0)
+            if (grpc_ingest_stream_trailers (call, trailers, trailer_count)
+                != 0)
               {
                 free (body);
+                *error_status = SOCKET_GRPC_STATUS_INTERNAL;
+                *error_message = "Invalid response trailers";
                 return -1;
               }
           }
@@ -981,6 +1543,8 @@ grpc_receive_body_and_trailers (SocketGRPC_Call_T call,
       if (n == 0 && grpc_h2_conn_process_safe (conn, 0) < 0)
         {
           free (body);
+          *error_status = SOCKET_GRPC_STATUS_UNAVAILABLE;
+          *error_message = "Failed to advance response stream";
           return -1;
         }
     }
@@ -1021,12 +1585,14 @@ grpc_build_call_url_heap (SocketGRPC_Call_T call)
       base = target + strlen ("dns:///");
       if (base[0] == '\0')
         return NULL;
-      scheme = call->channel->config.allow_http2_cleartext ? "http://" : "https://";
+      scheme = call->channel->config.allow_http2_cleartext ? "http://"
+                                                           : "https://";
     }
   else
     {
       base = target;
-      scheme = call->channel->config.allow_http2_cleartext ? "http://" : "https://";
+      scheme = call->channel->config.allow_http2_cleartext ? "http://"
+                                                           : "https://";
     }
 
   base_len = strlen (base);
@@ -1060,7 +1626,9 @@ grpc_build_call_url_heap (SocketGRPC_Call_T call)
 }
 
 static void
-grpc_stream_context_cleanup (SocketGRPC_Call_T call, int success, int cancel_stream)
+grpc_stream_context_cleanup (SocketGRPC_Call_T call,
+                             int success,
+                             int cancel_stream)
 {
   SocketGRPC_H2CallStream *ctx;
 
@@ -1088,6 +1656,10 @@ grpc_stream_context_cleanup (SocketGRPC_Call_T call, int success, int cancel_str
   ctx->recv_buffer = NULL;
   ctx->recv_cap = 0;
   ctx->recv_len = 0;
+  if (ctx->compression_arena != NULL)
+    Arena_dispose (&ctx->compression_arena);
+  ctx->request_deflater = NULL;
+  ctx->response_inflater = NULL;
 
   SocketHTTPClient_Response_free (&ctx->response);
   SocketHTTPClient_Request_free (&ctx->request);
@@ -1142,13 +1714,13 @@ grpc_stream_finalize_status (SocketGRPC_Call_T call, int http_status_code)
 
   if (!SocketGRPC_Trailers_has_status (call->response_trailers))
     {
-      status_code
-          = SocketGRPC_http_status_to_grpc (http_status_code);
-      (void)SocketGRPC_Trailers_set_status (call->response_trailers, status_code);
+      status_code = SocketGRPC_http_status_to_grpc (http_status_code);
+      (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                            status_code);
     }
 
-  status_code
-      = (SocketGRPC_StatusCode)SocketGRPC_Trailers_status (call->response_trailers);
+  status_code = (SocketGRPC_StatusCode)SocketGRPC_Trailers_status (
+      call->response_trailers);
   grpc_call_status_set (
       call, status_code, SocketGRPC_Trailers_message (call->response_trailers));
 }
@@ -1171,6 +1743,8 @@ grpc_stream_open_if_needed (SocketGRPC_Call_T call)
   ctx = (SocketGRPC_H2CallStream *)calloc (1, sizeof (*ctx));
   if (ctx == NULL)
     return NULL;
+  if (grpc_stream_context_init_compression (call, ctx) != 0)
+    goto fail;
 
   SocketHTTPClient_config_defaults (&cfg);
   cfg.max_version = HTTP_VERSION_2;
@@ -1178,7 +1752,7 @@ grpc_stream_open_if_needed (SocketGRPC_Call_T call)
   cfg.verify_ssl = call->channel->config.verify_peer;
   cfg.tls_context = call->channel->config.tls_context;
   cfg.request_timeout_ms = call->config.deadline_ms;
-  cfg.max_response_size = call->channel->config.max_inbound_message_bytes;
+  cfg.max_response_size = call->channel->config.max_cumulative_inflight_bytes;
 
   ctx->http_client = SocketHTTPClient_new (&cfg);
   if (ctx->http_client == NULL)
@@ -1235,7 +1809,8 @@ fail:
     free (url);
   if (ctx != NULL)
     {
-      if (ctx->conn != NULL && ctx->stream != NULL && ctx->active_stream_counted)
+      if (ctx->conn != NULL && ctx->stream != NULL
+          && ctx->active_stream_counted)
         {
           if (ctx->conn->proto.h2.active_streams > 0)
             ctx->conn->proto.h2.active_streams--;
@@ -1249,6 +1824,8 @@ fail:
       SocketHTTPClient_Request_free (&ctx->request);
       SocketHTTPClient_free (&ctx->http_client);
       free (ctx->recv_buffer);
+      if (ctx->compression_arena != NULL)
+        Arena_dispose (&ctx->compression_arena);
       free (ctx);
     }
   return NULL;
@@ -1271,31 +1848,40 @@ grpc_stream_send_frame (SocketGRPC_Call_T call,
     {
       if (SocketTimeout_expired (ctx->deadline_ms))
         {
-          return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded", 1);
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED,
+                                   "Deadline exceeded",
+                                   1);
         }
 
       if (grpc_h2_conn_flush_safe (ctx->h2conn) != 0)
         {
-          return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to flush stream send", 1);
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_UNAVAILABLE,
+                                   "Failed to flush stream send",
+                                   1);
         }
 
       ssize_t n = grpc_h2_stream_send_data_safe (
           ctx->stream, frame + offset, frame_len - offset, close_send);
       if (n < 0)
         {
-          return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to send stream frame", 1);
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_UNAVAILABLE,
+                                   "Failed to send stream frame",
+                                   1);
         }
       if (n == 0)
         {
           if (SocketTimeout_expired (ctx->deadline_ms))
             {
-              return grpc_stream_fail (
-                  call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded", 1);
+              return grpc_stream_fail (call,
+                                       SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED,
+                                       "Deadline exceeded",
+                                       1);
             }
-          if (grpc_h2_conn_process_safe (ctx->h2conn, 0) < 0 || ++idle_spins > 2048)
+          if (grpc_h2_conn_process_safe (ctx->h2conn, 0) < 0
+              || ++idle_spins > 2048)
             {
               return grpc_stream_fail (call,
                                        SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED,
@@ -1311,15 +1897,18 @@ grpc_stream_send_frame (SocketGRPC_Call_T call,
 
   if (grpc_h2_conn_flush_safe (ctx->h2conn) != 0)
     {
-      return grpc_stream_fail (
-          call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to flush stream send", 1);
+      return grpc_stream_fail (call,
+                               SOCKET_GRPC_STATUS_UNAVAILABLE,
+                               "Failed to flush stream send",
+                               1);
     }
 
   if (close_send)
     {
-      call->h2_stream_state = (call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_REMOTE)
-                                  ? GRPC_CALL_STREAM_CLOSED
-                                  : GRPC_CALL_STREAM_HALF_CLOSED_LOCAL;
+      call->h2_stream_state
+          = (call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_REMOTE)
+                ? GRPC_CALL_STREAM_CLOSED
+                : GRPC_CALL_STREAM_HALF_CLOSED_LOCAL;
     }
 
   return 0;
@@ -1339,16 +1928,17 @@ grpc_stream_append_recv (SocketGRPC_Call_T call,
   if (chunk_len == 0)
     return 0;
 
-  max_buffer = call->channel->config.max_inbound_message_bytes
-               + SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE;
+  max_buffer = call->channel->config.max_cumulative_inflight_bytes;
+  if (max_buffer < SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE)
+    max_buffer = SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE;
   needed = ctx->recv_len + chunk_len;
   if (needed > max_buffer)
     return -1;
 
   if (needed > ctx->recv_cap)
     {
-      size_t new_cap
-          = ctx->recv_cap == 0 ? GRPC_STREAM_RECV_BUFFER_INITIAL : ctx->recv_cap;
+      size_t new_cap = ctx->recv_cap == 0 ? GRPC_STREAM_RECV_BUFFER_INITIAL
+                                          : ctx->recv_cap;
       unsigned char *tmp;
       while (new_cap < needed)
         new_cap *= 2U;
@@ -1370,50 +1960,67 @@ grpc_stream_try_parse_message (SocketGRPC_Call_T call,
                                Arena_T arena,
                                uint8_t **response_payload,
                                size_t *response_payload_len,
+                               SocketGRPC_StatusCode *error_status,
+                               const char **error_message,
                                int *has_message)
 {
   SocketGRPC_FrameView frame;
   size_t consumed = 0;
+  size_t max_frame_payload;
   SocketGRPC_WireResult rc;
+  SocketGRPC_StatusCode decode_status;
+  const char *decode_message = "Malformed streaming response frame";
 
   if (call == NULL || ctx == NULL || arena == NULL || response_payload == NULL
-      || response_payload_len == NULL || has_message == NULL)
+      || response_payload_len == NULL || has_message == NULL
+      || error_status == NULL || error_message == NULL)
     return -1;
 
+  *error_status = SOCKET_GRPC_STATUS_INTERNAL;
+  *error_message = "Malformed streaming response frame";
   *has_message = 0;
   if (ctx->recv_len == 0)
     return 0;
 
-  rc = SocketGRPC_Frame_parse (ctx->recv_buffer,
-                               ctx->recv_len,
-                               call->channel->config.max_inbound_message_bytes,
-                               &frame,
-                               &consumed);
+  max_frame_payload = call->channel->config.max_cumulative_inflight_bytes;
+  if (max_frame_payload == 0)
+    max_frame_payload = call->channel->config.max_inbound_message_bytes;
+
+  rc = SocketGRPC_Frame_parse (
+      ctx->recv_buffer, ctx->recv_len, max_frame_payload, &frame, &consumed);
   if (rc == SOCKET_GRPC_WIRE_INCOMPLETE)
     return 0;
   if (rc != SOCKET_GRPC_WIRE_OK)
-    return -1;
-  if (frame.compressed != 0)
-    return -1;
-
-  if (frame.payload_len > 0)
     {
-      uint8_t *out = (uint8_t *)ALLOC (arena, frame.payload_len);
-      if (out == NULL)
-        return -1;
-      memcpy (out, frame.payload, frame.payload_len);
-      *response_payload = out;
-      *response_payload_len = frame.payload_len;
+      if (rc == SOCKET_GRPC_WIRE_LENGTH_EXCEEDED)
+        {
+          *error_status = SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+          *error_message
+              = "Streaming response exceeds configured inflight limit";
+        }
+      return -1;
     }
-  else
+
+  decode_status = grpc_decode_frame_payload (call,
+                                             ctx->response_compression,
+                                             ctx->response_inflater,
+                                             arena,
+                                             &frame,
+                                             response_payload,
+                                             response_payload_len,
+                                             &decode_message);
+  if (decode_status != SOCKET_GRPC_STATUS_OK)
     {
-      *response_payload = NULL;
-      *response_payload_len = 0;
+      *error_status = decode_status;
+      *error_message = decode_message;
+      return -1;
     }
 
   if (consumed < ctx->recv_len)
     {
-      memmove (ctx->recv_buffer, ctx->recv_buffer + consumed, ctx->recv_len - consumed);
+      memmove (ctx->recv_buffer,
+               ctx->recv_buffer + consumed,
+               ctx->recv_len - consumed);
     }
   ctx->recv_len -= consumed;
   *has_message = 1;
@@ -1427,8 +2034,12 @@ SocketGRPC_Call_send_message (SocketGRPC_Call_T call,
 {
   SocketGRPC_H2CallStream *ctx;
   unsigned char *framed;
+  unsigned char *compressed_payload = NULL;
+  const uint8_t *wire_payload = request_payload;
+  size_t wire_payload_len = request_payload_len;
   size_t framed_len = 0;
   size_t framed_cap;
+  int compressed_flag = 0;
   int rc;
 
   if (call == NULL || (request_payload == NULL && request_payload_len != 0))
@@ -1437,8 +2048,9 @@ SocketGRPC_Call_send_message (SocketGRPC_Call_T call,
       || call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_REMOTE
       || call->h2_stream_state == GRPC_CALL_STREAM_FAILED)
     {
-      grpc_call_status_set (
-          call, SOCKET_GRPC_STATUS_FAILED_PRECONDITION, "Send direction already closed");
+      grpc_call_status_set (call,
+                            SOCKET_GRPC_STATUS_FAILED_PRECONDITION,
+                            "Send direction already closed");
       return -1;
     }
   if (request_payload_len > call->channel->config.max_outbound_message_bytes
@@ -1456,29 +2068,63 @@ SocketGRPC_Call_send_message (SocketGRPC_Call_T call,
       return -1;
     }
 
-  framed_cap = SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE + request_payload_len;
+  if (ctx->request_compression == GRPC_COMPRESSION_GZIP)
+    {
+      if (ctx->request_deflater == NULL
+          || grpc_gzip_compress_payload (ctx->request_deflater,
+                                         request_payload,
+                                         request_payload_len,
+                                         &compressed_payload,
+                                         &wire_payload_len)
+                 != 0)
+        {
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_INTERNAL,
+                                   "Failed to compress streaming request",
+                                   1);
+        }
+      wire_payload = compressed_payload;
+      compressed_flag = 1;
+    }
+
+  if (wire_payload_len > (size_t)UINT32_MAX
+      || wire_payload_len > (SIZE_MAX - SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE))
+    {
+      free (compressed_payload);
+      return grpc_stream_fail (
+          call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL, 1);
+    }
+
+  framed_cap = SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE + wire_payload_len;
   framed = (unsigned char *)malloc (framed_cap);
   if (framed == NULL)
     {
-      return grpc_stream_fail (
-          call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, "Out of memory framing message", 1);
+      free (compressed_payload);
+      return grpc_stream_fail (call,
+                               SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED,
+                               "Out of memory framing message",
+                               1);
     }
 
-  if (SocketGRPC_Frame_encode (0,
-                               request_payload,
-                               (uint32_t)request_payload_len,
+  if (SocketGRPC_Frame_encode (compressed_flag,
+                               wire_payload,
+                               (uint32_t)wire_payload_len,
                                framed,
                                framed_cap,
                                &framed_len)
       != SOCKET_GRPC_WIRE_OK)
     {
       free (framed);
-      return grpc_stream_fail (
-          call, SOCKET_GRPC_STATUS_INTERNAL, "Failed to frame streaming request", 1);
+      free (compressed_payload);
+      return grpc_stream_fail (call,
+                               SOCKET_GRPC_STATUS_INTERNAL,
+                               "Failed to frame streaming request",
+                               1);
     }
 
   rc = grpc_stream_send_frame (call, ctx, framed, framed_len, 0);
   free (framed);
+  free (compressed_payload);
   return rc;
 }
 
@@ -1506,13 +2152,16 @@ SocketGRPC_Call_close_send (SocketGRPC_Call_T call)
   if (grpc_h2_stream_send_headers_safe (ctx->stream, NULL, 0, 1) != 0
       || grpc_h2_conn_flush_safe (ctx->h2conn) != 0)
     {
-      return grpc_stream_fail (
-          call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to close send direction", 1);
+      return grpc_stream_fail (call,
+                               SOCKET_GRPC_STATUS_UNAVAILABLE,
+                               "Failed to close send direction",
+                               1);
     }
 
-  call->h2_stream_state = (call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_REMOTE)
-                              ? GRPC_CALL_STREAM_CLOSED
-                              : GRPC_CALL_STREAM_HALF_CLOSED_LOCAL;
+  call->h2_stream_state
+      = (call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_REMOTE)
+            ? GRPC_CALL_STREAM_CLOSED
+            : GRPC_CALL_STREAM_HALF_CLOSED_LOCAL;
   return 0;
 }
 
@@ -1553,19 +2202,42 @@ SocketGRPC_Call_recv_message (SocketGRPC_Call_T call,
   if (!ctx->headers_received)
     {
       int end_stream = 0;
-      if (httpclient_http2_recv_headers (ctx->stream, ctx->h2conn, &ctx->response, &end_stream)
+      if (httpclient_http2_recv_headers (
+              ctx->stream, ctx->h2conn, &ctx->response, &end_stream)
           < 0)
         {
-          return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to receive stream headers", 1);
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_UNAVAILABLE,
+                                   "Failed to receive stream headers",
+                                   1);
         }
-      if (grpc_ingest_response_headers (call, ctx->response.headers, end_stream) != 0)
+      if (grpc_ingest_response_headers (call, ctx->response.headers, end_stream)
+          != 0)
         {
-          return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_INTERNAL, "Invalid streaming response headers", 1);
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_INTERNAL,
+                                   "Invalid streaming response headers",
+                                   1);
         }
       ctx->headers_received = 1;
       ctx->http_status_code = ctx->response.status_code;
+      ctx->response_compression
+          = grpc_response_compression_from_headers (ctx->response.headers);
+      if (ctx->response_compression == GRPC_COMPRESSION_UNSUPPORTED)
+        {
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_INTERNAL,
+                                   "Unsupported response compression encoding",
+                                   1);
+        }
+      if (ctx->response_compression == GRPC_COMPRESSION_GZIP
+          && !call->channel->config.enable_response_decompression)
+        {
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_INTERNAL,
+                                   "Response decompression is disabled",
+                                   1);
+        }
       if (end_stream)
         ctx->remote_end_stream = 1;
     }
@@ -1574,21 +2246,27 @@ SocketGRPC_Call_recv_message (SocketGRPC_Call_T call,
     {
       if (SocketTimeout_expired (ctx->deadline_ms))
         {
-          return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded", 1);
+          return grpc_stream_fail (call,
+                                   SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED,
+                                   "Deadline exceeded",
+                                   1);
         }
 
       int has_message = 0;
+      SocketGRPC_StatusCode parse_error_status = SOCKET_GRPC_STATUS_INTERNAL;
+      const char *parse_error_message = "Malformed streaming response frame";
       if (grpc_stream_try_parse_message (call,
                                          ctx,
                                          arena,
                                          response_payload,
                                          response_payload_len,
+                                         &parse_error_status,
+                                         &parse_error_message,
                                          &has_message)
           != 0)
         {
           return grpc_stream_fail (
-              call, SOCKET_GRPC_STATUS_INTERNAL, "Malformed streaming response frame", 1);
+              call, parse_error_status, parse_error_message, 1);
         }
       if (has_message)
         return 0;
@@ -1597,11 +2275,10 @@ SocketGRPC_Call_recv_message (SocketGRPC_Call_T call,
         {
           if (ctx->recv_len != 0)
             {
-              return grpc_stream_fail (
-                  call,
-                  SOCKET_GRPC_STATUS_INTERNAL,
-                  "Incomplete gRPC frame at end of stream",
-                  1);
+              return grpc_stream_fail (call,
+                                       SOCKET_GRPC_STATUS_INTERNAL,
+                                       "Incomplete gRPC frame at end of stream",
+                                       1);
             }
           if (!ctx->status_finalized)
             {
@@ -1620,21 +2297,27 @@ SocketGRPC_Call_recv_message (SocketGRPC_Call_T call,
             ctx->stream, chunk, sizeof (chunk), &end_stream);
         if (n < 0)
           {
-            return grpc_stream_fail (
-                call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to receive stream body", 1);
+            return grpc_stream_fail (call,
+                                     SOCKET_GRPC_STATUS_UNAVAILABLE,
+                                     "Failed to receive stream body",
+                                     1);
           }
-        if (n > 0
-            && grpc_stream_append_recv (call, ctx, chunk, (size_t)n) != 0)
+        if (n > 0 && grpc_stream_append_recv (call, ctx, chunk, (size_t)n) != 0)
           {
-            return grpc_stream_fail (
-                call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, "Streaming response exceeds limit", 1);
+            return grpc_stream_fail (call,
+                                     SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED,
+                                     "Streaming response exceeds limit",
+                                     1);
           }
 
         {
           SocketHPACK_Header trailers[SOCKETHTTP2_MAX_DECODED_HEADERS];
           size_t trailer_count = 0;
           int tr = grpc_h2_stream_recv_trailers_safe (
-              ctx->stream, trailers, SOCKETHTTP2_MAX_DECODED_HEADERS, &trailer_count);
+              ctx->stream,
+              trailers,
+              SOCKETHTTP2_MAX_DECODED_HEADERS,
+              &trailer_count);
           if (tr < 0)
             {
               return grpc_stream_fail (call,
@@ -1643,26 +2326,32 @@ SocketGRPC_Call_recv_message (SocketGRPC_Call_T call,
                                        1);
             }
           if (tr == 1 && trailer_count > 0
-              && grpc_ingest_stream_trailers (call, trailers, trailer_count) != 0)
+              && grpc_ingest_stream_trailers (call, trailers, trailer_count)
+                     != 0)
             {
-              return grpc_stream_fail (
-                  call, SOCKET_GRPC_STATUS_INTERNAL, "Invalid streaming response trailers", 1);
+              return grpc_stream_fail (call,
+                                       SOCKET_GRPC_STATUS_INTERNAL,
+                                       "Invalid streaming response trailers",
+                                       1);
             }
         }
 
         if (end_stream)
           {
-            call->h2_stream_state = (call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_LOCAL)
-                                        ? GRPC_CALL_STREAM_CLOSED
-                                        : GRPC_CALL_STREAM_HALF_CLOSED_REMOTE;
+            call->h2_stream_state
+                = (call->h2_stream_state == GRPC_CALL_STREAM_HALF_CLOSED_LOCAL)
+                      ? GRPC_CALL_STREAM_CLOSED
+                      : GRPC_CALL_STREAM_HALF_CLOSED_REMOTE;
             ctx->remote_end_stream = 1;
           }
 
         if (n == 0 && !ctx->remote_end_stream
             && grpc_h2_conn_process_safe (ctx->h2conn, 0) < 0)
           {
-            return grpc_stream_fail (
-                call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to advance stream state", 1);
+            return grpc_stream_fail (call,
+                                     SOCKET_GRPC_STATUS_UNAVAILABLE,
+                                     "Failed to advance stream state",
+                                     1);
           }
       }
     }
@@ -1673,13 +2362,14 @@ SocketGRPC_Call_metadata_add_ascii (SocketGRPC_Call_T call,
                                     const char *key,
                                     const char *value)
 {
-  if (call == NULL || key == NULL || value == NULL || call->request_metadata == NULL)
+  if (call == NULL || key == NULL || value == NULL
+      || call->request_metadata == NULL)
     return -1;
   if (SocketGRPC_Metadata_count (call->request_metadata)
       >= call->channel->config.max_metadata_entries)
     return -1;
   return SocketGRPC_Metadata_add_ascii (call->request_metadata, key, value)
-         == SOCKET_GRPC_WIRE_OK
+                 == SOCKET_GRPC_WIRE_OK
              ? 0
              : -1;
 }
@@ -1698,7 +2388,7 @@ SocketGRPC_Call_metadata_add_binary (SocketGRPC_Call_T call,
     return -1;
   return SocketGRPC_Metadata_add_binary (
              call->request_metadata, key, value, value_len)
-         == SOCKET_GRPC_WIRE_OK
+                 == SOCKET_GRPC_WIRE_OK
              ? 0
              : -1;
 }
@@ -1722,7 +2412,8 @@ SocketGRPC_Call_trailers (SocketGRPC_Call_T call)
 SocketGRPC_Status
 SocketGRPC_Call_status (SocketGRPC_Call_T call)
 {
-  SocketGRPC_Status status = { SOCKET_GRPC_STATUS_INTERNAL, "Status unavailable" };
+  SocketGRPC_Status status
+      = { SOCKET_GRPC_STATUS_INTERNAL, "Status unavailable" };
   if (call == NULL)
     return status;
   return call->last_status;
@@ -1737,10 +2428,10 @@ SocketGRPC_Call_cancel (SocketGRPC_Call_T call)
   if (call->response_trailers != NULL
       && !SocketGRPC_Trailers_has_status (call->response_trailers))
     {
-      (void)SocketGRPC_Trailers_set_status (
-          call->response_trailers, SOCKET_GRPC_STATUS_CANCELLED);
-      (void)SocketGRPC_Trailers_set_message (
-          call->response_trailers, "Call cancelled");
+      (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                            SOCKET_GRPC_STATUS_CANCELLED);
+      (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                             "Call cancelled");
     }
 
   grpc_call_status_set (call, SOCKET_GRPC_STATUS_CANCELLED, "Call cancelled");
@@ -1768,6 +2459,9 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
   SocketHTTP2_Conn_T h2conn;
   SocketHTTP2_Stream_T stream = NULL;
   unsigned char *framed = NULL;
+  unsigned char *compressed_request = NULL;
+  const uint8_t *wire_request_payload = request_payload;
+  size_t wire_request_payload_len = request_payload_len;
   size_t framed_cap = 0;
   size_t framed_len = 0;
   unsigned char *raw_response = NULL;
@@ -1776,6 +2470,13 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
   int status_code = -1;
   int transport_success = 0;
   int64_t call_deadline_ms = 0;
+  Arena_T compression_arena = NULL;
+  SocketDeflate_Deflater_T request_deflater = NULL;
+  SocketDeflate_Inflater_T response_inflater = NULL;
+  SocketGRPC_Compression response_compression = GRPC_COMPRESSION_IDENTITY;
+  SocketGRPC_StatusCode recv_error_status = SOCKET_GRPC_STATUS_UNAVAILABLE;
+  const char *recv_error_message = "Failed to receive response body";
+  int request_frame_compressed = 0;
 
   if (call == NULL || request_payload == NULL || arena == NULL
       || response_payload == NULL || response_payload_len == NULL)
@@ -1794,8 +2495,65 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
       grpc_call_status_set (call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
       return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
     }
+
+  request_frame_compressed
+      = call->channel->config.enable_request_compression ? 1 : 0;
+  if (request_frame_compressed
+      || call->channel->config.enable_response_decompression)
+    {
+      compression_arena = Arena_new ();
+      if (compression_arena == NULL)
+        {
+          grpc_call_status_set (
+              call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
+          return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+        }
+
+      if (request_frame_compressed)
+        {
+          request_deflater = SocketDeflate_Deflater_new (compression_arena,
+                                                         DEFLATE_LEVEL_DEFAULT);
+          if (request_deflater == NULL
+              || grpc_gzip_compress_payload (request_deflater,
+                                             request_payload,
+                                             request_payload_len,
+                                             &compressed_request,
+                                             &wire_request_payload_len)
+                     != 0)
+            {
+              grpc_call_status_set (call,
+                                    SOCKET_GRPC_STATUS_INTERNAL,
+                                    "Failed to compress request payload");
+              goto cleanup;
+            }
+          wire_request_payload = compressed_request;
+        }
+
+      if (call->channel->config.enable_response_decompression)
+        {
+          response_inflater = SocketDeflate_Inflater_new (
+              compression_arena,
+              call->channel->config.max_decompressed_message_bytes);
+          if (response_inflater == NULL)
+            {
+              grpc_call_status_set (
+                  call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
+              goto cleanup;
+            }
+        }
+    }
+
+  if (wire_request_payload_len > (size_t)UINT32_MAX
+      || wire_request_payload_len
+             > (SIZE_MAX - SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE))
+    {
+      grpc_call_status_set (call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
+      status_code = SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+      goto cleanup;
+    }
+
   call_deadline_ms = SocketTimeout_deadline_ms (call->config.deadline_ms);
-  framed_cap = SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE + request_payload_len;
+  framed_cap = SOCKET_GRPC_WIRE_FRAME_PREFIX_SIZE + wire_request_payload_len;
 
   *response_payload = NULL;
   *response_payload_len = 0;
@@ -1815,7 +2573,7 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
   cfg.verify_ssl = call->channel->config.verify_peer;
   cfg.tls_context = call->channel->config.tls_context;
   cfg.request_timeout_ms = call->config.deadline_ms;
-  cfg.max_response_size = call->channel->config.max_inbound_message_bytes;
+  cfg.max_response_size = call->channel->config.max_cumulative_inflight_bytes;
 
   http_client = SocketHTTPClient_new (&cfg);
   if (http_client == NULL)
@@ -1843,15 +2601,15 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
       goto cleanup;
     }
 
-  framed = (unsigned char *)ALLOC (arena, framed_cap);
+  framed = (unsigned char *)malloc (framed_cap);
   if (framed == NULL)
     {
       grpc_call_status_set (call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
       goto cleanup;
     }
-  if (SocketGRPC_Frame_encode (0,
-                               request_payload,
-                               (uint32_t)request_payload_len,
+  if (SocketGRPC_Frame_encode (request_frame_compressed,
+                               wire_request_payload,
+                               (uint32_t)wire_request_payload_len,
                                framed,
                                framed_cap,
                                &framed_len)
@@ -1872,10 +2630,10 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
   conn = httpclient_connect (http_client, &req->uri);
   if (conn == NULL)
     {
-      grpc_call_status_set (call,
-                            grpc_map_httpclient_error (
-                                SocketHTTPClient_last_error (http_client)),
-                            "Connection failed");
+      grpc_call_status_set (
+          call,
+          grpc_map_httpclient_error (SocketHTTPClient_last_error (http_client)),
+          "Connection failed");
       goto cleanup;
     }
 
@@ -1903,8 +2661,9 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
           stream, h2conn, &http_req, req->body, req->body_len)
       < 0)
     {
-      grpc_call_status_set (
-          call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to send HTTP/2 request");
+      grpc_call_status_set (call,
+                            SOCKET_GRPC_STATUS_UNAVAILABLE,
+                            "Failed to send HTTP/2 request");
       goto cleanup;
     }
 
@@ -1913,26 +2672,77 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
     if (httpclient_http2_recv_headers (stream, h2conn, &response, &end_stream)
         < 0)
       {
-        grpc_call_status_set (
-            call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to receive response headers");
+        grpc_call_status_set (call,
+                              SOCKET_GRPC_STATUS_UNAVAILABLE,
+                              "Failed to receive response headers");
         goto cleanup;
       }
 
     if (grpc_ingest_response_headers (call, response.headers, end_stream) != 0)
       {
-        grpc_call_status_set (
-            call, SOCKET_GRPC_STATUS_INTERNAL, "Invalid response header metadata");
+        grpc_call_status_set (call,
+                              SOCKET_GRPC_STATUS_INTERNAL,
+                              "Invalid response header metadata");
+        goto cleanup;
+      }
+
+    response_compression
+        = grpc_response_compression_from_headers (response.headers);
+    if (response_compression == GRPC_COMPRESSION_UNSUPPORTED)
+      {
+        status_code = SOCKET_GRPC_STATUS_INTERNAL;
+        (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                              status_code);
+        if (SocketGRPC_Trailers_message (call->response_trailers) == NULL)
+          {
+            (void)SocketGRPC_Trailers_set_message (
+                call->response_trailers,
+                "Unsupported response compression encoding");
+          }
+        grpc_call_status_set (call,
+                              SOCKET_GRPC_STATUS_INTERNAL,
+                              "Unsupported response compression encoding");
+        goto cleanup;
+      }
+    if (response_compression == GRPC_COMPRESSION_GZIP
+        && !call->channel->config.enable_response_decompression)
+      {
+        status_code = SOCKET_GRPC_STATUS_INTERNAL;
+        (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                              status_code);
+        if (SocketGRPC_Trailers_message (call->response_trailers) == NULL)
+          {
+            (void)SocketGRPC_Trailers_set_message (
+                call->response_trailers, "Response decompression is disabled");
+          }
+        grpc_call_status_set (call,
+                              SOCKET_GRPC_STATUS_INTERNAL,
+                              "Response decompression is disabled");
         goto cleanup;
       }
 
     if (!end_stream)
       {
-        if (grpc_receive_body_and_trailers (
-                call, stream, h2conn, &raw_response, &raw_response_len)
+        if (grpc_receive_body_and_trailers (call,
+                                            stream,
+                                            h2conn,
+                                            &raw_response,
+                                            &raw_response_len,
+                                            &recv_error_status,
+                                            &recv_error_message)
             != 0)
           {
-            grpc_call_status_set (
-                call, SOCKET_GRPC_STATUS_UNAVAILABLE, "Failed to receive response body");
+            status_code = recv_error_status;
+            (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                                  recv_error_status);
+            if (recv_error_message != NULL
+                && SocketGRPC_Trailers_message (call->response_trailers)
+                       == NULL)
+              {
+                (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                                       recv_error_message);
+              }
+            grpc_call_status_set (call, recv_error_status, recv_error_message);
             goto cleanup;
           }
       }
@@ -1940,17 +2750,18 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
 
   if (SocketTimeout_expired (call_deadline_ms))
     {
-      int existing_status = SocketGRPC_Trailers_has_status (call->response_trailers)
-                                ? SocketGRPC_Trailers_status (call->response_trailers)
-                                : SOCKET_GRPC_STATUS_OK;
+      int existing_status
+          = SocketGRPC_Trailers_has_status (call->response_trailers)
+                ? SocketGRPC_Trailers_status (call->response_trailers)
+                : SOCKET_GRPC_STATUS_OK;
       if (existing_status == SOCKET_GRPC_STATUS_OK)
         {
           (void)SocketGRPC_Trailers_set_status (
               call->response_trailers, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED);
           if (SocketGRPC_Trailers_message (call->response_trailers) == NULL)
             {
-              (void)SocketGRPC_Trailers_set_message (
-                  call->response_trailers, "Deadline exceeded");
+              (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                                     "Deadline exceeded");
             }
         }
     }
@@ -1963,51 +2774,61 @@ grpc_call_unary_h2_single_attempt (SocketGRPC_Call_T call,
     }
 
   status_code = SocketGRPC_Trailers_status (call->response_trailers);
-  grpc_call_status_set (
-      call,
-      (SocketGRPC_StatusCode)status_code,
-      SocketGRPC_Trailers_message (call->response_trailers));
+  grpc_call_status_set (call,
+                        (SocketGRPC_StatusCode)status_code,
+                        SocketGRPC_Trailers_message (call->response_trailers));
 
   if (status_code == SOCKET_GRPC_STATUS_OK && raw_response != NULL
       && raw_response_len > 0)
     {
       SocketGRPC_FrameView frame;
       size_t consumed = 0;
-      if (SocketGRPC_Frame_parse (raw_response,
-                                  raw_response_len,
-                                  call->channel->config.max_inbound_message_bytes,
-                                  &frame,
-                                  &consumed)
-          != SOCKET_GRPC_WIRE_OK
-          || consumed != raw_response_len || frame.compressed != 0)
+      size_t max_frame_payload
+          = call->channel->config.max_cumulative_inflight_bytes;
+      SocketGRPC_WireResult parse_rc;
+      SocketGRPC_StatusCode decode_status;
+      const char *decode_message = "Malformed gRPC response frame";
+
+      if (max_frame_payload == 0)
+        max_frame_payload = call->channel->config.max_inbound_message_bytes;
+
+      parse_rc = SocketGRPC_Frame_parse (
+          raw_response, raw_response_len, max_frame_payload, &frame, &consumed);
+      if (parse_rc != SOCKET_GRPC_WIRE_OK || consumed != raw_response_len)
         {
-          if (status_code == SOCKET_GRPC_STATUS_OK)
-            {
-              (void)SocketGRPC_Trailers_set_status (
-                  call->response_trailers, SOCKET_GRPC_STATUS_INTERNAL);
-              (void)SocketGRPC_Trailers_set_message (
-                  call->response_trailers, "Malformed gRPC response frame");
-              grpc_call_status_set (
-                  call,
-                  SOCKET_GRPC_STATUS_INTERNAL,
-                  "Malformed gRPC response frame");
-              status_code = SOCKET_GRPC_STATUS_INTERNAL;
-            }
-          goto cleanup;
+          decode_status = parse_rc == SOCKET_GRPC_WIRE_LENGTH_EXCEEDED
+                              ? SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED
+                              : SOCKET_GRPC_STATUS_INTERNAL;
+          if (parse_rc == SOCKET_GRPC_WIRE_LENGTH_EXCEEDED)
+            decode_message = "Response exceeds configured inflight limit";
         }
-      if (frame.payload_len > 0)
+      else
         {
-          uint8_t *out = (uint8_t *)ALLOC (arena, frame.payload_len);
-          if (out == NULL)
+          decode_status = grpc_decode_frame_payload (call,
+                                                     response_compression,
+                                                     response_inflater,
+                                                     arena,
+                                                     &frame,
+                                                     response_payload,
+                                                     response_payload_len,
+                                                     &decode_message);
+        }
+
+      if (decode_status != SOCKET_GRPC_STATUS_OK)
+        {
+          (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                                decode_status);
+          if (decode_message != NULL
+              && SocketGRPC_Trailers_message (call->response_trailers) == NULL)
             {
-              grpc_call_status_set (
-                  call, SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED, NULL);
-              status_code = SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
-              goto cleanup;
+              (void)SocketGRPC_Trailers_set_status (call->response_trailers,
+                                                    decode_status);
+              (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                                     decode_message);
             }
-          memcpy (out, frame.payload, frame.payload_len);
-          *response_payload = out;
-          *response_payload_len = frame.payload_len;
+          grpc_call_status_set (call, decode_status, decode_message);
+          status_code = decode_status;
+          goto cleanup;
         }
     }
   else
@@ -2028,6 +2849,10 @@ cleanup:
   if (conn != NULL)
     grpc_release_connection_safe (http_client, conn, transport_success);
   free (raw_response);
+  free (framed);
+  free (compressed_request);
+  if (compression_arena != NULL)
+    Arena_dispose (&compression_arena);
   SocketHTTPClient_Response_free (&response);
   SocketHTTPClient_Request_free (&req);
   SocketHTTPClient_free (&http_client);
@@ -2041,7 +2866,8 @@ grpc_retry_status_is_retryable (const SocketGRPC_RetryPolicy *policy,
 {
   if (policy == NULL || status_code < 0 || status_code >= 32)
     return 0;
-  return (policy->retryable_status_mask & (1U << (unsigned int)status_code)) != 0;
+  return (policy->retryable_status_mask & (1U << (unsigned int)status_code))
+         != 0;
 }
 
 static int64_t
@@ -2136,13 +2962,12 @@ SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
     }
 
   if (max_attempts <= 1)
-    return grpc_call_unary_h2_single_attempt (
-        call,
-        request_payload,
-        request_payload_len,
-        arena,
-        response_payload,
-        response_payload_len);
+    return grpc_call_unary_h2_single_attempt (call,
+                                              request_payload,
+                                              request_payload_len,
+                                              arena,
+                                              response_payload,
+                                              response_payload_len);
 
   original_deadline_ms = call->config.deadline_ms;
   call_deadline_ms = SocketTimeout_deadline_ms (original_deadline_ms);
@@ -2157,11 +2982,12 @@ SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
       if (SocketTimeout_expired (call_deadline_ms))
         {
           rc = SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED;
-          grpc_call_status_set (call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded");
+          grpc_call_status_set (
+              call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded");
           (void)SocketGRPC_Trailers_set_status (
               call->response_trailers, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED);
-          (void)SocketGRPC_Trailers_set_message (
-              call->response_trailers, "Deadline exceeded");
+          (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                                 "Deadline exceeded");
           break;
         }
 
@@ -2171,12 +2997,14 @@ SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
           if (remaining <= 0)
             {
               rc = SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED;
-              grpc_call_status_set (
-                  call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded");
+              grpc_call_status_set (call,
+                                    SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED,
+                                    "Deadline exceeded");
               (void)SocketGRPC_Trailers_set_status (
-                  call->response_trailers, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED);
-              (void)SocketGRPC_Trailers_set_message (
-                  call->response_trailers, "Deadline exceeded");
+                  call->response_trailers,
+                  SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED);
+              (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                                     "Deadline exceeded");
               break;
             }
           call->config.deadline_ms
@@ -2212,8 +3040,9 @@ SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
             if (remaining <= 0)
               {
                 rc = SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED;
-                grpc_call_status_set (
-                    call, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED, "Deadline exceeded");
+                grpc_call_status_set (call,
+                                      SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED,
+                                      "Deadline exceeded");
                 break;
               }
             if (wait_ms > remaining)
@@ -2231,8 +3060,8 @@ SocketGRPC_Call_unary_h2 (SocketGRPC_Call_T call,
     {
       (void)SocketGRPC_Trailers_set_status (
           call->response_trailers, SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED);
-      (void)SocketGRPC_Trailers_set_message (
-          call->response_trailers, "Deadline exceeded");
+      (void)SocketGRPC_Trailers_set_message (call->response_trailers,
+                                             "Deadline exceeded");
     }
 
   call->config.deadline_ms = original_deadline_ms;


### PR DESCRIPTION
## Summary
- add gzip request compression and gzip response decompression for gRPC over HTTP/2
- enforce decompression guardrails (max decompressed bytes, max cumulative inflight bytes, max ratio)
- fail closed on unsupported/disabled response encodings and expand unary/streaming h2 integration coverage

Fixes #3590

## Test plan
- [x] `cmake --build build -j$(nproc)`
- [x] `ctest -R grpc_unary_h2 -j$(nproc) --output-on-failure`
- [x] `ctest -R grpc_unary_server_h2 -j$(nproc) --output-on-failure`