### PR TITLE
test(grpc): add interop conformance matrix harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,13 @@ jobs:
         working-directory: build
         run: ctest --output-on-failure --parallel $(nproc)
 
+      - name: Run gRPC core conformance matrix
+        run: |
+          scripts/grpc-interop/run.sh \
+            --profile core \
+            --build-dir build \
+            --report build/grpc-interop-core-${{ matrix.build_type }}.json
+
   # Sanitizer builds (Linux)
   sanitizers:
     name: Sanitizers (${{ matrix.sanitizer }})

--- a/scripts/grpc-interop/grpcurl_grpcbin_smoke.sh
+++ b/scripts/grpc-interop/grpcurl_grpcbin_smoke.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PORT="${GRPC_INTEROP_GRPCBIN_PORT:-59090}"
+IMAGE="${GRPC_INTEROP_GRPCBIN_IMAGE:-moul/grpcbin}"
+CID=""
+LIST_OUT="$(mktemp)"
+LIST_ERR="$(mktemp)"
+
+cleanup() {
+  rm -f "$LIST_OUT" "$LIST_ERR"
+  if [ -n "$CID" ]; then
+    docker rm -f "$CID" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+CID="$(docker run -d --rm -p "${PORT}:9000" "$IMAGE")"
+
+for _ in $(seq 1 30); do
+  if grpcurl -plaintext "localhost:${PORT}" list >"$LIST_OUT" 2>"$LIST_ERR"; then
+    break
+  fi
+  sleep 1
+done
+
+if ! grpcurl -plaintext "localhost:${PORT}" list >"$LIST_OUT" 2>"$LIST_ERR"; then
+  echo "grpcurl reflection check failed" >&2
+  cat "$LIST_ERR" >&2
+  exit 1
+fi
+
+if ! grep -q "grpcbin.GRPCBin" "$LIST_OUT"; then
+  echo "expected grpcbin.GRPCBin service not found" >&2
+  cat "$LIST_OUT" >&2
+  exit 1
+fi
+
+# Metadata path smoke: ensure grpcurl can send custom metadata in a request path.
+if ! grpcurl -plaintext -H "x-interop-smoke: 1" "localhost:${PORT}" list >/dev/null 2>&1; then
+  echo "grpcurl metadata smoke check failed" >&2
+  exit 1
+fi
+
+echo "grpcurl grpcbin smoke passed"

--- a/scripts/grpc-interop/run.sh
+++ b/scripts/grpc-interop/run.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PROFILE="core"
+BUILD_DIR="${REPO_ROOT}/build"
+REPORT=""
+STRICT_OPTIONAL=0
+
+usage() {
+  cat <<USAGE
+Usage: scripts/grpc-interop/run.sh [options]
+
+Options:
+  --profile <core|extended>   Matrix profile to run (default: core)
+  --build-dir <path>          CMake build directory (default: ./build)
+  --report <path>             Output report path
+  --strict-optional           Fail if optional cases fail
+  -h, --help                  Show this help
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --profile)
+      PROFILE="$2"
+      shift 2
+      ;;
+    --build-dir)
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --report)
+      REPORT="$2"
+      shift 2
+      ;;
+    --strict-optional)
+      STRICT_OPTIONAL=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ "${PROFILE}" != "core" ] && [ "${PROFILE}" != "extended" ]; then
+  echo "Invalid profile: ${PROFILE}" >&2
+  exit 2
+fi
+
+if [ -d "${BUILD_DIR}" ]; then
+  BUILD_DIR="$(cd "${BUILD_DIR}" && pwd)"
+else
+  BUILD_DIR="$(cd "$(dirname "${BUILD_DIR}")" && pwd)/$(basename "${BUILD_DIR}")"
+fi
+
+MATRIX_PATH="${REPO_ROOT}/tests/grpc/interop/matrix-${PROFILE}.json"
+if [ ! -f "${MATRIX_PATH}" ]; then
+  echo "Matrix not found: ${MATRIX_PATH}" >&2
+  exit 2
+fi
+
+if [ -z "${REPORT}" ]; then
+  REPORT="${BUILD_DIR}/grpc-interop-${PROFILE}-report.json"
+fi
+
+CMD=(
+  python3
+  "${REPO_ROOT}/tests/grpc/interop/run_matrix.py"
+  --matrix "${MATRIX_PATH}"
+  --build-dir "${BUILD_DIR}"
+  --repo-root "${REPO_ROOT}"
+  --output "${REPORT}"
+)
+
+if [ "${STRICT_OPTIONAL}" -eq 1 ]; then
+  CMD+=(--strict-optional)
+fi
+
+echo "Running gRPC interop profile '${PROFILE}'"
+printf 'Command:'
+printf ' %q' "${CMD[@]}"
+echo
+
+"${CMD[@]}"

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -133,6 +133,12 @@ run_build_debug() {
     log_info "Running tests..."
     cd "$build_dir"
     ctest --output-on-failure --parallel "$NPROC" || return 1
+
+    log_info "Running gRPC core conformance matrix..."
+    "$PROJECT_ROOT/scripts/grpc-interop/run.sh" \
+        --profile core \
+        --build-dir "$build_dir" \
+        --report "$build_dir/grpc-interop-core-debug.json" || return 1
     
     return 0
 }
