### PR TITLE
feat(grpc): add docs, examples, and benchmark harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,12 +39,23 @@ jobs:
         working-directory: build
         run: ctest --output-on-failure --parallel $(nproc)
 
+      - name: Run gRPC example smoke tests
+        working-directory: build
+        run: ctest --output-on-failure -R "grpc_example_.*_smoke"
+
       - name: Run gRPC core conformance matrix
         run: |
           scripts/grpc-interop/run.sh \
             --profile core \
             --build-dir build \
             --report build/grpc-interop-core-${{ matrix.build_type }}.json
+
+      - name: Run gRPC benchmark smoke report
+        run: |
+          scripts/grpc-bench/run.sh \
+            --build-dir build \
+            --smoke \
+            --report build/grpc-bench-${{ matrix.build_type }}.json
 
   # Sanitizer builds (Linux)
   sanitizers:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1317,6 +1317,42 @@ foreach(test_name ${TEST_SOURCES})
     set_tests_properties(${test_name} PROPERTIES TIMEOUT 60)
 endforeach()
 
+# gRPC examples (always built; CI runs --smoke tests)
+set(GRPC_EXAMPLE_SOURCES
+    examples/grpc/unary_hello_world.c
+    examples/grpc/bidi_stream_chat.c
+    examples/grpc/deadline_cancellation.c
+    examples/grpc/tls_mtls_h2.c
+)
+
+set(GRPC_EXAMPLE_TARGETS)
+set(GRPC_EXAMPLE_SMOKE_TESTS)
+
+foreach(example_src ${GRPC_EXAMPLE_SOURCES})
+    get_filename_component(example_name ${example_src} NAME_WE)
+    set(example_target "grpc_example_${example_name}")
+    set(example_test "${example_target}_smoke")
+
+    add_executable(${example_target}
+        ${example_src}
+        $<TARGET_OBJECTS:socket_objects>
+    )
+    if(SOCKET_HAS_TLS)
+        target_link_libraries(${example_target} pthread m ${LIBURING_LIBRARIES} ${OPENSSL_LIBRARIES} ${HTTP_COMPRESSION_LIBS} ${WS_DEFLATE_LIBS})
+    else()
+        target_link_libraries(${example_target} pthread m ${LIBURING_LIBRARIES} ${HTTP_COMPRESSION_LIBS} ${WS_DEFLATE_LIBS})
+    endif()
+    target_include_directories(${example_target} PRIVATE ${CMAKE_SOURCE_DIR}/include)
+
+    add_test(NAME ${example_test} COMMAND ${example_target} --smoke)
+    set_tests_properties(${example_test} PROPERTIES TIMEOUT 20)
+
+    list(APPEND GRPC_EXAMPLE_TARGETS ${example_target})
+    list(APPEND GRPC_EXAMPLE_SMOKE_TESTS ${example_test})
+endforeach()
+
+list(APPEND EXTRA_TEST_TARGETS ${GRPC_EXAMPLE_TARGETS})
+
 # Custom target to build all tests
 add_custom_target(build_tests ALL DEPENDS ${TEST_SOURCES} ${EXTRA_TEST_TARGETS})
 
@@ -1386,6 +1422,14 @@ target_link_libraries(benchmark_synprotect socket_static pthread)
 
 add_executable(benchmark_client src/test/benchmark_client.c)
 target_link_libraries(benchmark_client socket_static pthread)
+
+add_executable(benchmark_grpc_transport src/test/benchmark_grpc_transport.c)
+if(SOCKET_HAS_TLS)
+    target_link_libraries(benchmark_grpc_transport socket_static pthread m ${LIBURING_LIBRARIES} ${OPENSSL_LIBRARIES} ${HTTP_COMPRESSION_LIBS} ${WS_DEFLATE_LIBS})
+else()
+    target_link_libraries(benchmark_grpc_transport socket_static pthread m ${LIBURING_LIBRARIES} ${HTTP_COMPRESSION_LIBS} ${WS_DEFLATE_LIBS})
+endif()
+target_include_directories(benchmark_grpc_transport PRIVATE ${CMAKE_SOURCE_DIR}/include)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_executable(benchmark_raw src/test/benchmark_raw.c)

--- a/Doxyfile
+++ b/Doxyfile
@@ -148,9 +148,14 @@ INPUT                  = include \
                          docs/mainpage.md \
                          docs/ASYNC_IO.md \
                          docs/HTTP.md \
+                         docs/grpc-overview.md \
+                         docs/grpc-client.md \
+                         docs/grpc-server.md \
+                         docs/grpc-http3.md \
                          docs/WEBSOCKET.md \
                          docs/PROXY.md \
                          docs/SECURITY.md \
+                         docs/GRPC-CODEGEN.md \
                          docs/MIGRATION.md \
                          examples
 INPUT_ENCODING         = UTF-8

--- a/docs/grpc-client.md
+++ b/docs/grpc-client.md
@@ -1,0 +1,94 @@
+# gRPC Client Guide
+
+This guide covers the `SocketGRPC` client APIs for unary and streaming calls.
+
+## Minimal Unary Flow
+
+```c
+SocketGRPC_Client_T client = SocketGRPC_Client_new(NULL);
+SocketGRPC_Channel_T channel = SocketGRPC_Channel_new(client, "https://127.0.0.1:50051", NULL);
+SocketGRPC_Call_T call = SocketGRPC_Call_new(channel, "/example.Echo/Ping", NULL);
+
+Arena_T arena = Arena_new();
+uint8_t *resp = NULL;
+size_t resp_len = 0;
+int rc = SocketGRPC_Call_unary_h2(call, req, req_len, arena, &resp, &resp_len);
+SocketGRPC_Status status = SocketGRPC_Call_status(call);
+```
+
+`SocketGRPC_Call_unary_h2()` is the unified unary entrypoint. It routes to
+HTTP/2 or HTTP/3 based on `SocketGRPC_ChannelConfig.channel_mode`.
+
+## Channel Configuration
+
+Use `SocketGRPC_ChannelConfig_defaults()` and override only what you need.
+
+Common fields:
+
+- `channel_mode`: `SOCKET_GRPC_CHANNEL_MODE_HTTP2` (default) or HTTP/3
+- `verify_peer`: TLS peer verification toggle
+- `tls_context`: HTTP/2 TLS context path
+- `ca_file`: CA bundle path (used by HTTP/3 client path)
+- `enable_request_compression`: gzip request compression (HTTP/2 only)
+- `enable_response_decompression`: gzip response decode (HTTP/2 only)
+- `max_inbound_message_bytes`, `max_outbound_message_bytes`
+- `max_metadata_entries`, `max_cumulative_inflight_bytes`
+
+## Deadlines and Cancellation
+
+Per-call behavior is configured in `SocketGRPC_CallConfig`:
+
+- `deadline_ms`: absolute RPC budget
+- `wait_for_ready`: wait behavior for unavailable backends
+- `retry_policy`: bounded backoff policy
+
+Cancellation:
+
+- `SocketGRPC_Call_cancel(call)` transitions active calls to `CANCELLED`
+- Cancellation is best-effort and transport-aware
+
+## Streaming APIs
+
+Client streaming and bidi-style client behavior use:
+
+- `SocketGRPC_Call_send_message()`
+- `SocketGRPC_Call_close_send()`
+- `SocketGRPC_Call_recv_message()`
+
+`recv_message()` contract:
+
+- `done = 0`: one message received
+- `done = 1`: stream finished; inspect status/trailers on call
+
+## Metadata and Interceptors
+
+Client metadata:
+
+- `SocketGRPC_Call_metadata_add_ascii()`
+- `SocketGRPC_Call_metadata_add_binary()`
+
+Interceptors:
+
+- Unary: `SocketGRPC_Call_add_unary_interceptor()`
+- Stream: `SocketGRPC_Call_add_stream_interceptor()`
+
+Reference interceptors include metadata injector and structured logging hooks.
+
+## Failure Handling Pattern
+
+Recommended pattern:
+
+1. Check integer return code (`-1` indicates local/transport failure path).
+2. Always inspect `SocketGRPC_Call_status()` for final canonical status.
+3. Use trailers via `SocketGRPC_Call_trailers()` for error details.
+
+## HTTP/3 Notes
+
+When `channel_mode` is HTTP/3:
+
+- Use HTTPS targets (`https://host:port`).
+- Request compression is not currently supported.
+- Compressed response decoding is not currently supported.
+- `tls_context` is ignored on the current HTTP/3 client path.
+
+See `docs/grpc-http3.md` for details and limitations.

--- a/docs/grpc-http3.md
+++ b/docs/grpc-http3.md
@@ -1,0 +1,61 @@
+# gRPC over HTTP/3
+
+This document captures current HTTP/3 behavior for `SocketGRPC`.
+
+## Enabling HTTP/3 Mode
+
+Set channel mode:
+
+```c
+SocketGRPC_ChannelConfig cfg;
+SocketGRPC_ChannelConfig_defaults(&cfg);
+cfg.channel_mode = SOCKET_GRPC_CHANNEL_MODE_HTTP3;
+cfg.verify_peer = 1;
+cfg.ca_file = "/path/to/ca.pem";
+```
+
+Target should be HTTPS form:
+
+- `https://host:port`
+
+## Supported Today
+
+- Unary gRPC client calls over HTTP/3
+- Unary gRPC server dispatch via `SocketGRPC_Server_bind_http3`
+- Client streaming APIs over HTTP/3 transport
+- Metadata/trailer handling and status propagation
+
+## Current HTTP/3 Limits
+
+The following are intentionally not supported yet:
+
+- Request compression over HTTP/3
+- Compressed response decoding over HTTP/3
+- Client-side `tls_context` parity with HTTP/2 channel path
+
+Current client TLS knobs for HTTP/3 are:
+
+- `ca_file`
+- `verify_peer`
+
+## Error/Skip Expectations
+
+In environments where QUIC/TLS runtime support is not available, HTTP/3 call
+paths may return `UNAVAILABLE`. CI and local smoke checks should treat this as
+runtime capability-aware skip, not as a protocol correctness regression.
+
+## mTLS Note
+
+mTLS parity differs by transport today:
+
+- HTTP/2 client paths can use `SocketTLSContext_T` via `tls_context`
+- HTTP/3 client paths currently do not accept `tls_context`
+
+If mTLS is required today, prefer HTTP/2 transport mode.
+
+## Recommended Rollout Pattern
+
+1. Keep HTTP/2 as default transport.
+2. Enable HTTP/3 per-channel for known-compatible environments.
+3. Keep compression disabled for HTTP/3 channels.
+4. Monitor status code distribution and retry behavior before broad rollout.

