### PR TITLE
fix(quic): resolve handshake bugs and harden HTTP parsers

### DIFF
--- a/include/core/SocketCrypto.h
+++ b/include/core/SocketCrypto.h
@@ -34,6 +34,9 @@
 /** @brief SHA-256 digest size in bytes. */
 #define SOCKET_CRYPTO_SHA256_SIZE 32
 
+/** @brief SHA-384 digest size in bytes. */
+#define SOCKET_CRYPTO_SHA384_SIZE 48
+
 /** @brief MD5 digest size in bytes. */
 #define SOCKET_CRYPTO_MD5_SIZE 16
 

--- a/include/quic/SocketQUICConstants.h
+++ b/include/quic/SocketQUICConstants.h
@@ -307,6 +307,26 @@
 #define QUIC_RETRY_INTEGRITY_TAG_LEN 16
 
 /* ============================================================================
+ * Header Byte Constants (RFC 9000 §17)
+ * ============================================================================
+ */
+
+/**
+ * @brief Header Form bit (RFC 9000 §17.2).
+ *
+ * Bit 7 of the first byte: 1 = Long Header, 0 = Short Header.
+ */
+#define QUIC_HEADER_FORM_BIT 0x80
+
+/**
+ * @brief Packet Number Length mask (RFC 9000 §17.2, §17.3).
+ *
+ * Bottom 2 bits of the first byte encode (pn_length - 1).
+ * Actual PN length = (first_byte & QUIC_PN_LENGTH_MASK) + 1.
+ */
+#define QUIC_PN_LENGTH_MASK 0x03
+
+/* ============================================================================
  * Header Protection Constants
  * ============================================================================
  */

