### PR TITLE
feat(grpc): add interceptor/middleware pipeline

### DIFF
--- a/include/grpc/SocketGRPC-private.h
+++ b/include/grpc/SocketGRPC-private.h
@@ -17,6 +17,12 @@
 #include "grpc/SocketGRPC.h"
 
 typedef struct SocketGRPC_ServerMethod SocketGRPC_ServerMethod;
+typedef struct SocketGRPC_ServerUnaryInterceptorEntry
+    SocketGRPC_ServerUnaryInterceptorEntry;
+typedef struct SocketGRPC_ClientUnaryInterceptorEntry
+    SocketGRPC_ClientUnaryInterceptorEntry;
+typedef struct SocketGRPC_ClientStreamInterceptorEntry
+    SocketGRPC_ClientStreamInterceptorEntry;
 
 typedef enum
 {
@@ -39,6 +45,9 @@ struct SocketGRPC_Server
   SocketGRPC_ServerConfig config;
   SocketGRPC_Status last_status;
   SocketGRPC_ServerMethod *methods;
+  SocketGRPC_ServerUnaryInterceptorEntry *unary_interceptors;
+  SocketGRPC_ServerUnaryInterceptorEntry *unary_interceptors_tail;
+  uint32_t unary_interceptor_count;
   uint32_t method_count;
   uint32_t inflight_calls;
   int shutting_down;
@@ -62,6 +71,12 @@ struct SocketGRPC_Call
   SocketGRPC_Metadata_T request_metadata;
   SocketGRPC_Trailers_T response_trailers;
   SocketGRPC_Status last_status;
+  SocketGRPC_ClientUnaryInterceptorEntry *unary_interceptors;
+  SocketGRPC_ClientUnaryInterceptorEntry *unary_interceptors_tail;
+  SocketGRPC_ClientStreamInterceptorEntry *stream_interceptors;
+  SocketGRPC_ClientStreamInterceptorEntry *stream_interceptors_tail;
+  uint32_t unary_interceptor_count;
+  uint32_t stream_interceptor_count;
   void *h2_stream_ctx;
   SocketGRPC_CallStreamState h2_stream_state;
   int retry_in_progress;
@@ -76,6 +91,7 @@ extern const char *
 SocketGRPC_status_default_message (SocketGRPC_StatusCode code);
 
 extern void SocketGRPC_server_methods_clear (SocketGRPC_Server_T server);
+extern void SocketGRPC_server_interceptors_clear (SocketGRPC_Server_T server);
 
 extern void SocketGRPC_Call_h2_stream_abort (SocketGRPC_Call_T call);
 

--- a/src/test/test_grpc_api_surface.c
+++ b/src/test/test_grpc_api_surface.c
@@ -30,10 +30,9 @@ TEST (grpc_status_accessors_are_null_safe)
 {
   ASSERT_EQ (SOCKET_GRPC_STATUS_INTERNAL, SocketGRPC_Status_code (NULL));
   ASSERT_NOT_NULL (SocketGRPC_Status_message (NULL));
-  ASSERT_EQ (
-      0,
-      strcmp (SocketGRPC_Status_code_name ((SocketGRPC_StatusCode)1024),
-              "UNKNOWN_CODE"));
+  ASSERT_EQ (0,
+             strcmp (SocketGRPC_Status_code_name ((SocketGRPC_StatusCode)1024),
+                     "UNKNOWN_CODE"));
 }
 
 TEST (grpc_status_accessors_support_custom_and_default_messages)
@@ -43,12 +42,14 @@ TEST (grpc_status_accessors_support_custom_and_default_messages)
   SocketGRPC_Status fallback = { SOCKET_GRPC_STATUS_NOT_FOUND, NULL };
 
   ASSERT_EQ (SOCKET_GRPC_STATUS_UNAVAILABLE, SocketGRPC_Status_code (&custom));
-  ASSERT_EQ (0, strcmp (SocketGRPC_Status_message (&custom),
-                        "upstream reset by peer"));
+  ASSERT_EQ (
+      0,
+      strcmp (SocketGRPC_Status_message (&custom), "upstream reset by peer"));
 
   ASSERT_EQ (SOCKET_GRPC_STATUS_NOT_FOUND, SocketGRPC_Status_code (&fallback));
-  ASSERT_EQ (0, strcmp (SocketGRPC_Status_message (&fallback),
-                        "Requested entity was not found"));
+  ASSERT_EQ (0,
+             strcmp (SocketGRPC_Status_message (&fallback),
+                     "Requested entity was not found"));
 }
 
 TEST (grpc_timeout_parse_and_format_helpers)
