### PR TITLE
fix(core): harden core security paths and add regression tests

### DIFF
--- a/include/core/SocketCrypto.h
+++ b/include/core/SocketCrypto.h
@@ -318,8 +318,9 @@ extern ssize_t SocketCrypto_base64_encode (const void *input,
 /**
  * @brief Decode Base64 string to binary data (RFC 4648).
  *
- * @param[in] input Base64 string (null-terminated if input_len == 0).
- * @param[in] input_len Length (0 for auto-detection).
+ * @param[in] input Base64 string.
+ * @param[in] input_len Explicit input length in bytes.
+ *            Use 0 only for empty string input.
  * @param[out] output Output buffer.
  * @param[in] output_size Buffer size.
  *

--- a/include/core/SocketRateLimit-private.h
+++ b/include/core/SocketRateLimit-private.h
@@ -50,6 +50,7 @@ struct T
   size_t tokens_per_sec;
   size_t bucket_size;
   size_t tokens;
+  size_t refill_remainder;
   int64_t last_refill_ms;
   pthread_mutex_t mutex;
   Arena_T arena;

--- a/src/core/Arena.c
+++ b/src/core/Arena.c
@@ -401,6 +401,10 @@ arena_release_all_chunks (T arena)
       chunk_cache_return (chunk);
     }
 
+  /* Ensure no stale pointers remain after all chunks are recycled/freed. */
+  arena->avail = NULL;
+  arena->limit = NULL;
+
   assert (arena->prev == NULL);
   assert (arena->avail == NULL);
   assert (arena->limit == NULL);

--- a/src/test/test_metrics.c
+++ b/src/test/test_metrics.c
@@ -1232,6 +1232,21 @@ TEST (metrics_export_statsd_type_suffixes)
   ASSERT_NOT_NULL (strstr (buffer, "|g"));
 }
 
+TEST (metrics_export_statsd_prefix_sanitized)
+{
+  SocketMetrics_init ();
+  SocketMetrics_reset ();
+  SocketMetrics_counter_add (SOCKET_CTR_SOCKET_CREATED, 1);
+
+  char buffer[8192];
+  size_t len = SocketMetrics_export_statsd (
+      buffer, sizeof (buffer), "app\nattack.metric:1|c");
+
+  ASSERT (len > 0);
+  ASSERT_NOT_NULL (strstr (buffer, "appattack.metric1c."));
+  ASSERT_NULL (strstr (buffer, "attack.metric:1|c"));
+}
+
 TEST (metrics_export_statsd_percentile_names)
 {
   SocketMetrics_init ();

--- a/src/test/test_socketlog.c
+++ b/src/test/test_socketlog.c
@@ -515,6 +515,26 @@ TEST (socketlog_structured_with_null_fields)
   SocketLog_setcallback (NULL, NULL);
 }
 
+TEST (socketlog_structured_fallback_escapes_injection_chars)
+{
+  reset_test_state ();
+  SocketLog_setcallback (test_callback, NULL);
+  SocketLog_setstructuredcallback (NULL, NULL);
+
+  SocketLogField fields[] = { { "user\nname", "line1\r\nline2=ok" } };
+
+  SocketLog_emit_structured (SOCKET_LOG_INFO, "Test", "Msg", fields, 1);
+
+  ASSERT_EQ (test_state.call_count, 1);
+  ASSERT_NOT_NULL (strstr (test_state.last_message,
+                           "user\\nname=line1\\r\\nline2\\=ok"));
+  ASSERT_NULL (strchr (test_state.last_message, '\n'));
+  ASSERT_NULL (strchr (test_state.last_message, '\r'));
+
+  SocketLog_setcallback (NULL, NULL);
+  SocketLog_setstructuredcallback (NULL, NULL);
+}
+
 TEST (socketlog_structured_field_with_null_key_value)
 {
   reset_test_state ();


### PR DESCRIPTION
## Summary
- fixes multiple core security issues discovered in the src/core audit
- hardens allocator, hashtable, crypto HKDF/base64, rate-limiter math, SYN protection capacity handling, timer-heap saturation behavior, metrics/log injection paths, and monotonic fallback handling
- adds/updates regression tests across core security-sensitive modules

## Security fixes
- Arena: clear stale allocator pointers after chunk release
- HashTable: clamp out-of-range bucket indices and ignore stale/forged remove `prev`
- Crypto: enforce HKDF info bounds and remove unsafe non-empty base64 auto-length scanning
- RateLimit: correct refill/wait math for low and high rates with fractional accumulation
- SYNProtect: eliminate fail-open behavior when tracked-IP capacity is reached
- Timer: avoid hard lockout at max heap size by evicting lower-priority timers under saturation
- Metrics: sanitize StatsD prefix to prevent injection
- Log: escape structured key/value control characters to prevent log-forging
- Util: harden CLOCK_REALTIME fallback monotonic behavior

## Validation
- `cmake -S . -B build`
- `cmake --build build -j$(nproc)`
- `ctest -R "test_(arena|hashtable|ratelimit|synprotect|timer_heap|metrics|socketlog|socketutil_time|crypto)$" --output-on-failure -j$(nproc)`
- `ctest -R "test_(synprotect_ip|synprotect_ip_parsing)$" --output-on-failure`
- `ctest -R "test_timer$" --output-on-failure`