### PR TITLE
feat(quic): expose peer CONNECTION_CLOSE error code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1048,6 +1048,7 @@ if(SOCKET_HAS_TLS)
         test_quic_initial
         test_quic_tls
         test_quic_transport_0rtt_api
+        test_quic_transport_peer_close
         test_quic_key_update
         test_quic_retry
         test_quic_rfc9001_vectors

--- a/include/quic/SocketQUICTransport.h
+++ b/include/quic/SocketQUICTransport.h
@@ -114,9 +114,10 @@ int SocketQUICTransport_connect (SocketQUICTransport_T t,
  * SocketQUICTransport_poll() until SocketQUICTransport_is_connected() returns
  * 1 (or an error occurs).
  *
- * If a resumption ticket is configured via SocketQUICTransport_set_resumption_ticket(),
- * this will attempt QUIC 0-RTT (early data). Early stream data can be sent
- * during the handshake using SocketQUICTransport_send_stream_0rtt().
+ * If a resumption ticket is configured via
+ * SocketQUICTransport_set_resumption_ticket(), this will attempt QUIC 0-RTT
+ * (early data). Early stream data can be sent during the handshake using
+ * SocketQUICTransport_send_stream_0rtt().
  *
  * @param t     Transport handle.
  * @param host  Remote hostname or IP.
@@ -250,12 +251,13 @@ int SocketQUICTransport_set_resumption_ticket (
  * @param alpn_len   In/out: buffer size / bytes written.
  * @return 0 on success, -1 on error.
  */
-int SocketQUICTransport_export_resumption (SocketQUICTransport_T t,
-                                           uint8_t *ticket,
-                                           size_t *ticket_len,
-                                           SocketQUICTransportParams_T *peer_params,
-                                           char *alpn,
-                                           size_t *alpn_len);
+int
+SocketQUICTransport_export_resumption (SocketQUICTransport_T t,
+                                       uint8_t *ticket,
+                                       size_t *ticket_len,
+                                       SocketQUICTransportParams_T *peer_params,
+                                       char *alpn,
+                                       size_t *alpn_len);
 
 /**
  * @brief Allocate the next client bidirectional stream ID.
@@ -266,6 +268,32 @@ int SocketQUICTransport_export_resumption (SocketQUICTransport_T t,
  * @return Stream ID, or UINT64_MAX on error.
  */
 uint64_t SocketQUICTransport_open_bidi_stream (SocketQUICTransport_T t);
+
+/**
+ * @brief Check whether the peer sent a CONNECTION_CLOSE frame.
+ *
+ * @param t  Transport handle.
+ * @return 1 if a peer CONNECTION_CLOSE was received, 0 otherwise.
+ */
+int SocketQUICTransport_peer_close_received (SocketQUICTransport_T t);
+
+/**
+ * @brief Get the error code from the peer's CONNECTION_CLOSE frame.
+ *
+ * Only meaningful when SocketQUICTransport_peer_close_received() returns 1.
+ *
+ * @param t  Transport handle.
+ * @return Error code (transport or application), or 0 if no close received.
+ */
+uint64_t SocketQUICTransport_peer_close_error (SocketQUICTransport_T t);
+
+/**
+ * @brief Check whether the peer's CONNECTION_CLOSE was application-level.
+ *
+ * @param t  Transport handle.
+ * @return 1 if application-level (frame type 0x1d), 0 if transport-level.
+ */
+int SocketQUICTransport_peer_close_is_app (SocketQUICTransport_T t);
 
 #endif /* SOCKET_HAS_TLS */
 

--- a/src/test/test_quic_transport_peer_close.c
+++ b/src/test/test_quic_transport_peer_close.c
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * Copyright (c) 2025 Tetsuo AI
+ * https://x.com/tetsuoai
+ */
+
+/**
+ * @file test_quic_transport_peer_close.c
+ * @brief Unit tests for SocketQUICTransport peer CONNECTION_CLOSE accessors.
+ */
+
+#include "core/Arena.h"
+#include "quic/SocketQUICTransport.h"
+#include "test/Test.h"
+
+TEST (quic_transport_peer_close_defaults_zero)
+{
+  Arena_T arena = Arena_new ();
+  ASSERT_NOT_NULL (arena);
+
+  SocketQUICTransport_T t = SocketQUICTransport_new (arena, NULL);
+  ASSERT_NOT_NULL (t);
+
+  ASSERT_EQ (SocketQUICTransport_peer_close_received (t), 0);
+  ASSERT_EQ (SocketQUICTransport_peer_close_error (t), 0);
+  ASSERT_EQ (SocketQUICTransport_peer_close_is_app (t), 0);
+
+  SocketQUICTransport_close (t);
+  Arena_dispose (&arena);
+}
+
+TEST (quic_transport_peer_close_null_safety)
+{
+  ASSERT_EQ (SocketQUICTransport_peer_close_received (NULL), 0);
+  ASSERT_EQ (SocketQUICTransport_peer_close_error (NULL), 0);
+  ASSERT_EQ (SocketQUICTransport_peer_close_is_app (NULL), 0);
+}
+
+/* ============================================================================
+ * Test Runner
+ * ============================================================================
+ */
+
+int
+main (void)
+{
+  Test_run_all ();
+  return Test_get_failures () > 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary
- Store peer's error code, application flag, and received indicator when processing CONNECTION_CLOSE frames (RFC 9000 §19.19)
- Add three public getter functions: `peer_close_received()`, `peer_close_error()`, `peer_close_is_app()`
- Add unit tests for default state and NULL safety

Fixes #3622

## Test plan
- [x] New tests pass (`test_quic_transport_peer_close`)
- [x] 213/213 tests pass with ASan+UBSan+leak detection
- [x] clang-format applied