### PR TITLE
refactor: consolidate duplicate code and improve cleanup paths

### DIFF
--- a/src/quic/SocketQUICPacket-initial.c
+++ b/src/quic/SocketQUICPacket-initial.c
@@ -266,7 +266,7 @@ construct_nonce (const uint8_t *iv, uint64_t pn, uint8_t *nonce)
 {
   memcpy (nonce, iv, QUIC_INITIAL_IV_LEN);
 
-  /* XOR packet number into last bytes of IV (big-endian) */
+  /* XOR packet number into last bytes of IV (RFC 9001 §5.3) */
   for (int i = 0; i < (int)sizeof (uint64_t); i++)
     nonce[QUIC_INITIAL_IV_LEN - 1 - i] ^= (uint8_t)((pn >> (8 * i)) & 0xFF);
 }

--- a/src/test/test_httpserver.c
+++ b/src/test/test_httpserver.c
@@ -553,10 +553,6 @@ TEST (httpserver_state_query)
     server = SocketHTTPServer_new (&config);
     ASSERT_NOT_NULL (server);
 
-    /* Before start */
-    SocketHTTPServer_State state1 = SocketHTTPServer_state (server);
-    (void)state1;
-
     SocketHTTPServer_start (server);
 
     /* After start */
@@ -629,9 +625,7 @@ TEST (httpserver_multiple_start_stop)
 
     SocketHTTPServer_stop (server);
 
-    /* State should be updated */
-    SocketHTTPServer_State state = SocketHTTPServer_state (server);
-    (void)state;
+    /* State should be updated after stop */
   }
   FINALLY
   {
@@ -898,7 +892,8 @@ TEST (httpserver_static_symlink_escape_blocked)
     ASSERT_NOT_NULL (server);
 
     SocketHTTPServer_set_handler (server, always_404_handler, NULL);
-    ASSERT_EQ (0, SocketHTTPServer_add_static_dir (server, "/static", base_dir));
+    ASSERT_EQ (0,
+               SocketHTTPServer_add_static_dir (server, "/static", base_dir));
     ASSERT_EQ (0, SocketHTTPServer_start (server));
 
     int listen_fd = SocketHTTPServer_fd (server);
@@ -920,14 +915,12 @@ TEST (httpserver_static_symlink_escape_blocked)
     addr.sin_port = htons ((uint16_t)port);
     ASSERT_EQ (1, inet_pton (AF_INET, "127.0.0.1", &addr.sin_addr));
 
-    ASSERT_EQ (0,
-               connect (client_fd, (struct sockaddr *)&addr, sizeof (addr)));
+    ASSERT_EQ (0, connect (client_fd, (struct sockaddr *)&addr, sizeof (addr)));
 
-    const char *req =
-        "GET /static/link/secret.txt HTTP/1.1\r\n"
-        "Host: 127.0.0.1\r\n"
-        "Connection: close\r\n"
-        "\r\n";
+    const char *req = "GET /static/link/secret.txt HTTP/1.1\r\n"
+                      "Host: 127.0.0.1\r\n"
+                      "Connection: close\r\n"
+                      "\r\n";
 
     size_t req_len = strlen (req);
     size_t sent = 0;
@@ -954,8 +947,8 @@ TEST (httpserver_static_symlink_escape_blocked)
       {
         (void)SocketHTTPServer_process (server, 10);
 
-        ssize_t n
-            = recv (client_fd, resp + resp_len, sizeof (resp) - 1 - resp_len, 0);
+        ssize_t n = recv (
+            client_fd, resp + resp_len, sizeof (resp) - 1 - resp_len, 0);
         if (n > 0)
           {
             resp_len += (size_t)n;


### PR DESCRIPTION
## Summary
- Extract shared patterns across QUIC transport, HTTP/2 client, HTTP/3 request handling, and gRPC benchmarks
- Eliminate ~160 net lines of duplicated code through macro composition, helper extraction, and parameterization
- Add proper cleanup paths (goto-fail) and exception handling (missing EXCEPT handlers)

### Changes by priority

**HIGH:**
- H1: `H2_SAFE_CALL` macro reduces 8 TRY/EXCEPT wrappers from ~250 lines to ~30
- H2: Unify `build_and_send_0rtt_packet_ex`/`build_and_send_1rtt_packet_ex` into `build_and_send_app_packet()`
- H3: Split `send_crypto_data()` into `send_crypto_initial()`/`send_crypto_handshake()` + dispatcher
- H4: Extract `fixture_setup_common()` from `fixture_start_h2()`/`fixture_start_h3()`

**MEDIUM:**
- M1: Extract `complete_handshake_setup()` and `complete_handshake_if_ready()` from QUIC transport
- M3: Extract `compute_payload_bounds()` from 3 duplicate QUIC receive functions
- M4: `CHECK_PSEUDO_DUP` macro for HTTP/2 pseudo-header duplicate detection
- M5: Extract `decode_indexed_field()`/`decode_literal_nameref()`/`decode_literal_field()` from QPACK decoder
- M6: Add `goto fail` cleanup in `connect_start()` preventing socket FD leaks

**LOW:**
- L1: Remove dead `state` captures in HTTP server tests
- L2: Fix unreachable ELSE block (TRY without EXCEPT) in gRPC benchmark
- L3: Fix misleading nonce XOR comment → cite RFC 9001 §5.3

Fixes #3624

## Test plan
- [x] Full test suite passes with ASan+UBSan (217 tests, 1 known flaky H3 integration timeout)
- [x] All changes are pure refactoring — no behavioral changes
- [x] clang-format applied to all 8 modified files