### PR TITLE
feat(quic): add 0-RTT to transport and harden parsing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1047,6 +1047,7 @@ if(SOCKET_HAS_TLS)
         test_quic_crypto
         test_quic_initial
         test_quic_tls
+        test_quic_transport_0rtt_api
         test_quic_key_update
         test_quic_retry
         test_quic_rfc9001_vectors

--- a/include/quic/SocketQUICLoss.h
+++ b/include/quic/SocketQUICLoss.h
@@ -71,6 +71,15 @@
 #define QUIC_LOSS_MAX_SENT_PACKETS 1024
 
 /**
+ * @brief Maximum number of ACK ranges to process per received ACK frame.
+ *
+ * QUIC peers can encode very large ACK ranges. We bound parsing (frame module)
+ * and processing (loss module) to avoid CPU exhaustion when ranges include
+ * packet numbers we never tracked.
+ */
+#define QUIC_LOSS_MAX_ACK_RANGES 256
+
+/**
  * @brief Maximum PTO backoff exponent.
  */
 #define QUIC_LOSS_MAX_PTO_COUNT 16

--- a/include/quic/SocketQUICTransport.h
+++ b/include/quic/SocketQUICTransport.h
@@ -18,7 +18,6 @@
  *
  * V1 Simplifications:
  * - No retransmission (detect losses but don't retransmit)
- * - No 0-RTT (always full handshake)
  * - No connection migration (fixed path)
  * - No PMTU discovery (assume 1200-byte minimum)
  * - Fixed 4-byte packet numbers
@@ -36,6 +35,7 @@
 #include <stdint.h>
 
 #include "core/Arena.h"
+#include "quic/SocketQUICTransportParams.h"
 
 /**
  * @brief QUIC transport configuration.
@@ -107,6 +107,27 @@ int SocketQUICTransport_connect (SocketQUICTransport_T t,
                                  int port);
 
 /**
+ * @brief Begin connecting to a remote QUIC server (non-blocking start).
+ *
+ * Sets up the UDP socket, initializes QUIC+TLS state, and sends the first
+ * Initial packet (ClientHello). The handshake is then advanced by calling
+ * SocketQUICTransport_poll() until SocketQUICTransport_is_connected() returns
+ * 1 (or an error occurs).
+ *
+ * If a resumption ticket is configured via SocketQUICTransport_set_resumption_ticket(),
+ * this will attempt QUIC 0-RTT (early data). Early stream data can be sent
+ * during the handshake using SocketQUICTransport_send_stream_0rtt().
+ *
+ * @param t     Transport handle.
+ * @param host  Remote hostname or IP.
+ * @param port  Remote port.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_connect_start (SocketQUICTransport_T t,
+                                       const char *host,
+                                       int port);
+
+/**
  * @brief Close the transport (send CONNECTION_CLOSE).
  *
  * @param t  Transport handle.
@@ -131,6 +152,29 @@ int SocketQUICTransport_send_stream (SocketQUICTransport_T t,
                                      const uint8_t *data,
                                      size_t len,
                                      int fin);
+
+/**
+ * @brief Send 0-RTT early data on a QUIC stream (client only).
+ *
+ * Builds a STREAM frame, wraps in a 0-RTT packet, encrypts, and sends.
+ * Only usable after SocketQUICTransport_connect_start() and before the
+ * connection is established.
+ *
+ * If the server rejects 0-RTT, the transport will automatically resend all
+ * buffered 0-RTT stream data as 1-RTT once the handshake completes.
+ *
+ * @param t          Transport handle.
+ * @param stream_id  QUIC stream ID.
+ * @param data       Payload data.
+ * @param len        Payload length.
+ * @param fin        1 to signal end-of-stream.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_send_stream_0rtt (SocketQUICTransport_T t,
+                                          uint64_t stream_id,
+                                          const uint8_t *data,
+                                          size_t len,
+                                          int fin);
 
 /**
  * @brief Poll for incoming data (blocking with timeout).
@@ -162,6 +206,56 @@ void SocketQUICTransport_set_stream_callback (SocketQUICTransport_T t,
  * @return 1 if connected, 0 otherwise.
  */
 int SocketQUICTransport_is_connected (SocketQUICTransport_T t);
+
+/**
+ * @brief Configure a TLS session ticket for resumption and QUIC 0-RTT.
+ *
+ * Call before SocketQUICTransport_connect_start() / connect().
+ *
+ * @param t                Transport handle.
+ * @param ticket           Serialized TLS session ticket.
+ * @param ticket_len       Ticket length.
+ * @param saved_peer_params Peer transport parameters from the original
+ *                         connection (RFC 9001 §4.6.3 validation).
+ * @param alpn             ALPN negotiated on the original connection.
+ * @param alpn_len         ALPN length in bytes.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_set_resumption_ticket (
+    SocketQUICTransport_T t,
+    const uint8_t *ticket,
+    size_t ticket_len,
+    const SocketQUICTransportParams_T *saved_peer_params,
+    const char *alpn,
+    size_t alpn_len);
+
+/**
+ * @brief Export resumption state for future 0-RTT connections.
+ *
+ * On success, writes:\n
+ * - a serialized TLS session ticket into @p ticket\n
+ * - the peer transport parameters into @p peer_params\n
+ * - the negotiated ALPN into @p alpn (not NUL-terminated)\n
+ *
+ * If @p ticket is NULL, the required ticket length is returned in
+ * @p ticket_len and the function returns 0.\n
+ * If @p alpn is NULL, the required ALPN length is returned in @p alpn_len and
+ * the function returns 0.\n
+ *
+ * @param t          Transport handle.
+ * @param ticket     Output ticket buffer (or NULL for size query).
+ * @param ticket_len In/out: buffer size / bytes written.
+ * @param peer_params Output: peer transport parameters (optional, may be NULL).
+ * @param alpn       Output ALPN buffer (or NULL for size query).
+ * @param alpn_len   In/out: buffer size / bytes written.
+ * @return 0 on success, -1 on error.
+ */
+int SocketQUICTransport_export_resumption (SocketQUICTransport_T t,
+                                           uint8_t *ticket,
+                                           size_t *ticket_len,
+                                           SocketQUICTransportParams_T *peer_params,
+                                           char *alpn,
+                                           size_t *alpn_len);
 
 /**
  * @brief Allocate the next client bidirectional stream ID.

--- a/src/quic/SocketQUICPacket-receive.c
+++ b/src/quic/SocketQUICPacket-receive.c
@@ -435,8 +435,12 @@ receive_initial_packet (SocketQUICReceive_T *ctx,
       = SocketQUICPacket_decode_pn (truncated_pn, pn_length, largest_pn);
 
   /* Calculate payload bounds with underflow protection */
+  if (pn_offset > SIZE_MAX - pn_length)
+    return QUIC_RECEIVE_ERROR_TRUNCATED;
   size_t header_len = pn_offset + pn_length;
-  if (packet_len < header_len + QUIC_AEAD_TAG_LEN)
+  if (packet_len < QUIC_AEAD_TAG_LEN)
+    return QUIC_RECEIVE_ERROR_TRUNCATED;
+  if (header_len > packet_len - QUIC_AEAD_TAG_LEN)
     return QUIC_RECEIVE_ERROR_TRUNCATED;
 
   result->packet_number = full_pn;
@@ -497,8 +501,12 @@ receive_protected_packet (const SocketQUICPacketKeys_T *keys,
       = SocketQUICPacket_decode_pn (truncated_pn, pn_length, largest_pn);
 
   /* Calculate header and payload bounds */
+  if (pn_offset > SIZE_MAX - pn_length)
+    return QUIC_RECEIVE_ERROR_TRUNCATED;
   size_t header_len = pn_offset + pn_length;
-  if (packet_len < header_len + QUIC_AEAD_TAG_LEN)
+  if (packet_len < QUIC_AEAD_TAG_LEN)
+    return QUIC_RECEIVE_ERROR_TRUNCATED;
+  if (header_len > packet_len - QUIC_AEAD_TAG_LEN)
     return QUIC_RECEIVE_ERROR_TRUNCATED;
 
   size_t ciphertext_len = packet_len - header_len;
@@ -596,8 +604,12 @@ receive_1rtt_packet (SocketQUICReceive_T *ctx,
     }
 
   /* Calculate header and payload bounds */
+  if (pn_offset > SIZE_MAX - pn_length)
+    return QUIC_RECEIVE_ERROR_TRUNCATED;
   size_t header_len = pn_offset + pn_length;
-  if (packet_len < header_len + QUIC_AEAD_TAG_LEN)
+  if (packet_len < QUIC_AEAD_TAG_LEN)
+    return QUIC_RECEIVE_ERROR_TRUNCATED;
+  if (header_len > packet_len - QUIC_AEAD_TAG_LEN)
     return QUIC_RECEIVE_ERROR_TRUNCATED;
 
   size_t ciphertext_len = packet_len - header_len;

--- a/src/quic/SocketQUICTransportParams.c
+++ b/src/quic/SocketQUICTransportParams.c
@@ -1202,7 +1202,9 @@ decode_single_param (const uint8_t *data,
   DECODE_VARINT_AT_POS (data, len, pos, param_len);
 
   /* Check we have enough data for the parameter value */
-  if (*pos + param_len > len)
+  if (*pos > len)
+    return QUIC_TP_ERROR_INCOMPLETE;
+  if (param_len > (uint64_t)(len - *pos))
     return QUIC_TP_ERROR_INCOMPLETE;
 
   /* Check for duplicates (limited to param IDs 0-63 by bitmap size).

--- a/src/test/test_quic_transport_0rtt_api.c
+++ b/src/test/test_quic_transport_0rtt_api.c
@@ -1,0 +1,131 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_quic_transport_0rtt_api.c
+ * @brief Unit tests for SocketQUICTransport 0-RTT/resumption API validation.
+ */
+
+#include "core/Arena.h"
+#include "quic/SocketQUICTransport.h"
+#include "quic/SocketQUICTransportParams.h"
+#include "test/Test.h"
+
+#include <string.h>
+
+static void
+init_saved_peer_params (SocketQUICTransportParams_T *params)
+{
+  SocketQUICTransportParams_init (params);
+
+  /* Populate a minimal, plausible set of peer params. */
+  params->initial_max_data = 1048576;
+  params->initial_max_stream_data_bidi_local = 262144;
+  params->initial_max_stream_data_bidi_remote = 262144;
+  params->initial_max_stream_data_uni = 262144;
+  params->initial_max_streams_bidi = 100;
+  params->initial_max_streams_uni = 3;
+  params->active_connection_id_limit = 8;
+  params->disable_active_migration = 0;
+}
+
+TEST (quic_transport_set_resumption_ticket_rejects_oversize)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICTransport_T t = SocketQUICTransport_new (arena, NULL);
+  ASSERT_NOT_NULL (t);
+
+  uint8_t ticket[(16 * 1024) + 1];
+  memset (ticket, 0x42, sizeof (ticket));
+
+  SocketQUICTransportParams_T saved;
+  init_saved_peer_params (&saved);
+
+  ASSERT_EQ (SocketQUICTransport_set_resumption_ticket (
+                 t, ticket, sizeof (ticket), &saved, "h3", 2),
+             -1);
+
+  Arena_dispose (&arena);
+}
+
+TEST (quic_transport_set_resumption_ticket_rejects_alpn_mismatch)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICTransport_T t = SocketQUICTransport_new (arena, NULL);
+  ASSERT_NOT_NULL (t);
+
+  uint8_t ticket[32];
+  memset (ticket, 0x33, sizeof (ticket));
+
+  SocketQUICTransportParams_T saved;
+  init_saved_peer_params (&saved);
+
+  ASSERT_EQ (SocketQUICTransport_set_resumption_ticket (
+                 t, ticket, sizeof (ticket), &saved, "nope", 4),
+             -1);
+
+  Arena_dispose (&arena);
+}
+
+TEST (quic_transport_set_resumption_ticket_accepts_valid)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICTransport_T t = SocketQUICTransport_new (arena, NULL);
+  ASSERT_NOT_NULL (t);
+
+  uint8_t ticket[32];
+  memset (ticket, 0x55, sizeof (ticket));
+
+  SocketQUICTransportParams_T saved;
+  init_saved_peer_params (&saved);
+
+  ASSERT_EQ (
+      SocketQUICTransport_set_resumption_ticket (
+          t, ticket, sizeof (ticket), &saved, "h3", 2),
+      0);
+
+  Arena_dispose (&arena);
+}
+
+TEST (quic_transport_export_resumption_requires_connected)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICTransport_T t = SocketQUICTransport_new (arena, NULL);
+  ASSERT_NOT_NULL (t);
+
+  uint8_t ticket[256];
+  size_t ticket_len = sizeof (ticket);
+
+  SocketQUICTransportParams_T peer;
+  char alpn[32];
+  size_t alpn_len = sizeof (alpn);
+
+  ASSERT_EQ (SocketQUICTransport_export_resumption (
+                 t, ticket, &ticket_len, &peer, alpn, &alpn_len),
+             -1);
+
+  Arena_dispose (&arena);
+}
+
+/* ============================================================================
+ * Test Runner
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
Changes:
- Harden QUIC frame/packet/transport-parameter parsing bounds checks.
- Fix ACK parsing lifetime, loss ACK CPU-DoS, and propagate fatal frame-processing errors.
- Add ordered STREAM receive reassembly + flow-control enforcement.
- Add client 0-RTT to SocketQUICTransport (connect_start, resumption import/export, early send + replay on rejection).
- Enforce server send-side flow control.

Tests:
- ctest --test-dir build -j64 (216 tests)