@@ -56,7 +57,8 @@ TEST (grpc_timeout_parse_and_format_helpers)
   char timeout_buf[32];
   int64_t timeout_ms = 0;
 
-  ASSERT_EQ (0, SocketGRPC_Timeout_format (2500, timeout_buf, sizeof (timeout_buf)));
+  ASSERT_EQ (
+      0, SocketGRPC_Timeout_format (2500, timeout_buf, sizeof (timeout_buf)));
   ASSERT_EQ (0, strcmp (timeout_buf, "2500m"));
 
   ASSERT_EQ (0, SocketGRPC_Timeout_parse ("2500m", &timeout_ms));
@@ -70,7 +72,8 @@ TEST (grpc_timeout_parse_and_format_helpers)
   ASSERT_EQ (0, SocketGRPC_Timeout_parse ("2500000n", &timeout_ms));
   ASSERT_EQ (3, timeout_ms);
 
-  ASSERT_EQ (-1, SocketGRPC_Timeout_format (0, timeout_buf, sizeof (timeout_buf)));
+  ASSERT_EQ (-1,
+             SocketGRPC_Timeout_format (0, timeout_buf, sizeof (timeout_buf)));
   ASSERT_EQ (-1, SocketGRPC_Timeout_parse ("", &timeout_ms));
   ASSERT_EQ (-1, SocketGRPC_Timeout_parse ("10", &timeout_ms));
   ASSERT_EQ (-1, SocketGRPC_Timeout_parse ("10x", &timeout_ms));
@@ -97,26 +100,25 @@ TEST (grpc_retry_policy_parse_and_validation)
   ASSERT_EQ (20, policy.initial_backoff_ms);
   ASSERT_EQ (200, policy.max_backoff_ms);
   ASSERT_EQ (15, policy.jitter_percent);
-  ASSERT ((policy.retryable_status_mask & (1U << SOCKET_GRPC_STATUS_UNAVAILABLE)) != 0);
+  ASSERT (
+      (policy.retryable_status_mask & (1U << SOCKET_GRPC_STATUS_UNAVAILABLE))
+      != 0);
   ASSERT ((policy.retryable_status_mask
            & (1U << SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED))
           != 0);
 
+  ASSERT_EQ (
+      -1,
+      SocketGRPC_RetryPolicy_parse_service_config ("max_attempts=0", &policy));
+  ASSERT_EQ (
+      -1,
+      SocketGRPC_RetryPolicy_parse_service_config ("max_attempts=3x", &policy));
+  ASSERT_EQ (
+      -1,
+      SocketGRPC_RetryPolicy_parse_service_config ("multiplier=nan", &policy));
   ASSERT_EQ (-1,
-             SocketGRPC_RetryPolicy_parse_service_config ("max_attempts=0",
-                                                          &policy));
-  ASSERT_EQ (
-      -1,
-      SocketGRPC_RetryPolicy_parse_service_config ("max_attempts=3x",
-                                                   &policy));
-  ASSERT_EQ (
-      -1,
-      SocketGRPC_RetryPolicy_parse_service_config ("multiplier=nan",
-                                                   &policy));
-  ASSERT_EQ (
-      -1,
-      SocketGRPC_RetryPolicy_parse_service_config ("retryable_codes=NOPE",
-                                                   &policy));
+             SocketGRPC_RetryPolicy_parse_service_config (
+                 "retryable_codes=NOPE", &policy));
 }
 
 TEST (grpc_handle_lifecycle_smoke)
@@ -191,6 +193,118 @@ noop_unary_handler_except (SocketGRPC_ServerContext_T ctx,
   (void)userdata;
 }
 
