### PR TITLE
fix(quic): adopt server SCID as DCID during handshake

### DIFF
--- a/src/quic/SocketQUICTransport.c
+++ b/src/quic/SocketQUICTransport.c
@@ -2105,6 +2105,17 @@ SocketQUICTransport_poll (SocketQUICTransport_T t, int timeout_ms)
 
       if (t->connecting && !t->connected)
         {
+          /* RFC 9000 §7.2: adopt server's SCID as our DCID upon receiving
+           * the first Initial or Handshake packet from the server. */
+          if (result.scid.len > 0
+              && (result.type == QUIC_PACKET_TYPE_INITIAL
+                  || result.type == QUIC_PACKET_TYPE_HANDSHAKE))
+            {
+              t->dcid = result.scid;
+              SocketQUICConnection_update_dcid (t->handshake->conn,
+                                                &result.scid);
+            }
+
           /* Drive TLS handshake forward after each packet. */
           check_and_derive_keys (t);
 


### PR DESCRIPTION
## Summary

- Fix client failing to capture the server's Source Connection ID from Initial/Handshake packets during the QUIC handshake
- The parsed `result.scid` was discarded, so `conn->peer_cids[0]` retained the original random 8-byte DCID
- All post-handshake 1-RTT packets used the wrong DCID, causing servers with >8-byte CIDs (nginx uses 20) to send stateless resets

Fixes #3631

## Test plan
- [x] All 37 QUIC tests pass with sanitizers
- [x] New test `quic_connection_update_dcid_longer_cid` validates 8-byte to 20-byte DCID update
- [x] Full test suite passes (217 tests, 2 pre-existing failures unrelated to this change)
- [ ] Manual testing against nginx QUIC server to verify interop