@@ -155,6 +161,12 @@ run_build_release() {
     log_info "Running tests..."
     cd "$build_dir"
     ctest --output-on-failure --parallel "$NPROC" || return 1
+
+    log_info "Running gRPC core conformance matrix..."
+    "$PROJECT_ROOT/scripts/grpc-interop/run.sh" \
+        --profile core \
+        --build-dir "$build_dir" \
+        --report "$build_dir/grpc-interop-core-release.json" || return 1
     
     return 0
 }
@@ -664,4 +676,3 @@ main() {
 }
 
 main "$@"
-

--- a/tests/grpc/interop/README.md
+++ b/tests/grpc/interop/README.md
@@ -1,0 +1,54 @@
+# gRPC Interop Matrix
+
+This directory contains the gRPC interoperability/conformance matrix and a
+runner that emits machine-readable pass/fail/skip reports.
+
+## Supported Conformance Subset
+
+The core profile validates the following semantics with deterministic local
+checks:
+
+| Requirement | Core Case ID | Backing Command |
+| --- | --- | --- |
+| Unary behavior over HTTP/2 | `unary_h2_core` | `ctest -R test_grpc_unary_h2` |
+| Server unary semantics and interceptors | `unary_server_h2_core` | `ctest -R test_grpc_unary_server_h2` |
+| Metadata and trailer behavior | `metadata_trailers_core` | `ctest -R test_grpc_metadata` |
+| Status code mapping / framing semantics | `status_mapping_core` | `ctest -R test_grpc_wire` |
+| HTTP/3 transport path checks | `transport_h3_core` | `ctest -R test_grpc_h3` |
+
+Deadlines, cancellation, and compression negotiation are covered by
+`test_grpc_unary_h2` scenarios in the core profile.
+
+## Profiles
+
+- `core`: Blocking profile for CI. Uses internal deterministic tests only.
+- `extended`: Optional local profile. Includes `core` plus external-tool smoke
+  checks for maintainers.
+
+## Skip Semantics
+
+The runner marks a case as skipped when command output includes one of:
+
+- `[SKIP]`
+- `[SKIPPED]`
+
+This is required because test binaries can return success while signaling
+runtime capability skips in output.
+
+## Usage
+
+Run via wrapper:
+
+```bash
+scripts/grpc-interop/run.sh --profile core --build-dir build
+scripts/grpc-interop/run.sh --profile extended --build-dir build
+```
+
+Run runner directly:
+
+```bash
+python3 tests/grpc/interop/run_matrix.py \
+  --matrix tests/grpc/interop/matrix-core.json \
+  --build-dir build \
+  --output build/grpc-interop-core-report.json
+```