+typedef struct
+{
+  int client_unary_events;
+  int stream_send_events;
+  int stream_recv_events;
+} InterceptorProbe;
+
+static int
+test_unary_continue_interceptor (SocketGRPC_Call_T call,
+                                 const uint8_t *request_payload,
+                                 size_t request_payload_len,
+                                 SocketGRPC_Status *status_io,
+                                 void *userdata)
+{
+  InterceptorProbe *probe = (InterceptorProbe *)userdata;
+  (void)call;
+  (void)request_payload;
+  (void)request_payload_len;
+  (void)status_io;
+  if (probe != NULL)
+    probe->client_unary_events++;
+  return SOCKET_GRPC_INTERCEPT_CONTINUE;
+}
+
+static int
+test_unary_stop_interceptor (SocketGRPC_Call_T call,
+                             const uint8_t *request_payload,
+                             size_t request_payload_len,
+                             SocketGRPC_Status *status_io,
+                             void *userdata)
+{
+  (void)call;
+  (void)request_payload;
+  (void)request_payload_len;
+  (void)userdata;
+  if (status_io != NULL)
+    {
+      status_io->code = SOCKET_GRPC_STATUS_UNAUTHENTICATED;
+      status_io->message = "blocked by unary interceptor";
+    }
+  return SOCKET_GRPC_INTERCEPT_STOP;
+}
+
+static int
+test_stream_probe_interceptor (SocketGRPC_Call_T call,
+                               SocketGRPC_StreamInterceptEvent event,
+                               const uint8_t *payload,
+                               size_t payload_len,
+                               SocketGRPC_Status *status_io,
+                               void *userdata)
+{
+  InterceptorProbe *probe = (InterceptorProbe *)userdata;
+  (void)call;
+  (void)payload;
+  (void)payload_len;
+  (void)status_io;
+  if (probe == NULL)
+    return SOCKET_GRPC_INTERCEPT_CONTINUE;
+  if (event == SOCKET_GRPC_STREAM_INTERCEPT_SEND)
+    probe->stream_send_events++;
+  else if (event == SOCKET_GRPC_STREAM_INTERCEPT_RECV)
+    probe->stream_recv_events++;
+  return SOCKET_GRPC_INTERCEPT_CONTINUE;
+}
+
+static int
+test_stream_stop_interceptor (SocketGRPC_Call_T call,
+                              SocketGRPC_StreamInterceptEvent event,
+                              const uint8_t *payload,
+                              size_t payload_len,
+                              SocketGRPC_Status *status_io,
+                              void *userdata)
+{
+  (void)call;
+  (void)payload;
+  (void)payload_len;
+  (void)userdata;
+  if (event != SOCKET_GRPC_STREAM_INTERCEPT_SEND)
+    return SOCKET_GRPC_INTERCEPT_CONTINUE;
+  if (status_io != NULL)
+    {
+      status_io->code = SOCKET_GRPC_STATUS_UNAUTHENTICATED;
+      status_io->message = "blocked by stream interceptor";
+    }
+  return SOCKET_GRPC_INTERCEPT_STOP;
+}
+
+static void
+test_log_hook (const SocketGRPC_LogEvent *event, void *userdata)
+{
+  InterceptorProbe *probe = (InterceptorProbe *)userdata;
+  if (probe == NULL || event == NULL)
+    return;
+  if (event->type == SOCKET_GRPC_LOG_EVENT_CLIENT_UNARY)
+    probe->client_unary_events++;
+}
+
+static int
+test_server_continue_interceptor (SocketGRPC_ServerContext_T ctx,
+                                  const uint8_t *request_payload,
+                                  size_t request_payload_len,
+                                  SocketGRPC_Status *status_io,
+                                  void *userdata)
+{
+  (void)ctx;
+  (void)request_payload;
+  (void)request_payload_len;
+  (void)status_io;
+  (void)userdata;
+  return SOCKET_GRPC_INTERCEPT_CONTINUE;
+}
+
 TEST (grpc_server_registration_and_shutdown_surface)
 {
   SocketGRPC_Server_T server = SocketGRPC_Server_new (NULL);
@@ -205,9 +319,10 @@ TEST (grpc_server_registration_and_shutdown_surface)
   ASSERT_EQ (-1,
              SocketGRPC_Server_register_unary (
                  server, "/bad-path", noop_unary_handler, NULL));
-  ASSERT_EQ (0,
-             SocketGRPC_Server_register_unary_except (
-                 server, "/test.Service/PingEx", noop_unary_handler_except, NULL));
+  ASSERT_EQ (
+      0,
+      SocketGRPC_Server_register_unary_except (
+          server, "/test.Service/PingEx", noop_unary_handler_except, NULL));
 
   ASSERT_EQ (0U, SocketGRPC_Server_inflight_calls (server));
   SocketGRPC_Server_begin_shutdown (server);
@@ -225,9 +340,9 @@ TEST (grpc_server_context_accessors_are_null_safe)
   ASSERT_NULL (SocketGRPC_ServerContext_service (NULL));
   ASSERT_NULL (SocketGRPC_ServerContext_method (NULL));
   ASSERT_EQ (1, SocketGRPC_ServerContext_is_cancelled (NULL));
-  ASSERT_EQ (-1,
-             SocketGRPC_ServerContext_set_status (
-                 NULL, SOCKET_GRPC_STATUS_OK, "x"));
+  ASSERT_EQ (
+      -1,
+      SocketGRPC_ServerContext_set_status (NULL, SOCKET_GRPC_STATUS_OK, "x"));
   ASSERT_EQ (-1,
              SocketGRPC_ServerContext_set_status_details_bin (
                  NULL, (const uint8_t *)"x", 1));
@@ -252,8 +367,7 @@ TEST (grpc_invalid_inputs_fail_without_crash)
   ASSERT_EQ (-1, SocketGRPC_Call_send_message (NULL, (const uint8_t *)"x", 1));
   ASSERT_EQ (-1, SocketGRPC_Call_close_send (NULL));
   ASSERT_EQ (-1, SocketGRPC_Call_cancel (NULL));
-  ASSERT_EQ (
-      -1, SocketGRPC_Call_recv_message (NULL, arena, NULL, NULL, NULL));
+  ASSERT_EQ (-1, SocketGRPC_Call_recv_message (NULL, arena, NULL, NULL, NULL));
 
   ASSERT_NULL (SocketGRPC_Channel_new (NULL, "dns:///x", NULL));
   ASSERT_NULL (SocketGRPC_Channel_new (client, NULL, NULL));
@@ -271,23 +385,137 @@ TEST (grpc_invalid_inputs_fail_without_crash)
     SocketGRPC_Call_T call
         = SocketGRPC_Call_new (channel, "/svc.Method/Stream", NULL);
     ASSERT_NOT_NULL (call);
+    ASSERT_EQ (-1, SocketGRPC_Call_send_message (call, NULL, 1));
+    ASSERT_EQ (0, SocketGRPC_Call_cancel (call));
+    ASSERT_EQ (SOCKET_GRPC_STATUS_CANCELLED,
+               SocketGRPC_Call_status (call).code);
     ASSERT_EQ (
         -1,
-        SocketGRPC_Call_send_message (call, NULL, 1));
-    ASSERT_EQ (0, SocketGRPC_Call_cancel (call));
-    ASSERT_EQ (SOCKET_GRPC_STATUS_CANCELLED, SocketGRPC_Call_status (call).code);
-    ASSERT_EQ (-1,
-               SocketGRPC_Call_recv_message (call,
-                                             arena,
-                                             &response_payload,
-                                             &response_payload_len,
-                                             &done));
+        SocketGRPC_Call_recv_message (
+            call, arena, &response_payload, &response_payload_len, &done));
     SocketGRPC_Call_free (&call);
   }
 
   SocketGRPC_Channel_free (&channel);
   SocketGRPC_Client_free (&client);
   Arena_dispose (&arena);