--- a/docs/grpc-overview.md
+++ b/docs/grpc-overview.md
@@ -1,0 +1,93 @@
+# gRPC Overview
+
+This guide describes the public gRPC surface in `SocketGRPC` and how it maps to
+HTTP/2 and HTTP/3 transports in this repository.
+
+## Scope
+
+`SocketGRPC` currently provides:
+
+- Unary client and server calls over HTTP/2
+- Unary client and server calls over HTTP/3
+- Client streaming and bidi-style client APIs (`send_message`, `recv_message`)
+- Metadata/trailers helpers
+- Deadline, cancellation, retry policy, and interceptor hooks
+
+## Lifecycle
+
+Core object lifecycle is explicit and handle-based:
+
+1. `SocketGRPC_Client_new()`
+2. `SocketGRPC_Channel_new()`
+3. `SocketGRPC_Call_new()`
+4. Execute unary or streaming API
+5. `SocketGRPC_Call_free()`
+6. `SocketGRPC_Channel_free()`
+7. `SocketGRPC_Client_free()`
+
+Server lifecycle:
+
+1. `SocketGRPC_Server_new()`
+2. `SocketGRPC_Server_register_unary()` (or `_except`)
+3. Bind dispatcher with `SocketGRPC_Server_bind_http2()` or
+   `SocketGRPC_Server_bind_http3()`
+4. Run transport server loop
+5. `SocketGRPC_Server_begin_shutdown()`
+6. `SocketGRPC_Server_free()`
+
+## Error Model
+
+`SocketGRPC` returns canonical gRPC status codes (`0-16`) for protocol
+completion and uses `-1` for local argument/setup failures.
+
+- Per-call final status: `SocketGRPC_Call_status()`
+- Status message fallback: `SocketGRPC_Status_message()`
+- Symbolic status name: `SocketGRPC_Status_code_name()`
+
+Common terminal semantics:
+
+- `OK`: RPC completed successfully
+- `DEADLINE_EXCEEDED`: call deadline elapsed
+- `CANCELLED`: call cancelled locally or remotely
+- `UNAVAILABLE`: transport/connectivity issue
+- `RESOURCE_EXHAUSTED`: configured payload/metadata limits exceeded
+
+## Thread Safety
+
+- `SocketGRPC_*_new()` and config default helpers are thread-safe.
+- Individual call/server handles are not intended for unsynchronized concurrent
+  mutation by multiple threads.
+- Treat each active call and server instance as thread-confined unless you
+  provide external synchronization.
+
+## Limits and Defaults
+
+Channel and runtime limits are configured via `SocketGRPC_ChannelConfig` and
+`SocketGRPC_CallConfig`.
+
+Important defaults (see `include/grpc/SocketGRPCConfig.h`):
+
+- `max_inbound_message_bytes`: 4 MiB
+- `max_outbound_message_bytes`: 4 MiB
+- `max_metadata_entries`: 64
+- `max_cumulative_inflight_bytes`: 8 MiB
+- `deadline_ms`: 30000
+- `verify_peer`: enabled
+
+## Transport Matrix
+
+| Capability | HTTP/2 | HTTP/3 |
+| --- | --- | --- |
+| Unary client | Yes | Yes |
+| Unary server | Yes | Yes |
+| Client stream APIs | Yes | Yes |
+| Request compression | Yes | No |
+| Compressed response decode | Yes | No |
+| Channel `tls_context` | Yes | No (use `ca_file` + `verify_peer`) |
+
+See also:
+
+- `docs/grpc-client.md`
+- `docs/grpc-server.md`
+- `docs/grpc-http3.md`
+- `docs/GRPC-CODEGEN.md`

--- a/docs/grpc-server.md
+++ b/docs/grpc-server.md
@@ -1,0 +1,86 @@
+# gRPC Server Guide
+
+This guide describes server-side gRPC setup for HTTP/2 and HTTP/3 dispatchers.
+
+## Server Setup
+
+```c
+SocketGRPC_Server_T grpc_server = SocketGRPC_Server_new(NULL);
+SocketGRPC_Server_register_unary(grpc_server,
+                                 "/example.Echo/Ping",
+                                 ping_handler,
+                                 NULL);
+```
+
+Unary handler signature:
+
+```c
+int handler(SocketGRPC_ServerContext_T ctx,
+            const uint8_t *request_payload,
+            size_t request_payload_len,
+            Arena_T arena,
+            uint8_t **response_payload,
+            size_t *response_payload_len,
+            void *userdata)
+```
+
+Return a canonical gRPC code (`0-16`).
+
+## Binding to HTTP/2
+
+1. Configure and start `SocketHTTPServer_T` with HTTP/2 enabled.
+2. Bind gRPC dispatcher:
+
+```c
+SocketGRPC_Server_bind_http2(grpc_server, http_server);
+```
+
+## Binding to HTTP/3
+
+1. Configure/start `SocketHTTP3_Server_T`.
+2. Bind gRPC dispatcher:
+
+```c
+SocketGRPC_Server_bind_http3(grpc_server, http3_server);
+```
+
+## Context and Trailers
+
+Within handlers, `SocketGRPC_ServerContext_T` exposes:
+
+- Request metadata (`SocketGRPC_ServerContext_metadata`)
+- Peer and method fields
+- Cancellation state (`SocketGRPC_ServerContext_is_cancelled`)
+- Status/trailer setters:
+  - `SocketGRPC_ServerContext_set_status`
+  - `SocketGRPC_ServerContext_set_status_details_bin`
+  - `SocketGRPC_ServerContext_add_trailing_metadata_*`
+
+## Interceptors and Observability
+
+Server extensions:
+
+- Unary interceptor chain:
+  `SocketGRPC_Server_add_unary_interceptor()`
+- Structured lifecycle hook:
+  `SocketGRPC_Server_set_observability_hook()`
+
+Use interceptors for auth, metadata policy, and structured logging.
+
+## Shutdown
+
+Graceful shutdown sequence:
+
+1. `SocketGRPC_Server_begin_shutdown(grpc_server)`
+2. Stop/drain transport server
+3. `SocketGRPC_Server_free(&grpc_server)`
+
+`SocketGRPC_Server_inflight_calls()` exposes active unary call count.
+
+## Current Limits
+
+The public server registration API currently supports unary method handlers.
+Streaming server registration APIs are not yet exposed in `SocketGRPC.h`.
+
+For client-streaming/bidi endpoint interop today, use explicit HTTP/2 or HTTP/3
+transport handlers where needed.

--- a/examples/grpc/README.md
+++ b/examples/grpc/README.md
@@ -1,0 +1,49 @@
+# gRPC Examples
+
+This directory contains small gRPC examples that align with the current
+`SocketGRPC` public API surface.
+
+## Programs
+
+- `grpc_example_unary_hello_world`
+  - Unary hello-world client flow.
+- `grpc_example_bidi_stream_chat`
+  - Client-side bidi/streaming call pattern.
+- `grpc_example_deadline_cancellation`
+  - Deadline and explicit cancellation usage.
+- `grpc_example_tls_mtls_h2`
+  - HTTP/2 TLS and mTLS channel configuration pattern.
+
+## CI Smoke Mode
+
+Each program supports `--smoke` for deterministic no-network validation. CI runs
+these smoke paths to ensure examples compile and execute.
+
+## Manual Usage
+
+```bash
+# unary over HTTP/2
+./grpc_example_unary_hello_world \
+  --target https://127.0.0.1:50051 \
+  --method /example.Echo/Ping \
+  --message "hello"
+
+# bidi client pattern over HTTP/3
+./grpc_example_bidi_stream_chat \
+  --h3 \
+  --target https://127.0.0.1:50053 \
+  --method /example.Chat/Chat
+
+# deadline + cancellation
+./grpc_example_deadline_cancellation \
+  --target https://127.0.0.1:50051 \
+  --deadline-ms 50 \
+  --cancel-before-send
+
+# TLS + mTLS (HTTP/2)
+./grpc_example_tls_mtls_h2 \
+  --target https://127.0.0.1:50051 \
+  --ca ./ca.pem \
+  --client-cert ./client.pem \
+  --client-key ./client.key
+```