--- a/tests/grpc/interop/matrix-core.json
+++ b/tests/grpc/interop/matrix-core.json
@@ -1,0 +1,75 @@
+{
+  "profile": "core",
+  "description": "Deterministic core gRPC conformance checks for CI",
+  "skip_patterns": [
+    "[SKIP]",
+    "[SKIPPED]"
+  ],
+  "cases": [
+    {
+      "id": "unary_h2_core",
+      "requirement": "unary",
+      "description": "Unary gRPC client semantics over HTTP/2, including deadlines/cancel/compression scenarios",
+      "command": [
+        "ctest",
+        "--test-dir",
+        "{build_dir}",
+        "-R",
+        "test_grpc_unary_h2",
+        "--output-on-failure"
+      ]
+    },
+    {
+      "id": "unary_server_h2_core",
+      "requirement": "unary",
+      "description": "Unary server semantics and interceptor pipeline behavior",
+      "command": [
+        "ctest",
+        "--test-dir",
+        "{build_dir}",
+        "-R",
+        "test_grpc_unary_server_h2",
+        "--output-on-failure"
+      ]
+    },
+    {
+      "id": "metadata_trailers_core",
+      "requirement": "metadata_trailers",
+      "description": "Metadata and trailer encode/decode and validation semantics",
+      "command": [
+        "ctest",
+        "--test-dir",
+        "{build_dir}",
+        "-R",
+        "test_grpc_metadata",
+        "--output-on-failure"
+      ]
+    },
+    {
+      "id": "status_mapping_core",
+      "requirement": "status_mapping",
+      "description": "gRPC wire framing and HTTP status to gRPC status mapping semantics",
+      "command": [
+        "ctest",
+        "--test-dir",
+        "{build_dir}",
+        "-R",
+        "test_grpc_wire",
+        "--output-on-failure"
+      ]
+    },
+    {
+      "id": "transport_h3_core",
+      "requirement": "streaming",
+      "description": "HTTP/3 transport path behavior with runtime capability-aware skip",
+      "command": [
+        "ctest",
+        "--test-dir",
+        "{build_dir}",
+        "-R",
+        "test_grpc_h3",
+        "--output-on-failure"
+      ]
+    }
+  ]
+}

--- a/tests/grpc/interop/matrix-extended.json
+++ b/tests/grpc/interop/matrix-extended.json
@@ -1,0 +1,38 @@
+{
+  "profile": "extended",
+  "description": "Core conformance plus optional external tooling smoke checks",
+  "extends": "matrix-core.json",
+  "skip_patterns": [
+    "[SKIP]",
+    "[SKIPPED]"
+  ],
+  "cases": [
+    {
+      "id": "external_grpcurl_grpcbin_smoke",
+      "requirement": "external_interop",
+      "description": "Optional grpcurl external-client smoke check against a containerized grpcbin server",
+      "optional": true,
+      "required_tools": [
+        "grpcurl",
+        "docker"
+      ],
+      "timeout_seconds": 180,
+      "command": [
+        "{repo_root}/scripts/grpc-interop/grpcurl_grpcbin_smoke.sh"
+      ]
+    },
+    {
+      "id": "external_go_toolchain_available",
+      "requirement": "external_interop",
+      "description": "Optional Go toolchain availability check for grpc-go interop workflows",
+      "optional": true,
+      "required_tools": [
+        "go"
+      ],
+      "command": [
+        "go",
+        "version"
+      ]
+    }
+  ]
+}