+}
+
+TEST (grpc_interceptor_api_and_short_circuit_surface)
+{
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Server_T server = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  Arena_T arena = NULL;
+  SocketGRPC_CallConfig call_cfg;
+  SocketGRPC_LogHookConfig log_cfg;
+  SocketGRPC_MetadataInjectorConfig md_cfg;
+  InterceptorProbe probe = { 0 };
+  uint8_t request_payload[] = { 0x08, 0x01 };
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  int rc;
+
+  SocketGRPC_CallConfig_defaults (&call_cfg);
+  call_cfg.deadline_ms = 25;
+
+  client = SocketGRPC_Client_new (NULL);
+  ASSERT_NOT_NULL (client);
+  server = SocketGRPC_Server_new (NULL);
+  ASSERT_NOT_NULL (server);
+  channel = SocketGRPC_Channel_new (client, "https://127.0.0.1:1", NULL);
+  ASSERT_NOT_NULL (channel);
+  call = SocketGRPC_Call_new (channel, "/test.Service/Unary", &call_cfg);
+  ASSERT_NOT_NULL (call);
+  arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  ASSERT_EQ (-1,
+             SocketGRPC_Call_add_unary_interceptor (
+                 NULL, test_unary_continue_interceptor, &probe));
+  ASSERT_EQ (-1,
+             SocketGRPC_Call_add_stream_interceptor (
+                 NULL, test_stream_probe_interceptor, &probe));
+  ASSERT_EQ (-1,
+             SocketGRPC_Server_add_unary_interceptor (
+                 NULL, test_server_continue_interceptor, NULL));
+
+  ASSERT_EQ (0,
+             SocketGRPC_Call_add_unary_interceptor (
+                 call, test_unary_continue_interceptor, &probe));
+  ASSERT_EQ (0,
+             SocketGRPC_Call_add_stream_interceptor (
+                 call, test_stream_probe_interceptor, &probe));
+  ASSERT_EQ (0,
+             SocketGRPC_Call_add_stream_interceptor (
+                 call, test_stream_stop_interceptor, NULL));
+  ASSERT_EQ (0,
+             SocketGRPC_Server_add_unary_interceptor (
+                 server, test_server_continue_interceptor, NULL));
+
+  md_cfg.key = "x-client-id";
+  md_cfg.ascii_value = "surface-test";
+  md_cfg.binary_value = NULL;
+  md_cfg.binary_value_len = 0;
+  md_cfg.is_binary = 0;
+  {
+    SocketGRPC_Status st = { SOCKET_GRPC_STATUS_OK, NULL };
+    ASSERT_EQ (
+        SOCKET_GRPC_INTERCEPT_CONTINUE,
+        SocketGRPC_Interceptor_metadata_injector (
+            call, request_payload, sizeof (request_payload), &st, &md_cfg));
+  }
+
+  md_cfg.key = "grpc-timeout";
+  {
+    SocketGRPC_Status st = { SOCKET_GRPC_STATUS_OK, NULL };
+    ASSERT_EQ (
+        SOCKET_GRPC_INTERCEPT_STOP,
+        SocketGRPC_Interceptor_metadata_injector (
+            call, request_payload, sizeof (request_payload), &st, &md_cfg));
+    ASSERT_EQ (SOCKET_GRPC_STATUS_INVALID_ARGUMENT, st.code);
+  }
+
+  log_cfg.hook = test_log_hook;
+  log_cfg.hook_userdata = &probe;
+  {
+    SocketGRPC_Status st = { SOCKET_GRPC_STATUS_OK, NULL };
+    ASSERT_EQ (
+        SOCKET_GRPC_INTERCEPT_CONTINUE,
+        SocketGRPC_Interceptor_client_logging (
+            call, request_payload, sizeof (request_payload), &st, &log_cfg));
+  }
+  ASSERT_EQ (1, probe.client_unary_events);
+
+  ASSERT_EQ (0,
+             SocketGRPC_Call_add_unary_interceptor (
+                 call, test_unary_stop_interceptor, NULL));
+
+  rc = SocketGRPC_Call_unary_h2 (call,
+                                 request_payload,
+                                 sizeof (request_payload),
+                                 arena,
+                                 &response_payload,
+                                 &response_payload_len);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_UNAUTHENTICATED, rc);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_UNAUTHENTICATED,
+             SocketGRPC_Call_status (call).code);
+  ASSERT_NULL (response_payload);
+  ASSERT_EQ (0U, response_payload_len);
+
+  rc = SocketGRPC_Call_send_message (
+      call, request_payload, sizeof (request_payload));
+  ASSERT_EQ (-1, rc);
+  ASSERT_EQ (SOCKET_GRPC_STATUS_UNAUTHENTICATED,
+             SocketGRPC_Call_status (call).code);
+  ASSERT_EQ (1, probe.stream_send_events);
+
+  Arena_dispose (&arena);
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Server_free (&server);
+  SocketGRPC_Client_free (&client);
 }
 
 int


### PR DESCRIPTION
## Summary
- add public interceptor APIs for client unary/stream and server unary flows
- implement interceptor registration/execution in client and server HTTP/2 paths with short-circuit semantics
- add reference interceptors (metadata injector, server auth token validator, structured logging)
- add lifecycle cleanup for interceptor chains and tests covering API surface, retries, stream recv/send, and server auth ordering

Fixes #3595

## Test plan
- cmake --build build -j64 --target test_grpc_api_surface test_grpc_unary_h2 test_grpc_unary_server_h2
- cd build && ctest -R "grpc_api_surface|grpc_unary_h2|grpc_unary_server_h2" -j64 --output-on-failure