--- a/examples/grpc/bidi_stream_chat.c
+++ b/examples/grpc/bidi_stream_chat.c
@@ -1,0 +1,265 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "grpc/SocketGRPC.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct
+{
+  int smoke;
+  int use_h3;
+  int insecure;
+  const char *target;
+  const char *method;
+} ChatOptions;
+
+typedef struct
+{
+  int send_events;
+  int recv_events;
+} ChatProbe;
+
+static void
+usage (const char *prog)
+{
+  printf ("Usage: %s [options]\n", prog);
+  printf ("\n");
+  printf ("Options:\n");
+  printf ("  --smoke             Run deterministic CI smoke path\n");
+  printf ("  --target <url>      gRPC target (example: https://127.0.0.1:50051)\n");
+  printf ("  --method <path>     Full method path (default: /example.Chat/Chat)\n");
+  printf ("  --h3                Use HTTP/3 channel mode\n");
+  printf ("  --insecure          Disable peer verification\n");
+  printf ("  -h, --help          Show this help\n");
+}
+
+static int
+parse_args (int argc, char **argv, ChatOptions *opts)
+{
+  int i;
+
+  if (opts == NULL)
+    return -1;
+
+  opts->smoke = 0;
+  opts->use_h3 = 0;
+  opts->insecure = 0;
+  opts->target = NULL;
+  opts->method = "/example.Chat/Chat";
+
+  for (i = 1; i < argc; i++)
+    {
+      if (strcmp (argv[i], "--smoke") == 0)
+        {
+          opts->smoke = 1;
+        }
+      else if (strcmp (argv[i], "--h3") == 0)
+        {
+          opts->use_h3 = 1;
+        }
+      else if (strcmp (argv[i], "--insecure") == 0)
+        {
+          opts->insecure = 1;
+        }
+      else if ((strcmp (argv[i], "--target") == 0) && (i + 1 < argc))
+        {
+          opts->target = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--method") == 0) && (i + 1 < argc))
+        {
+          opts->method = argv[++i];
+        }
+      else if ((strcmp (argv[i], "-h") == 0) || (strcmp (argv[i], "--help") == 0))
+        {
+          usage (argv[0]);
+          return 1;
+        }
+      else
+        {
+          fprintf (stderr, "Unknown argument: %s\n", argv[i]);
+          usage (argv[0]);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+static int
+chat_probe_interceptor (SocketGRPC_Call_T call,
+                        SocketGRPC_StreamInterceptEvent event,
+                        const uint8_t *payload,
+                        size_t payload_len,
+                        SocketGRPC_Status *status_io,
+                        void *userdata)
+{
+  ChatProbe *probe = (ChatProbe *)userdata;
+  (void)call;
+  (void)payload;
+  (void)payload_len;
+  (void)status_io;
+
+  if (probe == NULL)
+    return SOCKET_GRPC_INTERCEPT_CONTINUE;
+  if (event == SOCKET_GRPC_STREAM_INTERCEPT_SEND)
+    probe->send_events++;
+  else if (event == SOCKET_GRPC_STREAM_INTERCEPT_RECV)
+    probe->recv_events++;
+  return SOCKET_GRPC_INTERCEPT_CONTINUE;
+}
+
+static int
+run_smoke (void)
+{
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  ChatProbe probe;
+  int rc = 1;
+
+  memset (&probe, 0, sizeof (probe));
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel = SocketGRPC_Channel_new (client, "dns:///grpc-chat-smoke.local", &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  call = SocketGRPC_Call_new (channel, "/example.Chat/Chat", NULL);
+  if (call == NULL)
+    goto cleanup;
+
+  if (SocketGRPC_Call_add_stream_interceptor (call,
+                                              chat_probe_interceptor,
+                                              &probe)
+      != 0)
+    goto cleanup;
+
+  if (SocketGRPC_Call_metadata_add_ascii (call, "x-chat-room", "smoke") != 0)
+    goto cleanup;
+
+  if (SocketGRPC_Call_cancel (call) != 0)
+    goto cleanup;
+
+  printf ("grpc bidi chat smoke: PASS\n");
+  rc = 0;
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  return rc;
+}
+
+static int
+run_live (const ChatOptions *opts)
+{
+  Arena_T arena = NULL;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  uint8_t *payload = NULL;
+  size_t payload_len = 0;
+  int done = 0;
+  int rc;
+  int exit_code = 1;
+  const uint8_t msg1[] = { 0x0A, 0x05, 'h', 'e', 'l', 'l', 'o' };
+  const uint8_t msg2[] = { 0x0A, 0x05, 'w', 'o', 'r', 'l', 'd' };
+
+  if (opts == NULL || opts->target == NULL)
+    {
+      fprintf (stderr, "--target is required when not using --smoke\n");
+      return 1;
+    }
+
+  arena = Arena_new ();
+  if (arena == NULL)
+    return 1;
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.channel_mode = opts->use_h3 ? SOCKET_GRPC_CHANNEL_MODE_HTTP3
+                                          : SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+  channel_cfg.verify_peer = opts->insecure ? 0 : 1;
+
+  channel = SocketGRPC_Channel_new (client, opts->target, &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  call = SocketGRPC_Call_new (channel, opts->method, NULL);
+  if (call == NULL)
+    goto cleanup;
+
+  rc = SocketGRPC_Call_send_message (call, msg1, sizeof (msg1));
+  if (rc != 0)
+    goto report;
+
+  rc = SocketGRPC_Call_send_message (call, msg2, sizeof (msg2));
+  if (rc != 0)
+    goto report;
+
+  rc = SocketGRPC_Call_close_send (call);
+  if (rc != 0)
+    goto report;
+
+  while (!done)
+    {
+      rc = SocketGRPC_Call_recv_message (
+          call, arena, &payload, &payload_len, &done);
+      if (rc != 0)
+        goto report;
+      if (!done)
+        printf ("recv payload bytes=%zu\n", payload_len);
+    }
+
+report:
+  {
+    SocketGRPC_Status status = SocketGRPC_Call_status (call);
+    printf ("transport=%s rc=%d status=%d message=%s\n",
+            opts->use_h3 ? "h3" : "h2",
+            rc,
+            (int)status.code,
+            SocketGRPC_Status_message (&status));
+    if (rc == 0 && status.code == SOCKET_GRPC_STATUS_OK)
+      exit_code = 0;
+  }
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  Arena_dispose (&arena);
+  return exit_code;
+}
+
+int
+main (int argc, char **argv)
+{
+  ChatOptions opts;
+  int parse_rc;
+
+  parse_rc = parse_args (argc, argv, &opts);
+  if (parse_rc > 0)
+    return 0;
+  if (parse_rc < 0)
+    return 2;
+
+  if (opts.smoke)
+    return run_smoke ();
+  return run_live (&opts);
+}

--- a/examples/grpc/deadline_cancellation.c
+++ b/examples/grpc/deadline_cancellation.c
@@ -1,0 +1,268 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "core/Arena.h"
+#include "grpc/SocketGRPC.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct
+{
+  int smoke;
+  int use_h3;
+  int insecure;
+  int cancel_before_send;
+  int deadline_ms;
+  const char *target;
+  const char *method;
+} DeadlineOptions;
+
+static void
+usage (const char *prog)
+{
+  printf ("Usage: %s [options]\n", prog);
+  printf ("\n");
+  printf ("Options:\n");
+  printf ("  --smoke                Run deterministic CI smoke path\n");
+  printf ("  --target <url>         gRPC target (example: https://127.0.0.1:50051)\n");
+  printf ("  --method <path>        Full method path (default: /example.Echo/Ping)\n");
+  printf ("  --deadline-ms <ms>     Deadline in milliseconds (default: 100)\n");
+  printf ("  --cancel-before-send   Cancel call before invoking unary\n");
+  printf ("  --h3                   Use HTTP/3 channel mode\n");
+  printf ("  --insecure             Disable peer verification\n");
+  printf ("  -h, --help             Show this help\n");
+}
+
+static int
+parse_deadline_ms (const char *value, int *out)
+{
+  char *end = NULL;
+  long parsed;
+
+  if (value == NULL || out == NULL)
+    return -1;
+
+  parsed = strtol (value, &end, 10);
+  if (end == value || end == NULL || *end != '\0')
+    return -1;
+  if (parsed <= 0 || parsed > 600000)
+    return -1;
+
+  *out = (int)parsed;
+  return 0;
+}
+
+static int
+parse_args (int argc, char **argv, DeadlineOptions *opts)
+{
+  int i;
+
+  if (opts == NULL)
+    return -1;
+
+  opts->smoke = 0;
+  opts->use_h3 = 0;
+  opts->insecure = 0;
+  opts->cancel_before_send = 0;
+  opts->deadline_ms = 100;
+  opts->target = NULL;
+  opts->method = "/example.Echo/Ping";
+
+  for (i = 1; i < argc; i++)
+    {
+      if (strcmp (argv[i], "--smoke") == 0)
+        {
+          opts->smoke = 1;
+        }
+      else if (strcmp (argv[i], "--h3") == 0)
+        {
+          opts->use_h3 = 1;
+        }
+      else if (strcmp (argv[i], "--insecure") == 0)
+        {
+          opts->insecure = 1;
+        }
+      else if (strcmp (argv[i], "--cancel-before-send") == 0)
+        {
+          opts->cancel_before_send = 1;
+        }
+      else if ((strcmp (argv[i], "--target") == 0) && (i + 1 < argc))
+        {
+          opts->target = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--method") == 0) && (i + 1 < argc))
+        {
+          opts->method = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--deadline-ms") == 0) && (i + 1 < argc))
+        {
+          if (parse_deadline_ms (argv[++i], &opts->deadline_ms) != 0)
+            {
+              fprintf (stderr, "Invalid deadline value\n");
+              return -1;
+            }
+        }
+      else if ((strcmp (argv[i], "-h") == 0) || (strcmp (argv[i], "--help") == 0))
+        {
+          usage (argv[0]);
+          return 1;
+        }
+      else
+        {
+          fprintf (stderr, "Unknown argument: %s\n", argv[i]);
+          usage (argv[0]);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+static int
+run_smoke (void)
+{
+  char timeout_value[32];
+  int64_t parsed_ms = 0;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_CallConfig call_cfg;
+  int rc = 1;
+
+  if (SocketGRPC_Timeout_format (250, timeout_value, sizeof (timeout_value)) != 0)
+    goto cleanup;
+  if (SocketGRPC_Timeout_parse (timeout_value, &parsed_ms) != 0 || parsed_ms != 250)
+    goto cleanup;
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  channel
+      = SocketGRPC_Channel_new (client, "dns:///grpc-deadline-smoke.local", NULL);
+  if (channel == NULL)
+    goto cleanup;
+
+  SocketGRPC_CallConfig_defaults (&call_cfg);
+  call_cfg.deadline_ms = 25;
+  call = SocketGRPC_Call_new (channel, "/example.Echo/Ping", &call_cfg);
+  if (call == NULL)
+    goto cleanup;
+
+  if (SocketGRPC_Call_cancel (call) != 0)
+    goto cleanup;
+
+  if (SocketGRPC_Call_status (call).code != SOCKET_GRPC_STATUS_CANCELLED)
+    goto cleanup;
+
+  printf ("grpc deadline/cancellation smoke: PASS\n");
+  rc = 0;
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  return rc;
+}
+
+static int
+run_live (const DeadlineOptions *opts)
+{
+  Arena_T arena = NULL;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketGRPC_CallConfig call_cfg;
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  const uint8_t request_payload[] = { 0x0A, 0x04, 'p', 'i', 'n', 'g' };
+  int rc = -1;
+  int exit_code = 1;
+
+  if (opts == NULL || opts->target == NULL)
+    {
+      fprintf (stderr, "--target is required when not using --smoke\n");
+      return 1;
+    }
+
+  arena = Arena_new ();
+  if (arena == NULL)
+    return 1;
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.channel_mode = opts->use_h3 ? SOCKET_GRPC_CHANNEL_MODE_HTTP3
+                                          : SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+  channel_cfg.verify_peer = opts->insecure ? 0 : 1;
+
+  channel = SocketGRPC_Channel_new (client, opts->target, &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  SocketGRPC_CallConfig_defaults (&call_cfg);
+  call_cfg.deadline_ms = opts->deadline_ms;
+  call = SocketGRPC_Call_new (channel, opts->method, &call_cfg);
+  if (call == NULL)
+    goto cleanup;
+
+  if (opts->cancel_before_send)
+    {
+      if (SocketGRPC_Call_cancel (call) != 0)
+        goto report;
+    }
+
+  rc = SocketGRPC_Call_unary_h2 (call,
+                                 request_payload,
+                                 sizeof (request_payload),
+                                 arena,
+                                 &response_payload,
+                                 &response_payload_len);
+
+report:
+  {
+    SocketGRPC_Status status = SocketGRPC_Call_status (call);
+    printf ("transport=%s deadline_ms=%d rc=%d status=%d message=%s\n",
+            opts->use_h3 ? "h3" : "h2",
+            opts->deadline_ms,
+            rc,
+            (int)status.code,
+            SocketGRPC_Status_message (&status));
+    if (rc == SOCKET_GRPC_STATUS_OK
+        || status.code == SOCKET_GRPC_STATUS_DEADLINE_EXCEEDED
+        || status.code == SOCKET_GRPC_STATUS_CANCELLED)
+      exit_code = 0;
+  }
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  Arena_dispose (&arena);
+  return exit_code;
+}
+
+int
+main (int argc, char **argv)
+{
+  DeadlineOptions opts;
+  int parse_rc;
+
+  parse_rc = parse_args (argc, argv, &opts);
+  if (parse_rc > 0)
+    return 0;
+  if (parse_rc < 0)
+    return 2;
+
+  if (opts.smoke)
+    return run_smoke ();
+
+  return run_live (&opts);
+}

--- a/examples/grpc/tls_mtls_h2.c
+++ b/examples/grpc/tls_mtls_h2.c
@@ -1,0 +1,352 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "grpc/SocketGRPC.h"
+
+#if SOCKET_HAS_TLS
+#include "tls/SocketTLSContext.h"
+#endif
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct
+{
+  int smoke;
+  int insecure;
+  const char *target;
+  const char *method;
+  const char *ca_file;
+  const char *client_cert;
+  const char *client_key;
+  const char *message;
+} TLSOptions;
+
+static void
+usage (const char *prog)
+{
+  printf ("Usage: %s [options]\n", prog);
+  printf ("\n");
+  printf ("Options:\n");
+  printf ("  --smoke                Run deterministic CI smoke path\n");
+  printf ("  --target <url>         gRPC target (example: https://127.0.0.1:50051)\n");
+  printf ("  --method <path>        Full method path (default: /example.Echo/Ping)\n");
+  printf ("  --ca <path>            CA bundle for server verification\n");
+  printf ("  --client-cert <path>   Client certificate (PEM) for mTLS\n");
+  printf ("  --client-key <path>    Client key (PEM) for mTLS\n");
+  printf ("  --message <text>       Request payload (default: tls-demo)\n");
+  printf ("  --insecure             Disable peer verification\n");
+  printf ("  -h, --help             Show this help\n");
+}
+
+static int
+parse_args (int argc, char **argv, TLSOptions *opts)
+{
+  int i;
+
+  if (opts == NULL)
+    return -1;
+
+  opts->smoke = 0;
+  opts->insecure = 0;
+  opts->target = NULL;
+  opts->method = "/example.Echo/Ping";
+  opts->ca_file = NULL;
+  opts->client_cert = NULL;
+  opts->client_key = NULL;
+  opts->message = "tls-demo";
+
+  for (i = 1; i < argc; i++)
+    {
+      if (strcmp (argv[i], "--smoke") == 0)
+        {
+          opts->smoke = 1;
+        }
+      else if (strcmp (argv[i], "--insecure") == 0)
+        {
+          opts->insecure = 1;
+        }
+      else if ((strcmp (argv[i], "--target") == 0) && (i + 1 < argc))
+        {
+          opts->target = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--method") == 0) && (i + 1 < argc))
+        {
+          opts->method = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--ca") == 0) && (i + 1 < argc))
+        {
+          opts->ca_file = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--client-cert") == 0) && (i + 1 < argc))
+        {
+          opts->client_cert = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--client-key") == 0) && (i + 1 < argc))
+        {
+          opts->client_key = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--message") == 0) && (i + 1 < argc))
+        {
+          opts->message = argv[++i];
+        }
+      else if ((strcmp (argv[i], "-h") == 0) || (strcmp (argv[i], "--help") == 0))
+        {
+          usage (argv[0]);
+          return 1;
+        }
+      else
+        {
+          fprintf (stderr, "Unknown argument: %s\n", argv[i]);
+          usage (argv[0]);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+#if SOCKET_HAS_TLS
+
+static SocketTLSContext_T
+build_client_tls (const TLSOptions *opts)
+{
+  SocketTLSContext_T ctx = NULL;
+
+  if (opts == NULL)
+    return NULL;
+
+  TRY
+    {
+      ctx = SocketTLSContext_new_client (opts->ca_file);
+    }
+  EXCEPT (SocketTLS_Failed)
+    {
+      return NULL;
+    }
+  END_TRY;
+
+  if (ctx == NULL)
+    return NULL;
+
+  if (opts->client_cert != NULL || opts->client_key != NULL)
+    {
+      if (opts->client_cert == NULL || opts->client_key == NULL)
+        {
+          SocketTLSContext_free (&ctx);
+          return NULL;
+        }
+
+      TRY
+        {
+          SocketTLSContext_load_certificate (
+              ctx, opts->client_cert, opts->client_key);
+        }
+      EXCEPT (SocketTLS_Failed)
+        {
+          SocketTLSContext_free (&ctx);
+          return NULL;
+        }
+      END_TRY;
+    }
+
+  return ctx;
+}
+
+static int
+run_smoke (void)
+{
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketTLSContext_T client_tls = NULL;
+  int rc = 1;
+
+  TLSOptions opts;
+  memset (&opts, 0, sizeof (opts));
+
+  client_tls = build_client_tls (&opts);
+  if (client_tls == NULL)
+    goto cleanup;
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.channel_mode = SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+  channel_cfg.tls_context = client_tls;
+  channel_cfg.verify_peer = 0;
+
+  channel = SocketGRPC_Channel_new (client, "https://127.0.0.1:443", &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  call = SocketGRPC_Call_new (channel, "/example.Echo/Ping", NULL);
+  if (call == NULL)
+    goto cleanup;
+
+  if (SocketGRPC_Call_cancel (call) != 0)
+    goto cleanup;
+
+  printf ("grpc tls/mtls h2 smoke: PASS\n");
+  rc = 0;
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  SocketTLSContext_free (&client_tls);
+  return rc;
+}
+
+static int
+run_live (const TLSOptions *opts)
+{
+  Arena_T arena = NULL;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketTLSContext_T client_tls = NULL;
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  const uint8_t *request_payload = NULL;
+  size_t request_payload_len = 0;
+  int rc = -1;
+  int exit_code = 1;
+
+  if (opts == NULL || opts->target == NULL)
+    {
+      fprintf (stderr, "--target is required when not using --smoke\n");
+      return 1;
+    }
+
+  if (!opts->insecure && opts->ca_file == NULL)
+    {
+      fprintf (stderr, "--ca is required unless --insecure is used\n");
+      return 1;
+    }
+
+  if ((opts->client_cert != NULL && opts->client_key == NULL)
+      || (opts->client_cert == NULL && opts->client_key != NULL))
+    {
+      fprintf (stderr, "--client-cert and --client-key must be provided together\n");
+      return 1;
+    }
+
+  arena = Arena_new ();
+  if (arena == NULL)
+    return 1;
+
+  client_tls = build_client_tls (opts);
+  if (client_tls == NULL)
+    {
+      fprintf (stderr, "failed to create client TLS context\n");
+      goto cleanup;
+    }
+
+  if (opts->insecure)
+    {
+      TRY
+        {
+          SocketTLSContext_set_verify_mode (client_tls, TLS_VERIFY_NONE);
+        }
+      EXCEPT (SocketTLS_Failed)
+        {
+          fprintf (stderr, "failed to set insecure verify mode\n");
+          goto cleanup;
+        }
+      END_TRY;
+    }
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  request_payload = (const uint8_t *)opts->message;
+  request_payload_len = strlen (opts->message);
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.channel_mode = SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+  channel_cfg.tls_context = client_tls;
+  channel_cfg.verify_peer = opts->insecure ? 0 : 1;
+
+  channel = SocketGRPC_Channel_new (client, opts->target, &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  call = SocketGRPC_Call_new (channel, opts->method, NULL);
+  if (call == NULL)
+    goto cleanup;
+
+  rc = SocketGRPC_Call_unary_h2 (call,
+                                 request_payload,
+                                 request_payload_len,
+                                 arena,
+                                 &response_payload,
+                                 &response_payload_len);
+
+  {
+    SocketGRPC_Status status = SocketGRPC_Call_status (call);
+    printf ("transport=h2 tls_context=enabled rc=%d status=%d message=%s\n",
+            rc,
+            (int)status.code,
+            SocketGRPC_Status_message (&status));
+    if (opts->client_cert != NULL)
+      printf ("mTLS client cert mode enabled\n");
+    if (rc == SOCKET_GRPC_STATUS_OK)
+      exit_code = 0;
+  }
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  SocketTLSContext_free (&client_tls);
+  Arena_dispose (&arena);
+  return exit_code;
+}
+
+#else
+
+static int
+run_smoke (void)
+{
+  printf ("grpc tls/mtls h2 smoke: SKIPPED (SOCKET_HAS_TLS=0)\n");
+  return 0;
+}
+
+static int
+run_live (const TLSOptions *opts)
+{
+  (void)opts;
+  fprintf (stderr, "TLS support is disabled in this build\n");
+  return 1;
+}
+
+#endif
+
+int
+main (int argc, char **argv)
+{
+  TLSOptions opts;
+  int parse_rc;
+
+  parse_rc = parse_args (argc, argv, &opts);
+  if (parse_rc > 0)
+    return 0;
+  if (parse_rc < 0)
+    return 2;
+
+  if (opts.smoke)
+    return run_smoke ();
+
+  return run_live (&opts);
+}

--- a/examples/grpc/unary_hello_world.c
+++ b/examples/grpc/unary_hello_world.c
@@ -1,0 +1,256 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "grpc/SocketGRPC.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef struct
+{
+  int smoke;
+  int use_h3;
+  int insecure;
+  const char *target;
+  const char *method;
+  const char *message;
+} UnaryOptions;
+
+static void
+usage (const char *prog)
+{
+  printf ("Usage: %s [options]\n", prog);
+  printf ("\n");
+  printf ("Options:\n");
+  printf ("  --smoke             Run deterministic CI smoke path\n");
+  printf ("  --target <url>      gRPC target (example: https://127.0.0.1:50051)\n");
+  printf ("  --method <path>     Full method path (default: /example.Echo/Ping)\n");
+  printf ("  --message <text>    Request payload bytes (default: hello from tetsuo)\n");
+  printf ("  --h3                Use HTTP/3 channel mode\n");
+  printf ("  --insecure          Disable peer verification\n");
+  printf ("  -h, --help          Show this help\n");
+}
+
+static int
+parse_args (int argc, char **argv, UnaryOptions *opts)
+{
+  int i;
+
+  if (opts == NULL)
+    return -1;
+
+  opts->smoke = 0;
+  opts->use_h3 = 0;
+  opts->insecure = 0;
+  opts->target = NULL;
+  opts->method = "/example.Echo/Ping";
+  opts->message = "hello from tetsuo";
+
+  for (i = 1; i < argc; i++)
+    {
+      if (strcmp (argv[i], "--smoke") == 0)
+        {
+          opts->smoke = 1;
+        }
+      else if (strcmp (argv[i], "--h3") == 0)
+        {
+          opts->use_h3 = 1;
+        }
+      else if (strcmp (argv[i], "--insecure") == 0)
+        {
+          opts->insecure = 1;
+        }
+      else if ((strcmp (argv[i], "--target") == 0) && (i + 1 < argc))
+        {
+          opts->target = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--method") == 0) && (i + 1 < argc))
+        {
+          opts->method = argv[++i];
+        }
+      else if ((strcmp (argv[i], "--message") == 0) && (i + 1 < argc))
+        {
+          opts->message = argv[++i];
+        }
+      else if ((strcmp (argv[i], "-h") == 0) || (strcmp (argv[i], "--help") == 0))
+        {
+          usage (argv[0]);
+          return 1;
+        }
+      else
+        {
+          fprintf (stderr, "Unknown argument: %s\n", argv[i]);
+          usage (argv[0]);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+static int
+run_smoke (void)
+{
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketGRPC_Status status;
+  int rc = 1;
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel = SocketGRPC_Channel_new (client, "dns:///grpc-smoke.local", &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  call = SocketGRPC_Call_new (channel, "/example.Echo/Ping", NULL);
+  if (call == NULL)
+    goto cleanup;
+
+  if (SocketGRPC_Call_metadata_add_ascii (call, "x-example-mode", "smoke") != 0)
+    goto cleanup;
+
+  if (SocketGRPC_Call_cancel (call) != 0)
+    goto cleanup;
+
+  status = SocketGRPC_Call_status (call);
+  if (status.code != SOCKET_GRPC_STATUS_CANCELLED)
+    goto cleanup;
+
+  printf ("grpc unary hello-world smoke: PASS\n");
+  rc = 0;
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  return rc;
+}
+
+static int
+run_live (const UnaryOptions *opts)
+{
+  Arena_T arena = NULL;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  const uint8_t *request_payload = NULL;
+  size_t request_payload_len = 0;
+  SocketGRPC_Status status;
+  volatile int rc = -1;
+  volatile int exit_code = 1;
+
+  if (opts == NULL || opts->target == NULL)
+    {
+      fprintf (stderr, "--target is required when not using --smoke\n");
+      return 1;
+    }
+
+  request_payload = (const uint8_t *)opts->message;
+  request_payload_len = strlen (opts->message);
+
+  arena = Arena_new ();
+  if (arena == NULL)
+    {
+      fprintf (stderr, "failed to allocate arena\n");
+      return 1;
+    }
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    {
+      fprintf (stderr, "failed to allocate grpc client\n");
+      goto cleanup;
+    }
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.channel_mode = opts->use_h3 ? SOCKET_GRPC_CHANNEL_MODE_HTTP3
+                                          : SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+  channel_cfg.verify_peer = opts->insecure ? 0 : 1;
+
+  channel = SocketGRPC_Channel_new (client, opts->target, &channel_cfg);
+  if (channel == NULL)
+    {
+      fprintf (stderr, "failed to create channel\n");
+      goto cleanup;
+    }
+
+  call = SocketGRPC_Call_new (channel, opts->method, NULL);
+  if (call == NULL)
+    {
+      fprintf (stderr, "failed to create call\n");
+      goto cleanup;
+    }
+
+  TRY
+    {
+      rc = SocketGRPC_Call_unary_h2 (call,
+                                     request_payload,
+                                     request_payload_len,
+                                     arena,
+                                     &response_payload,
+                                     &response_payload_len);
+    }
+  ELSE
+    {
+      rc = -1;
+    }
+  END_TRY;
+
+  status = SocketGRPC_Call_status (call);
+
+  printf ("transport=%s rc=%d status=%d message=%s\n",
+          opts->use_h3 ? "h3" : "h2",
+          (int)rc,
+          (int)status.code,
+          SocketGRPC_Status_message (&status));
+
+  if (rc == SOCKET_GRPC_STATUS_OK)
+    {
+      printf ("response-bytes=%zu\n", response_payload_len);
+      if (response_payload != NULL && response_payload_len > 0)
+        {
+          printf ("response-text=%.*s\n",
+                  (int)response_payload_len,
+                  (const char *)response_payload);
+        }
+      exit_code = 0;
+    }
+
+cleanup:
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  Arena_dispose (&arena);
+  return exit_code;
+}
+
+int
+main (int argc, char **argv)
+{
+  UnaryOptions opts;
+  int parse_rc;
+
+  parse_rc = parse_args (argc, argv, &opts);
+  if (parse_rc > 0)
+    return 0;
+  if (parse_rc < 0)
+    return 2;
+
+  if (opts.smoke)
+    return run_smoke ();
+
+  return run_live (&opts);
+}

--- a/scripts/grpc-bench/run.sh
+++ b/scripts/grpc-bench/run.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+BUILD_DIR="${REPO_ROOT}/build"
+REPORT=""
+SMOKE=0
+ITERATIONS=""
+WARMUP=""
+
+usage() {
+  cat <<USAGE
+Usage: scripts/grpc-bench/run.sh [options]
+
+Options:
+  --build-dir <path>    CMake build directory (default: ./build)
+  --report <path>       Output JSON report path (default: <build-dir>/grpc-bench-report.json)
+  --smoke               Run quick smoke profile
+  --iterations <n>      Override measured calls per scenario
+  --warmup <n>          Override warmup calls per scenario
+  -h, --help            Show this help
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --build-dir)
+      BUILD_DIR="$2"
+      shift 2
+      ;;
+    --report)
+      REPORT="$2"
+      shift 2
+      ;;
+    --smoke)
+      SMOKE=1
+      shift
+      ;;
+    --iterations)
+      ITERATIONS="$2"
+      shift 2
+      ;;
+    --warmup)
+      WARMUP="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -d "${BUILD_DIR}" ]; then
+  BUILD_DIR="$(cd "${BUILD_DIR}" && pwd)"
+else
+  BUILD_DIR="$(cd "$(dirname "${BUILD_DIR}")" && pwd)/$(basename "${BUILD_DIR}")"
+fi
+
+BENCH_BIN="${BUILD_DIR}/benchmark_grpc_transport"
+if [ ! -x "${BENCH_BIN}" ]; then
+  echo "Benchmark binary not found/executable: ${BENCH_BIN}" >&2
+  echo "Build first: cmake --build ${BUILD_DIR} --parallel \$(nproc)" >&2
+  exit 2
+fi
+
+if [ -z "${REPORT}" ]; then
+  REPORT="${BUILD_DIR}/grpc-bench-report.json"
+fi
+
+CMD=("${BENCH_BIN}" "--report" "${REPORT}")
+
+if [ "${SMOKE}" -eq 1 ]; then
+  CMD+=("--smoke")
+fi
+if [ -n "${ITERATIONS}" ]; then
+  CMD+=("--iterations" "${ITERATIONS}")
+fi
+if [ -n "${WARMUP}" ]; then
+  CMD+=("--warmup" "${WARMUP}")
+fi
+
+echo "Running gRPC transport benchmark"
+printf 'Command:'
+printf ' %q' "${CMD[@]}"
+echo
+
+BENCH_ASAN_OPTIONS="${ASAN_OPTIONS:-}"
+if [ -n "${BENCH_ASAN_OPTIONS}" ]; then
+  BENCH_ASAN_OPTIONS="detect_leaks=0:${BENCH_ASAN_OPTIONS}"
+else
+  BENCH_ASAN_OPTIONS="detect_leaks=0"
+fi
+
+ASAN_OPTIONS="${BENCH_ASAN_OPTIONS}" "${CMD[@]}"
+
+echo "Benchmark report: ${REPORT}"

--- a/scripts/local_ci.sh
+++ b/scripts/local_ci.sh
@@ -134,11 +134,20 @@ run_build_debug() {
     cd "$build_dir"
     ctest --output-on-failure --parallel "$NPROC" || return 1
 
+    log_info "Running gRPC example smoke tests..."
+    ctest --output-on-failure -R "grpc_example_.*_smoke" || return 1
+
     log_info "Running gRPC core conformance matrix..."
     "$PROJECT_ROOT/scripts/grpc-interop/run.sh" \
         --profile core \
         --build-dir "$build_dir" \
         --report "$build_dir/grpc-interop-core-debug.json" || return 1
+
+    log_info "Running gRPC benchmark smoke report..."
+    "$PROJECT_ROOT/scripts/grpc-bench/run.sh" \
+        --build-dir "$build_dir" \
+        --smoke \
+        --report "$build_dir/grpc-bench-debug.json" || return 1
     
     return 0
 }
@@ -162,11 +171,20 @@ run_build_release() {
     cd "$build_dir"
     ctest --output-on-failure --parallel "$NPROC" || return 1
 
+    log_info "Running gRPC example smoke tests..."
+    ctest --output-on-failure -R "grpc_example_.*_smoke" || return 1
+
     log_info "Running gRPC core conformance matrix..."
     "$PROJECT_ROOT/scripts/grpc-interop/run.sh" \
         --profile core \
         --build-dir "$build_dir" \
         --report "$build_dir/grpc-interop-core-release.json" || return 1
+
+    log_info "Running gRPC benchmark smoke report..."
+    "$PROJECT_ROOT/scripts/grpc-bench/run.sh" \
+        --build-dir "$build_dir" \
+        --smoke \
+        --report "$build_dir/grpc-bench-release.json" || return 1
     
     return 0
 }

--- a/src/test/benchmark_grpc_transport.c
+++ b/src/test/benchmark_grpc_transport.c
@@ -1,0 +1,1227 @@
+/*
+ * SPDX-License-Identifier: MIT
+ */
+
+#include "core/Arena.h"
+#include "core/Except.h"
+#include "grpc/SocketGRPC.h"
+
+#if SOCKET_HAS_TLS
+#include "http/SocketHTTP3-server.h"
+#include "http/SocketHTTPServer.h"
+#include "tls/SocketTLSContext.h"
+#endif
+
+#include <errno.h>
+#include <pthread.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/utsname.h>
+#include <time.h>
+#include <unistd.h>
+
+#define BENCH_DEFAULT_ITERATIONS 200
+#define BENCH_DEFAULT_WARMUP 20
+#define BENCH_SMOKE_ITERATIONS 20
+#define BENCH_SMOKE_WARMUP 3
+#define BENCH_MAX_SCENARIOS 16
+#define BENCH_STATUS_LEN 16
+#define BENCH_NOTE_LEN 160
+#define BENCH_CERT_PATH_CAP 256
+#define BENCH_TARGET_CAP 160
+#define BENCH_METHOD "/bench.Echo/Ping"
+#define BENCH_H2_PORT_BASE 55100
+#define BENCH_H3_PORT_BASE 56100
+#define BENCH_SERVER_POLL_MS 20
+
+typedef struct
+{
+  int iterations;
+  int warmup;
+  int smoke;
+  const char *report_path;
+} BenchConfig;
+
+typedef struct
+{
+  const char *id;
+  SocketGRPC_ChannelMode mode;
+  size_t payload_bytes;
+  int request_compression;
+} BenchScenario;
+
+typedef struct
+{
+  BenchScenario spec;
+  char status[BENCH_STATUS_LEN];
+  char note[BENCH_NOTE_LEN];
+  int iterations;
+  int warmup;
+  int successes;
+  double avg_ms;
+  double p50_ms;
+  double p95_ms;
+  double p99_ms;
+  double throughput_rps;
+} BenchResult;
+
+#if SOCKET_HAS_TLS
+typedef struct
+{
+  SocketHTTPServer_T http2_server;
+  SocketHTTP3_Server_T http3_server;
+  SocketGRPC_Server_T grpc_server;
+  SocketTLSContext_T server_tls;
+  Arena_T arena;
+  pthread_t thread;
+  volatile int running;
+  volatile int started;
+  int use_h3;
+  int port;
+  char cert_path[BENCH_CERT_PATH_CAP];
+  char key_path[BENCH_CERT_PATH_CAP];
+} BenchFixture;
+#endif
+
+static int
+parse_positive_int (const char *value, int min_value, int max_value, int *out)
+{
+  char *end = NULL;
+  long parsed;
+
+  if (value == NULL || out == NULL)
+    return -1;
+
+  errno = 0;
+  parsed = strtol (value, &end, 10);
+  if (errno != 0 || end == value || end == NULL || *end != '\0')
+    return -1;
+  if (parsed < min_value || parsed > max_value)
+    return -1;
+
+  *out = (int)parsed;
+  return 0;
+}
+
+static void
+usage (const char *prog)
+{
+  printf ("Usage: %s [options]\n", prog);
+  printf ("\n");
+  printf ("Options:\n");
+  printf ("  --iterations <n>   Measured calls per scenario (default: %d)\n",
+          BENCH_DEFAULT_ITERATIONS);
+  printf ("  --warmup <n>       Warmup calls per scenario (default: %d)\n",
+          BENCH_DEFAULT_WARMUP);
+  printf ("  --smoke            CI smoke profile (%d iterations)\n",
+          BENCH_SMOKE_ITERATIONS);
+  printf ("  --report <path>    Write JSON report to file (default: stdout)\n");
+  printf ("  -h, --help         Show this help\n");
+}
+
+static int
+parse_args (int argc, char **argv, BenchConfig *cfg)
+{
+  int i;
+
+  if (cfg == NULL)
+    return -1;
+
+  cfg->iterations = BENCH_DEFAULT_ITERATIONS;
+  cfg->warmup = BENCH_DEFAULT_WARMUP;
+  cfg->smoke = 0;
+  cfg->report_path = NULL;
+
+  for (i = 1; i < argc; i++)
+    {
+      if (strcmp (argv[i], "--smoke") == 0)
+        {
+          cfg->smoke = 1;
+          cfg->iterations = BENCH_SMOKE_ITERATIONS;
+          cfg->warmup = BENCH_SMOKE_WARMUP;
+        }
+      else if ((strcmp (argv[i], "--iterations") == 0) && (i + 1 < argc))
+        {
+          if (parse_positive_int (argv[++i], 1, 100000, &cfg->iterations) != 0)
+            {
+              fprintf (stderr, "Invalid --iterations value\n");
+              return -1;
+            }
+        }
+      else if ((strcmp (argv[i], "--warmup") == 0) && (i + 1 < argc))
+        {
+          if (parse_positive_int (argv[++i], 0, 100000, &cfg->warmup) != 0)
+            {
+              fprintf (stderr, "Invalid --warmup value\n");
+              return -1;
+            }
+        }
+      else if ((strcmp (argv[i], "--report") == 0) && (i + 1 < argc))
+        {
+          cfg->report_path = argv[++i];
+        }
+      else if ((strcmp (argv[i], "-h") == 0) || (strcmp (argv[i], "--help") == 0))
+        {
+          usage (argv[0]);
+          return 1;
+        }
+      else
+        {
+          fprintf (stderr, "Unknown argument: %s\n", argv[i]);
+          usage (argv[0]);
+          return -1;
+        }
+    }
+
+  return 0;
+}
+
+static int64_t
+now_ns (void)
+{
+  struct timespec ts;
+
+  if (clock_gettime (CLOCK_MONOTONIC, &ts) != 0)
+    return 0;
+  return ((int64_t)ts.tv_sec * 1000000000LL) + ts.tv_nsec;
+}
+
+static int
+double_compare (const void *a, const void *b)
+{
+  double da = *(const double *)a;
+  double db = *(const double *)b;
+  if (da < db)
+    return -1;
+  if (da > db)
+    return 1;
+  return 0;
+}
+
+static double
+percentile (double *values, size_t count, double pct)
+{
+  double pos;
+  size_t idx;
+
+  if (values == NULL || count == 0)
+    return 0.0;
+  if (pct <= 0.0)
+    return values[0];
+  if (pct >= 100.0)
+    return values[count - 1U];
+
+  pos = (pct / 100.0) * (double)(count - 1U);
+  idx = (size_t)pos;
+  return values[idx];
+}
+
+static void
+json_print_string (FILE *out, const char *value)
+{
+  const unsigned char *p;
+
+  if (out == NULL)
+    return;
+
+  fputc ('"', out);
+  if (value != NULL)
+    {
+      for (p = (const unsigned char *)value; *p != '\0'; p++)
+        {
+          if (*p == '\\' || *p == '"')
+            {
+              fputc ('\\', out);
+              fputc ((int)*p, out);
+            }
+          else if (*p == '\n')
+            {
+              fputs ("\\n", out);
+            }
+          else if (*p < 0x20)
+            {
+              fputc (' ', out);
+            }
+          else
+            {
+              fputc ((int)*p, out);
+            }
+        }
+    }
+  fputc ('"', out);
+}
+
+static void
+iso8601_now_utc (char *out, size_t out_cap)
+{
+  time_t now;
+  struct tm tm_utc;
+
+  if (out == NULL || out_cap == 0)
+    return;
+
+  now = time (NULL);
+  gmtime_r (&now, &tm_utc);
+  strftime (out, out_cap, "%Y-%m-%dT%H:%M:%SZ", &tm_utc);
+}
+
+#if SOCKET_HAS_TLS
+
+static int
+next_h2_port (void)
+{
+  static int counter = 0;
+  int port = BENCH_H2_PORT_BASE + (counter % 800);
+  counter++;
+  return port;
+}
+
+static int
+next_h3_port (void)
+{
+  static int counter = 0;
+  int port = BENCH_H3_PORT_BASE + (counter % 800);
+  counter++;
+  return port;
+}
+
+static int
+create_temp_cert_files (char *cert_path,
+                        size_t cert_cap,
+                        char *key_path,
+                        size_t key_cap)
+{
+  static int serial = 0;
+  char cmd[1024];
+
+  if (cert_path == NULL || key_path == NULL)
+    return -1;
+
+  snprintf (cert_path,
+            cert_cap,
+            "/tmp/grpc_bench_cert_%d_%d.pem",
+            (int)getpid (),
+            serial);
+  snprintf (key_path,
+            key_cap,
+            "/tmp/grpc_bench_key_%d_%d.pem",
+            (int)getpid (),
+            serial);
+  serial++;
+
+  snprintf (cmd,
+            sizeof (cmd),
+            "openssl req -x509 -newkey rsa:2048 -nodes -sha256 "
+            "-days 1 -subj /CN=127.0.0.1 "
+            "-addext subjectAltName=IP:127.0.0.1 "
+            "-keyout %s -out %s >/dev/null 2>&1",
+            key_path,
+            cert_path);
+
+  if (system (cmd) != 0)
+    {
+      unlink (cert_path);
+      unlink (key_path);
+      return -1;
+    }
+
+  return 0;
+}
+
+static void
+remove_temp_cert_files (BenchFixture *fixture)
+{
+  if (fixture == NULL)
+    return;
+  if (fixture->cert_path[0] != '\0')
+    unlink (fixture->cert_path);
+  if (fixture->key_path[0] != '\0')
+    unlink (fixture->key_path);
+  fixture->cert_path[0] = '\0';
+  fixture->key_path[0] = '\0';
+}
+
+static int
+grpc_echo_handler (SocketGRPC_ServerContext_T ctx,
+                   const uint8_t *request_payload,
+                   size_t request_payload_len,
+                   Arena_T arena,
+                   uint8_t **response_payload,
+                   size_t *response_payload_len,
+                   void *userdata)
+{
+  uint8_t *copy;
+
+  (void)ctx;
+  (void)userdata;
+
+  if (arena == NULL || response_payload == NULL || response_payload_len == NULL)
+    return SOCKET_GRPC_STATUS_INTERNAL;
+
+  *response_payload = NULL;
+  *response_payload_len = 0;
+
+  if (request_payload == NULL || request_payload_len == 0)
+    return SOCKET_GRPC_STATUS_OK;
+
+  copy = ALLOC (arena, request_payload_len);
+  if (copy == NULL)
+    return SOCKET_GRPC_STATUS_RESOURCE_EXHAUSTED;
+
+  memcpy (copy, request_payload, request_payload_len);
+  *response_payload = copy;
+  *response_payload_len = request_payload_len;
+  return SOCKET_GRPC_STATUS_OK;
+}
+
+static void *
+fixture_h2_thread_main (void *arg)
+{
+  BenchFixture *fixture = (BenchFixture *)arg;
+
+  if (fixture == NULL || fixture->http2_server == NULL)
+    return NULL;
+
+  fixture->started = 1;
+  while (fixture->running)
+    SocketHTTPServer_process (fixture->http2_server, BENCH_SERVER_POLL_MS);
+
+  return NULL;
+}
+
+static void *
+fixture_h3_thread_main (void *arg)
+{
+  BenchFixture *fixture = (BenchFixture *)arg;
+
+  if (fixture == NULL || fixture->http3_server == NULL)
+    return NULL;
+
+  if (SocketHTTP3_Server_start (fixture->http3_server) != 0)
+    {
+      fixture->started = -1;
+      fixture->running = 0;
+      return NULL;
+    }
+
+  fixture->started = 1;
+  while (fixture->running)
+    SocketHTTP3_Server_poll (fixture->http3_server, BENCH_SERVER_POLL_MS);
+
+  return NULL;
+}
+
+static void
+fixture_stop (BenchFixture *fixture)
+{
+  if (fixture == NULL)
+    return;
+
+  if (fixture->grpc_server != NULL)
+    SocketGRPC_Server_begin_shutdown (fixture->grpc_server);
+
+  if (fixture->running)
+    {
+      fixture->running = 0;
+      if (!fixture->use_h3)
+        {
+          if (fixture->http2_server != NULL)
+            SocketHTTPServer_stop (fixture->http2_server);
+        }
+      pthread_join (fixture->thread, NULL);
+    }
+
+  SocketHTTPServer_free (&fixture->http2_server);
+  if (fixture->http3_server != NULL)
+    {
+      SocketHTTP3_Server_close (fixture->http3_server);
+      fixture->http3_server = NULL;
+    }
+  SocketGRPC_Server_free (&fixture->grpc_server);
+  SocketTLSContext_free (&fixture->server_tls);
+  Arena_dispose (&fixture->arena);
+  remove_temp_cert_files (fixture);
+}
+
+static int
+fixture_start_h2 (BenchFixture *fixture)
+{
+  SocketHTTPServer_Config cfg;
+  volatile int retries;
+  volatile int started = 0;
+
+  if (fixture == NULL)
+    return -1;
+
+  memset (fixture, 0, sizeof (*fixture));
+
+  if (create_temp_cert_files (fixture->cert_path,
+                              sizeof (fixture->cert_path),
+                              fixture->key_path,
+                              sizeof (fixture->key_path))
+      != 0)
+    {
+      return -1;
+    }
+
+  TRY
+    {
+      const char *alpn[2] = { "h2", "http/1.1" };
+      fixture->server_tls
+          = SocketTLSContext_new_server (fixture->cert_path, fixture->key_path, NULL);
+      SocketTLSContext_set_alpn_protos (fixture->server_tls, alpn, 2);
+    }
+  EXCEPT (SocketTLS_Failed)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+  END_TRY;
+
+  fixture->grpc_server = SocketGRPC_Server_new (NULL);
+  if (fixture->grpc_server == NULL)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  if (SocketGRPC_Server_register_unary (
+          fixture->grpc_server, BENCH_METHOD, grpc_echo_handler, NULL)
+      != 0)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  for (retries = 0; retries < 10 && !started; retries++)
+    {
+      fixture->port = next_h2_port ();
+      SocketHTTPServer_config_defaults (&cfg);
+      cfg.bind_address = "127.0.0.1";
+      cfg.port = fixture->port;
+      cfg.max_version = HTTP_VERSION_2;
+      cfg.tls_context = fixture->server_tls;
+
+      TRY
+        {
+          fixture->http2_server = SocketHTTPServer_new (&cfg);
+          if (fixture->http2_server != NULL)
+            {
+              SocketGRPC_Server_bind_http2 (fixture->grpc_server,
+                                            fixture->http2_server);
+              if (SocketHTTPServer_start (fixture->http2_server) == 0)
+                started = 1;
+              else
+                SocketHTTPServer_free (&fixture->http2_server);
+            }
+        }
+      EXCEPT (SocketHTTPServer_Failed)
+        {
+          SocketHTTPServer_free (&fixture->http2_server);
+        }
+      EXCEPT (Socket_Failed)
+        {
+          SocketHTTPServer_free (&fixture->http2_server);
+        }
+      END_TRY;
+
+      if (!started)
+        usleep (10000);
+    }
+
+  if (!started)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  fixture->use_h3 = 0;
+  fixture->running = 1;
+  if (pthread_create (&fixture->thread, NULL, fixture_h2_thread_main, fixture)
+      != 0)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  while (!fixture->started)
+    usleep (1000);
+  usleep (30000);
+  return 0;
+}
+
+static int
+fixture_start_h3 (BenchFixture *fixture)
+{
+  SocketHTTP3_ServerConfig cfg;
+
+  if (fixture == NULL)
+    return -1;
+
+  memset (fixture, 0, sizeof (*fixture));
+
+  if (create_temp_cert_files (fixture->cert_path,
+                              sizeof (fixture->cert_path),
+                              fixture->key_path,
+                              sizeof (fixture->key_path))
+      != 0)
+    {
+      return -1;
+    }
+
+  fixture->arena = Arena_new ();
+  if (fixture->arena == NULL)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  fixture->grpc_server = SocketGRPC_Server_new (NULL);
+  if (fixture->grpc_server == NULL)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  if (SocketGRPC_Server_register_unary (
+          fixture->grpc_server, BENCH_METHOD, grpc_echo_handler, NULL)
+      != 0)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  SocketHTTP3_ServerConfig_defaults (&cfg);
+  cfg.bind_addr = "127.0.0.1";
+  cfg.port = next_h3_port ();
+  cfg.cert_file = fixture->cert_path;
+  cfg.key_file = fixture->key_path;
+
+  fixture->port = cfg.port;
+  fixture->http3_server = SocketHTTP3_Server_new (fixture->arena, &cfg);
+  if (fixture->http3_server == NULL)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  SocketGRPC_Server_bind_http3 (fixture->grpc_server, fixture->http3_server);
+
+  fixture->use_h3 = 1;
+  fixture->running = 1;
+  fixture->started = 0;
+
+  if (pthread_create (&fixture->thread, NULL, fixture_h3_thread_main, fixture)
+      != 0)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  while (fixture->running && fixture->started == 0)
+    usleep (1000);
+
+  if (fixture->started < 0)
+    {
+      fixture_stop (fixture);
+      return -1;
+    }
+
+  usleep (30000);
+  return 0;
+}
+
+static int
+run_single_unary (const BenchScenario *scenario,
+                  const BenchFixture *fixture,
+                  const uint8_t *request_payload,
+                  size_t request_payload_len,
+                  double *latency_ms_out,
+                  SocketGRPC_Status *status_out)
+{
+  Arena_T arena = NULL;
+  SocketGRPC_Client_T client = NULL;
+  SocketGRPC_Channel_T channel = NULL;
+  SocketGRPC_Call_T call = NULL;
+  SocketGRPC_ChannelConfig channel_cfg;
+  SocketGRPC_CallConfig call_cfg;
+  SocketTLSContext_T client_tls = NULL;
+  uint8_t *response_payload = NULL;
+  size_t response_payload_len = 0;
+  char target[BENCH_TARGET_CAP];
+  int64_t started_ns = 0;
+  int64_t ended_ns = 0;
+  volatile int rc = -1;
+  SocketGRPC_Status status = { SOCKET_GRPC_STATUS_INTERNAL,
+                               "call not started" };
+
+  if (scenario == NULL || fixture == NULL || request_payload == NULL
+      || request_payload_len == 0)
+    {
+      return -1;
+    }
+
+  if (status_out != NULL)
+    {
+      status_out->code = SOCKET_GRPC_STATUS_INTERNAL;
+      status_out->message = "invalid arguments";
+    }
+  if (latency_ms_out != NULL)
+    *latency_ms_out = 0.0;
+
+  arena = Arena_new ();
+  if (arena == NULL)
+    goto cleanup;
+
+  client = SocketGRPC_Client_new (NULL);
+  if (client == NULL)
+    goto cleanup;
+
+  SocketGRPC_ChannelConfig_defaults (&channel_cfg);
+  channel_cfg.channel_mode = scenario->mode;
+  channel_cfg.verify_peer = 1;
+  channel_cfg.enable_request_compression = scenario->request_compression;
+  channel_cfg.enable_response_decompression = 1;
+
+  if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP2)
+    {
+      TRY
+        {
+          client_tls = SocketTLSContext_new_client (fixture->cert_path);
+        }
+      EXCEPT (SocketTLS_Failed)
+        {
+          goto cleanup;
+        }
+      END_TRY;
+      channel_cfg.tls_context = client_tls;
+    }
+  else
+    {
+      channel_cfg.ca_file = fixture->cert_path;
+    }
+
+  snprintf (target, sizeof (target), "https://127.0.0.1:%d", fixture->port);
+  channel = SocketGRPC_Channel_new (client, target, &channel_cfg);
+  if (channel == NULL)
+    goto cleanup;
+
+  SocketGRPC_CallConfig_defaults (&call_cfg);
+  call_cfg.deadline_ms = 2000;
+  call = SocketGRPC_Call_new (channel, BENCH_METHOD, &call_cfg);
+  if (call == NULL)
+    goto cleanup;
+
+  started_ns = now_ns ();
+  TRY
+    {
+      rc = SocketGRPC_Call_unary_h2 (call,
+                                     request_payload,
+                                     request_payload_len,
+                                     arena,
+                                     &response_payload,
+                                     &response_payload_len);
+    }
+  ELSE
+    {
+      rc = -1;
+    }
+  END_TRY;
+  ended_ns = now_ns ();
+
+  status = SocketGRPC_Call_status (call);
+
+  if (latency_ms_out != NULL && started_ns > 0 && ended_ns >= started_ns)
+    {
+      *latency_ms_out = (double)(ended_ns - started_ns) / 1000000.0;
+    }
+
+  if (rc == SOCKET_GRPC_STATUS_OK)
+    {
+      if (response_payload == NULL || response_payload_len != request_payload_len)
+        {
+          status.code = SOCKET_GRPC_STATUS_INTERNAL;
+          status.message = "response payload mismatch";
+          rc = SOCKET_GRPC_STATUS_INTERNAL;
+        }
+      else if (memcmp (response_payload, request_payload, request_payload_len) != 0)
+        {
+          status.code = SOCKET_GRPC_STATUS_INTERNAL;
+          status.message = "response payload differs";
+          rc = SOCKET_GRPC_STATUS_INTERNAL;
+        }
+    }
+
+cleanup:
+  if (status_out != NULL)
+    *status_out = status;
+
+  SocketGRPC_Call_free (&call);
+  SocketGRPC_Channel_free (&channel);
+  SocketGRPC_Client_free (&client);
+  SocketTLSContext_free (&client_tls);
+  Arena_dispose (&arena);
+
+  return (int)rc;
+}
+
+static void
+set_result_status (BenchResult *result, const char *status, const char *note)
+{
+  if (result == NULL)
+    return;
+
+  if (status == NULL)
+    status = "error";
+  if (note == NULL)
+    note = "";
+
+  snprintf (result->status, sizeof (result->status), "%s", status);
+  snprintf (result->note, sizeof (result->note), "%s", note);
+}
+
+static void
+run_scenario (const BenchScenario *scenario,
+              const BenchConfig *cfg,
+              BenchResult *result)
+{
+  BenchFixture fixture;
+  uint8_t *payload = NULL;
+  double *latencies = NULL;
+  int i;
+  double sum_ms = 0.0;
+  int started = 0;
+
+  if (scenario == NULL || cfg == NULL || result == NULL)
+    return;
+
+  memset (&fixture, 0, sizeof (fixture));
+  memset (result, 0, sizeof (*result));
+  result->spec = *scenario;
+  result->iterations = cfg->iterations;
+  result->warmup = cfg->warmup;
+  set_result_status (result, "error", "not executed");
+
+  if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP3
+      && scenario->request_compression)
+    {
+      set_result_status (result,
+                         "unsupported",
+                         "request compression over HTTP/3 is unsupported");
+      return;
+    }
+
+  if (cfg->smoke && scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP2
+      && scenario->request_compression)
+    {
+      set_result_status (
+          result, "skipped", "smoke profile skips HTTP/2 compression stress case");
+      return;
+    }
+
+  payload = (uint8_t *)malloc (scenario->payload_bytes);
+  if (payload == NULL)
+    {
+      set_result_status (result, "error", "failed to allocate payload");
+      return;
+    }
+
+  for (i = 0; i < (int)scenario->payload_bytes; i++)
+    payload[i] = (uint8_t)(i & 0xff);
+
+  if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP2)
+    started = (fixture_start_h2 (&fixture) == 0);
+  else
+    started = (fixture_start_h3 (&fixture) == 0);
+
+  if (!started)
+    {
+      if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP3)
+        set_result_status (
+            result, "skipped", "HTTP/3 runtime unavailable in this environment");
+      else
+        set_result_status (result, "error", "failed to start HTTP/2 fixture");
+      goto cleanup;
+    }
+
+  for (i = 0; i < cfg->warmup; i++)
+    {
+      SocketGRPC_Status warm_status;
+      double warm_latency_ms = 0.0;
+      int warm_rc = run_single_unary (scenario,
+                                      &fixture,
+                                      payload,
+                                      scenario->payload_bytes,
+                                      &warm_latency_ms,
+                                      &warm_status);
+      if (warm_rc != SOCKET_GRPC_STATUS_OK)
+        {
+          if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP3
+              && warm_status.code == SOCKET_GRPC_STATUS_UNAVAILABLE)
+            {
+              set_result_status (
+                  result,
+                  "skipped",
+                  "HTTP/3 transport unavailable during warmup");
+            }
+          else if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP2
+                   && scenario->request_compression)
+            {
+              set_result_status (
+                  result,
+                  "skipped",
+                  "HTTP/2 request compression unavailable in this runtime");
+            }
+          else
+            {
+              set_result_status (result,
+                                 "error",
+                                 SocketGRPC_Status_message (&warm_status));
+            }
+          goto cleanup;
+        }
+    }
+
+  latencies = (double *)malloc (sizeof (double) * (size_t)cfg->iterations);
+  if (latencies == NULL)
+    {
+      set_result_status (result, "error", "failed to allocate latency array");
+      goto cleanup;
+    }
+
+  for (i = 0; i < cfg->iterations; i++)
+    {
+      SocketGRPC_Status status;
+      double latency_ms = 0.0;
+      int rc = run_single_unary (scenario,
+                                 &fixture,
+                                 payload,
+                                 scenario->payload_bytes,
+                                 &latency_ms,
+                                 &status);
+
+      if (rc != SOCKET_GRPC_STATUS_OK)
+        {
+          if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP3
+              && status.code == SOCKET_GRPC_STATUS_UNAVAILABLE)
+            {
+              set_result_status (
+                  result,
+                  "skipped",
+                  "HTTP/3 transport unavailable during measured run");
+            }
+          else if (scenario->mode == SOCKET_GRPC_CHANNEL_MODE_HTTP2
+                   && scenario->request_compression)
+            {
+              set_result_status (
+                  result,
+                  "skipped",
+                  "HTTP/2 request compression unavailable in this runtime");
+            }
+          else
+            {
+              set_result_status (result,
+                                 "error",
+                                 SocketGRPC_Status_message (&status));
+            }
+          goto cleanup;
+        }
+
+      latencies[i] = latency_ms;
+      sum_ms += latency_ms;
+      result->successes++;
+    }
+
+  qsort (latencies, (size_t)result->successes, sizeof (double), double_compare);
+
+  if (result->successes > 0)
+    {
+      result->avg_ms = sum_ms / (double)result->successes;
+      result->p50_ms = percentile (latencies, (size_t)result->successes, 50.0);
+      result->p95_ms = percentile (latencies, (size_t)result->successes, 95.0);
+      result->p99_ms = percentile (latencies, (size_t)result->successes, 99.0);
+      if (sum_ms > 0.0)
+        result->throughput_rps
+            = ((double)result->successes / sum_ms) * 1000.0;
+    }
+
+  set_result_status (result, "ok", "");
+
+cleanup:
+  fixture_stop (&fixture);
+  free (payload);
+  free (latencies);
+}
+
+static int
+build_scenarios (const BenchConfig *cfg,
+                 BenchScenario *out,
+                 size_t out_cap,
+                 size_t *out_count)
+{
+  size_t payload_sizes[3];
+  size_t payload_count = 0;
+  size_t count = 0;
+  size_t i;
+
+  if (cfg == NULL || out == NULL || out_count == NULL)
+    return -1;
+
+  if (cfg->smoke)
+    {
+      payload_sizes[0] = 128;
+      payload_sizes[1] = 4096;
+      payload_count = 2;
+    }
+  else
+    {
+      payload_sizes[0] = 128;
+      payload_sizes[1] = 4096;
+      payload_sizes[2] = 65536;
+      payload_count = 3;
+    }
+
+  for (i = 0; i < payload_count; i++)
+    {
+      if (count >= out_cap)
+        return -1;
+      out[count].id = "h2_unary";
+      out[count].mode = SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+      out[count].payload_bytes = payload_sizes[i];
+      out[count].request_compression = 0;
+      count++;
+    }
+
+  if (count + 2 > out_cap)
+    return -1;
+  out[count].id = "h2_compression";
+  out[count].mode = SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+  out[count].payload_bytes = 4096;
+  out[count].request_compression = 1;
+  count++;
+
+  for (i = 0; i < payload_count; i++)
+    {
+      if (count >= out_cap)
+        return -1;
+      out[count].id = "h3_unary";
+      out[count].mode = SOCKET_GRPC_CHANNEL_MODE_HTTP3;
+      out[count].payload_bytes = payload_sizes[i];
+      out[count].request_compression = 0;
+      count++;
+    }
+
+  if (count >= out_cap)
+    return -1;
+  out[count].id = "h3_compression";
+  out[count].mode = SOCKET_GRPC_CHANNEL_MODE_HTTP3;
+  out[count].payload_bytes = 4096;
+  out[count].request_compression = 1;
+  count++;
+
+  *out_count = count;
+  return 0;
+}
+
+#endif /* SOCKET_HAS_TLS */
+
+static void
+write_report (FILE *out,
+              const BenchConfig *cfg,
+              const BenchResult *results,
+              size_t result_count)
+{
+  struct utsname sys;
+  char timestamp[40];
+  char host[128] = "unknown";
+  long cpus = sysconf (_SC_NPROCESSORS_ONLN);
+  size_t i;
+  int ok_count = 0;
+  int skipped_count = 0;
+  int unsupported_count = 0;
+  int error_count = 0;
+
+  if (out == NULL || cfg == NULL)
+    return;
+
+  memset (&sys, 0, sizeof (sys));
+  (void)uname (&sys);
+  (void)gethostname (host, sizeof (host) - 1U);
+  host[sizeof (host) - 1U] = '\0';
+  iso8601_now_utc (timestamp, sizeof (timestamp));
+
+  for (i = 0; i < result_count; i++)
+    {
+      if (strcmp (results[i].status, "ok") == 0)
+        ok_count++;
+      else if (strcmp (results[i].status, "skipped") == 0)
+        skipped_count++;
+      else if (strcmp (results[i].status, "unsupported") == 0)
+        unsupported_count++;
+      else
+        error_count++;
+    }
+
+  fprintf (out, "{\n");
+  fprintf (out, "  \"profile\": ");
+  json_print_string (out, cfg->smoke ? "smoke" : "full");
+  fprintf (out, ",\n");
+  fprintf (out, "  \"generated_at\": ");
+  json_print_string (out, timestamp);
+  fprintf (out, ",\n");
+  fprintf (out, "  \"environment\": {\n");
+  fprintf (out, "    \"hostname\": ");
+  json_print_string (out, host);
+  fprintf (out, ",\n");
+  fprintf (out, "    \"sysname\": ");
+  json_print_string (out, sys.sysname[0] ? sys.sysname : "unknown");
+  fprintf (out, ",\n");
+  fprintf (out, "    \"release\": ");
+  json_print_string (out, sys.release[0] ? sys.release : "unknown");
+  fprintf (out, ",\n");
+  fprintf (out, "    \"machine\": ");
+  json_print_string (out, sys.machine[0] ? sys.machine : "unknown");
+  fprintf (out, ",\n");
+  fprintf (out, "    \"cpu_count\": %ld,\n", cpus > 0 ? cpus : 1);
+  fprintf (out, "    \"tls_enabled\": %d\n", (int)SOCKET_HAS_TLS);
+  fprintf (out, "  },\n");
+  fprintf (out, "  \"config\": {\n");
+  fprintf (out, "    \"iterations\": %d,\n", cfg->iterations);
+  fprintf (out, "    \"warmup\": %d\n", cfg->warmup);
+  fprintf (out, "  },\n");
+  fprintf (out, "  \"summary\": {\n");
+  fprintf (out, "    \"total\": %zu,\n", result_count);
+  fprintf (out, "    \"ok\": %d,\n", ok_count);
+  fprintf (out, "    \"skipped\": %d,\n", skipped_count);
+  fprintf (out, "    \"unsupported\": %d,\n", unsupported_count);
+  fprintf (out, "    \"error\": %d\n", error_count);
+  fprintf (out, "  },\n");
+  fprintf (out, "  \"results\": [\n");
+
+  for (i = 0; i < result_count; i++)
+    {
+      const BenchResult *r = &results[i];
+      fprintf (out, "    {\n");
+      fprintf (out, "      \"id\": ");
+      json_print_string (out, r->spec.id);
+      fprintf (out, ",\n");
+      fprintf (out, "      \"transport\": ");
+      json_print_string (
+          out,
+          (r->spec.mode == SOCKET_GRPC_CHANNEL_MODE_HTTP3) ? "http3" : "http2");
+      fprintf (out, ",\n");
+      fprintf (out, "      \"payload_bytes\": %zu,\n", r->spec.payload_bytes);
+      fprintf (out,
+               "      \"request_compression\": %s,\n",
+               r->spec.request_compression ? "true" : "false");
+      fprintf (out, "      \"status\": ");
+      json_print_string (out, r->status);
+      fprintf (out, ",\n");
+      fprintf (out, "      \"note\": ");
+      json_print_string (out, r->note);
+      fprintf (out, ",\n");
+      fprintf (out, "      \"iterations\": %d,\n", r->iterations);
+      fprintf (out, "      \"warmup\": %d,\n", r->warmup);
+      fprintf (out, "      \"successes\": %d,\n", r->successes);
+      fprintf (out, "      \"avg_latency_ms\": %.6f,\n", r->avg_ms);
+      fprintf (out, "      \"p50_latency_ms\": %.6f,\n", r->p50_ms);
+      fprintf (out, "      \"p95_latency_ms\": %.6f,\n", r->p95_ms);
+      fprintf (out, "      \"p99_latency_ms\": %.6f,\n", r->p99_ms);
+      fprintf (out, "      \"throughput_rps\": %.3f\n", r->throughput_rps);
+      fprintf (out, "    }%s\n", (i + 1U < result_count) ? "," : "");
+    }
+
+  fprintf (out, "  ]\n");
+  fprintf (out, "}\n");
+}
+
+int
+main (int argc, char **argv)
+{
+  BenchConfig cfg;
+  int parse_rc;
+  FILE *report = stdout;
+  int exit_code = 0;
+
+  parse_rc = parse_args (argc, argv, &cfg);
+  if (parse_rc > 0)
+    return 0;
+  if (parse_rc < 0)
+    return 2;
+
+#if SOCKET_HAS_TLS
+  {
+    BenchScenario scenarios[BENCH_MAX_SCENARIOS];
+    BenchResult results[BENCH_MAX_SCENARIOS];
+    size_t scenario_count = 0;
+    size_t i;
+
+    if (build_scenarios (&cfg,
+                         scenarios,
+                         sizeof (scenarios) / sizeof (scenarios[0]),
+                         &scenario_count)
+        != 0)
+      {
+        fprintf (stderr, "failed to build scenario matrix\n");
+        return 1;
+      }
+
+    for (i = 0; i < scenario_count; i++)
+      {
+        run_scenario (&scenarios[i], &cfg, &results[i]);
+        if (scenarios[i].mode == SOCKET_GRPC_CHANNEL_MODE_HTTP2
+            && !scenarios[i].request_compression
+            && strcmp (results[i].status, "ok") != 0)
+          exit_code = 1;
+      }
+
+    if (cfg.report_path != NULL)
+      {
+        report = fopen (cfg.report_path, "w");
+        if (report == NULL)
+          {
+            fprintf (stderr, "failed to open report path: %s\n", cfg.report_path);
+            return 1;
+          }
+      }
+
+    write_report (report, &cfg, results, scenario_count);
+
+    if (report != stdout)
+      fclose (report);
+  }
+#else
+  {
+    BenchResult result;
+
+    memset (&result, 0, sizeof (result));
+    result.spec.id = "grpc_benchmark";
+    result.spec.mode = SOCKET_GRPC_CHANNEL_MODE_HTTP2;
+    result.spec.payload_bytes = 0;
+    result.spec.request_compression = 0;
+    snprintf (result.status, sizeof (result.status), "skipped");
+    snprintf (result.note,
+              sizeof (result.note),
+              "TLS is disabled; gRPC transport benchmark unavailable");
+
+    if (cfg.report_path != NULL)
+      {
+        report = fopen (cfg.report_path, "w");
+        if (report == NULL)
+          {
+            fprintf (stderr, "failed to open report path: %s\n", cfg.report_path);
+            return 1;
+          }
+      }
+
+    write_report (report, &cfg, &result, 1);
+
+    if (report != stdout)
+      fclose (report);
+  }
+#endif
+
+  return exit_code;
+}

--- a/tests/grpc/bench/README.md
+++ b/tests/grpc/bench/README.md
@@ -1,0 +1,44 @@
+# gRPC Benchmark Harness
+
+This benchmark suite measures unary gRPC transport behavior for HTTP/2 and
+HTTP/3 using local loopback fixtures and emits machine-readable JSON reports.
+
+## Coverage
+
+The harness includes scenarios for:
+
+- HTTP/2 latency/throughput across payload sizes
+- HTTP/3 latency/throughput across payload sizes
+- Compression tradeoff checks:
+  - HTTP/2 request compression enabled
+  - HTTP/3 request compression marked `unsupported`
+
+If HTTP/3 runtime transport support is unavailable in the current environment,
+HTTP/3 scenarios are marked `skipped` in the report.
+
+## Run
+
+```bash
+scripts/grpc-bench/run.sh --build-dir build --report build/grpc-bench-report.json
+```
+
+Quick smoke profile:
+
+```bash
+scripts/grpc-bench/run.sh --build-dir build --smoke
+```
+
+## Report Format
+
+Reports include:
+
+- Environment metadata (host, OS, CPU count)
+- Config metadata (iterations, warmup)
+- Per-scenario metrics:
+  - `avg_latency_ms`
+  - `p50_latency_ms`
+  - `p95_latency_ms`
+  - `p99_latency_ms`
+  - `throughput_rps`
+
+See `tests/grpc/bench/report-template.json` for a template.

--- a/tests/grpc/bench/report-template.json
+++ b/tests/grpc/bench/report-template.json
@@ -1,0 +1,41 @@
+{
+  "profile": "full",
+  "generated_at": "2026-01-01T00:00:00Z",
+  "environment": {
+    "hostname": "host",
+    "sysname": "Linux",
+    "release": "6.x",
+    "machine": "x86_64",
+    "cpu_count": 8,
+    "tls_enabled": 1
+  },
+  "config": {
+    "iterations": 200,
+    "warmup": 20
+  },
+  "summary": {
+    "total": 8,
+    "ok": 6,
+    "skipped": 1,
+    "unsupported": 1,
+    "error": 0
+  },
+  "results": [
+    {
+      "id": "h2_unary",
+      "transport": "http2",
+      "payload_bytes": 4096,
+      "request_compression": false,
+      "status": "ok",
+      "note": "",
+      "iterations": 200,
+      "warmup": 20,
+      "successes": 200,
+      "avg_latency_ms": 1.234,
+      "p50_latency_ms": 1.100,
+      "p95_latency_ms": 1.800,
+      "p99_latency_ms": 2.100,
+      "throughput_rps": 810.4
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add gRPC docs for overview, client usage, server usage, and HTTP/3 constraints
- add smoke-runnable gRPC examples for unary, bidi client pattern, deadline/cancel, and TLS+mTLS (HTTP/2)
- add `benchmark_grpc_transport` with JSON output plus `scripts/grpc-bench/run.sh` and report template docs
- wire benchmark smoke report + example smoke execution into CI and local CI script
- include new gRPC docs in Doxygen input

Fixes #3594

## Test plan
- `cmake --build build -j$(nproc)`
- `ctest --test-dir build -R "grpc_example_.*_smoke" --output-on-failure`
- `ctest --test-dir build -R "test_grpc_api_surface|test_grpc_unary_h2|test_grpc_h3" --output-on-failure`
- `scripts/grpc-bench/run.sh --build-dir build --smoke --report build/grpc-bench-local.json`
- `ASAN_OPTIONS=detect_leaks=0 scripts/grpc-interop/run.sh --profile core --build-dir build --report build/grpc-interop-core-local-3594.json`