--- a/tests/grpc/interop/run_matrix.py
+++ b/tests/grpc/interop/run_matrix.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Run a gRPC interop/conformance matrix and emit machine-readable results."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+from typing import Any, Dict, Iterable, List, Tuple
+
+DEFAULT_SKIP_PATTERNS = ["[SKIP]", "[SKIPPED]"]
+MAX_CAPTURE_CHARS = 12000
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run gRPC interop matrix")
+    parser.add_argument("--matrix", required=True, help="Path to matrix JSON")
+    parser.add_argument(
+        "--build-dir",
+        default="build",
+        help="CMake build directory used by ctest commands",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=".",
+        help="Repository root for script execution context",
+    )
+    parser.add_argument(
+        "--output",
+        default="",
+        help="Output report JSON path (default: <build-dir>/grpc-interop-report.json)",
+    )
+    parser.add_argument(
+        "--strict-optional",
+        action="store_true",
+        help="Fail overall run if optional cases fail",
+    )
+    return parser.parse_args()
+
+
+def load_matrix(path: Path, stack: Tuple[Path, ...] = ()) -> Dict[str, Any]:
+    resolved = path.resolve()
+    if resolved in stack:
+        chain = " -> ".join(str(p) for p in (stack + (resolved,)))
+        raise ValueError(f"Matrix include cycle detected: {chain}")
+
+    with resolved.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Matrix must be an object: {resolved}")
+
+    if "extends" not in data:
+        matrix = copy.deepcopy(data)
+        matrix["_path"] = str(resolved)
+        return matrix
+
+    parent_ref = data.get("extends")
+    if not isinstance(parent_ref, str) or not parent_ref:
+        raise ValueError(f"Invalid extends field in {resolved}")
+
+    parent = load_matrix(resolved.parent / parent_ref, stack + (resolved,))
+    child = copy.deepcopy(data)
+    child.pop("extends", None)
+
+    merged = copy.deepcopy(parent)
+    parent_cases = list(parent.get("cases", []))
+    child_cases = list(child.pop("cases", []))
+
+    for key, value in child.items():
+        merged[key] = value
+
+    merged["cases"] = parent_cases + child_cases
+    merged["_path"] = str(resolved)
+    return merged
+
+
+def replace_tokens(value: str, tokens: Dict[str, str]) -> str:
+    out = value
+    for key, token_value in tokens.items():
+        out = out.replace("{" + key + "}", token_value)
+    return out
+
+
+def capture_excerpt(text: str) -> str:
+    if len(text) <= MAX_CAPTURE_CHARS:
+        return text
+    return text[:MAX_CAPTURE_CHARS] + "\n...[truncated]"
+
+
+def case_timeout_seconds(case: Dict[str, Any], default_seconds: int = 300) -> int:
+    raw = case.get("timeout_seconds", default_seconds)
+    if not isinstance(raw, int) or raw <= 0:
+        return default_seconds
+    return raw
+
+
+def find_missing_tools(required_tools: Iterable[str]) -> List[str]:
+    missing: List[str] = []
+    for tool in required_tools:
+        if shutil.which(tool) is None:
+            missing.append(tool)
+    return missing
+
+
+def command_has_skip(output: str, skip_patterns: Iterable[str]) -> bool:
+    for pattern in skip_patterns:
+        if pattern in output:
+            return True
+    return False
+
+
+def run_case(
+    case: Dict[str, Any],
+    tokens: Dict[str, str],
+    repo_root: Path,
+    default_skip_patterns: List[str],
+) -> Dict[str, Any]:
+    case_id = str(case.get("id", ""))
+    description = str(case.get("description", ""))
+    requirement = str(case.get("requirement", ""))
+    optional = bool(case.get("optional", False))
+    required_tools = list(case.get("required_tools", []))
+    skip_patterns = list(case.get("skip_patterns", default_skip_patterns))
+
+    command = case.get("command")
+    if not isinstance(command, list) or not command:
+        return {
+            "id": case_id,
+            "requirement": requirement,
+            "description": description,
+            "optional": optional,
+            "status": "fail",
+            "reason": "Invalid or empty command",
+            "returncode": None,
+            "duration_seconds": 0.0,
+            "command": command,
+            "stdout": "",
+            "stderr": "",
+        }
+
+    expanded_cmd = [replace_tokens(str(item), tokens) for item in command]
+
+    missing_tools = find_missing_tools(required_tools)
+    if missing_tools:
+        return {
+            "id": case_id,
+            "requirement": requirement,
+            "description": description,
+            "optional": optional,
+            "status": "skipped",
+            "reason": "Missing required tools: " + ", ".join(missing_tools),
+            "returncode": None,
+            "duration_seconds": 0.0,
+            "command": expanded_cmd,
+            "stdout": "",
+            "stderr": "",
+        }
+
+    env = os.environ.copy()
+    env_overrides = case.get("env", {})
+    if isinstance(env_overrides, dict):
+        for key, value in env_overrides.items():
+            env[str(key)] = replace_tokens(str(value), tokens)
+
+    timeout_seconds = case_timeout_seconds(case)
+    started = time.time()
+
+    try:
+        proc = subprocess.run(
+            expanded_cmd,
+            cwd=str(repo_root),
+            env=env,
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+            check=False,
+        )
+        duration = time.time() - started
+    except subprocess.TimeoutExpired as exc:
+        duration = time.time() - started
+        stdout = exc.stdout or ""
+        stderr = exc.stderr or ""
+        return {
+            "id": case_id,
+            "requirement": requirement,
+            "description": description,
+            "optional": optional,
+            "status": "fail",
+            "reason": f"Timed out after {timeout_seconds}s",
+            "returncode": None,
+            "duration_seconds": round(duration, 3),
+            "command": expanded_cmd,
+            "stdout": capture_excerpt(stdout),
+            "stderr": capture_excerpt(stderr),
+        }
+
+    combined = (proc.stdout or "") + "\n" + (proc.stderr or "")
+    if proc.returncode != 0:
+        status = "fail"
+        reason = f"Command exited with code {proc.returncode}"
+    elif command_has_skip(combined, skip_patterns):
+        status = "skipped"
+        reason = "Skip pattern matched"
+    else:
+        status = "pass"
+        reason = "Command exited successfully"
+
+    return {
+        "id": case_id,
+        "requirement": requirement,
+        "description": description,
+        "optional": optional,
+        "status": status,
+        "reason": reason,
+        "returncode": proc.returncode,
+        "duration_seconds": round(duration, 3),
+        "command": expanded_cmd,
+        "stdout": capture_excerpt(proc.stdout or ""),
+        "stderr": capture_excerpt(proc.stderr or ""),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+
+    repo_root = Path(args.repo_root).resolve()
+    build_dir = Path(args.build_dir).resolve()
+    matrix_path = Path(args.matrix).resolve()
+
+    if args.output:
+        output_path = Path(args.output).resolve()
+    else:
+        output_path = build_dir / "grpc-interop-report.json"
+
+    matrix = load_matrix(matrix_path)
+    cases = matrix.get("cases", [])
+    if not isinstance(cases, list):
+        raise ValueError("Matrix cases must be a list")
+
+    tokens = {
+        "repo_root": str(repo_root),
+        "build_dir": str(build_dir),
+    }
+
+    skip_patterns = list(matrix.get("skip_patterns", DEFAULT_SKIP_PATTERNS))
+    started = time.time()
+    results: List[Dict[str, Any]] = []
+
+    print(f"Interop profile: {matrix.get('profile', 'unknown')}")
+    print(f"Matrix: {matrix_path}")
+
+    for case in cases:
+        if not isinstance(case, dict):
+            results.append(
+                {
+                    "id": "<invalid>",
+                    "requirement": "",
+                    "description": "",
+                    "optional": False,
+                    "status": "fail",
+                    "reason": "Matrix case is not an object",
+                    "returncode": None,
+                    "duration_seconds": 0.0,
+                    "command": [],
+                    "stdout": "",
+                    "stderr": "",
+                }
+            )
+            print("[FAIL] <invalid> matrix case is not an object")
+            continue
+
+        case_result = run_case(case, tokens, repo_root, skip_patterns)
+        results.append(case_result)
+
+        status = case_result["status"].upper()
+        case_id = case_result.get("id", "<unknown>")
+        optional_suffix = " (optional)" if case_result.get("optional") else ""
+        reason = case_result.get("reason", "")
+        print(f"[{status}] {case_id}{optional_suffix} :: {reason}")
+
+    elapsed = time.time() - started
+
+    pass_count = sum(1 for r in results if r["status"] == "pass")
+    fail_count = sum(1 for r in results if r["status"] == "fail")
+    skip_count = sum(1 for r in results if r["status"] == "skipped")
+    required_fail_count = sum(
+        1 for r in results if r["status"] == "fail" and not r.get("optional", False)
+    )
+    optional_fail_count = sum(
+        1 for r in results if r["status"] == "fail" and r.get("optional", False)
+    )
+
+    report = {
+        "profile": matrix.get("profile", "unknown"),
+        "description": matrix.get("description", ""),
+        "matrix_path": str(matrix_path),
+        "generated_at_unix": int(time.time()),
+        "duration_seconds": round(elapsed, 3),
+        "summary": {
+            "total": len(results),
+            "passed": pass_count,
+            "failed": fail_count,
+            "skipped": skip_count,
+            "required_failed": required_fail_count,
+            "optional_failed": optional_fail_count,
+            "strict_optional": bool(args.strict_optional),
+        },
+        "cases": results,
+    }
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as f:
+        json.dump(report, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+    print(
+        "Summary: "
+        f"pass={pass_count} fail={fail_count} skip={skip_count} "
+        f"required_fail={required_fail_count} optional_fail={optional_fail_count}"
+    )
+    print(f"Report: {output_path}")
+
+    if required_fail_count > 0:
+        return 1
+    if args.strict_optional and optional_fail_count > 0:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        print(f"Fatal: {exc}", file=sys.stderr)
+        raise SystemExit(2)


### PR DESCRIPTION
## Summary
- add a matrix-driven gRPC interop/conformance runner in `tests/grpc/interop/`
- define a blocking `core` profile for deterministic internal conformance checks
- define an `extended` profile with optional external tooling smoke checks
- add `scripts/grpc-interop/run.sh` wrapper for local and CI execution
- wire core conformance execution into GitHub Actions build jobs
- keep local CI parity by running the same core profile in build debug/release flows

Fixes #3593

## Test plan
- [x] `scripts/grpc-interop/run.sh --profile core --build-dir build --report build/grpc-interop-core-local.json`
- [x] `scripts/grpc-interop/run.sh --profile extended --build-dir build --report build/grpc-interop-extended-local.json`
- [x] `python3 -m py_compile tests/grpc/interop/run_matrix.py`