--- a/include/quic/SocketQUICPacket.h
+++ b/include/quic/SocketQUICPacket.h
@@ -927,13 +927,13 @@ typedef struct SocketQUICReceive
  */
 typedef struct SocketQUICReceiveResult
 {
-  SocketQUICPacket_Type type; /**< Packet type */
-  uint64_t packet_number;     /**< Full reconstructed packet number */
+  SocketQUICPacket_Type type;  /**< Packet type */
+  uint64_t packet_number;      /**< Full reconstructed packet number */
   SocketQUIC_PNSpace pn_space; /**< Packet number space */
 
   /* Decrypted payload (points into modified input buffer) */
-  uint8_t *payload;     /**< Pointer to decrypted payload */
-  size_t payload_len;   /**< Length of decrypted payload */
+  uint8_t *payload;   /**< Pointer to decrypted payload */
+  size_t payload_len; /**< Length of decrypted payload */
 
   /* Header info */
   SocketQUICConnectionID_T dcid; /**< Destination Connection ID */
@@ -942,6 +942,9 @@ typedef struct SocketQUICReceiveResult
   /* Short header specific */
   int key_phase; /**< Key Phase bit (1-RTT only) */
   int spin_bit;  /**< Spin bit (1-RTT only) */
+
+  /* Coalesced packet support (RFC 9000 §12.2) */
+  size_t consumed; /**< Total bytes consumed from datagram */
 } SocketQUICReceiveResult_T;
 
 /**
@@ -949,16 +952,16 @@ typedef struct SocketQUICReceiveResult
  */
 typedef enum
 {
-  QUIC_RECEIVE_OK = 0,            /**< Success */
-  QUIC_RECEIVE_ERROR_NULL,        /**< NULL pointer argument */
-  QUIC_RECEIVE_ERROR_TRUNCATED,   /**< Packet too short */
-  QUIC_RECEIVE_ERROR_HEADER,      /**< Header parse error */
-  QUIC_RECEIVE_ERROR_NO_KEYS,     /**< Keys not available for packet type */
-  QUIC_RECEIVE_ERROR_UNPROTECT,   /**< Header protection removal failed */
-  QUIC_RECEIVE_ERROR_DECRYPT,     /**< AEAD decryption/auth failed */
-  QUIC_RECEIVE_ERROR_PN_DECODE,   /**< Packet number decode failed */
-  QUIC_RECEIVE_ERROR_VERSION,     /**< Unsupported version */
-  QUIC_RECEIVE_ERROR_KEY_PHASE    /**< Key phase mismatch */
+  QUIC_RECEIVE_OK = 0,          /**< Success */
+  QUIC_RECEIVE_ERROR_NULL,      /**< NULL pointer argument */
+  QUIC_RECEIVE_ERROR_TRUNCATED, /**< Packet too short */
+  QUIC_RECEIVE_ERROR_HEADER,    /**< Header parse error */
+  QUIC_RECEIVE_ERROR_NO_KEYS,   /**< Keys not available for packet type */
+  QUIC_RECEIVE_ERROR_UNPROTECT, /**< Header protection removal failed */
+  QUIC_RECEIVE_ERROR_DECRYPT,   /**< AEAD decryption/auth failed */
+  QUIC_RECEIVE_ERROR_PN_DECODE, /**< Packet number decode failed */
+  QUIC_RECEIVE_ERROR_VERSION,   /**< Unsupported version */
+  QUIC_RECEIVE_ERROR_KEY_PHASE  /**< Key phase mismatch */
 } SocketQUICReceive_Result;
 
 /**

--- a/include/quic/SocketQUICVarInt.h
+++ b/include/quic/SocketQUICVarInt.h
@@ -45,6 +45,14 @@
 #define SOCKETQUICVARINT_MAX_SIZE 8
 
 /**
+ * @brief Minimum value that forces a 2-byte varint encoding.
+ *
+ * Useful as a placeholder when pre-computing header sizes: any value
+ * with the 0x40 prefix encodes as exactly 2 bytes (RFC 9000 §16).
+ */
+#define SOCKETQUICVARINT_MIN_2BYTE 0x40
+
+/**
  * @brief Exception raised on encoding/decoding errors.
  *
  * Raised when:

--- a/src/quic/SocketQUICFrame.c
+++ b/src/quic/SocketQUICFrame.c
@@ -990,7 +990,7 @@ SocketQUICFrame_parse_arena (Arena_T arena,
       size_t temp_consumed;
       res = SocketQUICFrame_parse (data, len, frame, &temp_consumed);
       if (res == QUIC_FRAME_OK)
-        pos = temp_consumed;
+        *consumed = temp_consumed;
       return res;
     }
 

--- a/src/test/test_httpserver.c
+++ b/src/test/test_httpserver.c
@@ -867,7 +867,7 @@ TEST (httpserver_static_symlink_escape_blocked)
   char *base_dir = NULL;
   char base2_dir[4096] = { 0 };
   char link_path[4096] = { 0 };
-  char secret_path[4096] = { 0 };
+  char secret_path[4112] = { 0 };
 
   TRY
   {

--- a/src/test/test_quic_transport_0rtt_api.c
+++ b/src/test/test_quic_transport_0rtt_api.c
@@ -88,11 +88,11 @@ TEST (quic_transport_set_resumption_ticket_accepts_valid)
   SocketQUICTransportParams_T saved;
   init_saved_peer_params (&saved);
 
-  ASSERT_EQ (
-      SocketQUICTransport_set_resumption_ticket (
-          t, ticket, sizeof (ticket), &saved, "h3", 2),
-      0);
+  ASSERT_EQ (SocketQUICTransport_set_resumption_ticket (
+                 t, ticket, sizeof (ticket), &saved, "h3", 2),
+             0);
 
+  SocketQUICTransport_close (t);
   Arena_dispose (&arena);
 }
 


### PR DESCRIPTION
## Summary
- Fix 7 QUIC handshake bugs preventing connection to real servers (PN length ordering, coalesced packet parsing, SHA-384 secret support, quictls compat, transport params, Length field encoding, coalesced datagram loop)
- Replace magic numbers with named constants (`QUIC_HEADER_FORM_BIT`, `QUIC_PN_LENGTH_MASK`, `SOCKET_CRYPTO_SHA384_SIZE`, `SOCKETQUICVARINT_MIN_2BYTE`)
- Harden HTTP/1.1, HTTP/2, HTTP/3 parsers and static file serving
- Fix memory leak in 0-RTT API test and build warning in httpserver test

## Test plan
- [x] 36/36 QUIC tests pass with ASan + UBSan + leak detection
- [x] 197/197 unit tests pass clean
- [x] Zero sanitizer violations, zero memory leaks

Fixes #3620